### PR TITLE
feat(cli): addon registry routes, verify command, PKU940 cast guard

### DIFF
--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -118,28 +118,6 @@ async function makeValidProject(root: string) {
     '.pikku\n.pikku-runtime\n.opencode\n.reports\n__fabric_scaffold.vite.config.mjs\n*.gen.ts\n*.gen.js\n',
     'utf8'
   )
-  await mkdir(join(root, 'db'), { recursive: true })
-  await writeFile(
-    join(root, 'db', 'annotations.ts'),
-    '// db annotations\n',
-    'utf8'
-  )
-  await mkdir(join(root, 'knowledge'), { recursive: true })
-  await writeFile(
-    join(root, 'knowledge', 'design-language.md'),
-    '# Design Language\n',
-    'utf8'
-  )
-  await writeFile(
-    join(root, 'knowledge', 'security.md'),
-    '# Security\n',
-    'utf8'
-  )
-  await writeFile(
-    join(root, 'knowledge', 'technology.md'),
-    '# Technology\n',
-    'utf8'
-  )
 }
 
 describe('pikku fabric validate', () => {

--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -93,6 +93,27 @@ async function makeValidProject(root: string) {
     recursive: true,
   })
   await writeFile(
+    join(root, 'db', 'annotations.ts'),
+    '// db column annotations\nexport const annotations = {}\n',
+    'utf8'
+  )
+  await mkdir(join(root, 'knowledge'), { recursive: true })
+  await writeFile(
+    join(root, 'knowledge', 'design-language.md'),
+    '# Design Language\n',
+    'utf8'
+  )
+  await writeFile(
+    join(root, 'knowledge', 'security.md'),
+    '# Security\n',
+    'utf8'
+  )
+  await writeFile(
+    join(root, 'knowledge', 'technology.md'),
+    '# Technology\n',
+    'utf8'
+  )
+  await writeFile(
     join(root, '.gitignore'),
     '.pikku\n.pikku-runtime\n.opencode\n.reports\n__fabric_scaffold.vite.config.mjs\n*.gen.ts\n*.gen.js\n',
     'utf8'


### PR DESCRIPTION
## Summary

- Renames publish routes `/registry/packages` → `/registry/addons`
- Adds `pikku fabric addon verify` command with structured output
- Adds PKU940 inspector rule — blocks type casts on `rpc.invoke()` calls
- Refactors `inline:false` → `workflowQueued:true` on function meta
- Splits bulky skill references on demand
- Adds `fabric validate` checks for `db/annotations.ts` and `knowledge/*.md` required files (with gitignore warnings)
- Fixes test fixture (`makeValidProject`) to include the new required files so validate tests pass

## Test plan

- [ ] `yarn workspace @pikku/cli test` — 265/265 passing locally
- [ ] CI Build passes (was failing due to missing fixture files — fixed in this PR)
- [ ] `pikku fabric addon verify` smoke-test against a local registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated validation test scaffold to generate required project artifacts earlier in the setup process.
  * Adjusted live-validation assertions for improved readability, without changing the expected findings or severity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->