### PR TITLE
feat(ai): @pikku/ai-tanstack runner (stacked on #930)

### DIFF
--- a/.changeset/ai-runner-interchangeable.md
+++ b/.changeset/ai-runner-interchangeable.md
@@ -1,0 +1,13 @@
+---
+"@pikku/ai-tanstack": patch
+---
+
+Throw on provider stream errors instead of returning `finishReason: 'error'`
+
+The TanStack runner now throws when the underlying provider stream errors
+(`RUN_ERROR`), so the core AI stream handler marks the run failed and fires
+`onError` middleware — matching the vercel runner. Previously it returned a
+step with `finishReason: 'error'`, which core treated as a normal completed
+step (run left `completed`). This makes the two runners interchangeable on the
+error path, not just the happy path; the full `@ai` e2e suite passes against
+both (`PIKKU_AI_RUNNER=tanstack|vercel`).

--- a/.changeset/ai-tanstack-runner.md
+++ b/.changeset/ai-tanstack-runner.md
@@ -1,0 +1,5 @@
+---
+"@pikku/ai-tanstack": patch
+---
+
+Add @pikku/ai-tanstack package implementing AIAgentRunnerService with TanStack AI (@tanstack/ai + @tanstack/ai-openai)

--- a/.changeset/assistant-ui-ag-ui-client.md
+++ b/.changeset/assistant-ui-ag-ui-client.md
@@ -1,0 +1,11 @@
+---
+"@pikku/assistant-ui": patch
+---
+
+Replace hand-rolled SSE parser with AG-UI client runtime
+
+`usePikkuAgentRuntime` now uses `PikkuAgent extends HttpAgent` from `@ag-ui/client` and `useAgUiRuntime` from `@assistant-ui/react-ag-ui`, removing ~200 lines of custom SSE parsing. The non-streaming runtime (`usePikkuAgentNonStreamingRuntime`) has been removed; all agent chat is now streaming-only.
+
+The approval/resume flow is preserved: `agent.queueResume()` routes the next `runAgent()` call to the `/resume` endpoint instead of `/stream`.
+
+Root `resolutions` pin `@assistant-ui/core`, `assistant-stream`, `@assistant-ui/tap`, and `zustand` to exact versions. `@assistant-ui/react` and `@assistant-ui/react-ag-ui` must resolve to a *single* shared instance of each — the runtime context and zustand stores are singletons, so a duplicated copy would make the react-ag-ui runtime invisible to the react primitives. The pins force yarn to dedupe.

--- a/.changeset/better-auth-catch-getsecret.md
+++ b/.changeset/better-auth-catch-getsecret.md
@@ -1,0 +1,7 @@
+---
+"@pikku/better-auth": patch
+---
+
+Catch getSecret throw in betterAuthStatelessSession
+
+When the secret isn't configured (e.g. during Next.js static export), `secrets.getSecret()` throws instead of returning null. The middleware now catches the error, logs a warning, and skips gracefully rather than crashing.

--- a/.changeset/ts6-pikku-wire-constraint-fix.md
+++ b/.changeset/ts6-pikku-wire-constraint-fix.md
@@ -1,0 +1,9 @@
+---
+"@pikku/core": patch
+---
+
+Fix TypeScript 6 PikkuWire constraint collapse for rpc field
+
+TypeScript 6 collapses `Partial<{field: any}>` to `{field: any}` (required) when the type arg is bare `any`, because `any | undefined = any`. This caused the generated `.gen.ts` files to fail type-checking because `rpc` appeared as a required field.
+
+Changes: narrowed `PikkuRPC` default type params from `any` to `Function`, and replaced bare `any` TypedRPC args in `CorePikkuPermission` and related types with `PikkuRPC`.

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -68,6 +68,7 @@ runs:
           packages/**/dist/**
           packages/**/bin/**
           packages/**/.pikku/**
+          packages/cli/console-app/**
           templates/**/.pikku/**
           templates/**/dist/**
         include-hidden-files: true

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -83,23 +83,23 @@ jobs:
       - name: Run e2e tests
         run: yarn test:e2e --force-exit
 
-  # e2e-ai:
-  #   name: E2E AI
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: mcr.microsoft.com/playwright:v1.58.2-noble
-  #   timeout-minutes: 10
-  #   needs: [e2e, verifiers, templates]
-  #   steps:
-  #     - uses: actions/checkout@v7
-  #     - name: Install native build tools
-  #       run: apt-get update && apt-get install -y build-essential python3
-  #     - uses: ./.github/actions/setup
-  #     - uses: ./.github/actions/e2e-codegen
-  #     - name: Run AI e2e tests
-  #       run: yarn test:e2e:ai
-  #       env:
-  #         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  e2e-ai:
+    name: E2E AI
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+    timeout-minutes: 30
+    needs: build
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install native build tools
+        run: apt-get update && apt-get install -y build-essential python3 unzip
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/e2e-codegen
+      - name: Run AI e2e tests
+        run: yarn test:e2e:ai
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
   verifiers:
     name: Verifiers (${{ matrix.verifier }}, ${{ matrix.package-manager }})

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -84,12 +84,16 @@ jobs:
         run: yarn test:e2e --force-exit
 
   e2e-ai:
-    name: E2E AI
+    name: E2E AI (${{ matrix.runner }})
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 30
     needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [tanstack, vercel]
     steps:
       - uses: actions/checkout@v7
       - name: Install native build tools
@@ -100,6 +104,7 @@ jobs:
         run: yarn test:e2e:ai
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PIKKU_AI_RUNNER: ${{ matrix.runner }}
 
   verifiers:
     name: Verifiers (${{ matrix.verifier }}, ${{ matrix.package-manager }})

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -38,6 +38,7 @@
     "@pikku/addon-console": "workspace:*",
     "@pikku/addon-graph": "workspace:*",
     "@pikku/addon-hmac-signer": "workspace:*",
+    "@pikku/ai-tanstack": "workspace:*",
     "@pikku/ai-vercel": "workspace:*",
     "@pikku/better-auth": "workspace:*",
     "@pikku/core": "workspace:*",

--- a/e2e/packages/functions/src/agents/todo.agent.ts
+++ b/e2e/packages/functions/src/agents/todo.agent.ts
@@ -6,7 +6,7 @@ export const todoAgent = pikkuAIAgent({
   name: 'todo-agent',
   description: 'Manages a todo list',
   goal: 'You help users manage their todos. You can list all todos, get details of a specific todo, add new todos, and delete todos.',
-  model: 'openai/o4-mini',
+  model: 'openai/gpt-4o-mini',
   tools: [
     ref('todos:listTodos'),
     ref('todos:getTodo'),

--- a/e2e/src/services.ts
+++ b/e2e/src/services.ts
@@ -10,9 +10,8 @@ import {
 import type { EmailService } from '@pikku/core/services'
 import { pikkuServices } from '#pikku/pikku-types.gen.js'
 import { CFWorkerSchemaService } from '@pikku/schema-cfworker'
-import { VercelAIAgentRunner } from '@pikku/ai-vercel'
+import type { AIAgentRunnerService } from '@pikku/core/services'
 import { JoseJWTService } from '@pikku/jose'
-import { createOpenAI } from '@ai-sdk/openai'
 import type { KyselyPikkuDB } from '@pikku/kysely'
 import { requiredSingletonServices } from '#pikku/pikku-services.gen.js'
 import { PikkuMetaService } from '../.pikku/pikku-meta-service.gen.js'
@@ -39,9 +38,17 @@ export const createSingletonServices = pikkuServices(
 
     const schema = new CFWorkerSchemaService(logger)
 
-    const aiAgentRunner = new VercelAIAgentRunner({
-      openai: createOpenAI(),
-    })
+    const aiRunner = process.env.PIKKU_AI_RUNNER ?? 'tanstack'
+    logger.info(`AI agent runner: ${aiRunner}`)
+    let aiAgentRunner: AIAgentRunnerService
+    if (aiRunner === 'vercel') {
+      const { VercelAIAgentRunner } = await import('@pikku/ai-vercel')
+      const { createOpenAI } = await import('@ai-sdk/openai')
+      aiAgentRunner = new VercelAIAgentRunner({ openai: createOpenAI() })
+    } else {
+      const { TanstackAIAgentRunner } = await import('@pikku/ai-tanstack')
+      aiAgentRunner = new TanstackAIAgentRunner()
+    }
 
     const backend = process.env.DB_BACKEND ?? 'sqlite'
     let aiStorage: any

--- a/e2e/tests/features/credential-agent.feature
+++ b/e2e/tests/features/credential-agent.feature
@@ -16,3 +16,15 @@ Feature: AI Agent with OAuth Credential Gating
       """
     And I open the "oauthApiAgent" playground
     Then I should not see "Connect your accounts" in the chat
+
+  Scenario: Mid-chat credential request connects via OAuth popup and resumes
+    Given I set credential "user-oauth" with value:
+      """
+      { "accessToken": "" }
+      """
+    And I open the "oauthApiAgent" playground
+    When I send "Get my profile and show me my access token verbatim"
+    Then I should see "Credential required" in the chat
+    When I connect the OAuth credential via the popup
+    And I wait for the response
+    Then I should see "mock-access-token" in the chat

--- a/e2e/tests/features/todo-agent.feature
+++ b/e2e/tests/features/todo-agent.feature
@@ -39,8 +39,8 @@ Feature: Todo Agent via Console
     When I send "Create these 3 todos: 'Learn to juggle', 'Eat a cloud', 'Befriend a squirrel'"
     Then I should see 3 approval requests
     When I deny the 2nd approval and approve the rest
-    Then I should see 2 "done" badges in the chat
-    And I should see 1 "denied" badges in the chat
+    Then I should see 2 "Done" badges in the chat
+    And I should see 1 "Denied" badges in the chat
     And I should see "Learn to juggle" in the chat
     And I should see "Befriend a squirrel" in the chat
 

--- a/e2e/tests/steps/credential.steps.ts
+++ b/e2e/tests/steps/credential.steps.ts
@@ -1,6 +1,7 @@
 import { Given, When, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
 import { config } from '../support/types.js'
+import type { AgentWorld } from '../support/world.js'
 
 async function rpc(name: string, data: Record<string, unknown> = {}) {
   const res = await fetch(`${config.apiUrl}/rpc/${name}`, {
@@ -338,5 +339,21 @@ Then(
       state.lastWorkflowResult.payload?.error ||
       JSON.stringify(state.lastWorkflowResult).includes(expectedError)
     expect(hasError).toBeTruthy()
+  }
+)
+
+When(
+  'I connect the OAuth credential via the popup',
+  async function (this: AgentWorld) {
+    const popupPromise = this.page.waitForEvent('popup')
+    await this.page
+      .getByRole('button', { name: /^Connect / })
+      .last()
+      .click()
+    const popup = await popupPromise
+    await popup
+      .getByText('success', { exact: false })
+      .waitFor({ state: 'visible', timeout: 15_000 })
+    await popup.close()
   }
 )

--- a/e2e/tests/support/world.ts
+++ b/e2e/tests/support/world.ts
@@ -29,10 +29,32 @@ export class AgentWorld extends World {
     this.browser = await chromium.launch({
       headless: !headed,
       slowMo: headed ? 200 : 0,
+      ...(process.env.PIKKU_E2E_BROWSER_LOG === '1' ? { dumpio: true } : {}),
     })
     this.context = await this.browser.newContext()
     this.page = await this.context.newPage()
     this.page.setDefaultTimeout(config.responseTimeout)
+    if (process.env.PIKKU_E2E_BROWSER_LOG === '1') {
+      this.page.on('console', (msg) => {
+        if (msg.type() === 'error' || msg.type() === 'warning') {
+          process.stdout.write(`[browser:${msg.type()}] ${msg.text()}\n`)
+        }
+      })
+      this.page.on('pageerror', (err) => {
+        process.stdout.write(
+          `[browser:pageerror] ${err.stack ?? err.message}\n`
+        )
+      })
+      this.page.on('crash', () => {
+        process.stdout.write(`[browser:CRASH] page crashed\n`)
+      })
+      this.page.on('close', () => {
+        process.stdout.write(`[browser:close] page closed\n`)
+      })
+      this.page.on('popup', (p) => {
+        process.stdout.write(`[browser:popup] ${p.url()}\n`)
+      })
+    }
     // Point the Pikku Console at the e2e backend
     await this.page.addInitScript((apiUrl: string) => {
       localStorage.setItem('pikku-server-url', apiUrl)
@@ -120,7 +142,9 @@ export class AgentWorld extends World {
     )
     // Wait for either the chat input or a credential prompt to be ready
     await Promise.race([
-      this.page.getByPlaceholder('Message...').waitFor({ state: 'visible' }),
+      this.page
+        .getByPlaceholder('Type a message…')
+        .waitFor({ state: 'visible' }),
       this.page
         .getByText('Connect your accounts')
         .waitFor({ state: 'visible' }),
@@ -131,37 +155,88 @@ export class AgentWorld extends World {
    * Type a message and send it.
    * Waits for the textarea to be enabled first (in case a previous response is completing).
    * After submitting, verifies the runtime accepted the message by checking the textarea was cleared.
-   * Retries submission if the runtime didn't pick it up (happens after approval-resume cycles).
+   * Retries submission if the runtime didn't pick it up: assistant-ui silently
+   * drops composer.send() while a run is in flight, and the textarea's enabled
+   * state doesn't track thread.isRunning — so the first submit after an
+   * approval-resume cycle can land mid-resume-run and be discarded.
    */
   async sendMessage(message: string) {
-    const input = this.page.getByPlaceholder('Message...')
+    const debug = process.env.PIKKU_E2E_BROWSER_LOG === '1'
+    const dump = async (label: string) => {
+      if (!debug) return
+      const state = await this.page.evaluate(() => {
+        const ta = document.querySelector('textarea')
+        return {
+          value: ta?.value,
+          disabled: ta?.disabled,
+          placeholder: ta?.placeholder,
+          forms: document.querySelectorAll('form').length,
+        }
+      })
+      process.stdout.write(
+        `[sendMessage ${Date.now() % 100000}] ${label}: ${JSON.stringify(state)}\n`
+      )
+    }
+    const input = this.page.getByPlaceholder('Type a message…')
     // Wait for textarea to be enabled (runtime back to idle)
     await this.waitForTextareaEnabled()
+    await dump('after-enabled-wait')
 
     // Try submitting, with retries if the runtime doesn't process the message
     for (let attempt = 0; attempt < 5; attempt++) {
       // Brief settle for assistant-ui runtime after approval-resume cycles
       await this.page.waitForTimeout(1_000)
 
+      await dump(`attempt-${attempt}-before-click`)
       await input.click()
       await input.fill(message)
-      await this.page.evaluate(() => {
-        const form = document.querySelector('form')
-        if (form) form.requestSubmit()
-      })
+      await dump(`attempt-${attempt}-after-fill`)
+      const submitResult = await Promise.race([
+        this.page
+          .evaluate(() => {
+            const form = document.querySelector('form')
+            if (form) form.requestSubmit()
+            return 'submitted'
+          })
+          .catch((e) => `submit-error: ${e}`),
+        new Promise<string>((r) =>
+          setTimeout(() => r('SUBMIT-EVALUATE-FROZEN'), 5_000)
+        ),
+      ])
+      if (debug) {
+        process.stdout.write(`[sendMessage] submit: ${submitResult}\n`)
+      }
 
-      // Wait for textarea to be cleared (runtime consumed the message)
+      // Wait for textarea to be cleared (runtime consumed the message).
+      // Raced node-side: the page-side poll never fires if the main thread
+      // is frozen, so the timeout alone can hang far past 5s.
       try {
-        await this.page.waitForFunction(
-          () => {
-            const ta = document.querySelector('textarea')
-            return ta && ta.value === ''
-          },
-          { timeout: 5_000 }
-        )
+        await Promise.race([
+          this.page.waitForFunction(
+            () => {
+              const ta = document.querySelector('textarea')
+              return ta && ta.value === ''
+            },
+            { timeout: 5_000 }
+          ),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('cleared-wait timed out')), 6_000)
+          ),
+        ])
         return // Message accepted
       } catch {
         // Textarea still has text — runtime didn't consume it. Retry.
+        if (debug) {
+          const alive = await Promise.race([
+            this.page.evaluate(() => 'alive').catch((e) => `dead: ${e}`),
+            new Promise<string>((r) =>
+              setTimeout(() => r('PAGE-FROZEN'), 3_000)
+            ),
+          ])
+          process.stdout.write(
+            `[sendMessage] attempt-${attempt}-not-consumed page=${alive}\n`
+          )
+        }
         await this.waitForTextareaEnabled()
       }
     }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,11 @@
   },
   "resolutions": {
     "esbuild": "0.27.2",
-    "pikkufabric": "portal:/Users/yasser/git/pikku/fabric"
+    "pikkufabric": "portal:/Users/yasser/git/pikku/fabric",
+    "@assistant-ui/core": "0.2.19",
+    "assistant-stream": "0.3.24",
+    "@assistant-ui/tap": "0.9.3",
+    "zustand": "5.0.14"
   },
   "engines": {
     "node": ">=24"

--- a/packages/assistant-ui/package.json
+++ b/packages/assistant-ui/package.json
@@ -20,7 +20,9 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "@assistant-ui/react": "^0.12.12 || ^0.14.0",
+    "@ag-ui/client": "^0.0.57",
+    "@assistant-ui/react": "^0.14.24",
+    "@assistant-ui/react-ag-ui": "^0.0.43",
     "react-markdown": "^10.1.0"
   },
   "peerDependencies": {

--- a/packages/assistant-ui/src/index.ts
+++ b/packages/assistant-ui/src/index.ts
@@ -1,6 +1,5 @@
 export {
   usePikkuAgentRuntime,
-  usePikkuAgentNonStreamingRuntime,
   PikkuApprovalContext,
   usePikkuApproval,
   convertDbMessages,

--- a/packages/assistant-ui/src/pikku-agent-chat.tsx
+++ b/packages/assistant-ui/src/pikku-agent-chat.tsx
@@ -149,10 +149,14 @@ const ToolCallDisplay: FunctionComponent<{
 }> = ({ toolCallId, toolName, args, result, status, addResult }) => {
   const colors = useContext(ColorsContext)
   const hideToolCalls = useContext(HideToolCallsContext)
-  const { handleApproval } = usePikkuApproval()
+  const { handleApproval, pendingApprovals } = usePikkuApproval()
   const [expanded, setExpanded] = useState(false)
   const isApproval = status.type === 'requires-action'
-  const approvalReason = (args as any)?.__approvalReason
+  const approvalReason =
+    (args as any)?.__approvalReason ??
+    pendingApprovals.find(
+      (a) => a.toolCallId === toolCallId && a.type !== 'credential-request'
+    )?.reason
   const displayArgs = { ...args }
   delete (displayArgs as any).__approvalReason
   const [responded, setResponded] = useState<'approved' | 'denied' | null>(null)
@@ -214,10 +218,11 @@ const ToolCallDisplay: FunctionComponent<{
         </pre>
         <div style={{ display: 'flex', gap: 8 }}>
           <button
-            onClick={() => {
+            onClick={async () => {
               setResponded('approved')
-              handleApproval(toolCallId, true)
-              addResult?.({ approved: true })
+              if (await handleApproval(toolCallId, true)) {
+                addResult?.({ approved: true })
+              }
             }}
             style={{
               padding: '4px 12px',
@@ -232,10 +237,11 @@ const ToolCallDisplay: FunctionComponent<{
             Approve
           </button>
           <button
-            onClick={() => {
+            onClick={async () => {
               setResponded('denied')
-              handleApproval(toolCallId, false)
-              addResult?.({ approved: false })
+              if (await handleApproval(toolCallId, false)) {
+                addResult?.({ approved: false })
+              }
             }}
             style={{
               padding: '4px 12px',

--- a/packages/assistant-ui/src/use-pikku-agent-runtime.ts
+++ b/packages/assistant-ui/src/use-pikku-agent-runtime.ts
@@ -1,15 +1,24 @@
 import {
   createContext,
+  useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useState,
-  useCallback,
 } from 'react'
+import { HttpAgent } from '@ag-ui/client'
+import type {
+  RunAgentInput,
+  BaseEvent,
+  CustomEvent as AgUiCustomEvent,
+} from '@ag-ui/client'
+import type { Observable } from 'rxjs'
+import { useAgUiRuntime } from '@assistant-ui/react-ag-ui'
 import {
-  useLocalRuntime,
-  type ChatModelAdapter,
+  ExportedMessageRepository,
   type ThreadMessageLike,
+  type ThreadHistoryAdapter,
 } from '@assistant-ui/react'
 
 export interface PikkuAgentRuntimeOptions {
@@ -17,7 +26,6 @@ export interface PikkuAgentRuntimeOptions {
   agentName: string
   threadId: string
   resourceId: string
-  initialMessages?: any[]
   onFinish?: () => void
   credentials?: RequestCredentials
   headers?: Record<string, string>
@@ -27,6 +35,11 @@ export interface PikkuAgentRuntimeOptions {
    *  Provide upfront state (e.g. current org/project/branch/deployment IDs)
    *  so the agent can call tools without asking the user. */
   context?: string
+  /** Prior messages to hydrate the thread with (e.g. converted from persisted
+   *  DB history via `convertDbMessages`). Loaded once on mount, so the
+   *  consumer must keep the chat unmounted until these are available (key or
+   *  gate on load) — the runtime does not re-hydrate when they change later. */
+  initialMessages?: ThreadMessageLike[]
 }
 
 export interface PendingApproval {
@@ -34,7 +47,7 @@ export interface PendingApproval {
   toolName: string
   args: unknown
   reason?: string
-  runId: string
+  runId?: string
   type?: 'approval-request' | 'credential-request'
   credentialName?: string
   credentialType?: 'oauth2' | 'apikey'
@@ -43,178 +56,18 @@ export interface PendingApproval {
 
 export interface PikkuApprovalContextValue {
   pendingApprovals: PendingApproval[]
-  handleApproval: (toolCallId: string, approved: boolean) => void
+  /** Resolve an approval/credential request. Returns `true` when the request
+   *  was found and acknowledged — callers must gate their `addResult` call on
+   *  this so a stray result can't start a resume run with nothing queued. */
+  handleApproval: (toolCallId: string, approved: boolean) => Promise<boolean>
 }
 
 export const PikkuApprovalContext = createContext<PikkuApprovalContextValue>({
   pendingApprovals: [],
-  handleApproval: () => {},
+  handleApproval: async () => false,
 })
 
 export const usePikkuApproval = () => useContext(PikkuApprovalContext)
-
-async function* parseSSEStream(
-  reader: ReadableStreamDefaultReader<Uint8Array>
-) {
-  const decoder = new TextDecoder()
-  let buffer = ''
-
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-
-    buffer += decoder.decode(value, { stream: true })
-    const lines = buffer.split('\n')
-    buffer = lines.pop()!
-
-    for (const line of lines) {
-      if (line.startsWith('data: ')) {
-        const data = line.slice(6)
-        if (data) {
-          try {
-            yield JSON.parse(data)
-          } catch {
-            // skip unparseable lines
-          }
-        }
-      }
-    }
-  }
-}
-
-type ToolCall = {
-  type: 'tool-call'
-  toolCallId: string
-  toolName: string
-  args: Record<string, unknown>
-  result?: string
-  isError?: boolean
-}
-
-type StructuredPart =
-  | {
-      type: 'generative-ui'
-      spec: unknown
-    }
-  | {
-      type: 'data'
-      name: string
-      data: unknown
-    }
-
-/**
- * Shared helper: consume an SSE stream and populate text/toolCalls.
- * Returns an array of PendingApprovals when the stream requests them, or empty when done.
- */
-async function processStream(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  text: { value: string },
-  toolCalls: ToolCall[],
-  structuredParts: StructuredPart[],
-  yieldContent: () => void,
-  onFinish?: () => void
-): Promise<PendingApproval[]> {
-  const pendingApprovals: PendingApproval[] = []
-
-  for await (const event of parseSSEStream(reader)) {
-    switch (event.type) {
-      case 'text-delta':
-        text.value += event.text
-        break
-      case 'tool-call': {
-        let parsedArgs = event.args
-        if (typeof event.args === 'string') {
-          try {
-            parsedArgs = JSON.parse(event.args)
-          } catch {
-            parsedArgs = {}
-          }
-        }
-        toolCalls.push({
-          type: 'tool-call',
-          toolCallId: event.toolCallId,
-          toolName: event.toolName,
-          args: parsedArgs,
-        })
-        break
-      }
-      case 'tool-result': {
-        // Skip tool-results that contain __approvalRequired
-        const resultObj = typeof event.result === 'object' ? event.result : null
-        if (resultObj && '__approvalRequired' in resultObj) {
-          break
-        }
-        const tc = toolCalls.find((t) => t.toolCallId === event.toolCallId)
-        if (tc) {
-          tc.result =
-            typeof event.result === 'string'
-              ? event.result
-              : JSON.stringify(event.result)
-          if (event.isError) {
-            tc.isError = true
-          }
-        }
-        break
-      }
-      case 'generative-ui': {
-        const nextPart = {
-          type: 'generative-ui' as const,
-          spec: event.spec,
-        }
-        const existingIndex = structuredParts.findIndex(
-          (part) => part.type === 'generative-ui'
-        )
-        if (existingIndex === -1) structuredParts.push(nextPart)
-        else structuredParts[existingIndex] = nextPart
-        break
-      }
-      case 'data': {
-        const nextPart = {
-          type: 'data' as const,
-          name: event.name,
-          data: event.data,
-        }
-        const existingIndex = structuredParts.findIndex(
-          (part) => part.type === 'data' && part.name === event.name
-        )
-        if (existingIndex === -1) structuredParts.push(nextPart)
-        else structuredParts[existingIndex] = nextPart
-        break
-      }
-      case 'approval-request':
-        pendingApprovals.push({
-          toolCallId: event.toolCallId,
-          toolName: event.toolName,
-          args: event.args,
-          reason: event.reason,
-          runId: event.runId,
-          type: 'approval-request',
-        })
-        break
-      case 'credential-request':
-        pendingApprovals.push({
-          toolCallId: event.toolCallId,
-          toolName: event.toolName,
-          args: event.args,
-          runId: event.runId,
-          type: 'credential-request',
-          credentialName: event.credentialName,
-          credentialType: event.credentialType,
-          connectUrl: event.connectUrl,
-        })
-        break
-      case 'error':
-        text.value += `\n\nError: ${event.message || event.errorText || 'Unknown error'}`
-        break
-      case 'done':
-        onFinish?.()
-        continue
-    }
-    yieldContent()
-  }
-
-  return pendingApprovals
-}
 
 export function isDeniedResult(result: unknown): boolean {
   if (result == null) return false
@@ -276,341 +129,6 @@ export function resolvePikkuToolStatus(
   if (typeof result === 'string' && result.startsWith('Error:'))
     return { type: 'error' }
   return { type: 'completed' }
-}
-
-function buildRichContent(
-  text: { value: string },
-  structuredParts: StructuredPart[],
-  toolCalls: ToolCall[]
-): any[] {
-  const content: any[] = []
-  if (text.value) content.push({ type: 'text' as const, text: text.value })
-  content.push(...structuredParts)
-  content.push(...toolCalls)
-  return content
-}
-
-function buildContentFromAgentResult(result: unknown): any[] {
-  const content: any[] = []
-
-  if (typeof result === 'string') {
-    if (result) content.push({ type: 'text' as const, text: result })
-    return content
-  }
-
-  if (!result || typeof result !== 'object') return content
-
-  const record = result as Record<string, unknown>
-  if (typeof record.text === 'string' && record.text) {
-    content.push({ type: 'text' as const, text: record.text })
-  }
-  if (record.ui != null) {
-    content.push({ type: 'generative-ui' as const, spec: record.ui })
-  }
-
-  return content
-}
-
-function createPikkuStreamingAdapter(
-  optionsRef: React.RefObject<PikkuAgentRuntimeOptions>,
-  pendingApprovalsRef: React.RefObject<PendingApproval[]>,
-  approvalDecisionsRef: React.RefObject<
-    { toolCallId: string; approved: boolean }[]
-  >,
-  setPendingApprovalsRef: React.RefObject<
-    (approvals: PendingApproval[]) => void
-  >,
-  onFinishRef: React.RefObject<(() => void) | undefined>
-): ChatModelAdapter {
-  return {
-    async *run({ messages, abortSignal }) {
-      const opts = optionsRef.current!
-
-      // Check if this run() is a continuation after approval decisions.
-      // assistant-ui calls run() again after addResult provides tool results for ALL tool calls.
-      const pendingApprovals = pendingApprovalsRef.current
-      if (pendingApprovals.length > 0) {
-        // Read the decisions accumulated by handleApproval() from click handlers.
-        const decisions = approvalDecisionsRef.current
-        approvalDecisionsRef.current = []
-
-        if (decisions.length === 0) {
-          // No decisions set — shouldn't happen if composer is disabled.
-          return
-        }
-
-        // Clear pending approvals state
-        pendingApprovalsRef.current = []
-        setPendingApprovalsRef.current([])
-
-        // Send /resume for each decision sequentially.
-        // All but the last resume will return quickly (just tool-result + done).
-        // The last resume triggers continuation (next LLM step).
-        let lastText = { value: '' }
-        let lastToolCalls: ToolCall[] = []
-        let lastStructuredParts: StructuredPart[] = []
-        let nextApprovals: PendingApproval[] = []
-
-        for (let i = 0; i < decisions.length; i++) {
-          const decision = decisions[i]
-          // Find the runId from the matching pending approval
-          const matchingApproval = pendingApprovals.find(
-            (p) => p.toolCallId === decision.toolCallId
-          )
-          const runId = matchingApproval?.runId ?? pendingApprovals[0]?.runId
-
-          const resumeResponse = await fetch(
-            `${opts.api}/${opts.agentName}/resume`,
-            {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                ...opts.headers,
-              },
-              body: JSON.stringify({
-                runId,
-                toolCallId: decision.toolCallId,
-                approved: decision.approved,
-              }),
-              signal: abortSignal,
-              credentials: opts.credentials,
-            }
-          )
-
-          if (!resumeResponse.ok || !resumeResponse.body) {
-            const errorText = resumeResponse.body
-              ? await resumeResponse.text().catch(() => '')
-              : ''
-            throw new Error(
-              `Resume failed: ${resumeResponse.status}${errorText ? ` - ${errorText}` : ''}`
-            )
-          }
-
-          const text = { value: '' }
-          const toolCalls: ToolCall[] = []
-          const structuredParts: StructuredPart[] = []
-          const reader = resumeResponse.body.getReader()
-          const streamApprovals = await processStream(
-            reader,
-            text,
-            toolCalls,
-            structuredParts,
-            () => {},
-            i === decisions.length - 1
-              ? (onFinishRef.current ?? undefined)
-              : undefined
-          )
-
-          // Keep the last resume's output (it has continuation content)
-          lastText = text
-          lastToolCalls = toolCalls
-          lastStructuredParts = structuredParts
-          if (streamApprovals.length > 0) {
-            nextApprovals = streamApprovals
-          }
-        }
-
-        // Build content from the last resume's output
-        const content = buildRichContent(
-          lastText,
-          lastStructuredParts,
-          lastToolCalls
-        )
-
-        if (nextApprovals.length > 0) {
-          // More approvals from continuation — show them
-          pendingApprovalsRef.current = nextApprovals
-          setPendingApprovalsRef.current(nextApprovals)
-
-          // Add approval tool calls to content
-          for (const approval of nextApprovals) {
-            const approvalToolCall: ToolCall = {
-              type: 'tool-call',
-              toolCallId: approval.toolCallId,
-              toolName: approval.toolName,
-              args: {
-                ...(typeof approval.args === 'object' && approval.args !== null
-                  ? (approval.args as Record<string, unknown>)
-                  : {}),
-                ...(approval.reason
-                  ? { __approvalReason: approval.reason }
-                  : {}),
-              },
-            }
-            const idx = lastToolCalls.findIndex(
-              (tc) => tc.toolCallId === approval.toolCallId && !tc.result
-            )
-            if (idx !== -1) {
-              lastToolCalls[idx] = approvalToolCall
-            } else {
-              lastToolCalls.push(approvalToolCall)
-            }
-          }
-
-          const updatedContent = buildRichContent(
-            lastText,
-            lastStructuredParts,
-            lastToolCalls
-          )
-          yield {
-            content: updatedContent,
-            status: {
-              type: 'requires-action' as const,
-              reason: 'tool-calls' as const,
-            },
-          }
-        } else if (content.length > 0) {
-          yield { content }
-        }
-        return
-      }
-
-      // Normal flow: new user message → stream
-      const lastUserMsg = [...messages].reverse().find((m) => m.role === 'user')
-      if (!lastUserMsg) return
-
-      let messageText = ''
-      if (lastUserMsg.content) {
-        for (const part of lastUserMsg.content) {
-          if ('text' in part && part.type === 'text') {
-            messageText += (part as { text: string }).text
-          }
-        }
-      }
-
-      let response: Response
-      try {
-        response = await fetch(`${opts.api}/${opts.agentName}/stream`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...opts.headers },
-          body: JSON.stringify({
-            agentName: opts.agentName,
-            message: messageText,
-            threadId: opts.threadId,
-            resourceId: opts.resourceId,
-            model: opts.model,
-            temperature: opts.temperature,
-            ...(opts.context ? { context: opts.context } : {}),
-          }),
-          signal: abortSignal,
-          credentials: opts.credentials,
-        })
-      } catch (e: any) {
-        const msg = e?.message || 'Unknown error'
-        let errorText = 'Failed to connect to the agent.'
-        if (
-          msg.includes('Failed to fetch') ||
-          msg.includes('NetworkError') ||
-          msg.includes('CORS')
-        ) {
-          errorText =
-            'Unable to reach the agent server. The deployment may be down or the URL may be incorrect.'
-        } else if (msg.includes('abort')) {
-          return
-        }
-        yield { content: [{ type: 'text' as const, text: `⚠️ ${errorText}` }] }
-        return
-      }
-
-      if (!response.ok || !response.body) {
-        let errorText = `Request failed (${response.status}).`
-        if (response.status === 401 || response.status === 403) {
-          errorText = 'Authentication error.'
-        } else if (response.status === 404) {
-          errorText =
-            'Agent not found — the agent may not be configured for this project.'
-        } else if (response.status === 502 || response.status === 503) {
-          errorText =
-            'The agent server is currently unavailable. Try again in a moment.'
-        } else if (response.status === 429) {
-          errorText = 'Rate limited — too many requests. Please wait a moment.'
-        }
-        yield { content: [{ type: 'text' as const, text: `⚠️ ${errorText}` }] }
-        return
-      }
-
-      const text = { value: '' }
-      const toolCalls: ToolCall[] = []
-      const structuredParts: StructuredPart[] = []
-      let pendingContent: any[] | null = null
-      const yieldContent = () => {
-        const content = buildRichContent(text, structuredParts, toolCalls)
-        if (content.length > 0) pendingContent = content
-      }
-
-      const reader = response.body.getReader()
-      const approvals = await processStream(
-        reader,
-        text,
-        toolCalls,
-        structuredParts,
-        yieldContent,
-        onFinishRef.current ?? undefined
-      )
-
-      if (approvals.length === 0) {
-        // No approval needed — yield final content and done
-        if (pendingContent) {
-          yield { content: pendingContent }
-        }
-        return
-      }
-
-      // Approvals requested: store them for the next run() call
-      pendingApprovalsRef.current = approvals
-      setPendingApprovalsRef.current(approvals)
-
-      // Each approval tool call needs to be shown without a result
-      // so assistant-ui renders them as requires-action
-      for (const approval of approvals) {
-        const approvalToolCall: ToolCall = {
-          type: 'tool-call',
-          toolCallId: approval.toolCallId,
-          toolName: approval.toolName,
-          args: {
-            ...(typeof approval.args === 'object' && approval.args !== null
-              ? (approval.args as Record<string, unknown>)
-              : {}),
-            ...(approval.reason ? { __approvalReason: approval.reason } : {}),
-          },
-        }
-
-        // Replace the existing tool call (if any) with the approval version
-        const parentIdx = toolCalls.findIndex(
-          (tc) => tc.toolCallId === approval.toolCallId && !tc.result
-        )
-        if (parentIdx !== -1) {
-          toolCalls[parentIdx] = approvalToolCall
-        } else {
-          toolCalls.push(approvalToolCall)
-        }
-      }
-
-      // Remove any forwarded sub-agent tool calls that duplicate approval tool names
-      const approvalToolCallIds = new Set(approvals.map((a) => a.toolCallId))
-      const approvalToolNames = new Set(approvals.map((a) => a.toolName))
-      for (let i = toolCalls.length - 1; i >= 0; i--) {
-        if (
-          approvalToolNames.has(toolCalls[i].toolName) &&
-          !approvalToolCallIds.has(toolCalls[i].toolCallId)
-        ) {
-          toolCalls.splice(i, 1)
-        }
-      }
-
-      const content = buildRichContent(text, structuredParts, toolCalls)
-      yield {
-        content,
-        status: {
-          type: 'requires-action' as const,
-          reason: 'tool-calls' as const,
-        },
-      }
-      // Generator returns here. assistant-ui will show the approval UI for each tool call.
-      // When the user clicks Approve/Deny on ALL tools → handleApproval accumulates decisions →
-      // addResult for each → run() is called again when all have results.
-    },
-  }
 }
 
 export const convertDbMessages = (dbMessages: any[]): ThreadMessageLike[] => {
@@ -728,340 +246,238 @@ export const convertDbMessages = (dbMessages: any[]): ThreadMessageLike[] => {
   return result
 }
 
+type PendingResume = {
+  runId: string
+  toolCallId: string
+  approved: boolean
+}
+
+function extractLastUserMessage(messages: RunAgentInput['messages']): string {
+  const lastUser = [...messages].reverse().find((m) => m.role === 'user')
+  if (!lastUser) return ''
+  const content = lastUser.content
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .filter((p: any) => p.type === 'text')
+      .map((p: any) => (p.text as string) ?? '')
+      .join('')
+  }
+  return ''
+}
+
+class PikkuAgent extends HttpAgent {
+  private pikkuOpts: PikkuAgentRuntimeOptions
+  private _pendingResume: PendingResume | null = null
+  private _currentResume: PendingResume | null = null
+
+  constructor(opts: PikkuAgentRuntimeOptions) {
+    super({
+      url: `${opts.api}/${opts.agentName}/stream`,
+      threadId: opts.threadId,
+    })
+    this.pikkuOpts = opts
+  }
+
+  updateOpts(opts: PikkuAgentRuntimeOptions) {
+    this.pikkuOpts = opts
+  }
+
+  queueResume(data: PendingResume) {
+    this._pendingResume = data
+  }
+
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    const resume = this._pendingResume
+    this._pendingResume = null
+    this._currentResume = resume
+    this.url = resume
+      ? `${this.pikkuOpts.api}/${this.pikkuOpts.agentName}/resume`
+      : `${this.pikkuOpts.api}/${this.pikkuOpts.agentName}/stream`
+    return super.run(input)
+  }
+
+  protected requestInit(input: RunAgentInput): RequestInit {
+    const base = super.requestInit(input)
+    const resume = this._currentResume
+    const opts = this.pikkuOpts
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'text/event-stream',
+      ...opts.headers,
+    }
+
+    if (resume) {
+      return {
+        ...base,
+        headers,
+        credentials: opts.credentials,
+        body: JSON.stringify(resume),
+      }
+    }
+
+    return {
+      ...base,
+      headers,
+      credentials: opts.credentials,
+      body: JSON.stringify({
+        agentName: opts.agentName,
+        message: extractLastUserMessage(input.messages),
+        threadId: opts.threadId,
+        resourceId: opts.resourceId,
+        model: opts.model,
+        temperature: opts.temperature,
+        ...(opts.context ? { context: opts.context } : {}),
+      }),
+    }
+  }
+}
+
 export function usePikkuAgentRuntime(options: PikkuAgentRuntimeOptions) {
   const [pendingApprovals, setPendingApprovals] = useState<PendingApproval[]>(
     []
   )
-
-  const optionsRef = useRef(options)
-  optionsRef.current = options
+  // Authoritative pending list, mutated synchronously so two approval clicks
+  // in the same tick can't both read a stale "remaining" and skip the resume.
+  // State mirrors it purely for rendering.
+  const pendingApprovalsRef = useRef<PendingApproval[]>([])
+  const commitPending = useCallback((next: PendingApproval[]) => {
+    pendingApprovalsRef.current = next
+    setPendingApprovals(next)
+  }, [])
 
   const onFinishRef = useRef(options.onFinish)
   onFinishRef.current = options.onFinish
 
-  const pendingApprovalsRef = useRef<PendingApproval[]>([])
-  const approvalDecisionsRef = useRef<
-    { toolCallId: string; approved: boolean }[]
-  >([])
-
-  const setPendingApprovalsRef = useRef(setPendingApprovals)
-  setPendingApprovalsRef.current = setPendingApprovals
-
-  const adapter = useMemo(
-    () =>
-      createPikkuStreamingAdapter(
-        optionsRef,
-        pendingApprovalsRef,
-        approvalDecisionsRef,
-        setPendingApprovalsRef,
-        onFinishRef
-      ),
+  const agent = useMemo(
+    () => new PikkuAgent(options),
+    // agent is intentionally created once; opts are synced via updateOpts
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
 
-  const initialMessages = useMemo(
-    () =>
-      options.initialMessages
-        ? convertDbMessages(options.initialMessages)
-        : undefined,
-    [options.initialMessages]
-  )
+  useEffect(() => {
+    agent.updateOpts(options)
+  })
 
-  const runtime = useLocalRuntime(adapter, { initialMessages })
-
-  // handleApproval is called from the Approve/Deny button click handler.
-  // It accumulates the decision in the ref. assistant-ui will call run()
-  // when ALL tool calls have results (via addResult).
-  const handleApproval = useCallback(
-    (toolCallId: string, approved: boolean) => {
-      approvalDecisionsRef.current.push({ toolCallId, approved })
-    },
-    []
-  )
-
-  const isAwaitingApproval = pendingApprovals.length > 0
-
-  return {
-    runtime,
-    pendingApprovals,
-    isAwaitingApproval,
-    handleApproval,
-  }
-}
-
-function createPikkuNonStreamingAdapter(
-  optionsRef: React.RefObject<PikkuAgentRuntimeOptions>,
-  pendingApprovalsRef: React.RefObject<PendingApproval[]>,
-  approvalDecisionsRef: React.RefObject<
-    { toolCallId: string; approved: boolean }[]
-  >,
-  setPendingApprovalsRef: React.RefObject<
-    (approvals: PendingApproval[]) => void
-  >,
-  onFinishRef: React.RefObject<(() => void) | undefined>
-): ChatModelAdapter {
-  return {
-    async *run({ messages, abortSignal }) {
-      const opts = optionsRef.current!
-
-      // Continuation after approval decisions
-      const pendingApprovals = pendingApprovalsRef.current
-      if (pendingApprovals.length > 0) {
-        const decisions = approvalDecisionsRef.current
-        approvalDecisionsRef.current = []
-
-        if (decisions.length === 0) return
-
-        pendingApprovalsRef.current = []
-        setPendingApprovalsRef.current([])
-
-        // Resume uses SSE (same as streaming mode)
-        let lastText = { value: '' }
-        let lastToolCalls: ToolCall[] = []
-        let lastStructuredParts: StructuredPart[] = []
-        let nextApprovals: PendingApproval[] = []
-
-        for (let i = 0; i < decisions.length; i++) {
-          const decision = decisions[i]
-          const matchingApproval = pendingApprovals.find(
-            (p) => p.toolCallId === decision.toolCallId
-          )
-          const runId = matchingApproval?.runId ?? pendingApprovals[0]?.runId
-
-          const resumeResponse = await fetch(
-            `${opts.api}/${opts.agentName}/resume`,
+  useEffect(() => {
+    const { unsubscribe } = agent.subscribe({
+      onCustomEvent: ({ event }) => {
+        const e = event as AgUiCustomEvent
+        if (e.name === 'pikku:approval-request') {
+          const v = e.value as any
+          commitPending([
+            ...pendingApprovalsRef.current,
             {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                ...opts.headers,
-              },
-              body: JSON.stringify({
-                runId,
-                toolCallId: decision.toolCallId,
-                approved: decision.approved,
-              }),
-              signal: abortSignal,
-              credentials: opts.credentials,
-            }
-          )
-
-          if (!resumeResponse.ok || !resumeResponse.body) {
-            const errorText = resumeResponse.body
-              ? await resumeResponse.text().catch(() => '')
-              : ''
-            throw new Error(
-              `Resume failed: ${resumeResponse.status}${errorText ? ` - ${errorText}` : ''}`
-            )
-          }
-
-          const text = { value: '' }
-          const toolCalls: ToolCall[] = []
-          const structuredParts: StructuredPart[] = []
-          const reader = resumeResponse.body.getReader()
-          const streamApprovals = await processStream(
-            reader,
-            text,
-            toolCalls,
-            structuredParts,
-            () => {},
-            i === decisions.length - 1
-              ? (onFinishRef.current ?? undefined)
-              : undefined
-          )
-
-          lastText = text
-          lastToolCalls = toolCalls
-          lastStructuredParts = structuredParts
-          if (streamApprovals.length > 0) {
-            nextApprovals = streamApprovals
-          }
-        }
-
-        const content = buildRichContent(
-          lastText,
-          lastStructuredParts,
-          lastToolCalls
-        )
-
-        if (nextApprovals.length > 0) {
-          pendingApprovalsRef.current = nextApprovals
-          setPendingApprovalsRef.current(nextApprovals)
-
-          for (const approval of nextApprovals) {
-            const approvalToolCall: ToolCall = {
-              type: 'tool-call',
-              toolCallId: approval.toolCallId,
-              toolName: approval.toolName,
-              args: {
-                ...(typeof approval.args === 'object' && approval.args !== null
-                  ? (approval.args as Record<string, unknown>)
-                  : {}),
-                ...(approval.reason
-                  ? { __approvalReason: approval.reason }
-                  : {}),
-              },
-            }
-            const idx = lastToolCalls.findIndex(
-              (tc) => tc.toolCallId === approval.toolCallId && !tc.result
-            )
-            if (idx !== -1) {
-              lastToolCalls[idx] = approvalToolCall
-            } else {
-              lastToolCalls.push(approvalToolCall)
-            }
-          }
-
-          const updatedContent = buildRichContent(
-            lastText,
-            lastStructuredParts,
-            lastToolCalls
-          )
-          yield {
-            content: updatedContent,
-            status: {
-              type: 'requires-action' as const,
-              reason: 'tool-calls' as const,
+              toolCallId: v.toolCallId,
+              toolName: v.toolName,
+              args: v.args,
+              reason: v.reason,
+              runId: v.runId,
+              type: 'approval-request' as const,
             },
-          }
-        } else if (content.length > 0) {
-          yield { content }
+          ])
+        } else if (e.name === 'pikku:credential-request') {
+          const v = e.value as any
+          commitPending([
+            ...pendingApprovalsRef.current,
+            {
+              toolCallId: v.toolCallId,
+              toolName: v.toolName,
+              args: v.args,
+              runId: v.runId,
+              type: 'credential-request' as const,
+              credentialName: v.credentialName,
+              credentialType: v.credentialType,
+              connectUrl: v.connectUrl,
+            },
+          ])
         }
-        return
-      }
+      },
+      onRunFinalized: () => {
+        onFinishRef.current?.()
+      },
+    })
+    return unsubscribe
+  }, [agent, commitPending])
 
-      // Normal flow: new user message → non-streaming POST
-      const lastUserMsg = [...messages].reverse().find((m) => m.role === 'user')
-      if (!lastUserMsg) return
+  // Hydrate the thread from prior messages via the AG-UI history adapter,
+  // which useAgUiRuntime loads once on mount. Built once — see the
+  // initialMessages doc note about keeping the chat unmounted until ready.
+  const history = useMemo<ThreadHistoryAdapter | undefined>(() => {
+    if (!options.initialMessages?.length) return undefined
+    const repository = ExportedMessageRepository.fromArray(
+      options.initialMessages
+    )
+    return {
+      load: async () => repository,
+      append: async () => {},
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
-      let messageText = ''
-      if (lastUserMsg.content) {
-        for (const part of lastUserMsg.content) {
-          if ('text' in part && part.type === 'text') {
-            messageText += (part as { text: string }).text
-          }
-        }
-      }
-
-      const response = await fetch(`${opts.api}/${opts.agentName}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...opts.headers },
-        body: JSON.stringify({
-          agentName: opts.agentName,
-          message: messageText,
-          threadId: opts.threadId,
-          resourceId: opts.resourceId,
-          model: opts.model,
-          temperature: opts.temperature,
-          ...(opts.context ? { context: opts.context } : {}),
-        }),
-        signal: abortSignal,
-        credentials: opts.credentials,
-      })
-
-      if (!response.ok) {
-        throw new Error(`Agent run failed: ${response.status}`)
-      }
-
-      const json = await response.json()
-
-      if (json.status === 'suspended' && json.pendingApprovals?.length > 0) {
-        const approvals: PendingApproval[] = json.pendingApprovals
-        pendingApprovalsRef.current = approvals
-        setPendingApprovalsRef.current(approvals)
-
-        const toolCalls: ToolCall[] = approvals.map((approval) => ({
-          type: 'tool-call' as const,
-          toolCallId: approval.toolCallId,
-          toolName: approval.toolName,
-          args: {
-            ...(typeof approval.args === 'object' && approval.args !== null
-              ? (approval.args as Record<string, unknown>)
-              : {}),
-            ...(approval.reason ? { __approvalReason: approval.reason } : {}),
-          },
-        }))
-
-        const content: any[] = []
-        content.push(...buildContentFromAgentResult(json.result))
-        content.push(...toolCalls)
-
-        yield {
-          content,
-          status: {
-            type: 'requires-action' as const,
-            reason: 'tool-calls' as const,
-          },
-        }
-        return
-      }
-
-      // No approvals — yield complete content
-      onFinishRef.current?.()
-      const content = buildContentFromAgentResult(json.result)
-      if (content.length > 0) {
-        yield { content }
-      }
-    },
-  }
-}
-
-export function usePikkuAgentNonStreamingRuntime(
-  options: PikkuAgentRuntimeOptions
-) {
-  const [pendingApprovals, setPendingApprovals] = useState<PendingApproval[]>(
-    []
+  const runtime = useAgUiRuntime(
+    history ? { agent, adapters: { history } } : { agent }
   )
 
   const optionsRef = useRef(options)
   optionsRef.current = options
+  const resumeChainRef = useRef<Promise<void>>(Promise.resolve())
 
-  const onFinishRef = useRef(options.onFinish)
-  onFinishRef.current = options.onFinish
-
-  const pendingApprovalsRef = useRef<PendingApproval[]>([])
-  const approvalDecisionsRef = useRef<
-    { toolCallId: string; approved: boolean }[]
-  >([])
-
-  const setPendingApprovalsRef = useRef(setPendingApprovals)
-  setPendingApprovalsRef.current = setPendingApprovals
-
-  const adapter = useMemo(
-    () =>
-      createPikkuNonStreamingAdapter(
-        optionsRef,
-        pendingApprovalsRef,
-        approvalDecisionsRef,
-        setPendingApprovalsRef,
-        onFinishRef
-      ),
-    []
-  )
-
-  const initialMessages = useMemo(
-    () =>
-      options.initialMessages
-        ? convertDbMessages(options.initialMessages)
-        : undefined,
-    [options.initialMessages]
-  )
-
-  const runtime = useLocalRuntime(adapter, { initialMessages })
-
+  // The runtime only aggregates events from runs it starts itself, so the
+  // final approval is queued on the agent and triggered by the caller's
+  // addResult (which makes the runtime start the resume run once every tool
+  // call has a result). Earlier approvals in a batch are acknowledged with
+  // plain requests — their stream carries no content beyond 'done'.
   const handleApproval = useCallback(
-    (toolCallId: string, approved: boolean) => {
-      approvalDecisionsRef.current.push({ toolCallId, approved })
-    },
-    []
-  )
+    async (toolCallId: string, approved: boolean): Promise<boolean> => {
+      const approval = pendingApprovalsRef.current.find(
+        (p) => p.toolCallId === toolCallId
+      )
+      if (!approval || !approval.runId) return false
+      const remaining = pendingApprovalsRef.current.filter(
+        (p) => p.toolCallId !== toolCallId
+      )
+      commitPending(remaining)
+      const resume = { runId: approval.runId, toolCallId, approved }
 
-  const isAwaitingApproval = pendingApprovals.length > 0
+      if (remaining.length > 0) {
+        resumeChainRef.current = resumeChainRef.current.then(async () => {
+          const opts = optionsRef.current
+          try {
+            const response = await fetch(
+              `${opts.api}/${opts.agentName}/resume`,
+              {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'text/event-stream',
+                  ...opts.headers,
+                },
+                credentials: opts.credentials,
+                body: JSON.stringify(resume),
+              }
+            )
+            await response.text()
+          } catch (err) {
+            console.error('[pikku] failed to resolve approval', err)
+          }
+        })
+        await resumeChainRef.current
+        return true
+      }
+
+      await resumeChainRef.current
+      agent.queueResume(resume)
+      return true
+    },
+    [agent, commitPending]
+  )
 
   return {
     runtime,
     pendingApprovals,
-    isAwaitingApproval,
+    isAwaitingApproval: pendingApprovals.length > 0,
     handleApproval,
   }
 }

--- a/packages/console/src/components/project/AgentChat.tsx
+++ b/packages/console/src/components/project/AgentChat.tsx
@@ -25,10 +25,10 @@ import {
 } from '@assistant-ui/react'
 import {
   usePikkuAgentRuntime,
-  usePikkuAgentNonStreamingRuntime,
   PikkuApprovalContext,
   usePikkuApproval,
   resolvePikkuToolStatus,
+  convertDbMessages,
   type PikkuToolStatus,
   type MissingCredentialPayload,
 } from '@pikku/assistant-ui'
@@ -93,10 +93,15 @@ const ToolCallDisplay: React.FC<{
   )
   const isCredentialRequest = !!credentialPayload || !!pendingCredential
   const isApproval = status.type === 'requires-action' && !isCredentialRequest
-  const approvalReason = (args as any)?.__approvalReason
+  const approvalReason =
+    (args as any)?.__approvalReason ??
+    pendingApprovals.find(
+      (a) => a.toolCallId === toolCallId && a.type !== 'credential-request'
+    )?.reason
   const displayArgs = { ...args }
   delete (displayArgs as any).__approvalReason
   const [responded, setResponded] = useState<'approved' | 'denied' | null>(null)
+  const [popupBlocked, setPopupBlocked] = useState(false)
   const oauthTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
@@ -108,16 +113,18 @@ const ToolCallDisplay: React.FC<{
     }
   }, [])
 
-  const handleApprove = () => {
+  const handleApprove = async () => {
     setResponded('approved')
-    handleApproval(toolCallId, true)
-    addResult?.({ approved: true })
+    if (await handleApproval(toolCallId, true)) {
+      addResult?.({ approved: true })
+    }
   }
 
-  const handleDeny = () => {
+  const handleDeny = async () => {
     setResponded('denied')
-    handleApproval(toolCallId, false)
-    addResult?.({ approved: false })
+    if (await handleApproval(toolCallId, false)) {
+      addResult?.({ approved: false })
+    }
   }
 
   if (isApproval && !responded) {
@@ -190,6 +197,13 @@ const ToolCallDisplay: React.FC<{
       ? `${serverUrl}${rawConnectUrl}`
       : rawConnectUrl
 
+    const approveCredential = async () => {
+      setResponded('approved')
+      if (await handleApproval(toolCallId, true)) {
+        addResult?.({ approved: true })
+      }
+    }
+
     const handleConnect = () => {
       if (cred?.credentialType === 'oauth2' && connectUrl) {
         const popup = window.open(
@@ -197,26 +211,29 @@ const ToolCallDisplay: React.FC<{
           'oauth-connect',
           'width=600,height=700'
         )
+        // A blocked popup returns null — don't treat that as "connected", or
+        // the run resumes with no credential and the tool fails again.
+        if (!popup) {
+          setPopupBlocked(true)
+          return
+        }
         oauthTimerRef.current = setInterval(() => {
-          if (!popup || popup.closed) {
+          if (popup.closed) {
             clearInterval(oauthTimerRef.current!)
             oauthTimerRef.current = null
-            setResponded('approved')
-            handleApproval(toolCallId, true)
-            addResult?.({ approved: true })
+            void approveCredential()
           }
         }, 500)
       } else {
-        setResponded('approved')
-        handleApproval(toolCallId, true)
-        addResult?.({ approved: true })
+        void approveCredential()
       }
     }
 
-    const handleIgnore = () => {
+    const handleIgnore = async () => {
       setResponded('denied')
-      handleApproval(toolCallId, false)
-      addResult?.({ approved: false })
+      if (await handleApproval(toolCallId, false)) {
+        addResult?.({ approved: false })
+      }
     }
 
     return (
@@ -241,6 +258,13 @@ const ToolCallDisplay: React.FC<{
           <strong>{asI18n(cred?.credentialName ?? 'OAuth')}</strong>{' '}
           {m.agent_credential_to_be_connected()}
         </Box>
+        {popupBlocked && (
+          <Text size="xs" c="red" mb="xs">
+            {asI18n(
+              'Popup blocked — allow popups for this site, then click Connect again.'
+            )}
+          </Text>
+        )}
         <Group gap="xs">
           <Button size="xs" variant="light" onClick={handleConnect}>
             {asI18n(`Connect ${cred?.credentialName ?? 'OAuth'}`)}
@@ -442,19 +466,18 @@ const AgentComposer: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
   )
 }
 
-export const AgentChat: React.FC<{
-  streaming?: boolean
-}> = ({ streaming = false }) => {
+export const AgentChat: React.FC = () => {
   useLocale()
-  const {
-    agentId,
-    threadId,
-    setThreadId,
-    refetchThreads,
-    dbMessages,
-    model,
-    temperature,
-  } = useAgentPlayground()
+  const { agentId, threadId, refetchThreads, model, temperature, dbMessages } =
+    useAgentPlayground()
+
+  const initialMessages = useMemo(
+    () =>
+      dbMessages && dbMessages.length
+        ? convertDbMessages(dbMessages)
+        : undefined,
+    [dbMessages]
+  )
 
   const onStreamDone = useCallback(() => {
     refetchThreads()
@@ -480,18 +503,16 @@ export const AgentChat: React.FC<{
     agentName: agentId,
     threadId: effectiveThreadId,
     resourceId: 'default',
-    initialMessages: dbMessages,
     onFinish: onStreamDone,
     model,
     temperature,
     headers,
+    credentials: 'include' as RequestCredentials,
+    initialMessages,
   }
 
-  const streamingHook = usePikkuAgentRuntime(runtimeOptions)
-  const nonStreamingHook = usePikkuAgentNonStreamingRuntime(runtimeOptions)
-
   const { runtime, isAwaitingApproval, pendingApprovals, handleApproval } =
-    streaming ? streamingHook : nonStreamingHook
+    usePikkuAgentRuntime(runtimeOptions)
 
   return (
     <PikkuApprovalContext.Provider value={{ pendingApprovals, handleApproval }}>

--- a/packages/console/src/pages/AgentPlaygroundPage.tsx
+++ b/packages/console/src/pages/AgentPlaygroundPage.tsx
@@ -4,7 +4,6 @@ import {
   Center,
   Loader,
   Text,
-  SegmentedControl,
   Stack,
   Paper,
   Group,
@@ -113,10 +112,15 @@ const AgentPlaygroundInner: React.FC<{
 }> = ({ agentId, agentData, agentItems, onAgentSelect }) => {
   useLocale()
   const { openAgent } = usePanelContext()
-  const { threadId, setThreadId, threads, createNewThread, refetchThreads } =
-    useAgentPlayground()
+  const {
+    threadId,
+    setThreadId,
+    threads,
+    createNewThread,
+    refetchThreads,
+    dbMessages,
+  } = useAgentPlayground()
   const deleteThread = useDeleteAgentThread()
-  const [streaming, setStreaming] = useState(false)
   const [selectorOpen, setSelectorOpen] = useState(false)
   const [search, setSearch] = useState('')
   const {
@@ -268,32 +272,18 @@ const AgentPlaygroundInner: React.FC<{
       emptyPanelMessage={m.agent_playground_panel_message()}
     >
       <Box style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-        <Box
-          px="md"
-          py="xs"
-          style={{
-            borderBottom: '1px solid var(--mantine-color-default-border)',
-            flexShrink: 0,
-          }}
-        >
-          <SegmentedControl
-            size="xs"
-            value={streaming ? 'stream' : 'normal'}
-            onChange={(v) => setStreaming(v === 'stream')}
-            data={[
-              { label: 'Normal', value: 'normal' },
-              { label: 'Stream', value: 'stream' },
-            ]}
-          />
-        </Box>
         <Box style={{ flex: 1, minHeight: 0 }}>
           {!credLoading && !allConnected ? (
             <CredentialPrompt
               requirements={requirements}
               onRefresh={refetchCreds}
             />
+          ) : threadId != null && dbMessages === undefined ? (
+            <Center h="100%">
+              <Loader />
+            </Center>
           ) : (
-            <AgentChat key={`${threadId}-${streaming}`} streaming={streaming} />
+            <AgentChat key={`${agentId}-${threadId}`} />
           )}
         </Box>
       </Box>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,7 @@
     "picoquery": "^2.5.0"
   },
   "devDependencies": {
+    "@ag-ui/core": "0.0.57",
     "@types/node": "^24.11.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3"

--- a/packages/core/src/function/functions.types.ts
+++ b/packages/core/src/function/functions.types.ts
@@ -6,6 +6,7 @@ import type {
   PikkuWire,
   PickRequired,
 } from '../types/core.types.js'
+import type { PikkuRPC } from '../wirings/rpc/rpc-types.js'
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { PikkuError } from '../errors/error-handler.js'
 import type { CoreNodeConfig } from '../wirings/node/node.types.js'
@@ -29,12 +30,8 @@ export type CorePikkuFunction<
   Out,
   Services extends CoreSingletonServices = CoreServices,
   Session extends CoreUserSession = CoreUserSession,
-  Wire extends PikkuWire<In, Out, true, Session> = PikkuWire<
-    In,
-    Out,
-    true,
-    Session
-  >,
+  Wire extends PikkuWire<In, Out, true, Session, PikkuRPC, null, string> =
+    PikkuWire<In, Out, true, Session>,
 > = (
   services: Services,
   data: In,
@@ -54,15 +51,8 @@ export type CorePikkuFunctionSessionless<
   Out,
   Services extends CoreSingletonServices = CoreServices,
   Session extends CoreUserSession = CoreUserSession,
-  Wire extends PikkuWire<In, Out, false, Session, any, any, any> = PikkuWire<
-    In,
-    Out,
-    false,
-    Session,
-    any,
-    any,
-    any
-  >,
+  Wire extends PikkuWire<In, Out, false, Session, PikkuRPC, null, string> =
+    PikkuWire<In, Out, false, Session>,
 > = (
   services: Services,
   data: In,
@@ -79,15 +69,8 @@ export type CorePikkuFunctionSessionless<
 export type CorePikkuPermission<
   In = any,
   Services extends CoreSingletonServices = CoreServices,
-  Wire extends PikkuWire<In, never, false, any, any, never, never> = PikkuWire<
-    In,
-    never,
-    false,
-    any,
-    never,
-    never,
-    never
-  >,
+  Wire extends PikkuWire<In, never, false, any, PikkuRPC, never, never> =
+    PikkuWire<In, never, false, any, PikkuRPC, never, never>,
 > = (services: Services, data: In, wire: Wire) => Promise<boolean>
 
 /**
@@ -100,12 +83,8 @@ export type CorePikkuPermission<
 export type CorePikkuPermissionConfig<
   In = any,
   Services extends CoreSingletonServices = CoreServices,
-  Wire extends PikkuWire<In, never, false, any> = PikkuWire<
-    In,
-    never,
-    false,
-    any
-  >,
+  Wire extends PikkuWire<In, never, false, any, PikkuRPC, never, never> =
+    PikkuWire<In, never, false, any, PikkuRPC, never, never>,
 > = {
   /** The permission function */
   func: CorePikkuPermission<In, Services, Wire>
@@ -143,8 +122,13 @@ export type CorePikkuPermissionConfig<
 export const pikkuPermission = <
   In = any,
   Services extends CoreSingletonServices = CoreServices,
-  Wire extends PickRequired<PikkuWire<In, never, false, any>, 'session'> =
-    PickRequired<PikkuWire<In, never, false, any>, 'session'>,
+  Wire extends PickRequired<
+    PikkuWire<In, never, false, any, PikkuRPC, never, never>,
+    'session'
+  > = PickRequired<
+    PikkuWire<In, never, false, any, PikkuRPC, never, never>,
+    'session'
+  >,
 >(
   permission:
     | CorePikkuPermission<In, Services, Wire>
@@ -164,12 +148,8 @@ export const pikkuPermission = <
 export type CorePikkuPermissionFactory<
   In = any,
   Services extends CoreSingletonServices = CoreServices,
-  Wire extends PikkuWire<In, never, false, any> = PikkuWire<
-    In,
-    never,
-    false,
-    any
-  >,
+  Wire extends PikkuWire<In, never, false, any, PikkuRPC, never, never> =
+    PikkuWire<In, never, false, any, PikkuRPC, never, never>,
 > = (input: In) => CorePikkuPermission<any, Services, Wire>
 
 /**

--- a/packages/core/src/wirings/ai-agent/ai-agent-agui.test.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-agui.test.ts
@@ -1,0 +1,1127 @@
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventSchemas } from '@ag-ui/core'
+import { wrapChannelWithAGUI } from './ai-agent-agui.js'
+import type { AIStreamChannel, AIStreamEvent } from './ai-agent.types.js'
+
+function makeChannel(): { channel: AIStreamChannel; events: unknown[] } {
+  const events: unknown[] = []
+  const channel: AIStreamChannel = {
+    channelId: 'test-id',
+    openingData: null,
+    state: 'open',
+    setState: () => {},
+    getState: () => undefined as any,
+    clearState: () => {},
+    sendBinary: () => {},
+    close: () => {},
+    send: (e) => events.push(e),
+  }
+  return { channel, events }
+}
+
+function types(events: unknown[]): string[] {
+  return (events as any[]).map((e) => e.type)
+}
+
+function find<T = any>(
+  events: unknown[],
+  type: string,
+  name?: string
+): T | undefined {
+  return (events as any[]).find(
+    (e) => e.type === type && (name === undefined || e.name === name)
+  ) as T
+}
+
+describe('wrapChannelWithAGUI — text streaming', () => {
+  it('sends TEXT_MESSAGE_START only once for consecutive text-deltas', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'text-delta', text: 'a' } as AIStreamEvent)
+    wrapped.send({ type: 'text-delta', text: 'b' } as AIStreamEvent)
+    wrapped.send({ type: 'text-delta', text: 'c' } as AIStreamEvent)
+
+    assert.equal(
+      events.filter((e: any) => e.type === 'TEXT_MESSAGE_START').length,
+      1
+    )
+    assert.equal(
+      events.filter((e: any) => e.type === 'TEXT_MESSAGE_CONTENT').length,
+      3
+    )
+  })
+
+  it('uses the same messageId for START, all CONTENTs, and END', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'text-delta', text: 'hello' } as AIStreamEvent)
+    wrapped.send({ type: 'text-delta', text: ' world' } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    const start = find(events, 'TEXT_MESSAGE_START')
+    const end = find(events, 'TEXT_MESSAGE_END')
+    const contents = (events as any[]).filter(
+      (e) => e.type === 'TEXT_MESSAGE_CONTENT'
+    )
+
+    assert.ok(start)
+    assert.ok(end)
+    assert.equal(end.messageId, start.messageId)
+    for (const c of contents) {
+      assert.equal(c.messageId, start.messageId)
+    }
+  })
+
+  it('closes open text message when done arrives', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'text-delta', text: 'hi' } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    assert.ok(find(events, 'TEXT_MESSAGE_END'))
+  })
+
+  it('closes open text message when error arrives', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'text-delta', text: 'partial' } as AIStreamEvent)
+    wrapped.send({ type: 'error', message: 'oops' } as AIStreamEvent)
+
+    const t = types(events)
+    assert.ok(t.indexOf('TEXT_MESSAGE_END') < t.indexOf('RUN_ERROR'))
+  })
+
+  it('does not emit TEXT_MESSAGE_END when no text was sent', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    assert.equal(
+      events.filter((e: any) => e.type === 'TEXT_MESSAGE_END').length,
+      0
+    )
+  })
+})
+
+describe('wrapChannelWithAGUI — reasoning streaming', () => {
+  it('sends THINKING_TEXT_MESSAGE_START only once for consecutive reasoning-deltas', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'reasoning-delta', text: 'step 1' } as AIStreamEvent)
+    wrapped.send({ type: 'reasoning-delta', text: 'step 2' } as AIStreamEvent)
+
+    assert.equal(
+      events.filter((e: any) => e.type === 'THINKING_TEXT_MESSAGE_START')
+        .length,
+      1
+    )
+    assert.equal(
+      events.filter((e: any) => e.type === 'THINKING_TEXT_MESSAGE_CONTENT')
+        .length,
+      2
+    )
+  })
+
+  it('closes thinking message and opens text message when switching', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'reasoning-delta', text: 'thinking' } as AIStreamEvent)
+    wrapped.send({ type: 'text-delta', text: 'answer' } as AIStreamEvent)
+
+    const t = types(events)
+    assert.ok(t.includes('THINKING_TEXT_MESSAGE_END'))
+    assert.ok(
+      t.indexOf('THINKING_TEXT_MESSAGE_END') < t.indexOf('TEXT_MESSAGE_START')
+    )
+  })
+
+  it('closes thinking message before tool-call', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'reasoning-delta',
+      text: 'reasoning',
+    } as AIStreamEvent)
+    wrapped.send({
+      type: 'tool-call',
+      toolCallId: 'tc1',
+      toolName: 'fn',
+      args: {},
+    } as AIStreamEvent)
+
+    const t = types(events)
+    assert.ok(
+      t.indexOf('THINKING_TEXT_MESSAGE_END') < t.indexOf('TOOL_CALL_START')
+    )
+  })
+
+  it('uses consistent messageId across THINKING START, CONTENT, END', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'reasoning-delta', text: 'reason' } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    const start = find(events, 'THINKING_TEXT_MESSAGE_START')
+    const end = find(events, 'THINKING_TEXT_MESSAGE_END')
+    const content = find(events, 'THINKING_TEXT_MESSAGE_CONTENT')
+
+    assert.ok(start && end && content)
+    assert.equal(content.messageId, start.messageId)
+    assert.equal(end.messageId, start.messageId)
+  })
+})
+
+describe('wrapChannelWithAGUI — tool calls', () => {
+  it('closes text message before TOOL_CALL_START', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'text-delta', text: 'preamble' } as AIStreamEvent)
+    wrapped.send({
+      type: 'tool-call',
+      toolCallId: 'tc1',
+      toolName: 'myTool',
+      args: { x: 1 },
+    } as AIStreamEvent)
+
+    const t = types(events)
+    assert.ok(t.indexOf('TEXT_MESSAGE_END') < t.indexOf('TOOL_CALL_START'))
+  })
+
+  it('emits TOOL_CALL_START, TOOL_CALL_ARGS, TOOL_CALL_END in sequence', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'tool-call',
+      toolCallId: 'tc1',
+      toolName: 'search',
+      args: { q: 'hi' },
+    } as AIStreamEvent)
+
+    const t = types(events)
+    const startIdx = t.indexOf('TOOL_CALL_START')
+    const argsIdx = t.indexOf('TOOL_CALL_ARGS')
+    const endIdx = t.indexOf('TOOL_CALL_END')
+    assert.ok(startIdx !== -1 && argsIdx !== -1 && endIdx !== -1)
+    assert.equal(argsIdx, startIdx + 1)
+    assert.equal(endIdx, argsIdx + 1)
+  })
+
+  it('propagates toolCallId and toolCallName to START, ARGS and END', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'tool-call',
+      toolCallId: 'abc',
+      toolName: 'myFunc',
+      args: { n: 42 },
+    } as AIStreamEvent)
+
+    const start = find(events, 'TOOL_CALL_START')
+    const args = find(events, 'TOOL_CALL_ARGS')
+    const end = find(events, 'TOOL_CALL_END')
+    assert.equal(start.toolCallId, 'abc')
+    assert.equal(start.toolCallName, 'myFunc')
+    assert.equal(args.toolCallId, 'abc')
+    assert.equal(args.delta, '{"n":42}')
+    assert.equal(end.toolCallId, 'abc')
+  })
+
+  it('handles multiple tool calls in sequence', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'tool-call',
+      toolCallId: 'tc1',
+      toolName: 'fn1',
+      args: {},
+    } as AIStreamEvent)
+    wrapped.send({
+      type: 'tool-call',
+      toolCallId: 'tc2',
+      toolName: 'fn2',
+      args: {},
+    } as AIStreamEvent)
+
+    const starts = (events as any[]).filter((e) => e.type === 'TOOL_CALL_START')
+    const ends = (events as any[]).filter((e) => e.type === 'TOOL_CALL_END')
+    assert.equal(starts.length, 2)
+    assert.equal(ends.length, 2)
+    assert.equal(starts[0].toolCallId, 'tc1')
+    assert.equal(starts[1].toolCallId, 'tc2')
+  })
+
+  it('converts object tool-result to JSON string in content', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'tool-result',
+      toolCallId: 'tc1',
+      toolName: 'fn',
+      result: { ok: true },
+    } as AIStreamEvent)
+
+    const r = find(events, 'TOOL_CALL_RESULT')
+    assert.equal(r.content, '{"ok":true}')
+    assert.equal(r.role, 'tool')
+  })
+
+  it('passes string tool-result through unchanged', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'tool-result',
+      toolCallId: 'tc1',
+      toolName: 'fn',
+      result: 'plain text',
+    } as AIStreamEvent)
+
+    const r = find(events, 'TOOL_CALL_RESULT')
+    assert.equal(r.content, 'plain text')
+  })
+})
+
+describe('wrapChannelWithAGUI — run lifecycle', () => {
+  it('emits RUN_FINISHED with full usage fields', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'usage',
+      tokens: { input: 100, output: 50 },
+      model: 'claude-3-5',
+    } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    const f = find(events, 'RUN_FINISHED')
+    assert.ok(f)
+    assert.equal(f.model, 'claude-3-5')
+    assert.equal(f.usage.promptTokens, 100)
+    assert.equal(f.usage.completionTokens, 50)
+    assert.equal(f.usage.totalTokens, 150)
+  })
+
+  it('emits RUN_FINISHED exactly once when both usage and done arrive', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'usage',
+      tokens: { input: 1, output: 1 },
+      model: 'm',
+    } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    assert.equal(events.filter((e: any) => e.type === 'RUN_FINISHED').length, 1)
+  })
+
+  it('emits RUN_FINISHED on done when there was no usage event', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    assert.ok(find(events, 'RUN_FINISHED'))
+  })
+
+  it('usage event closes any open text message before RUN_FINISHED', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'text-delta', text: 'hi' } as AIStreamEvent)
+    wrapped.send({
+      type: 'usage',
+      tokens: { input: 1, output: 1 },
+      model: 'm',
+    } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    const t = types(events)
+    assert.ok(t.indexOf('TEXT_MESSAGE_END') < t.indexOf('RUN_FINISHED'))
+  })
+
+  it('emits RUN_ERROR and closes open text on error', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'text-delta', text: 'partial' } as AIStreamEvent)
+    wrapped.send({ type: 'error', message: 'network timeout' } as AIStreamEvent)
+
+    const err = find(events, 'RUN_ERROR')
+    assert.ok(err)
+    assert.equal(err.message, 'network timeout')
+    const t = types(events)
+    assert.ok(t.indexOf('TEXT_MESSAGE_END') < t.indexOf('RUN_ERROR'))
+  })
+
+  it('emits RUN_ERROR and closes open thinking message on error', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'reasoning-delta', text: 'thinking' } as AIStreamEvent)
+    wrapped.send({ type: 'error', message: 'fail' } as AIStreamEvent)
+
+    const t = types(events)
+    assert.ok(t.indexOf('THINKING_TEXT_MESSAGE_END') < t.indexOf('RUN_ERROR'))
+  })
+})
+
+describe('wrapChannelWithAGUI — step events', () => {
+  it('emits STEP_STARTED for step-start with the agent in the step name', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'step-start',
+      stepNumber: 1,
+      agent: 'researcher',
+    } as AIStreamEvent)
+
+    const s = find(events, 'STEP_STARTED')
+    assert.ok(s)
+    assert.ok(
+      typeof s.stepName === 'string' && s.stepName.includes('researcher')
+    )
+  })
+
+  it('emits STEP_STARTED with a defined stepName when agent is absent', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'step-start', stepNumber: 1 } as AIStreamEvent)
+
+    const s = find(events, 'STEP_STARTED')
+    assert.ok(s)
+    assert.ok(typeof s.stepName === 'string' && s.stepName.length > 0)
+  })
+})
+
+describe('wrapChannelWithAGUI — Pikku CUSTOM events', () => {
+  it('emits CUSTOM pikku:approval-request with all fields', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'approval-request',
+      toolCallId: 'tc1',
+      toolName: 'deleteUser',
+      args: { userId: 99 },
+      reason: 'irreversible action',
+      agent: 'admin-agent',
+      session: 'sess-1',
+    } as AIStreamEvent)
+
+    const c = find(events, 'CUSTOM', 'pikku:approval-request')
+    assert.ok(c)
+    assert.equal(c.value.toolCallId, 'tc1')
+    assert.equal(c.value.toolName, 'deleteUser')
+    assert.deepEqual(c.value.args, { userId: 99 })
+    assert.equal(c.value.reason, 'irreversible action')
+    assert.equal(c.value.agent, 'admin-agent')
+    assert.equal(c.value.session, 'sess-1')
+  })
+
+  it('closes open text message before emitting approval-request', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'text-delta', text: 'about to ask' } as AIStreamEvent)
+    wrapped.send({
+      type: 'approval-request',
+      toolCallId: 'tc1',
+      toolName: 'fn',
+      args: {},
+    } as AIStreamEvent)
+
+    const t = types(events)
+    assert.ok(t.indexOf('TEXT_MESSAGE_END') < t.indexOf('CUSTOM'))
+  })
+
+  it('emits CUSTOM pikku:credential-request with all fields', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'credential-request',
+      toolCallId: 'tc2',
+      toolName: 'githubSearch',
+      args: { repo: 'pikku' },
+      credentialName: 'github-token',
+      credentialType: 'oauth2',
+      connectUrl: 'https://github.com/oauth',
+      runId: 'run-abc',
+      agent: 'dev-agent',
+    } as AIStreamEvent)
+
+    const c = find(events, 'CUSTOM', 'pikku:credential-request')
+    assert.ok(c)
+    assert.equal(c.value.credentialName, 'github-token')
+    assert.equal(c.value.credentialType, 'oauth2')
+    assert.equal(c.value.connectUrl, 'https://github.com/oauth')
+    assert.equal(c.value.runId, 'run-abc')
+    assert.equal(c.value.toolCallId, 'tc2')
+  })
+
+  it('emits CUSTOM pikku:generative-ui', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'generative-ui',
+      spec: { component: 'Chart', props: { data: [1, 2] } },
+    } as AIStreamEvent)
+
+    const c = find(events, 'CUSTOM', 'pikku:generative-ui')
+    assert.ok(c)
+    assert.deepEqual(c.value.spec, {
+      component: 'Chart',
+      props: { data: [1, 2] },
+    })
+  })
+
+  it('emits CUSTOM pikku:data', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'data',
+      name: 'search-results',
+      data: [{ title: 'foo' }],
+    } as AIStreamEvent)
+
+    const c = find(events, 'CUSTOM', 'pikku:data')
+    assert.ok(c)
+    assert.equal(c.value.name, 'search-results')
+    assert.deepEqual(c.value.data, [{ title: 'foo' }])
+  })
+
+  it('emits CUSTOM pikku:workflow-created', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'workflow-created',
+      workflowName: 'myFlow',
+      graph: { nodes: [] },
+    } as AIStreamEvent)
+
+    const c = find(events, 'CUSTOM', 'pikku:workflow-created')
+    assert.ok(c)
+    assert.equal(c.value.workflowName, 'myFlow')
+    assert.deepEqual(c.value.graph, { nodes: [] })
+  })
+
+  it('emits CUSTOM pikku:agent-call', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'agent-call',
+      agentName: 'sub-agent',
+      session: 'sess-2',
+      input: { query: 'hello' },
+    } as AIStreamEvent)
+
+    const c = find(events, 'CUSTOM', 'pikku:agent-call')
+    assert.ok(c)
+    assert.equal(c.value.agentName, 'sub-agent')
+    assert.equal(c.value.session, 'sess-2')
+    assert.deepEqual(c.value.input, { query: 'hello' })
+  })
+
+  it('emits CUSTOM pikku:agent-result', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'agent-result',
+      agentName: 'sub-agent',
+      session: 'sess-2',
+      result: 'done',
+    } as AIStreamEvent)
+
+    const c = find(events, 'CUSTOM', 'pikku:agent-result')
+    assert.ok(c)
+    assert.equal(c.value.agentName, 'sub-agent')
+    assert.equal(c.value.result, 'done')
+  })
+
+  it('emits CUSTOM pikku:suspended', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'suspended',
+      reason: 'rpc-missing',
+      missingRpcs: ['stripe.charge'],
+    } as AIStreamEvent)
+
+    const c = find(events, 'CUSTOM', 'pikku:suspended')
+    assert.ok(c)
+    assert.equal(c.value.reason, 'rpc-missing')
+    assert.deepEqual(c.value.missingRpcs, ['stripe.charge'])
+  })
+})
+
+describe('wrapChannelWithAGUI — silently dropped events', () => {
+  it('drops audio-delta without emitting anything', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'audio-delta',
+      data: 'base64abc',
+      format: 'mp3',
+    } as AIStreamEvent)
+
+    assert.equal(events.length, 0)
+  })
+
+  it('drops audio-done without emitting anything', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'audio-done' } as AIStreamEvent)
+
+    assert.equal(events.length, 0)
+  })
+})
+
+describe('wrapChannelWithAGUI — channel proxy', () => {
+  it('exposes the inner channelId', () => {
+    const { channel } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+    assert.equal(wrapped.channelId, 'test-id')
+  })
+
+  it('delegates setState / getState / clearState to inner', () => {
+    let stored: unknown
+    const { channel } = makeChannel()
+    channel.setState = (v) => {
+      stored = v
+    }
+    channel.getState = () => stored as any
+    channel.clearState = () => {
+      stored = undefined
+    }
+
+    const wrapped = wrapChannelWithAGUI(channel)
+    wrapped.setState('my-state')
+    assert.equal(wrapped.getState(), 'my-state')
+    wrapped.clearState()
+    assert.equal(wrapped.getState(), undefined)
+  })
+
+  it('delegates sendBinary to inner', () => {
+    const binaries: unknown[] = []
+    const { channel } = makeChannel()
+    channel.sendBinary = (d) => binaries.push(d)
+
+    const wrapped = wrapChannelWithAGUI(channel)
+    wrapped.sendBinary(new Uint8Array([1, 2, 3]))
+    assert.equal(binaries.length, 1)
+  })
+
+  it('delegates close to inner', () => {
+    let closed = false
+    const { channel } = makeChannel()
+    channel.close = () => {
+      closed = true
+    }
+
+    const wrapped = wrapChannelWithAGUI(channel)
+    wrapped.close()
+    assert.ok(closed)
+  })
+
+  it('reflects inner state property', () => {
+    const { channel } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+    assert.equal(wrapped.state, 'open')
+    channel.state = 'closed'
+    assert.equal(wrapped.state, 'closed')
+  })
+})
+
+/**
+ * Replicates the ordering rules enforced by @ag-ui/client's verifyEvents so
+ * the bridge's output is checked against the same contract the browser
+ * applies. Throws on the first violation.
+ */
+function assertClientAcceptsStream(events: any[]): void {
+  let started = false
+  let finished = false
+  let errored = false
+  const activeTexts = new Set<string>()
+  const activeTools = new Set<string>()
+  const activeSteps = new Set<string>()
+  let thinkingStep = false
+  let thinkingMessage = false
+
+  for (const e of events) {
+    const parsed = EventSchemas.safeParse(e)
+    assert.ok(
+      parsed.success,
+      `event failed @ag-ui/core schema: ${JSON.stringify(e)} — ${JSON.stringify(parsed.success ? [] : parsed.error.issues)}`
+    )
+    assert.ok(!errored, `event '${e.type}' sent after RUN_ERROR`)
+    assert.ok(
+      !finished || e.type === 'RUN_ERROR' || e.type === 'RUN_STARTED',
+      `event '${e.type}' sent after RUN_FINISHED`
+    )
+    if (!started) {
+      started = true
+      assert.ok(
+        e.type === 'RUN_STARTED' || e.type === 'RUN_ERROR',
+        `first event must be RUN_STARTED, got '${e.type}'`
+      )
+    }
+    switch (e.type) {
+      case 'TEXT_MESSAGE_START':
+        assert.ok(!activeTexts.has(e.messageId), 'text already active')
+        activeTexts.add(e.messageId)
+        break
+      case 'TEXT_MESSAGE_CONTENT':
+        assert.ok(activeTexts.has(e.messageId), 'text content without start')
+        break
+      case 'TEXT_MESSAGE_END':
+        assert.ok(activeTexts.delete(e.messageId), 'text end without start')
+        break
+      case 'TOOL_CALL_START':
+        assert.ok(!activeTools.has(e.toolCallId), 'tool already active')
+        activeTools.add(e.toolCallId)
+        break
+      case 'TOOL_CALL_ARGS':
+        assert.ok(activeTools.has(e.toolCallId), 'tool args without start')
+        break
+      case 'TOOL_CALL_END':
+        assert.ok(activeTools.delete(e.toolCallId), 'tool end without start')
+        break
+      case 'STEP_STARTED':
+        assert.ok(
+          !activeSteps.has(e.stepName),
+          `step '${e.stepName}' already active`
+        )
+        activeSteps.add(e.stepName)
+        break
+      case 'STEP_FINISHED':
+        assert.ok(
+          activeSteps.delete(e.stepName),
+          `step '${e.stepName}' not started`
+        )
+        break
+      case 'THINKING_START':
+        assert.ok(!thinkingStep, 'thinking step already active')
+        thinkingStep = true
+        break
+      case 'THINKING_END':
+        assert.ok(thinkingStep, 'thinking end without start')
+        thinkingStep = false
+        break
+      case 'THINKING_TEXT_MESSAGE_START':
+        assert.ok(thinkingStep, 'thinking message outside THINKING_START')
+        assert.ok(!thinkingMessage, 'thinking message already active')
+        thinkingMessage = true
+        break
+      case 'THINKING_TEXT_MESSAGE_CONTENT':
+        assert.ok(thinkingMessage, 'thinking content without start')
+        break
+      case 'THINKING_TEXT_MESSAGE_END':
+        assert.ok(thinkingMessage, 'thinking message end without start')
+        thinkingMessage = false
+        break
+      case 'RUN_FINISHED':
+        assert.equal(activeSteps.size, 0, 'RUN_FINISHED with active steps')
+        assert.equal(activeTexts.size, 0, 'RUN_FINISHED with active text')
+        assert.equal(activeTools.size, 0, 'RUN_FINISHED with active tools')
+        finished = true
+        break
+      case 'RUN_ERROR':
+        errored = true
+        break
+    }
+  }
+}
+
+describe('wrapChannelWithAGUI — AG-UI protocol conformance', () => {
+  it('emits RUN_STARTED with threadId and runId as the first event', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel, {
+      threadId: 'thread-1',
+      runId: 'run-1',
+    })
+
+    wrapped.send({ type: 'text-delta', text: 'hi' } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    const first = events[0] as any
+    assert.equal(first.type, 'RUN_STARTED')
+    assert.equal(first.threadId, 'thread-1')
+    assert.equal(first.runId, 'run-1')
+  })
+
+  it('carries the same threadId and runId on RUN_FINISHED', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel, {
+      threadId: 'thread-1',
+      runId: 'run-1',
+    })
+
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    const f = find(events, 'RUN_FINISHED')
+    assert.equal(f.threadId, 'thread-1')
+    assert.equal(f.runId, 'run-1')
+  })
+
+  it('does not emit RUN_FINISHED on mid-run usage; accumulates into final RUN_FINISHED', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'step-start', stepNumber: 0 } as AIStreamEvent)
+    wrapped.send({
+      type: 'tool-call',
+      toolCallId: 'tc1',
+      toolName: 'listTodos',
+      args: {},
+    } as AIStreamEvent)
+    wrapped.send({
+      type: 'tool-result',
+      toolCallId: 'tc1',
+      toolName: 'listTodos',
+      result: ['a'],
+    } as AIStreamEvent)
+    wrapped.send({
+      type: 'usage',
+      tokens: { input: 10, output: 5 },
+      model: 'gpt-4o',
+    } as AIStreamEvent)
+    wrapped.send({ type: 'step-start', stepNumber: 1 } as AIStreamEvent)
+    wrapped.send({
+      type: 'text-delta',
+      text: 'You have 1 todo',
+    } as AIStreamEvent)
+    wrapped.send({
+      type: 'usage',
+      tokens: { input: 20, output: 8 },
+      model: 'gpt-4o',
+    } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    const finishes = (events as any[]).filter((e) => e.type === 'RUN_FINISHED')
+    assert.equal(finishes.length, 1)
+    assert.equal((events as any[]).at(-1).type, 'RUN_FINISHED')
+    assert.equal(finishes[0].usage.promptTokens, 30)
+    assert.equal(finishes[0].usage.completionTokens, 13)
+    assert.equal(finishes[0].usage.totalTokens, 43)
+    const t = types(events)
+    assert.ok(
+      t.lastIndexOf('TEXT_MESSAGE_CONTENT') < t.indexOf('RUN_FINISHED'),
+      'text must arrive before RUN_FINISHED'
+    )
+    assertClientAcceptsStream(events as any[])
+  })
+
+  it('swallows events after done so nothing follows RUN_FINISHED', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+    wrapped.send({
+      type: 'usage',
+      tokens: { input: 1, output: 1 },
+      model: 'm',
+    } as AIStreamEvent)
+    wrapped.send({ type: 'text-delta', text: 'late' } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    assert.equal((events as any[]).at(-1).type, 'RUN_FINISHED')
+    assert.equal(events.filter((e: any) => e.type === 'RUN_FINISHED').length, 1)
+  })
+
+  it('gives TOOL_CALL_RESULT a messageId', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'tool-result',
+      toolCallId: 'tc1',
+      toolName: 'fn',
+      result: 'ok',
+    } as AIStreamEvent)
+
+    const r = find(events, 'TOOL_CALL_RESULT')
+    assert.ok(r.messageId, 'TOOL_CALL_RESULT requires a messageId')
+  })
+
+  it('streams tool args via TOOL_CALL_ARGS between START and END', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'tool-call',
+      toolCallId: 'tc1',
+      toolName: 'addTodo',
+      args: { text: 'buy milk' },
+    } as AIStreamEvent)
+
+    const t = types(events)
+    const argsIdx = t.indexOf('TOOL_CALL_ARGS')
+    assert.ok(argsIdx !== -1, 'TOOL_CALL_ARGS must be emitted')
+    assert.ok(t.indexOf('TOOL_CALL_START') < argsIdx)
+    assert.ok(argsIdx < t.indexOf('TOOL_CALL_END'))
+    const args = find(events, 'TOOL_CALL_ARGS')
+    assert.equal(args.delta, '{"text":"buy milk"}')
+  })
+
+  it('wraps thinking messages in THINKING_START / THINKING_END', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'reasoning-delta', text: 'hmm' } as AIStreamEvent)
+    wrapped.send({ type: 'text-delta', text: 'answer' } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    const t = types(events)
+    assert.ok(
+      t.indexOf('THINKING_START') < t.indexOf('THINKING_TEXT_MESSAGE_START')
+    )
+    assert.ok(
+      t.indexOf('THINKING_TEXT_MESSAGE_END') < t.indexOf('THINKING_END')
+    )
+    assertClientAcceptsStream(events as any[])
+  })
+
+  it('closes the open step before RUN_FINISHED and keeps step names unique', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'step-start', stepNumber: 0 } as AIStreamEvent)
+    wrapped.send({
+      type: 'step-start',
+      stepNumber: 0,
+      agent: 'todoAgent',
+    } as AIStreamEvent)
+    wrapped.send({ type: 'step-start', stepNumber: 1 } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    const startNames = (events as any[])
+      .filter((e) => e.type === 'STEP_STARTED')
+      .map((e) => e.stepName)
+    assert.equal(new Set(startNames).size, startNames.length)
+    assertClientAcceptsStream(events as any[])
+  })
+
+  it('accepts the full multi-agent delegate wire sequence', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel, {
+      threadId: 't1',
+      runId: 'r1',
+    })
+
+    const send = (e: any) => wrapped.send(e as AIStreamEvent)
+    send({ type: 'step-start', stepNumber: 0 })
+    send({
+      type: 'tool-call',
+      toolCallId: 'p1',
+      toolName: 'todoAgent',
+      args: { message: 'list' },
+    })
+    send({
+      type: 'agent-call',
+      agentName: 'todoAgent',
+      session: 's',
+      input: 'list',
+    })
+    send({ type: 'step-start', stepNumber: 0, agent: 'todoAgent' })
+    send({
+      type: 'tool-call',
+      toolCallId: 'c1',
+      toolName: 'todos__listTodos',
+      args: {},
+    })
+    send({
+      type: 'tool-result',
+      toolCallId: 'c1',
+      toolName: 'todos__listTodos',
+      result: ['x'],
+    })
+    send({
+      type: 'usage',
+      tokens: { input: 5, output: 2 },
+      model: 'gpt-4o-mini',
+    })
+    send({ type: 'step-start', stepNumber: 1, agent: 'todoAgent' })
+    for (const chunk of ['You ', 'have ', 'one ', 'todo']) {
+      send({ type: 'text-delta', text: chunk })
+    }
+    send({
+      type: 'usage',
+      tokens: { input: 7, output: 9 },
+      model: 'gpt-4o-mini',
+    })
+    send({
+      type: 'agent-result',
+      agentName: 'todoAgent',
+      session: 's',
+      result: 'You have one todo',
+    })
+    send({
+      type: 'tool-result',
+      toolCallId: 'p1',
+      toolName: 'todoAgent',
+      result: 'You have one todo',
+    })
+    send({
+      type: 'usage',
+      tokens: { input: 11, output: 3 },
+      model: 'gpt-4o-mini',
+    })
+    send({ type: 'step-start', stepNumber: 1 })
+    send({
+      type: 'usage',
+      tokens: { input: 4, output: 1 },
+      model: 'gpt-4o-mini',
+    })
+    send({ type: 'done' })
+
+    assertClientAcceptsStream(events as any[])
+    assert.equal((events as any[]).at(-1).type, 'RUN_FINISHED')
+    assert.ok(find(events, 'CUSTOM', 'pikku:agent-call'))
+    assert.ok(find(events, 'CUSTOM', 'pikku:agent-result'))
+    assert.equal(
+      (events as any[]).filter((e) => e.type === 'TEXT_MESSAGE_CONTENT').length,
+      4
+    )
+  })
+
+  it('approval flow ends with CUSTOM approval-request then RUN_FINISHED', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'step-start', stepNumber: 0 } as AIStreamEvent)
+    wrapped.send({
+      type: 'tool-call',
+      toolCallId: 'tc1',
+      toolName: 'addTodo',
+      args: { text: 'x' },
+    } as AIStreamEvent)
+    wrapped.send({
+      type: 'approval-request',
+      toolCallId: 'tc1',
+      toolName: 'addTodo',
+      args: { text: 'x' },
+      reason: 'Add a todo',
+      runId: 'run-9',
+    } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    assertClientAcceptsStream(events as any[])
+    const c = find(events, 'CUSTOM', 'pikku:approval-request')
+    assert.equal(c.value.runId, 'run-9')
+    const t = types(events)
+    assert.ok(t.indexOf('CUSTOM') < t.indexOf('RUN_FINISHED'))
+  })
+})
+
+describe('wrapChannelWithAGUI — realistic full turn', () => {
+  it('handles think → text → tool-call → tool-result → usage → done sequence', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({
+      type: 'reasoning-delta',
+      text: 'let me search',
+    } as AIStreamEvent)
+    wrapped.send({
+      type: 'text-delta',
+      text: 'I will look that up.',
+    } as AIStreamEvent)
+    wrapped.send({
+      type: 'tool-call',
+      toolCallId: 'tc1',
+      toolName: 'search',
+      args: { q: 'pikku' },
+    } as AIStreamEvent)
+    wrapped.send({
+      type: 'tool-result',
+      toolCallId: 'tc1',
+      toolName: 'search',
+      result: 'found it',
+    } as AIStreamEvent)
+    wrapped.send({
+      type: 'text-delta',
+      text: 'Here is what I found.',
+    } as AIStreamEvent)
+    wrapped.send({
+      type: 'usage',
+      tokens: { input: 200, output: 80 },
+      model: 'gpt-4o',
+    } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    const t = types(events)
+    assert.ok(t.includes('THINKING_TEXT_MESSAGE_START'))
+    assert.ok(t.includes('THINKING_TEXT_MESSAGE_END'))
+    assert.ok(t.includes('TEXT_MESSAGE_START'))
+    assert.ok(t.includes('TEXT_MESSAGE_END'))
+    assert.ok(t.includes('TOOL_CALL_START'))
+    assert.ok(t.includes('TOOL_CALL_END'))
+    assert.ok(t.includes('TOOL_CALL_RESULT'))
+    assert.ok(t.includes('RUN_FINISHED'))
+    assert.equal(t.filter((x) => x === 'RUN_FINISHED').length, 1)
+    assert.equal(t.filter((x) => x === 'TEXT_MESSAGE_START').length, 2)
+  })
+})
+
+describe('wrapChannelWithAGUI — late-bound runId', () => {
+  it('resolves getRunId at the first event, not at wrap time', () => {
+    const { channel, events } = makeChannel()
+    let runId: string | undefined
+    const wrapped = wrapChannelWithAGUI(channel, {
+      threadId: 't1',
+      getRunId: () => runId,
+    })
+
+    runId = 'run-from-state-service'
+    wrapped.send({ type: 'text-delta', text: 'hi' } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    const started = find(events, 'RUN_STARTED')
+    const finished = find(events, 'RUN_FINISHED')
+    assert.equal(started.runId, 'run-from-state-service')
+    assert.equal(finished.runId, 'run-from-state-service')
+  })
+
+  it('prefers an explicit runId over getRunId and falls back to a UUID', () => {
+    const explicit = makeChannel()
+    wrapChannelWithAGUI(explicit.channel, {
+      runId: 'explicit-run',
+      getRunId: () => 'ignored',
+    }).send({ type: 'done' } as AIStreamEvent)
+    assert.equal(find(explicit.events, 'RUN_STARTED').runId, 'explicit-run')
+
+    const fallback = makeChannel()
+    wrapChannelWithAGUI(fallback.channel, {
+      getRunId: () => undefined,
+    }).send({ type: 'done' } as AIStreamEvent)
+    const started = find(fallback.events, 'RUN_STARTED')
+    assert.ok(started.runId)
+    assert.equal(started.runId, find(fallback.events, 'RUN_FINISHED').runId)
+  })
+})

--- a/packages/core/src/wirings/ai-agent/ai-agent-agui.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-agui.ts
@@ -1,0 +1,386 @@
+import type { AIStreamChannel, AIStreamEvent } from './ai-agent.types.js'
+import { randomUUID } from './ai-agent-utils.js'
+
+type AGUIEvent =
+  | { type: 'TEXT_MESSAGE_START'; messageId: string }
+  | { type: 'TEXT_MESSAGE_CONTENT'; messageId: string; delta: string }
+  | { type: 'TEXT_MESSAGE_END'; messageId: string }
+  | { type: 'TOOL_CALL_START'; toolCallId: string; toolCallName: string }
+  | { type: 'TOOL_CALL_ARGS'; toolCallId: string; delta: string }
+  | { type: 'TOOL_CALL_END'; toolCallId: string; toolCallName: string }
+  | {
+      type: 'TOOL_CALL_RESULT'
+      messageId: string
+      toolCallId: string
+      role: 'tool'
+      content: string
+    }
+  | { type: 'THINKING_START' }
+  | { type: 'THINKING_TEXT_MESSAGE_START'; messageId: string }
+  | { type: 'THINKING_TEXT_MESSAGE_CONTENT'; messageId: string; delta: string }
+  | { type: 'THINKING_TEXT_MESSAGE_END'; messageId: string }
+  | { type: 'THINKING_END' }
+  | { type: 'RUN_STARTED'; threadId: string; runId: string }
+  | {
+      type: 'RUN_FINISHED'
+      threadId: string
+      runId: string
+      model?: string
+      usage?: {
+        promptTokens: number
+        completionTokens: number
+        totalTokens: number
+      }
+    }
+  | { type: 'RUN_ERROR'; message: string; code?: string }
+  | { type: 'STEP_STARTED'; stepName: string }
+  | { type: 'STEP_FINISHED'; stepName: string }
+  | { type: 'CUSTOM'; name: string; value: unknown }
+
+export type { AGUIEvent }
+
+export type AGUIChannelOptions = {
+  threadId?: string
+  runId?: string
+  /**
+   * Late-bound runId source, resolved when the run is opened (first event).
+   * Lets the stream path report the AIRunStateService runId on RUN_STARTED
+   * even though that id is only created after the channel is wrapped.
+   */
+  getRunId?: () => string | undefined
+}
+
+function resultToString(result: unknown): string {
+  if (typeof result === 'string') return result
+  try {
+    return JSON.stringify(result, (_key, val) =>
+      typeof val === 'bigint' ? val.toString() : val
+    )
+  } catch {
+    return String(result)
+  }
+}
+
+export function wrapChannelWithAGUI(
+  inner: AIStreamChannel,
+  options?: AGUIChannelOptions
+): AIStreamChannel {
+  const threadId = options?.threadId ?? randomUUID()
+  let runId: string | null = options?.runId ?? null
+
+  function resolveRunId(): string {
+    if (!runId) {
+      runId = options?.getRunId?.() ?? randomUUID()
+    }
+    return runId
+  }
+
+  let textMessageId: string | null = null
+  let thinkingMessageId: string | null = null
+  let openStepName: string | null = null
+  let stepSeq = 0
+  let runStartedSent = false
+  let terminal = false
+  let sawUsage = false
+  let usageModel: string | undefined
+  const usageTotals = { input: 0, output: 0 }
+
+  // The AG-UI client rejects any event arriving before RUN_STARTED, so the
+  // run is opened lazily with the first translated event.
+  function send(event: AGUIEvent): void {
+    if (!runStartedSent) {
+      runStartedSent = true
+      inner.send({
+        type: 'RUN_STARTED',
+        threadId,
+        runId: resolveRunId(),
+      } as unknown as AIStreamEvent)
+    }
+    inner.send(event as unknown as AIStreamEvent)
+  }
+
+  function endTextMessage(): void {
+    if (textMessageId) {
+      send({ type: 'TEXT_MESSAGE_END', messageId: textMessageId })
+      textMessageId = null
+    }
+  }
+
+  function endThinkingMessage(): void {
+    if (thinkingMessageId) {
+      send({ type: 'THINKING_TEXT_MESSAGE_END', messageId: thinkingMessageId })
+      send({ type: 'THINKING_END' })
+      thinkingMessageId = null
+    }
+  }
+
+  function endStep(): void {
+    if (openStepName) {
+      send({ type: 'STEP_FINISHED', stepName: openStepName })
+      openStepName = null
+    }
+  }
+
+  function ensureTextMessage(): string {
+    if (!textMessageId) {
+      textMessageId = randomUUID()
+      send({ type: 'TEXT_MESSAGE_START', messageId: textMessageId })
+    }
+    return textMessageId
+  }
+
+  function ensureThinkingMessage(): string {
+    if (!thinkingMessageId) {
+      thinkingMessageId = randomUUID()
+      send({ type: 'THINKING_START' })
+      send({
+        type: 'THINKING_TEXT_MESSAGE_START',
+        messageId: thinkingMessageId,
+      })
+    }
+    return thinkingMessageId
+  }
+
+  // The AG-UI client treats RUN_FINISHED as terminal and rejects everything
+  // after it, so it is emitted exactly once — on 'done' — with the usage
+  // accumulated across all steps (per-step 'usage' events must NOT finish
+  // the run: on multi-step tool runs later steps would arrive after
+  // RUN_FINISHED and the client would drop the whole stream).
+  function finishRun(): void {
+    endTextMessage()
+    endThinkingMessage()
+    endStep()
+    send({
+      type: 'RUN_FINISHED',
+      threadId,
+      runId: resolveRunId(),
+      ...(usageModel ? { model: usageModel } : {}),
+      ...(sawUsage
+        ? {
+            usage: {
+              promptTokens: usageTotals.input,
+              completionTokens: usageTotals.output,
+              totalTokens: usageTotals.input + usageTotals.output,
+            },
+          }
+        : {}),
+    })
+    terminal = true
+  }
+
+  return {
+    channelId: inner.channelId,
+    openingData: inner.openingData,
+    get state() {
+      return inner.state
+    },
+    setState: (s) => inner.setState(s),
+    getState: () => inner.getState(),
+    clearState: () => inner.clearState(),
+    sendBinary: (data) => inner.sendBinary(data),
+    close: () => inner.close(),
+
+    send: (event: AIStreamEvent) => {
+      if (terminal) return
+
+      switch (event.type) {
+        case 'text-delta': {
+          endThinkingMessage()
+          const id = ensureTextMessage()
+          send({
+            type: 'TEXT_MESSAGE_CONTENT',
+            messageId: id,
+            delta: event.text,
+          })
+          break
+        }
+
+        case 'reasoning-delta': {
+          endTextMessage()
+          const id = ensureThinkingMessage()
+          send({
+            type: 'THINKING_TEXT_MESSAGE_CONTENT',
+            messageId: id,
+            delta: event.text,
+          })
+          break
+        }
+
+        case 'tool-call': {
+          endTextMessage()
+          endThinkingMessage()
+          send({
+            type: 'TOOL_CALL_START',
+            toolCallId: event.toolCallId,
+            toolCallName: event.toolName,
+          })
+          send({
+            type: 'TOOL_CALL_ARGS',
+            toolCallId: event.toolCallId,
+            delta: resultToString(event.args) || '{}',
+          })
+          send({
+            type: 'TOOL_CALL_END',
+            toolCallId: event.toolCallId,
+            toolCallName: event.toolName,
+          })
+          break
+        }
+
+        case 'tool-result': {
+          send({
+            type: 'TOOL_CALL_RESULT',
+            messageId: randomUUID(),
+            toolCallId: event.toolCallId,
+            role: 'tool',
+            content: resultToString(event.result),
+          })
+          break
+        }
+
+        case 'usage': {
+          endTextMessage()
+          endThinkingMessage()
+          sawUsage = true
+          usageTotals.input += event.tokens.input
+          usageTotals.output += event.tokens.output
+          if (event.model) usageModel = event.model
+          break
+        }
+
+        case 'error': {
+          endTextMessage()
+          endThinkingMessage()
+          endStep()
+          send({ type: 'RUN_ERROR', message: event.message })
+          terminal = true
+          break
+        }
+
+        case 'done': {
+          finishRun()
+          break
+        }
+
+        // Step names must be unique among active steps on the client and
+        // sub-agents reuse step numbers on the shared channel, so each
+        // step-start closes the previous step and gets a sequential name.
+        case 'step-start': {
+          endTextMessage()
+          endThinkingMessage()
+          endStep()
+          stepSeq += 1
+          openStepName = `${event.agent ?? 'step'}#${stepSeq}`
+          send({ type: 'STEP_STARTED', stepName: openStepName })
+          break
+        }
+
+        case 'approval-request': {
+          endTextMessage()
+          endThinkingMessage()
+          send({
+            type: 'CUSTOM',
+            name: 'pikku:approval-request',
+            value: {
+              toolCallId: event.toolCallId,
+              toolName: event.toolName,
+              args: event.args,
+              reason: event.reason,
+              runId: event.runId,
+              agent: event.agent,
+              session: event.session,
+            },
+          })
+          break
+        }
+
+        case 'credential-request': {
+          endTextMessage()
+          endThinkingMessage()
+          send({
+            type: 'CUSTOM',
+            name: 'pikku:credential-request',
+            value: {
+              toolCallId: event.toolCallId,
+              toolName: event.toolName,
+              args: event.args,
+              credentialName: event.credentialName,
+              credentialType: event.credentialType,
+              connectUrl: event.connectUrl,
+              runId: event.runId,
+              agent: event.agent,
+              session: event.session,
+            },
+          })
+          break
+        }
+
+        case 'generative-ui': {
+          send({
+            type: 'CUSTOM',
+            name: 'pikku:generative-ui',
+            value: { spec: event.spec },
+          })
+          break
+        }
+
+        case 'data': {
+          send({
+            type: 'CUSTOM',
+            name: 'pikku:data',
+            value: { name: event.name, data: event.data },
+          })
+          break
+        }
+
+        case 'workflow-created': {
+          send({
+            type: 'CUSTOM',
+            name: 'pikku:workflow-created',
+            value: { workflowName: event.workflowName, graph: event.graph },
+          })
+          break
+        }
+
+        case 'agent-call': {
+          send({
+            type: 'CUSTOM',
+            name: 'pikku:agent-call',
+            value: {
+              agentName: event.agentName,
+              session: event.session,
+              input: event.input,
+            },
+          })
+          break
+        }
+
+        case 'agent-result': {
+          send({
+            type: 'CUSTOM',
+            name: 'pikku:agent-result',
+            value: {
+              agentName: event.agentName,
+              session: event.session,
+              result: event.result,
+            },
+          })
+          break
+        }
+
+        case 'suspended': {
+          send({
+            type: 'CUSTOM',
+            name: 'pikku:suspended',
+            value: { reason: event.reason, missingRpcs: event.missingRpcs },
+          })
+          break
+        }
+
+        case 'audio-delta':
+        case 'audio-done':
+          break
+      }
+    },
+  }
+}

--- a/packages/core/src/wirings/ai-agent/ai-agent-prepare.test.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-prepare.test.ts
@@ -150,6 +150,7 @@ describe('ai-agent-prepare', () => {
       toolCallId: 'tc-1',
       toolName: 'tool-a',
       args: { x: 1 },
+      reason: 'Delete todo "x"',
       runId: 'run-1',
     } as AIStreamEvent)
     channel.send({ type: 'done' } as AIStreamEvent)
@@ -161,6 +162,7 @@ describe('ai-agent-prepare', () => {
         toolCallId: 'tc-1',
         toolName: 'tool-a',
         args: { x: 1 },
+        reason: 'Delete todo "x"',
         runId: 'run-1',
       },
     ])

--- a/packages/core/src/wirings/ai-agent/ai-agent-prepare.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-prepare.ts
@@ -38,6 +38,11 @@ export type RunAIAgentParams = {
 
 export type StreamAIAgentOptions = {
   requiresToolApproval?: 'all' | 'explicit' | false
+  /**
+   * Invoked as soon as the run's AIRunStateService id exists, so transport
+   * wrappers (e.g. the AG-UI bridge) can stamp the real runId on RUN_STARTED.
+   */
+  onRunCreated?: (runId: string) => void
 }
 
 export class ToolApprovalRequired extends PikkuError {
@@ -219,6 +224,7 @@ export type ScopedChannel = AIStreamChannel & {
     toolCallId: string
     toolName: string
     args: unknown
+    reason?: string
     runId: string
   }>
 }
@@ -248,6 +254,7 @@ export function createScopedChannel(
           toolCallId: event.toolCallId,
           toolName: event.toolName,
           args: event.args,
+          ...(event.reason !== undefined ? { reason: event.reason } : {}),
           runId: (event as any).runId,
         })
         return
@@ -538,6 +545,7 @@ export async function buildToolDefs(
                 toolCallId: a.toolCallId,
                 toolName: a.toolName,
                 args: a.args,
+                reason: a.reason,
                 runId: a.runId,
               })),
             }

--- a/packages/core/src/wirings/ai-agent/ai-agent-stream.test.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-stream.test.ts
@@ -878,8 +878,23 @@ describe('streamAIAgent', () => {
         debug: () => {},
       },
       aiAgentRunner: {
-        stream: async (): Promise<AIAgentStepResult> =>
-          makeStepResult({
+        stream: async (
+          _params: unknown,
+          streamChannel: AIStreamChannel | null
+        ): Promise<AIAgentStepResult> => {
+          const credentialResult = {
+            __credentialRequired: true,
+            credentialName: 'github',
+            credentialType: 'oauth2',
+            connectUrl: '/connect',
+          }
+          streamChannel?.send({
+            type: 'tool-result',
+            toolCallId: 'cred-1',
+            toolName: 'secretTool',
+            result: credentialResult,
+          })
+          return makeStepResult({
             toolCalls: [
               { toolCallId: 'cred-1', toolName: 'secretTool', args: { id: 1 } },
             ],
@@ -887,15 +902,11 @@ describe('streamAIAgent', () => {
               {
                 toolCallId: 'cred-1',
                 toolName: 'secretTool',
-                result: {
-                  __credentialRequired: true,
-                  credentialName: 'github',
-                  credentialType: 'oauth2',
-                  connectUrl: '/connect',
-                },
+                result: credentialResult,
               },
             ],
-          }),
+          })
+        },
       },
       aiRunState: {
         createRun: async () => 'run-cred',
@@ -945,6 +956,24 @@ describe('streamAIAgent', () => {
       },
     ])
     assert.ok(events.every((event) => event.type !== 'approval-request'))
+    assert.ok(
+      events.every((event) => event.type !== 'tool-result'),
+      '__credentialRequired tool result must not reach the client'
+    )
+    const credentialEvent = events.find(
+      (event) => event.type === 'credential-request'
+    )
+    assert.ok(credentialEvent, 'credential-request event must be emitted')
+    assert.deepEqual(credentialEvent, {
+      type: 'credential-request',
+      toolCallId: 'cred-1',
+      toolName: 'secretTool',
+      args: { id: 1 },
+      credentialName: 'github',
+      credentialType: 'oauth2',
+      connectUrl: '/connect',
+      runId: 'run-cred',
+    })
     assert.equal(events.at(-1)?.type, 'done')
   })
 
@@ -1096,6 +1125,7 @@ describe('ai-agent-stream helpers', () => {
                   toolCallId: 'sub-1',
                   toolName: 'deleteTodo',
                   args: { todoId: '1' },
+                  reason: 'Delete the todo "1"',
                   runId: 'sub-run-1',
                 },
               ],
@@ -1123,6 +1153,7 @@ describe('ai-agent-stream helpers', () => {
     assert.equal(approvals[1].toolName, 'sub-agent')
     assert.equal(approvals[1].displayToolName, 'deleteTodo')
     assert.equal(approvals[1].agentRunId, 'sub-run-1')
+    assert.equal(approvals[1].reason, 'Delete the todo "1"')
   })
 
   test('checkForCredentialRequests and appendStepMessages handle structured results', () => {

--- a/packages/core/src/wirings/ai-agent/ai-agent-stream.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-stream.ts
@@ -347,6 +347,7 @@ export function checkForApprovals(
           toolCallId: string
           toolName: string
           args: unknown
+          reason?: string
           runId: string
         }>
       }
@@ -357,7 +358,7 @@ export function checkForApprovals(
               sub.toolCallId,
               r.toolName,
               r.args,
-              undefined,
+              sub.reason,
               sub.toolName,
               sub.args,
               r.agentRunId
@@ -512,7 +513,7 @@ function handleApprovals(
         reason: err.reason,
         runId,
       }
-      channel.send(approvalEvent as any)
+      channel.send(approvalEvent)
     }
     channel.send({ type: 'done' })
     channel.close()
@@ -545,9 +546,22 @@ function handleCredentialRequests(
       pendingApprovals,
     })
 
-    // Don't send credential-request SSE events — the tool result with
-    // __credentialRequired was already streamed. The frontend detects it
-    // from the tool result and shows Connect/Ignore buttons.
+    // The __credentialRequired tool result is suppressed from the stream, so
+    // credential-request events (with the runId needed for /resume) are the
+    // client's signal to show Connect/Ignore buttons — mirroring how
+    // approval-request suspensions work.
+    for (const req of requests) {
+      channel.send({
+        type: 'credential-request',
+        toolCallId: req.toolCallId,
+        toolName: req.toolName,
+        args: req.args,
+        credentialName: req.credentialName,
+        credentialType: req.credentialType,
+        connectUrl: req.connectUrl,
+        runId,
+      })
+    }
     channel.send({ type: 'done' })
     channel.close()
   })()
@@ -654,6 +668,7 @@ export async function streamAIAgent(
     createdAt: new Date(),
     updatedAt: new Date(),
   })
+  options?.onRunCreated?.(runId)
 
   if (storage) {
     await storage.saveMessages(threadId, [userMessage])
@@ -705,6 +720,25 @@ export async function streamAIAgent(
         ).channel as AIStreamChannel)
       : persistingChannel
 
+  // Tool results carrying the __credentialRequired marker must never reach
+  // the client or persisted history: the run suspends with credential-request
+  // events instead (mirroring approvals), and leaving the tool call
+  // unresulted is what lets the client resume it after connecting.
+  const credentialFilteredChannel: AIStreamChannel = {
+    ...wrappedChannel,
+    send: (event: AIStreamEvent) => {
+      if (
+        event.type === 'tool-result' &&
+        event.result !== null &&
+        typeof event.result === 'object' &&
+        '__credentialRequired' in event.result
+      ) {
+        return
+      }
+      wrappedChannel.send(event)
+    },
+  }
+
   // In delegate mode (default), suppress parent's text from reaching the client
   // AFTER a sub-agent has been called. If the parent responds directly (no delegation),
   // its text goes through normally. Sub-agent text bypasses this path entirely
@@ -716,18 +750,18 @@ export async function streamAIAgent(
   }
   const outputChannel = isDelegateMode
     ? {
-        ...wrappedChannel,
+        ...credentialFilteredChannel,
         send: (event: AIStreamEvent) => {
           if (
             delegateState.delegated &&
             (event.type === 'text-delta' || event.type === 'reasoning-delta')
           )
             return
-          wrappedChannel.send(event)
+          credentialFilteredChannel.send(event)
         },
         delegateState,
       }
-    : wrappedChannel
+    : credentialFilteredChannel
 
   try {
     const loopResult = await runStreamStepLoop({
@@ -875,6 +909,16 @@ export async function resumeAIAgent(
         },
       ])
     }
+
+    channel.send({
+      type: 'tool-result',
+      toolCallId: input.toolCallId,
+      toolName:
+        pending.type === 'tool-call' || pending.type === 'credential-request'
+          ? pending.toolName
+          : pending.agentName,
+      result: denialResult,
+    })
 
     // Check remaining pending approvals
     const updatedRun = await aiRunState.getRun(run.runId)

--- a/packages/core/src/wirings/ai-agent/ai-agent.types.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent.types.ts
@@ -275,6 +275,7 @@ export type AIStreamEvent =
       toolName: string
       args: unknown
       reason?: string
+      runId?: string
       agent?: string
       session?: string
     }

--- a/packages/core/src/wirings/ai-agent/index.ts
+++ b/packages/core/src/wirings/ai-agent/index.ts
@@ -4,6 +4,7 @@ export {
   agentResume,
   agentApprove,
 } from './ai-agent-helpers.js'
+export { wrapChannelWithAGUI, type AGUIEvent } from './ai-agent-agui.js'
 export { runAIAgent, resumeAIAgentSync } from './ai-agent-runner.js'
 export { streamAIAgent, resumeAIAgent } from './ai-agent-stream.js'
 export { voiceInput } from './voice-input.js'

--- a/packages/core/src/wirings/rpc/rpc-runner.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.ts
@@ -28,6 +28,7 @@ import type { AIStreamChannel } from '../ai-agent/ai-agent.types.js'
 import type { StreamAIAgentOptions } from '../ai-agent/ai-agent-prepare.js'
 import { runAIAgent, resumeAIAgentSync } from '../ai-agent/ai-agent-runner.js'
 import { streamAIAgent, resumeAIAgent } from '../ai-agent/ai-agent-stream.js'
+import { wrapChannelWithAGUI } from '../ai-agent/ai-agent-agui.js'
 
 /**
  * Resolve a namespaced function reference to package and function names
@@ -338,16 +339,26 @@ export class ContextAwareRPCService {
       ) => {
         const channel = this.wire.channel as unknown as AIStreamChannel
         if (!channel) throw new Error('No channel available for streaming')
+        let currentRunId: string | undefined
         await streamAIAgent(
           agentName,
           input,
-          channel,
+          wrapChannelWithAGUI(channel, {
+            threadId: input.threadId,
+            getRunId: () => currentRunId,
+          }),
           {
             sessionService: this.options.sessionService,
             getCredential: this.wire.getCredential?.bind(this.wire),
           },
           undefined,
-          options
+          {
+            ...options,
+            onRunCreated: (runId) => {
+              currentRunId = runId
+              options?.onRunCreated?.(runId)
+            },
+          }
         )
       },
       resume: async (
@@ -359,7 +370,7 @@ export class ContextAwareRPCService {
         if (!channel) throw new Error('No channel available for streaming')
         await resumeAIAgent(
           { runId, ...input },
-          channel,
+          wrapChannelWithAGUI(channel, { runId }),
           {
             sessionService: this.options.sessionService,
             getCredential: this.wire.getCredential?.bind(this.wire),

--- a/packages/core/src/wirings/rpc/rpc-types.ts
+++ b/packages/core/src/wirings/rpc/rpc-types.ts
@@ -1,9 +1,9 @@
 export type PikkuRPC<
-  Invoke extends Function = any,
-  Remote extends Function = any,
-  startWorkflow extends Function = any,
-  AgentRun extends Function = any,
-  AgentStream extends Function = any,
+  Invoke extends (...args: any[]) => any = (...args: any[]) => any,
+  Remote extends (...args: any[]) => any = (...args: any[]) => any,
+  startWorkflow extends (...args: any[]) => any = (...args: any[]) => any,
+  AgentRun extends (...args: any[]) => any = (...args: any[]) => any,
+  AgentStream extends (...args: any[]) => any = (...args: any[]) => any,
 > = {
   depth: number
   global: boolean

--- a/packages/services/ai-tanstack/package.json
+++ b/packages/services/ai-tanstack/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@pikku/ai-tanstack",
+  "version": "0.12.0",
+  "author": "yasser.fadl@gmail.com",
+  "license": "MIT",
+  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "tsc": "tsc",
+    "ncu": "npx npm-check-updates",
+    "build": "tsc -b",
+    "test": "bash run-tests.sh",
+    "test:coverage": "bash run-tests.sh --coverage",
+    "prepublishOnly": "yarn build"
+  },
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "peerDependencies": {
+    "@pikku/core": "^0.12.35"
+  },
+  "dependencies": {
+    "@tanstack/ai": "^0.39.0",
+    "@tanstack/ai-openai": "^0.15.9",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "typescript": "^5.9"
+  }
+}

--- a/packages/services/ai-tanstack/run-tests.sh
+++ b/packages/services/ai-tanstack/run-tests.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir" || exit 1
+
+# Enable nullglob to handle cases where no files match the pattern
+shopt -s nullglob
+
+# Initialize variables for options
+watch_mode=false
+coverage_mode=false
+
+# Parse command-line options
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --watch)
+      watch_mode=true
+      shift
+      ;;
+    --coverage)
+      coverage_mode=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Define the pattern to match your test files
+pattern="src/**/*.test.ts"
+
+# Expand the pattern into an array of files
+files=($(find src -type f -name "*.test.ts"))
+
+# Check if any files matched the pattern
+if [ ${#files[@]} -eq 0 ]; then
+  echo "No test files found matching pattern: $pattern"
+  if [ "${STRICT_TEST_DISCOVERY}" = "1" ]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+# Construct the node command
+node_cmd="node --import tsx --test"
+
+# Append options based on flags
+if [ "$watch_mode" = true ]; then
+  node_cmd="$node_cmd --watch"
+fi
+
+if [ "$coverage_mode" = true ]; then
+  node_cmd="$node_cmd --test-coverage-include=\"src/**/*.{ts,js}\" --test-coverage-exclude=\"**/dist/**\" --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info"
+fi
+
+# Execute the node command with the expanded list of files
+$node_cmd "${files[@]}"

--- a/packages/services/ai-tanstack/src/index.ts
+++ b/packages/services/ai-tanstack/src/index.ts
@@ -1,0 +1,1 @@
+export { TanstackAIAgentRunner } from './tanstack-ai-agent-runner.js'

--- a/packages/services/ai-tanstack/src/tanstack-ai-agent-runner.test.ts
+++ b/packages/services/ai-tanstack/src/tanstack-ai-agent-runner.test.ts
@@ -1,0 +1,496 @@
+import { describe, test, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { TanstackAIAgentRunner } from './tanstack-ai-agent-runner.js'
+
+type SSEChunk = Record<string, unknown>
+
+/**
+ * Spins up a mock OpenAI-compatible Chat Completions endpoint so the real
+ * adapter + TanStack agent loop can be exercised without a live API key.
+ * Each `/chat/completions` call consumes the next scripted list of SSE deltas
+ * and records the request body for assertions.
+ */
+let server: http.Server
+let baseUrl: string
+let script: SSEChunk[][] = []
+let callIndex = 0
+let seenRequests: Array<{ url: string | undefined; body: any }> = []
+/** Per-call HTTP status override; a non-200 makes the adapter fail the stream. */
+let httpStatus: (number | null)[] = []
+
+function chunk(
+  delta: Record<string, unknown>,
+  finish: string | null = null,
+  usage: Record<string, number> | null = null
+): SSEChunk {
+  const c: SSEChunk = {
+    id: 'chatcmpl-mock',
+    object: 'chat.completion.chunk',
+    created: 0,
+    model: 'gpt-4o-mini',
+    choices: [{ index: 0, delta, finish_reason: finish }],
+  }
+  if (usage) c.usage = usage
+  return c
+}
+
+function makeChannel() {
+  const events: any[] = []
+  return {
+    channel: {
+      channelId: 'test',
+      openingData: {},
+      state: 'open',
+      close: () => {},
+      sendBinary: () => {},
+      send: (e: any) => events.push(e),
+      setState: () => {},
+      getState: () => ({}),
+      clearState: () => {},
+    } as any,
+    events,
+  }
+}
+
+async function withTimeout<T>(p: Promise<T>, ms: number, label: string) {
+  let timer: NodeJS.Timeout
+  const timeout = new Promise<never>((_, rej) => {
+    timer = setTimeout(() => rej(new Error(`TIMEOUT ${ms}ms: ${label}`)), ms)
+  })
+  try {
+    return await Promise.race([p, timeout])
+  } finally {
+    clearTimeout(timer!)
+  }
+}
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    let body = ''
+    req.on('data', (d) => (body += d))
+    req.on('end', () => {
+      seenRequests.push({ url: req.url, body: JSON.parse(body || '{}') })
+      const status = httpStatus[callIndex] ?? 200
+      const chunks = script[callIndex] ?? script[script.length - 1] ?? []
+      callIndex++
+      if (status !== 200) {
+        res.writeHead(status, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: { message: 'mock provider error' } }))
+        return
+      }
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' })
+      for (const c of chunks) res.write(`data: ${JSON.stringify(c)}\n\n`)
+      res.write('data: [DONE]\n\n')
+      res.end()
+    })
+  })
+  await new Promise<void>((r) => server.listen(0, r))
+  const port = (server.address() as AddressInfo).port
+  baseUrl = `http://localhost:${port}/v1`
+  process.env.OPENAI_BASE_URL = baseUrl
+  process.env.OPENAI_API_KEY = 'sk-mock-dummy'
+})
+
+after(() => {
+  server.close()
+})
+
+beforeEach(() => {
+  script = []
+  callIndex = 0
+  seenRequests = []
+  httpStatus = []
+})
+
+const baseParams = {
+  model: 'openai/gpt-4o-mini',
+  tools: [],
+  maxSteps: 10,
+  toolChoice: 'auto' as const,
+}
+
+describe('TanstackAIAgentRunner.stream', () => {
+  test('forwards params.instructions as the leading system prompt', async () => {
+    script = [
+      [
+        chunk({ role: 'assistant', content: '' }),
+        chunk({ content: 'hi' }),
+        chunk({}, 'stop', { prompt_tokens: 1, completion_tokens: 1 }),
+      ],
+    ]
+    const { channel } = makeChannel()
+    const runner = new TanstackAIAgentRunner()
+    await withTimeout(
+      runner.stream(
+        {
+          ...baseParams,
+          instructions: 'You are the routing agent. Always delegate.',
+          messages: [
+            { id: 'u1', role: 'user', content: 'hello', createdAt: new Date() },
+          ] as any,
+        },
+        channel
+      ),
+      10_000,
+      'instructions'
+    )
+
+    const sent = seenRequests[0]?.body?.messages
+    assert.deepEqual(sent[0], {
+      role: 'system',
+      content: 'You are the routing agent. Always delegate.',
+    })
+  })
+
+  test('throws when the provider stream errors, rather than completing', async () => {
+    // A non-200 from the completions endpoint surfaces as a RUN_ERROR in the
+    // agent loop. The runner must throw (so core marks the run failed and
+    // fires onError) instead of returning finishReason 'error' — this is what
+    // keeps it interchangeable with the vercel runner on the error path.
+    httpStatus = [400, 400, 400, 400]
+    script = [[]]
+    const { channel } = makeChannel()
+    const runner = new TanstackAIAgentRunner()
+    await assert.rejects(
+      withTimeout(
+        runner.stream(
+          {
+            ...baseParams,
+            instructions: 'x',
+            messages: [
+              {
+                id: 'u1',
+                role: 'user',
+                content: 'hello',
+                createdAt: new Date(),
+              },
+            ] as any,
+          },
+          channel
+        ),
+        20_000,
+        'error-throw'
+      )
+    )
+  })
+
+  test('streams plain text and reports finishReason stop', async () => {
+    script = [
+      [
+        chunk({ role: 'assistant', content: '' }),
+        chunk({ content: 'Hello there' }),
+        chunk({}, 'stop', { prompt_tokens: 5, completion_tokens: 2 }),
+      ],
+    ]
+    const { channel, events } = makeChannel()
+    const runner = new TanstackAIAgentRunner()
+    const result = await withTimeout(
+      runner.stream(
+        {
+          ...baseParams,
+          instructions: 'You are helpful.',
+          messages: [
+            { id: 'u1', role: 'user', content: 'hi', createdAt: new Date() },
+          ] as any,
+        },
+        channel
+      ),
+      10_000,
+      'plain text'
+    )
+
+    assert.equal(result.text, 'Hello there')
+    assert.equal(result.finishReason, 'stop')
+    assert.equal(result.toolCalls.length, 0)
+    assert.equal(
+      events
+        .filter((e) => e.type === 'text-delta')
+        .map((e) => e.text)
+        .join(''),
+      'Hello there'
+    )
+  })
+
+  test('executes non-approval tools and returns call + result', async () => {
+    let executed = 0
+    const listTodos = {
+      name: 'todos__listTodos',
+      description: 'List todos',
+      inputSchema: { type: 'object', properties: {} },
+      execute: async () => {
+        executed++
+        return [{ id: '1', title: 'Buy groceries' }]
+      },
+    }
+    script = [
+      [
+        chunk({
+          role: 'assistant',
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'todos__listTodos', arguments: '' },
+            },
+          ],
+        }),
+        chunk({ tool_calls: [{ index: 0, function: { arguments: '{}' } }] }),
+        chunk({}, 'tool_calls', { prompt_tokens: 10, completion_tokens: 3 }),
+      ],
+    ]
+    const { channel } = makeChannel()
+    const runner = new TanstackAIAgentRunner()
+    const result = await withTimeout(
+      runner.stream(
+        {
+          ...baseParams,
+          instructions: 'You manage todos.',
+          tools: [listTodos] as any,
+          messages: [
+            {
+              id: 'u1',
+              role: 'user',
+              content: 'list todos',
+              createdAt: new Date(),
+            },
+          ] as any,
+        },
+        channel
+      ),
+      10_000,
+      'tool call'
+    )
+
+    assert.equal(executed, 1)
+    assert.equal(result.toolCalls.length, 1)
+    assert.equal(result.toolCalls[0].toolName, 'todos__listTodos')
+    assert.equal(result.toolResults.length, 1)
+    assert.equal(result.finishReason, 'tool-calls')
+  })
+
+  test('emits the usage event after the tool-result event', async () => {
+    const listTodos = {
+      name: 'todos__listTodos',
+      description: 'List todos',
+      inputSchema: { type: 'object', properties: {} },
+      execute: async () => [{ id: '1', title: 'Buy groceries' }],
+    }
+    script = [
+      [
+        chunk({
+          role: 'assistant',
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'todos__listTodos', arguments: '' },
+            },
+          ],
+        }),
+        chunk({ tool_calls: [{ index: 0, function: { arguments: '{}' } }] }),
+        chunk({}, 'tool_calls', { prompt_tokens: 10, completion_tokens: 3 }),
+      ],
+    ]
+    const { channel, events } = makeChannel()
+    const runner = new TanstackAIAgentRunner()
+    await withTimeout(
+      runner.stream(
+        {
+          ...baseParams,
+          instructions: 'You manage todos.',
+          tools: [listTodos] as any,
+          messages: [
+            {
+              id: 'u1',
+              role: 'user',
+              content: 'list todos',
+              createdAt: new Date(),
+            },
+          ] as any,
+        },
+        channel
+      ),
+      10_000,
+      'usage order'
+    )
+
+    const types = events.map((e) => e.type)
+    const toolResultIndex = types.indexOf('tool-result')
+    const usageIndex = types.indexOf('usage')
+    assert.notEqual(toolResultIndex, -1, 'tool-result must be emitted')
+    assert.notEqual(usageIndex, -1, 'usage must be emitted')
+    assert.ok(
+      toolResultIndex < usageIndex,
+      `usage (idx ${usageIndex}) must follow tool-result (idx ${toolResultIndex}); got order ${types.join(',')}`
+    )
+  })
+
+  test('does not execute approval-required tools and signals tool-calls', async () => {
+    let executed = 0
+    const addTodo = {
+      name: 'todos__addTodo',
+      description: 'Add a todo',
+      inputSchema: {
+        type: 'object',
+        properties: { title: { type: 'string' } },
+        required: ['title'],
+      },
+      needsApproval: true,
+      execute: async () => {
+        executed++
+        return { id: '99' }
+      },
+    }
+    script = [
+      [
+        chunk({
+          role: 'assistant',
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_2',
+              type: 'function',
+              function: { name: 'todos__addTodo', arguments: '' },
+            },
+          ],
+        }),
+        chunk({
+          tool_calls: [
+            { index: 0, function: { arguments: '{"title":"Write tests"}' } },
+          ],
+        }),
+        chunk({}, 'tool_calls', { prompt_tokens: 12, completion_tokens: 4 }),
+      ],
+    ]
+    const { channel } = makeChannel()
+    const runner = new TanstackAIAgentRunner()
+    const result = await withTimeout(
+      runner.stream(
+        {
+          ...baseParams,
+          instructions: 'You manage todos.',
+          tools: [addTodo] as any,
+          messages: [
+            {
+              id: 'u1',
+              role: 'user',
+              content: 'add a todo',
+              createdAt: new Date(),
+            },
+          ] as any,
+        },
+        channel
+      ),
+      10_000,
+      'approval'
+    )
+
+    assert.equal(executed, 0)
+    assert.equal(result.toolCalls.length, 1)
+    assert.equal(result.toolCalls[0].toolName, 'todos__addTodo')
+    assert.deepEqual(result.toolCalls[0].args, { title: 'Write tests' })
+    assert.equal(result.toolResults.length, 0)
+    assert.equal(result.finishReason, 'tool-calls')
+  })
+
+  test('round-trips tool results into a valid second request', async () => {
+    const listTodos = {
+      name: 'todos__listTodos',
+      description: 'List todos',
+      inputSchema: { type: 'object', properties: {} },
+      execute: async () => [{ id: '1', title: 'Buy groceries' }],
+    }
+    script = [
+      [
+        chunk({
+          role: 'assistant',
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'todos__listTodos', arguments: '' },
+            },
+          ],
+        }),
+        chunk({ tool_calls: [{ index: 0, function: { arguments: '{}' } }] }),
+        chunk({}, 'tool_calls', { prompt_tokens: 10, completion_tokens: 3 }),
+      ],
+      [
+        chunk({ role: 'assistant', content: '' }),
+        chunk({ content: 'You have: Buy groceries' }),
+        chunk({}, 'stop', { prompt_tokens: 20, completion_tokens: 5 }),
+      ],
+    ]
+    const runner = new TanstackAIAgentRunner()
+    const messages: any[] = [
+      { id: 'u1', role: 'user', content: 'list todos', createdAt: new Date() },
+    ]
+    const params = {
+      ...baseParams,
+      instructions: 'You manage todos.',
+      tools: [listTodos] as any,
+    }
+
+    const step0 = await withTimeout(
+      runner.stream({ ...params, messages }, makeChannel().channel),
+      10_000,
+      'step0'
+    )
+    // Mirror core's appendStepMessages so step 1 sees the tool round-trip.
+    messages.push({
+      id: 'a1',
+      role: 'assistant',
+      content: step0.text || undefined,
+      toolCalls: step0.toolCalls.map((tc) => ({
+        id: tc.toolCallId,
+        name: tc.toolName,
+        args: tc.args,
+      })),
+      createdAt: new Date(),
+    })
+    messages.push({
+      id: 't1',
+      role: 'tool',
+      toolResults: step0.toolResults.map((tr) => ({
+        id: tr.toolCallId,
+        name: tr.toolName,
+        result:
+          typeof tr.result === 'string' ? tr.result : JSON.stringify(tr.result),
+      })),
+      createdAt: new Date(),
+    })
+
+    const step1 = await withTimeout(
+      runner.stream({ ...params, messages }, makeChannel().channel),
+      10_000,
+      'step1'
+    )
+
+    assert.equal(step1.text, 'You have: Buy groceries')
+    assert.equal(step1.finishReason, 'stop')
+    assert.equal(step1.toolCalls.length, 0)
+
+    const secondCall = seenRequests[1].body.messages
+    assert.deepEqual(secondCall[2], {
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'todos__listTodos', arguments: '{}' },
+        },
+      ],
+    })
+    assert.deepEqual(secondCall[3], {
+      role: 'tool',
+      tool_call_id: 'call_1',
+      content: '[{"id":"1","title":"Buy groceries"}]',
+    })
+  })
+})

--- a/packages/services/ai-tanstack/src/tanstack-ai-agent-runner.ts
+++ b/packages/services/ai-tanstack/src/tanstack-ai-agent-runner.ts
@@ -1,0 +1,335 @@
+import { chat, toolDefinition, maxIterations } from '@tanstack/ai'
+import { openaiChatCompletions } from '@tanstack/ai-openai'
+import type {
+  AIAgentRunnerParams,
+  AIAgentRunnerService,
+  AIAgentStepResult,
+} from '@pikku/core/services'
+import type { AIStreamChannel } from '@pikku/core/ai-agent'
+import type { AIMessage, AIContentPart } from '@pikku/core/ai-agent'
+
+function parseModel(model: string): { provider: string; modelName: string } {
+  const slashIndex = model.indexOf('/')
+  if (slashIndex === -1) {
+    throw new Error(
+      `Invalid model format '${model}'. Expected 'provider/model' (e.g. 'openai/gpt-4o-mini').`
+    )
+  }
+  return {
+    provider: model.slice(0, slashIndex),
+    modelName: model.slice(slashIndex + 1),
+  }
+}
+
+function contentToString(
+  content: string | AIContentPart[] | undefined | null
+): string {
+  if (!content) return ''
+  if (typeof content === 'string') return content
+  return content
+    .filter(
+      (p): p is Extract<AIContentPart, { type: 'text' }> => p.type === 'text'
+    )
+    .map((p) => p.text)
+    .join('')
+}
+
+function contentToStringOrNull(
+  content: string | AIContentPart[] | undefined | null
+): string | null {
+  if (content == null) return null
+  if (typeof content === 'string') return content
+  const text = content
+    .filter(
+      (p): p is Extract<AIContentPart, { type: 'text' }> => p.type === 'text'
+    )
+    .map((p) => p.text)
+    .join('')
+  return text || null
+}
+
+function convertMessages(messages: AIMessage[]): {
+  systemPrompts: string[]
+  modelMessages: Array<{
+    role: 'user' | 'assistant' | 'tool'
+    content: string | null
+    toolCalls?: Array<{
+      id: string
+      type: 'function'
+      function: { name: string; arguments: string }
+    }>
+    toolCallId?: string
+  }>
+} {
+  const systemPrompts: string[] = []
+  const modelMessages: Array<{
+    role: 'user' | 'assistant' | 'tool'
+    content: string | null
+    toolCalls?: Array<{
+      id: string
+      type: 'function'
+      function: { name: string; arguments: string }
+    }>
+    toolCallId?: string
+  }> = []
+
+  for (const msg of messages) {
+    if (msg.role === 'system') {
+      const text = contentToString(msg.content)
+      if (text) systemPrompts.push(text)
+      continue
+    }
+
+    if (msg.role === 'user') {
+      modelMessages.push({
+        role: 'user',
+        content: contentToString(msg.content),
+      })
+      continue
+    }
+
+    if (msg.role === 'assistant') {
+      const tc = msg.toolCalls?.map((call) => ({
+        id: call.id,
+        type: 'function' as const,
+        function: {
+          name: call.name,
+          arguments:
+            typeof call.args === 'string'
+              ? call.args
+              : JSON.stringify(call.args),
+        },
+      }))
+      modelMessages.push({
+        role: 'assistant',
+        content: contentToStringOrNull(msg.content),
+        ...(tc?.length ? { toolCalls: tc } : {}),
+      })
+      continue
+    }
+
+    if (msg.role === 'tool' && msg.toolResults) {
+      for (const tr of msg.toolResults) {
+        modelMessages.push({
+          role: 'tool',
+          content:
+            typeof tr.result === 'string'
+              ? tr.result
+              : JSON.stringify(tr.result),
+          toolCallId: tr.id,
+        })
+      }
+    }
+  }
+
+  return { systemPrompts, modelMessages }
+}
+
+function buildTools(params: AIAgentRunnerParams) {
+  return params.tools.map((t) => {
+    if (t.needsApproval) {
+      return toolDefinition({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+        needsApproval: true,
+      })
+    }
+    return toolDefinition({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    }).server(async (input: unknown) => {
+      try {
+        return await t.execute(input)
+      } catch (err: any) {
+        if (err?.payload?.error === 'missing_credential') {
+          return { __credentialRequired: true, ...err.payload }
+        }
+        throw err
+      }
+    })
+  })
+}
+
+async function runStream(
+  params: AIAgentRunnerParams,
+  channel: AIStreamChannel | null
+): Promise<AIAgentStepResult> {
+  const { provider, modelName } = parseModel(params.model)
+
+  if (provider !== 'openai') {
+    throw new Error(
+      `@pikku/ai-tanstack only supports OpenAI provider. Got: '${provider}'`
+    )
+  }
+
+  const adapter = openaiChatCompletions(modelName as any)
+  const { systemPrompts, modelMessages } = convertMessages(params.messages)
+  const tools = buildTools(params)
+
+  const allSystemPrompts = params.instructions
+    ? [params.instructions, ...systemPrompts]
+    : systemPrompts
+
+  const stepResult: AIAgentStepResult = {
+    text: '',
+    toolCalls: [],
+    toolResults: [],
+    usage: { inputTokens: 0, outputTokens: 0 },
+    finishReason: 'unknown',
+  }
+
+  const firstSeenToolCallIds = new Set<string>()
+  const completedFromLLMIds = new Set<string>()
+  const toolNameMap = new Map<string, string>()
+  const argsBuffer = new Map<string, string>()
+  let usagePending = false
+  let approvalBreak = false
+
+  const chatStream = chat({
+    adapter,
+    messages: modelMessages as any,
+    systemPrompts: allSystemPrompts.map((s) => ({ content: s })),
+    tools: tools as any,
+    agentLoopStrategy: maxIterations(1),
+    ...(params.temperature !== undefined
+      ? { modelOptions: { temperature: params.temperature } as any }
+      : {}),
+  })
+
+  for await (const chunk of chatStream as AsyncIterable<any>) {
+    const type = chunk.type as string
+
+    if (type === 'TEXT_MESSAGE_CONTENT') {
+      const delta: string = chunk.delta ?? ''
+      stepResult.text += delta
+      channel?.send({ type: 'text-delta', text: delta })
+      continue
+    }
+
+    if (type === 'TOOL_CALL_START') {
+      const id: string = chunk.toolCallId
+      if (!firstSeenToolCallIds.has(id)) {
+        firstSeenToolCallIds.add(id)
+        const name: string = chunk.toolCallName ?? chunk.toolName ?? ''
+        toolNameMap.set(id, name)
+        argsBuffer.set(id, '')
+      }
+      continue
+    }
+
+    if (type === 'TOOL_CALL_ARGS') {
+      const id: string = chunk.toolCallId
+      if (firstSeenToolCallIds.has(id) && !completedFromLLMIds.has(id)) {
+        argsBuffer.set(id, (argsBuffer.get(id) ?? '') + (chunk.delta ?? ''))
+      }
+      continue
+    }
+
+    if (type === 'TOOL_CALL_END') {
+      const id: string = chunk.toolCallId
+      if (
+        firstSeenToolCallIds.has(id) &&
+        !completedFromLLMIds.has(id) &&
+        chunk.result === undefined
+      ) {
+        completedFromLLMIds.add(id)
+        const toolName = toolNameMap.get(id) ?? ''
+        const argsStr = argsBuffer.get(id) ?? '{}'
+        let args: unknown = {}
+        try {
+          args = JSON.parse(argsStr)
+        } catch {}
+        stepResult.toolCalls.push({ toolCallId: id, toolName, args })
+        channel?.send({ type: 'tool-call', toolCallId: id, toolName, args })
+      }
+      continue
+    }
+
+    if (type === 'TOOL_CALL_RESULT') {
+      const id: string = chunk.toolCallId
+      const toolName = toolNameMap.get(id) ?? chunk.toolName ?? ''
+      const content: string = chunk.content ?? ''
+      let result: unknown = content
+      try {
+        result = JSON.parse(content)
+      } catch {}
+      stepResult.toolResults.push({ toolCallId: id, toolName, result })
+      channel?.send({ type: 'tool-result', toolCallId: id, toolName, result })
+      continue
+    }
+
+    if (type === 'RUN_FINISHED') {
+      if (chunk.usage) {
+        stepResult.usage = {
+          inputTokens: chunk.usage.promptTokens ?? chunk.usage.inputTokens ?? 0,
+          outputTokens:
+            chunk.usage.completionTokens ?? chunk.usage.outputTokens ?? 0,
+        }
+      }
+      const fr = chunk.finishReason
+      stepResult.finishReason =
+        fr === 'tool_calls'
+          ? 'tool-calls'
+          : fr === 'stop'
+            ? 'stop'
+            : (fr ?? 'unknown')
+      usagePending = true
+      continue
+    }
+
+    if (type === 'RUN_ERROR') {
+      const msg: string =
+        chunk.message ?? chunk.error?.message ?? 'Unknown error'
+      // Throw rather than returning finishReason 'error' so core's stream
+      // handler marks the run failed and fires onError — matching the vercel
+      // runner, so the two are interchangeable on the error path too.
+      throw new Error(msg)
+    }
+
+    if (type === 'CUSTOM' && chunk.name === 'approval-requested') {
+      const id: string = chunk.value?.toolCallId
+      if (id && !completedFromLLMIds.has(id) && firstSeenToolCallIds.has(id)) {
+        completedFromLLMIds.add(id)
+        const toolName = toolNameMap.get(id) ?? ''
+        const argsStr = argsBuffer.get(id) ?? '{}'
+        let args: unknown = {}
+        try {
+          args = JSON.parse(argsStr)
+        } catch {}
+        stepResult.toolCalls.push({ toolCallId: id, toolName, args })
+        channel?.send({ type: 'tool-call', toolCallId: id, toolName, args })
+      }
+      stepResult.finishReason = 'tool-calls'
+      approvalBreak = true
+      break
+    }
+  }
+
+  if (usagePending && !approvalBreak && stepResult.finishReason !== 'error') {
+    channel?.send({
+      type: 'usage',
+      tokens: {
+        input: stepResult.usage.inputTokens,
+        output: stepResult.usage.outputTokens,
+      },
+      model: modelName,
+    })
+  }
+
+  return stepResult
+}
+
+export class TanstackAIAgentRunner implements AIAgentRunnerService {
+  async stream(
+    params: AIAgentRunnerParams,
+    channel: AIStreamChannel
+  ): Promise<AIAgentStepResult> {
+    return runStream(params, channel)
+  }
+
+  async run(params: AIAgentRunnerParams): Promise<AIAgentStepResult> {
+    return runStream(params, null)
+  }
+}

--- a/packages/services/ai-tanstack/tsconfig.json
+++ b/packages/services/ai-tanstack/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "module": "Node18",
+    "outDir": "dist",
+    "target": "esnext",
+    "declaration": true,
+    "composite": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.test.ts", "node_modules"],
+  "references": [
+    {
+      "path": "../../core/tsconfig.json"
+    }
+  ]
+}

--- a/packages/services/better-auth/src/auth-session-stateless.ts
+++ b/packages/services/better-auth/src/auth-session-stateless.ts
@@ -53,7 +53,8 @@ export const betterAuthStatelessSession = (
       let secret: string | undefined
       try {
         secret = await (services as any).secrets?.getSecret(secretId)
-      } catch {
+      } catch (e: any) {
+        if (e?.message !== 'Requested secret not found') throw e
         services.logger?.error(
           `betterAuthStatelessSession: secret '${secretId}' not found — session middleware skipped. Ensure ${secretId} is configured.`
         )

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,6 +43,54 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ag-ui/client@npm:^0.0.57":
+  version: 0.0.57
+  resolution: "@ag-ui/client@npm:0.0.57"
+  dependencies:
+    "@ag-ui/core": "npm:0.0.57"
+    "@ag-ui/encoder": "npm:0.0.57"
+    "@ag-ui/proto": "npm:0.0.57"
+    "@types/uuid": "npm:^10.0.0"
+    compare-versions: "npm:^6.1.1"
+    fast-json-patch: "npm:^3.1.1"
+    rxjs: "npm:7.8.1"
+    untruncate-json: "npm:^0.0.1"
+    uuid: "npm:^11.1.0"
+    zod: "npm:^3.22.4"
+  checksum: 10/7acd3a369aba3943f776a63d0c68d5f5be4c09b61feada0fd23e337c79651fb3ee6ef62a4912684235110a6dddd210668a10b6d838a6ebc34f7ca33e711a24d8
+  languageName: node
+  linkType: hard
+
+"@ag-ui/core@npm:0.0.57":
+  version: 0.0.57
+  resolution: "@ag-ui/core@npm:0.0.57"
+  dependencies:
+    zod: "npm:^3.22.4"
+  checksum: 10/5319de8abc1abc561942a2251824c97101652809a05d88c5f3bd20c64ab276ad3d9900f5699ab21e371b8692086605a761bfe79a6b70cfc4e667950f9704cf4e
+  languageName: node
+  linkType: hard
+
+"@ag-ui/encoder@npm:0.0.57":
+  version: 0.0.57
+  resolution: "@ag-ui/encoder@npm:0.0.57"
+  dependencies:
+    "@ag-ui/core": "npm:0.0.57"
+    "@ag-ui/proto": "npm:0.0.57"
+  checksum: 10/0764e488ca47794025b6022417bb6ede1fa23a874e74fdaeda43beeb78dbce4883bba31c047e63ed90be33afee744461b975a333b619760cb9fb4859061621d3
+  languageName: node
+  linkType: hard
+
+"@ag-ui/proto@npm:0.0.57":
+  version: 0.0.57
+  resolution: "@ag-ui/proto@npm:0.0.57"
+  dependencies:
+    "@ag-ui/core": "npm:0.0.57"
+    "@bufbuild/protobuf": "npm:^2.2.5"
+    "@protobuf-ts/protoc": "npm:^2.11.1"
+  checksum: 10/974fdcbd1d82578098e0fc7e5ff823725b82c5e9996510029c2a012ac6c861d096e7036c858522ebae8710151537875b5d344bac6c8d830e6170d06fe964b154
+  languageName: node
+  linkType: hard
+
 "@ai-sdk/anthropic@npm:^3.0.50":
   version: 3.0.50
   resolution: "@ai-sdk/anthropic@npm:3.0.50"
@@ -120,15 +168,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@assistant-ui/core@npm:^0.2.12":
-  version: 0.2.12
-  resolution: "@assistant-ui/core@npm:0.2.12"
+"@assistant-ui/core@npm:0.2.19":
+  version: 0.2.19
+  resolution: "@assistant-ui/core@npm:0.2.19"
   dependencies:
-    assistant-stream: "npm:^0.3.21"
-    nanoid: "npm:^5.1.11"
+    assistant-stream: "npm:^0.3.24"
+    nanoid: "npm:^5.1.15"
   peerDependencies:
     "@assistant-ui/store": ^0.2.13
-    "@assistant-ui/tap": ^0.6.1
+    "@assistant-ui/tap": ^0.9.0
     "@types/react": "*"
     assistant-cloud: ^0.1.31
     react: ^18 || ^19
@@ -142,29 +190,50 @@ __metadata:
       optional: true
     zustand:
       optional: true
-  checksum: 10/e1f228f7a43f814cdadf1da15c2f6a4c71e1d8f3607cc687889a125896aec97e8358ab9952332e44b7f95afb69e0695d0329fb1675f6de4763fd706c35ad0369
+  checksum: 10/d62a71d953b53b845797e59c285e663c249f6e8df8d6ff0c804a7856a9e5c82dbb3444d1e8ddb290ebfebe5a63056fab9b26e1acde8798fbdb3a1b9536d77a5a
   languageName: node
   linkType: hard
 
-"@assistant-ui/react@npm:^0.12.12 || ^0.14.0":
-  version: 0.14.16
-  resolution: "@assistant-ui/react@npm:0.14.16"
+"@assistant-ui/react-ag-ui@npm:^0.0.43":
+  version: 0.0.43
+  resolution: "@assistant-ui/react-ag-ui@npm:0.0.43"
   dependencies:
-    "@assistant-ui/core": "npm:^0.2.12"
-    "@assistant-ui/store": "npm:^0.2.14"
-    "@assistant-ui/tap": "npm:^0.6.1"
+    "@ag-ui/client": "npm:^0.0.57"
+    "@assistant-ui/core": "npm:^0.2.19"
+    "@assistant-ui/store": "npm:^0.2.19"
+    assistant-stream: "npm:^0.3.24"
+    fast-json-patch: "npm:^3.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^18 || ^19
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/e9f2c92967bdb1fd412b410a16efefdb673e6c0e38328f304e9124a3859f06d0c3bb4730b52070eed423ea30f2469ea2a77f374c0244ccb1459be5a1c2976ec5
+  languageName: node
+  linkType: hard
+
+"@assistant-ui/react@npm:^0.14.24":
+  version: 0.14.26
+  resolution: "@assistant-ui/react@npm:0.14.26"
+  dependencies:
+    "@assistant-ui/core": "npm:^0.2.20"
+    "@assistant-ui/store": "npm:^0.2.19"
+    "@assistant-ui/tap": "npm:^0.9.3"
     "@radix-ui/primitive": "npm:^1.1.4"
+    "@radix-ui/react-collection": "npm:^1.1.10"
     "@radix-ui/react-compose-refs": "npm:^1.1.3"
     "@radix-ui/react-context": "npm:^1.1.4"
-    "@radix-ui/react-primitive": "npm:^2.1.5"
+    "@radix-ui/react-primitive": "npm:^2.1.6"
     "@radix-ui/react-use-callback-ref": "npm:^1.1.2"
+    "@radix-ui/react-use-controllable-state": "npm:^1.2.3"
     "@radix-ui/react-use-escape-keydown": "npm:^1.1.2"
-    assistant-cloud: "npm:^0.1.32"
-    assistant-stream: "npm:^0.3.21"
-    nanoid: "npm:^5.1.11"
-    radix-ui: "npm:^1.5.0"
+    assistant-cloud: "npm:^0.1.34"
+    assistant-stream: "npm:^0.3.25"
+    nanoid: "npm:^5.1.15"
+    radix-ui: "npm:^1.6.0"
     react-textarea-autosize: "npm:^8.5.9"
-    safe-content-frame: "npm:^0.0.21"
+    safe-content-frame: "npm:^0.0.22"
     zod: "npm:^4.4.3"
     zustand: "npm:^5.0.14"
   peerDependencies:
@@ -177,36 +246,36 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/2781522c3d0a0737292f20ccb3afc09c86066c7cc21b22ade8c434bebb239d73d25ed3a3bec5763fa4e20abd55fa70e24c0c4c8fa85aa5dfd80fd280d5bf796f
+  checksum: 10/2f9bd9e2d9e5d5a068e329e2cf30502c537e0c7ce28ed3f795d3aa2c07879fe2845b96e3c251ac60c94b100c7f57e846581d3ffd3a69c99821a728b27a82ec9d
   languageName: node
   linkType: hard
 
-"@assistant-ui/store@npm:^0.2.14":
-  version: 0.2.14
-  resolution: "@assistant-ui/store@npm:0.2.14"
+"@assistant-ui/store@npm:^0.2.19":
+  version: 0.2.20
+  resolution: "@assistant-ui/store@npm:0.2.20"
   dependencies:
     use-effect-event: "npm:^2.0.3"
   peerDependencies:
-    "@assistant-ui/tap": ^0.6.0
+    "@assistant-ui/tap": ^0.5.16 || ^0.7.1 || ^0.8.1 || ^0.9.0
     "@types/react": "*"
     react: ^18 || ^19
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/dd4284693c17663961120e8b68f9ee594ba9216a35b7f76e69abafd680d1c4e1a65470155b53e542f1d561d3fc4421134e7ec99a78772596ddc379abc6e1698e
+  checksum: 10/097b1498167e8d8a1b2e776b7c990432f994d9cc6041c2be5895236213e846c48118acc6099072c91998ffa6327f2d771ec78e0a67f0c2fcfb7bd84525a8c0ee
   languageName: node
   linkType: hard
 
-"@assistant-ui/tap@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "@assistant-ui/tap@npm:0.6.1"
+"@assistant-ui/tap@npm:0.9.3":
+  version: 0.9.3
+  resolution: "@assistant-ui/tap@npm:0.9.3"
   peerDependencies:
     "@types/react": "*"
     react: ^18 || ^19
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0f4895e880c6375947b1cc24ec1c51635f65cdbe0ace1183e32a2ad53d90958ce1a754f3998ec670ecdc8e5e0e6b3516bd7f0b1db172d6b59f7c95450905db24
+  checksum: 10/043b979e2b4b93ddbfaf44502b37b883f2509d5689fc011352cc6736df11ccb3b3dd6d27b4beb837ce002e14405eebd323e25fd982ffecdd5d5bff17164c6fbb
   languageName: node
   linkType: hard
 
@@ -2520,6 +2589,13 @@ __metadata:
   version: 1.3.0
   resolution: "@better-fetch/fetch@npm:1.3.0"
   checksum: 10/c1190be172ec72218cc9a30ae70d2edcad7e2bf56857d91601d868f9472702684b6d6ec1f0b38d95ff0fbd7de6464965f03ace4d9ed83df56c7effd06cbb870f
+  languageName: node
+  linkType: hard
+
+"@bufbuild/protobuf@npm:^2.2.5":
+  version: 2.12.1
+  resolution: "@bufbuild/protobuf@npm:2.12.1"
+  checksum: 10/9a47dd781f58bfc464aebe17d6b02377eafef2a9cd40a2bdb07de1be07c284618cebe1df4e31061f91fdaf166ba9bb2d76da0082fd125a1d3c26cf35f0329928
   languageName: node
   linkType: hard
 
@@ -5692,7 +5768,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/assistant-ui@workspace:packages/assistant-ui"
   dependencies:
-    "@assistant-ui/react": "npm:^0.12.12 || ^0.14.0"
+    "@ag-ui/client": "npm:^0.0.57"
+    "@assistant-ui/react": "npm:^0.14.24"
+    "@assistant-ui/react-ag-ui": "npm:^0.0.43"
     "@types/react": "npm:^19"
     "@types/react-dom": "npm:^19"
     react: "npm:^19"
@@ -5940,6 +6018,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/core@workspace:packages/core"
   dependencies:
+    "@ag-ui/core": "npm:0.0.57"
     "@standard-schema/spec": "npm:^1.1.0"
     "@types/json-schema": "npm:^7.0.15"
     "@types/node": "npm:^24.11.0"
@@ -7406,6 +7485,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@protobuf-ts/protoc@npm:^2.11.1":
+  version: 2.11.1
+  resolution: "@protobuf-ts/protoc@npm:2.11.1"
+  bin:
+    protoc: protoc.js
+  checksum: 10/1a6ec0279ea76ae0b8bdeecc032e027bae233d2b1c643f0d9ea91045cd3c41d27b6f321b906bf49f2bae77ecdd346edaa45fbeb6bed6a85c9c07ec3e8778d9b7
+  languageName: node
+  linkType: hard
+
 "@puppeteer/browsers@npm:2.2.4":
   version: 2.2.4
   resolution: "@puppeteer/browsers@npm:2.2.4"
@@ -7431,18 +7519,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/primitive@npm:1.1.4, @radix-ui/primitive@npm:^1.1.4":
+"@radix-ui/primitive@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@radix-ui/primitive@npm:1.1.5"
+  checksum: 10/1a7ccfe484503c6333ac854c40a5b0c41eadcf22ca05916cf236d8ef90423a97bc477dceae1b1819691d01fdb98ccfd81b9d2ad70aaba2cf183f833c01a789e0
+  languageName: node
+  linkType: hard
+
+"@radix-ui/primitive@npm:^1.1.4":
   version: 1.1.4
   resolution: "@radix-ui/primitive@npm:1.1.4"
   checksum: 10/983f49f953b39eca8cc0fa26f429375bd153535371a222255814ee7b9d2ff89c6ab3c73399eb77c027944d76289e7bc4eec03121c1f782a93d27623de11ad135
   languageName: node
   linkType: hard
 
-"@radix-ui/react-accessible-icon@npm:1.1.9":
-  version: 1.1.9
-  resolution: "@radix-ui/react-accessible-icon@npm:1.1.9"
+"@radix-ui/react-accessible-icon@npm:1.1.11":
+  version: 1.1.11
+  resolution: "@radix-ui/react-accessible-icon@npm:1.1.11"
   dependencies:
-    "@radix-ui/react-visually-hidden": "npm:1.2.5"
+    "@radix-ui/react-visually-hidden": "npm:1.2.7"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -7453,22 +7548,22 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/098488e9bc13b1f83c24c9be46599611a88a443791aa183a06bb90f97d1fa94694ecafa2365602be1a033391a287c97eda0e23d593e8d159dfbe78857481730e
+  checksum: 10/eef947edf3fea332444c7752f2a4f3157069a4010d941da11e9eb15a16ddb82f8fc7855105b6a44609f21865e4843e85d27cc26c16a84eb81b3bc30f12985bfb
   languageName: node
   linkType: hard
 
-"@radix-ui/react-accordion@npm:1.2.13":
-  version: 1.2.13
-  resolution: "@radix-ui/react-accordion@npm:1.2.13"
+"@radix-ui/react-accordion@npm:1.2.16":
+  version: 1.2.16
+  resolution: "@radix-ui/react-accordion@npm:1.2.16"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-collapsible": "npm:1.1.13"
-    "@radix-ui/react-collection": "npm:1.1.9"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-collapsible": "npm:1.1.16"
+    "@radix-ui/react-collection": "npm:1.1.12"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-direction": "npm:1.1.2"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
   peerDependencies:
     "@types/react": "*"
@@ -7480,20 +7575,19 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/2c25d4c2736867ad4d5d6f6577a6fe834c9cee4a0ae72688dfa7570e76231e68a09390083ff014cece8c0093cc6398afcfd3f7554e5a2ffc42d2bc93aecf0a98
+  checksum: 10/d273dd089f9250acd83f60bf5f52a535e47f7ecba28b70a8faaeafe02aac7a59c293348715d3f7e3af0a5436e0d55d4a29ad481233083577546392cd135713b4
   languageName: node
   linkType: hard
 
-"@radix-ui/react-alert-dialog@npm:1.1.16":
-  version: 1.1.16
-  resolution: "@radix-ui/react-alert-dialog@npm:1.1.16"
+"@radix-ui/react-alert-dialog@npm:1.1.19":
+  version: 1.1.19
+  resolution: "@radix-ui/react-alert-dialog@npm:1.1.19"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-dialog": "npm:1.1.16"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-slot": "npm:1.2.5"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-dialog": "npm:1.1.19"
+    "@radix-ui/react-primitive": "npm:2.1.7"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -7504,15 +7598,15 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/cce09c84f75eb2c7d90489aad82670a9c9b3af076eeb30cdfdd82f764d97beb1d46a9dcd427bf0e194e9b61254f84d299d37c9d4517c6eb95737dfaf31f54aa9
+  checksum: 10/90c2a98bf1ad5e99406836649410b5c2419c85b2cb2adc29abb7f93ef6f8aee3de9650a4358dada34115f91323031a91729a26e97d1719f3e58a0b26e80c661a
   languageName: node
   linkType: hard
 
-"@radix-ui/react-arrow@npm:1.1.9":
-  version: 1.1.9
-  resolution: "@radix-ui/react-arrow@npm:1.1.9"
+"@radix-ui/react-arrow@npm:1.1.11":
+  version: 1.1.11
+  resolution: "@radix-ui/react-arrow@npm:1.1.11"
   dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.7"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -7523,15 +7617,15 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/4c12f2ba02e4853e80196085b2eb35b5cc9a022d9c54d49be330b722c67a10bd697885a89e46e9bb473986280a70f2118f374294a3a3ee292860e91099005574
+  checksum: 10/0233661e711d58064a8503645d2e505abf01c4c1857f6820861396c775f41d4378829d74dbac7c627b99cb55b76d060cf7049aa7ada2f230d508035644c78875
   languageName: node
   linkType: hard
 
-"@radix-ui/react-aspect-ratio@npm:1.1.9":
-  version: 1.1.9
-  resolution: "@radix-ui/react-aspect-ratio@npm:1.1.9"
+"@radix-ui/react-aspect-ratio@npm:1.1.11":
+  version: 1.1.11
+  resolution: "@radix-ui/react-aspect-ratio@npm:1.1.11"
   dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.7"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -7542,16 +7636,16 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/f2db00b68e302bb436a8b67f7bf390367ee24030c42f055fd551d392f7b2ebd7d73d5f9c44efdbde33f1174888cd30ab8da1addf36570fd8e877343f2e660792
+  checksum: 10/271c6038284a9b7369a208f55eb9d9b3c328e0a47bf5a5e7a006a925d83ca38875e27b6efd14d1eab716397317e52518a051060cc4dc311ae7cb6757a04fb0d4
   languageName: node
   linkType: hard
 
-"@radix-ui/react-avatar@npm:1.1.12":
-  version: 1.1.12
-  resolution: "@radix-ui/react-avatar@npm:1.1.12"
+"@radix-ui/react-avatar@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@radix-ui/react-avatar@npm:1.2.2"
   dependencies:
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-callback-ref": "npm:1.1.2"
     "@radix-ui/react-use-is-hydrated": "npm:0.1.1"
     "@radix-ui/react-use-layout-effect": "npm:1.1.2"
@@ -7565,19 +7659,19 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/de206f7d569bab1287cfaf0f984fe04facc967b1304d9520083696e68b597a02759d694336c99c62bfd87baf7b1f426b91d29db21fe306d6d1b0795ba107b878
+  checksum: 10/07e18e6bf8483f6c2c02f4b4d6c8f9982181a5f05d939474cc02f1af5cd8c38240200182fd7fa61a8244fdafeff76a4ee769373e8ee428c00aeee743e074c1f9
   languageName: node
   linkType: hard
 
-"@radix-ui/react-checkbox@npm:1.3.4":
-  version: 1.3.4
-  resolution: "@radix-ui/react-checkbox@npm:1.3.4"
+"@radix-ui/react-checkbox@npm:1.3.7":
+  version: 1.3.7
+  resolution: "@radix-ui/react-checkbox@npm:1.3.7"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
     "@radix-ui/react-use-previous": "npm:1.1.2"
     "@radix-ui/react-use-size": "npm:1.1.2"
@@ -7591,20 +7685,20 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/7e162c8005d99b31118c8f215f2705e1a07d5ab66510f2d1a74d40d7ab5922b1e381317f46d5a63c5ca2d1765e08de3a3401db8310da6390e33c63e9948f8240
+  checksum: 10/2d5025528620bca9c9d8a0abe1819a52c318b0d9b056f83af5c25b196f424e0d5c28b7a10c75a5cdd8eb187193b226f751c145422bb2bd91543040f9a144dfb6
   languageName: node
   linkType: hard
 
-"@radix-ui/react-collapsible@npm:1.1.13":
-  version: 1.1.13
-  resolution: "@radix-ui/react-collapsible@npm:1.1.13"
+"@radix-ui/react-collapsible@npm:1.1.16":
+  version: 1.1.16
+  resolution: "@radix-ui/react-collapsible@npm:1.1.16"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
     "@radix-ui/react-use-layout-effect": "npm:1.1.2"
   peerDependencies:
@@ -7617,18 +7711,18 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/7cb7a04b6f842997b8538fda20b5f340aaae519b1597f65ab3ad3633b32281b9ab557eab798612cde4b5b604247cd1f986eaa2e8ba9b2df89ec386e4abd30276
+  checksum: 10/b4816954b6933af89bf232a0e7db67188214c91093ab8145da450b155c35ba78481d633b4a984d7ea99c2ee3906e7aa626290120528e7d4223166fe06bad450b
   languageName: node
   linkType: hard
 
-"@radix-ui/react-collection@npm:1.1.9":
-  version: 1.1.9
-  resolution: "@radix-ui/react-collection@npm:1.1.9"
+"@radix-ui/react-collection@npm:1.1.12, @radix-ui/react-collection@npm:^1.1.10":
+  version: 1.1.12
+  resolution: "@radix-ui/react-collection@npm:1.1.12"
   dependencies:
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-slot": "npm:1.2.5"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-primitive": "npm:2.1.7"
+    "@radix-ui/react-slot": "npm:1.3.0"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -7639,7 +7733,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/c65427f70046a6f0a4520caede31298dfb1f243032849471cb10befa3a3a1cd75d040e564af8ec2f6bd97fe61532326ea49ce1e7210056baa99ccb54f4171498
+  checksum: 10/26edf47c270784e81bbf2d674823d0cff6212a34084d87ecb9857cbf9aa3412112ab995e7df8ee0bc6d34b0c3080618d97929c3a452b666ad53a3ff4db18580b
   languageName: node
   linkType: hard
 
@@ -7656,14 +7750,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-context-menu@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@radix-ui/react-context-menu@npm:2.3.0"
+"@radix-ui/react-context-menu@npm:2.3.3":
+  version: 2.3.3
+  resolution: "@radix-ui/react-context-menu@npm:2.3.3"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-menu": "npm:2.1.17"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-menu": "npm:2.1.20"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
   peerDependencies:
     "@types/react": "*"
@@ -7675,11 +7769,24 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/a55ab55d8485ebe1d19bbf80fcbde22c5d04d71b8b3d31f82a28d92f6167a91d1883f4cdb69242035bca239a072239b9e4df80ca5be84b372ff5a7e9682b475e
+  checksum: 10/f24d173f34e38dbc2d72c8ec7353f7418d5ffd522cf54d11bc73b7372f2ac21ee583d8703e4eb04c84b8ace7bed774b3a729e9e367c6e7b53f5fbc8003b56515
   languageName: node
   linkType: hard
 
-"@radix-ui/react-context@npm:1.1.4, @radix-ui/react-context@npm:^1.1.4":
+"@radix-ui/react-context@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@radix-ui/react-context@npm:1.2.0"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/5e845a68235b649cc5aca7538a89086f8c4cfe67cf00090eb4d84f54c7a4de46c6c81b6c6bb59fe3d8091583b2d7ed594414da575ae8a3b58617017e6ad88404
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-context@npm:^1.1.4":
   version: 1.1.4
   resolution: "@radix-ui/react-context@npm:1.1.4"
   peerDependencies:
@@ -7692,21 +7799,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-dialog@npm:1.1.16":
-  version: 1.1.16
-  resolution: "@radix-ui/react-dialog@npm:1.1.16"
+"@radix-ui/react-dialog@npm:1.1.19":
+  version: 1.1.19
+  resolution: "@radix-ui/react-dialog@npm:1.1.19"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.12"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.15"
     "@radix-ui/react-focus-guards": "npm:1.1.4"
-    "@radix-ui/react-focus-scope": "npm:1.1.9"
+    "@radix-ui/react-focus-scope": "npm:1.1.12"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-portal": "npm:1.1.11"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-slot": "npm:1.2.5"
+    "@radix-ui/react-portal": "npm:1.1.13"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
+    "@radix-ui/react-slot": "npm:1.3.0"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
     aria-hidden: "npm:^1.2.4"
     react-remove-scroll: "npm:^2.7.2"
@@ -7720,7 +7827,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/b6454088b8626d2c3e7b77f7fc4ccdbb9bd028cb8ef3ec528e63baa767421ce56e9ddc77a9e2109d8a0973c64473e80bf5f040ddbaa38bfa19f03f73290634af
+  checksum: 10/9ca78469798dc7ee0b740205cdcbeb00a3995436c6d48df5d0fdbd86219b092f39eda8439977cfa290bc7f55ac3a194c8e6996f45d3cf755dc705c11e92523c2
   languageName: node
   linkType: hard
 
@@ -7737,15 +7844,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-dismissable-layer@npm:1.1.12":
-  version: 1.1.12
-  resolution: "@radix-ui/react-dismissable-layer@npm:1.1.12"
+"@radix-ui/react-dismissable-layer@npm:1.1.15":
+  version: 1.1.15
+  resolution: "@radix-ui/react-dismissable-layer@npm:1.1.15"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-callback-ref": "npm:1.1.2"
-    "@radix-ui/react-use-escape-keydown": "npm:1.1.2"
+    "@radix-ui/react-use-effect-event": "npm:0.0.3"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -7756,20 +7863,20 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/cf75d9adde67cfc9e45324ed50736caf3028128383a301302daf28b0983257ea1690333a8940810f37e85236c2fb802010de6176186a109924b8ce1bea4bcb3d
+  checksum: 10/1c621f9fb813b2783498908c4946e844671cefc34e4c05876c5180db5f3924f3242e0e443a39da5ae6630df07269d3e0b76a4dc073bf6245c3ea25529323b621
   languageName: node
   linkType: hard
 
-"@radix-ui/react-dropdown-menu@npm:2.1.17":
-  version: 2.1.17
-  resolution: "@radix-ui/react-dropdown-menu@npm:2.1.17"
+"@radix-ui/react-dropdown-menu@npm:2.1.20":
+  version: 2.1.20
+  resolution: "@radix-ui/react-dropdown-menu@npm:2.1.20"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-menu": "npm:2.1.17"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-menu": "npm:2.1.20"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
   peerDependencies:
     "@types/react": "*"
@@ -7781,7 +7888,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/5967dd14870165d6782f272d3d02e1f85e1fa070a9dab87adc8156ac2e054ea8a92056408066906d28091bceff0dfde8adeca2dccf4fe4381e243da7e9e1a111
+  checksum: 10/f0850b55601035a16cc714b3126ab5b4ea34483fb4f12650602731f1936e3f328fc273a5d7e7cea18ad70f9db11e8abe90b1fb5a3e9e78e7cd31d7429b5874f2
   languageName: node
   linkType: hard
 
@@ -7798,12 +7905,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-focus-scope@npm:1.1.9":
-  version: 1.1.9
-  resolution: "@radix-ui/react-focus-scope@npm:1.1.9"
+"@radix-ui/react-focus-scope@npm:1.1.12":
+  version: 1.1.12
+  resolution: "@radix-ui/react-focus-scope@npm:1.1.12"
   dependencies:
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-callback-ref": "npm:1.1.2"
   peerDependencies:
     "@types/react": "*"
@@ -7815,20 +7922,20 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/dac890f16543a6881175e25660821b040b70977ad8b3878e91085382c59e061efbdbf48ae7d27e372673719966990d66b1e3ef13510902093dca7e58d301d6bc
+  checksum: 10/db544d3e5cdf6b4b2f616041f95b5898793b8ab8de22eb8e2f22b53f5554789f831e1ddf4d2276fe4a18e2e113d0c0d1ae6cc5d8b224746a321570fc4c804c48
   languageName: node
   linkType: hard
 
-"@radix-ui/react-form@npm:0.1.9":
-  version: 0.1.9
-  resolution: "@radix-ui/react-form@npm:0.1.9"
+"@radix-ui/react-form@npm:0.1.12":
+  version: 0.1.12
+  resolution: "@radix-ui/react-form@npm:0.1.12"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-label": "npm:2.1.9"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-label": "npm:2.1.11"
+    "@radix-ui/react-primitive": "npm:2.1.7"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -7839,22 +7946,22 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/88c80385c525747e8eddbcc6e66d18e5d21e489e2351d1d46c3c7c92557b106ce6da3af7ae030a68342a258ec16940c8edf9b8fd646d6265af77f0d33b0a969e
+  checksum: 10/4c24c247274985e328af9045e1cd1ec47ad84920303dfb7e5af25f82b0515b9c00767b44ff370e8d2c67cabb781cb0a2c80904a1b3867ddda22c3ff154a95e75
   languageName: node
   linkType: hard
 
-"@radix-ui/react-hover-card@npm:1.1.16":
-  version: 1.1.16
-  resolution: "@radix-ui/react-hover-card@npm:1.1.16"
+"@radix-ui/react-hover-card@npm:1.1.19":
+  version: 1.1.19
+  resolution: "@radix-ui/react-hover-card@npm:1.1.19"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.12"
-    "@radix-ui/react-popper": "npm:1.3.0"
-    "@radix-ui/react-portal": "npm:1.1.11"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.15"
+    "@radix-ui/react-popper": "npm:1.3.3"
+    "@radix-ui/react-portal": "npm:1.1.13"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
   peerDependencies:
     "@types/react": "*"
@@ -7866,7 +7973,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/98220cf995c2f4d59c9e594546fba025bb8790b8a33a5cb86fd7a9098e1bd4e9bd0c21255bb8442cd4419870667241f25b181cf2ce0cae0f329e491e2faa3ad8
+  checksum: 10/365eff57dfdf1068ce2dc8a9da55e803420adcfac246b81cf1c7c80fa6ca39be6d5768d8c233e90e34cc6756533ce66aaff705d882b5f40a40fd0abcba5ff033
   languageName: node
   linkType: hard
 
@@ -7885,11 +7992,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-label@npm:2.1.9":
-  version: 2.1.9
-  resolution: "@radix-ui/react-label@npm:2.1.9"
+"@radix-ui/react-label@npm:2.1.11":
+  version: 2.1.11
+  resolution: "@radix-ui/react-label@npm:2.1.11"
   dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.7"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -7900,29 +8007,29 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/518d063c4cb5b82502bf977b3363a8e624ffd1f56898ffc8b15382856010adef2f963afc058a520e5f6185316b2a0dfd37811ba10cb605d9e1f17d32dfdea38b
+  checksum: 10/e905c146ff006ab0a083c8d6c68f69174892a0644acad7f062052d48655034d0aea0adbe2ac6cba8d5ec6770fbea058267e608afea181881637bdfe64f7bd663
   languageName: node
   linkType: hard
 
-"@radix-ui/react-menu@npm:2.1.17":
-  version: 2.1.17
-  resolution: "@radix-ui/react-menu@npm:2.1.17"
+"@radix-ui/react-menu@npm:2.1.20":
+  version: 2.1.20
+  resolution: "@radix-ui/react-menu@npm:2.1.20"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-collection": "npm:1.1.9"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-collection": "npm:1.1.12"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-direction": "npm:1.1.2"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.12"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.15"
     "@radix-ui/react-focus-guards": "npm:1.1.4"
-    "@radix-ui/react-focus-scope": "npm:1.1.9"
+    "@radix-ui/react-focus-scope": "npm:1.1.12"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-popper": "npm:1.3.0"
-    "@radix-ui/react-portal": "npm:1.1.11"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-roving-focus": "npm:1.1.12"
-    "@radix-ui/react-slot": "npm:1.2.5"
+    "@radix-ui/react-popper": "npm:1.3.3"
+    "@radix-ui/react-portal": "npm:1.1.13"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
+    "@radix-ui/react-roving-focus": "npm:1.1.15"
+    "@radix-ui/react-slot": "npm:1.3.0"
     "@radix-ui/react-use-callback-ref": "npm:1.1.2"
     aria-hidden: "npm:^1.2.4"
     react-remove-scroll: "npm:^2.7.2"
@@ -7936,23 +8043,23 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/6989847a27c52c99328369a95d3acd8643b524095672e2a21c062e86c2c45e77cd8a4fb5e11baeea05e9e51f7242b1afc955dc3382ef11f5d2dbe7656b4aaa17
+  checksum: 10/4c57ea5d2754fb618df8fff622221b9e5732ccf00e51ec48f2c3b8e8193b28a92bdd962dc3c2eb18bcdb0f06e9d705364cedb25170ef0cd520c4655c44607434
   languageName: node
   linkType: hard
 
-"@radix-ui/react-menubar@npm:1.1.17":
-  version: 1.1.17
-  resolution: "@radix-ui/react-menubar@npm:1.1.17"
+"@radix-ui/react-menubar@npm:1.1.20":
+  version: 1.1.20
+  resolution: "@radix-ui/react-menubar@npm:1.1.20"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-collection": "npm:1.1.9"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-collection": "npm:1.1.12"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-direction": "npm:1.1.2"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-menu": "npm:2.1.17"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-roving-focus": "npm:1.1.12"
+    "@radix-ui/react-menu": "npm:2.1.20"
+    "@radix-ui/react-primitive": "npm:2.1.7"
+    "@radix-ui/react-roving-focus": "npm:1.1.15"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
   peerDependencies:
     "@types/react": "*"
@@ -7964,28 +8071,28 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/dd9c9fbd14352395fd640c677c06390d2a306968a6e95ea397e170556de5e49c722814ad12ca3e35fde9d4f5293adb8faa5784067ebb8b12a2d314b81fd97205
+  checksum: 10/99ca89e789cfc657b4eb064c088b3e2bf06c07aa09242736a0f046f1261463b2a3138b718d76a589a071a77f4b9fbfc2369fecbfc0bab853a93a65eec4b11603
   languageName: node
   linkType: hard
 
-"@radix-ui/react-navigation-menu@npm:1.2.15":
-  version: 1.2.15
-  resolution: "@radix-ui/react-navigation-menu@npm:1.2.15"
+"@radix-ui/react-navigation-menu@npm:1.2.18":
+  version: 1.2.18
+  resolution: "@radix-ui/react-navigation-menu@npm:1.2.18"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-collection": "npm:1.1.9"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-collection": "npm:1.1.12"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-direction": "npm:1.1.2"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.12"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.15"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-callback-ref": "npm:1.1.2"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
     "@radix-ui/react-use-layout-effect": "npm:1.1.2"
     "@radix-ui/react-use-previous": "npm:1.1.2"
-    "@radix-ui/react-visually-hidden": "npm:1.2.5"
+    "@radix-ui/react-visually-hidden": "npm:1.2.7"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -7996,22 +8103,22 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/0c8c6b50ceb3639ceab5345885b306d46d603957d14b5933da9dfe3c0733de3f9e32a38f3782d7bf9814450f8a878fc221f7baafeea36d7b41e3a3a1cd825a29
+  checksum: 10/0519bbdd1d432d91c0cdbc8b0c6600b2ba0d616ef6cc66341cc87364b40b214578ee6db11ee0fd736a9c649da706f91571bde9d3559071b3a88b5ab2430cf7b9
   languageName: node
   linkType: hard
 
-"@radix-ui/react-one-time-password-field@npm:0.1.9":
-  version: 0.1.9
-  resolution: "@radix-ui/react-one-time-password-field@npm:0.1.9"
+"@radix-ui/react-one-time-password-field@npm:0.1.12":
+  version: 0.1.12
+  resolution: "@radix-ui/react-one-time-password-field@npm:0.1.12"
   dependencies:
     "@radix-ui/number": "npm:1.1.2"
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-collection": "npm:1.1.9"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-collection": "npm:1.1.12"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-direction": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-roving-focus": "npm:1.1.12"
+    "@radix-ui/react-primitive": "npm:2.1.7"
+    "@radix-ui/react-roving-focus": "npm:1.1.15"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
     "@radix-ui/react-use-effect-event": "npm:0.0.3"
     "@radix-ui/react-use-is-hydrated": "npm:0.1.1"
@@ -8026,19 +8133,19 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/0732be964510160e43fa0bb5b96209f461dba83048df16c6969cf723ceaaecbe07d71a96285d75e47abfabd67484de02b18664ce4d80088fb2346d7876c55c4c
+  checksum: 10/7f65874b93ff5c973b9595ffdf5ce429deeb4b5dcc5850a69aff0ff1eb5c02124a2ac551d3a5ceb469127c8dba8a246268c63de6ebbd4417527e868eff502ea8
   languageName: node
   linkType: hard
 
-"@radix-ui/react-password-toggle-field@npm:0.1.4":
-  version: 0.1.4
-  resolution: "@radix-ui/react-password-toggle-field@npm:0.1.4"
+"@radix-ui/react-password-toggle-field@npm:0.1.7":
+  version: 0.1.7
+  resolution: "@radix-ui/react-password-toggle-field@npm:0.1.7"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
     "@radix-ui/react-use-effect-event": "npm:0.0.3"
     "@radix-ui/react-use-is-hydrated": "npm:0.1.1"
@@ -8052,26 +8159,26 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/076f670a01fef025c28afc690ca6e9ca4696fe9df90d5ffe2ccb879ff001e91b3d84ae7077388d884e3aef4185298e8015a8c3ed4b40e22a3e527e08e9ae0696
+  checksum: 10/394a28c0a24e2b7acac4ace2dfb5386323080698a596b64031db839b82d4b996e7eb2e09dc7c81c950ff1f7e21a1afb4323fe9ae9a6989ca44634ee4097c4023
   languageName: node
   linkType: hard
 
-"@radix-ui/react-popover@npm:1.1.16":
-  version: 1.1.16
-  resolution: "@radix-ui/react-popover@npm:1.1.16"
+"@radix-ui/react-popover@npm:1.1.19":
+  version: 1.1.19
+  resolution: "@radix-ui/react-popover@npm:1.1.19"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.12"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.15"
     "@radix-ui/react-focus-guards": "npm:1.1.4"
-    "@radix-ui/react-focus-scope": "npm:1.1.9"
+    "@radix-ui/react-focus-scope": "npm:1.1.12"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-popper": "npm:1.3.0"
-    "@radix-ui/react-portal": "npm:1.1.11"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-slot": "npm:1.2.5"
+    "@radix-ui/react-popper": "npm:1.3.3"
+    "@radix-ui/react-portal": "npm:1.1.13"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
+    "@radix-ui/react-slot": "npm:1.3.0"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
     aria-hidden: "npm:^1.2.4"
     react-remove-scroll: "npm:^2.7.2"
@@ -8085,19 +8192,19 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/8fac31c227299a5e5447b4028d888b0d2872850407161a02c0c86dbab198f2edbdc3cceb0b2aa447d79b29202a563cc80dd698890792185e9a4da320667ed3f7
+  checksum: 10/58bd98916305a01b13222c4a040597f106dcf767a5fbf31ca636c3c743c8bac746d328fd9373a8760c9fb73a653743ceb6d491ce4785b9809aeb21600ef51ab5
   languageName: node
   linkType: hard
 
-"@radix-ui/react-popper@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@radix-ui/react-popper@npm:1.3.0"
+"@radix-ui/react-popper@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@radix-ui/react-popper@npm:1.3.3"
   dependencies:
     "@floating-ui/react-dom": "npm:^2.0.0"
-    "@radix-ui/react-arrow": "npm:1.1.9"
+    "@radix-ui/react-arrow": "npm:1.1.11"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-callback-ref": "npm:1.1.2"
     "@radix-ui/react-use-layout-effect": "npm:1.1.2"
     "@radix-ui/react-use-rect": "npm:1.1.2"
@@ -8113,15 +8220,15 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/a22aae921e2c586c42a3a0dd01dcd1be8ae70a8bff0e2700790c6e388e807cec04ca4b76b43615ae3236c186c068b0e6e01c454cbb1488f0eed9be71ab76fb62
+  checksum: 10/a40c8c77e789333e3137d39986ac37d92d44b9f8b1b765bf941081ef3f79acf42f20d579e37970bb6df099b66816133fefe1f9aae819aee11e2dd8fcebe17e1e
   languageName: node
   linkType: hard
 
-"@radix-ui/react-portal@npm:1.1.11":
-  version: 1.1.11
-  resolution: "@radix-ui/react-portal@npm:1.1.11"
+"@radix-ui/react-portal@npm:1.1.13":
+  version: 1.1.13
+  resolution: "@radix-ui/react-portal@npm:1.1.13"
   dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-layout-effect": "npm:1.1.2"
   peerDependencies:
     "@types/react": "*"
@@ -8133,13 +8240,13 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/e26eec8e326504164dc52a40acdc291ed58ffab6db1827d67a89cceb4de2b5d64a93f8f3af3848f71ff555f1bda46290a491f616496a3ef75f0bd58653a873b0
+  checksum: 10/b896dd705a93c869e27280af25bade70068bf27e504ed27ee93b669a4250169f8628626010dd82502e51da148e19511cf921b42d8ebfb61e61edd0d61794afa6
   languageName: node
   linkType: hard
 
-"@radix-ui/react-presence@npm:1.1.6":
-  version: 1.1.6
-  resolution: "@radix-ui/react-presence@npm:1.1.6"
+"@radix-ui/react-presence@npm:1.1.7":
+  version: 1.1.7
+  resolution: "@radix-ui/react-presence@npm:1.1.7"
   dependencies:
     "@radix-ui/react-use-layout-effect": "npm:1.1.2"
   peerDependencies:
@@ -8152,15 +8259,15 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/3ce1a1ee37406a7a58717908085b8bc2b8d4f9b725fa1bcc62cefd8032fc6929777a93899ed9a12527bf2f62dbcbf99ae7cd98cc0c99f78859dccfd0cc003ca0
+  checksum: 10/a300a1762d156f9b4b5bd8c2173e8dd6fabee26e867cbe09f7b8cb045a7427a9ffb776d874900cf04c9ff35470dc0a0f5bd0fc6cb5f9a81f8653728d18d6875a
   languageName: node
   linkType: hard
 
-"@radix-ui/react-primitive@npm:2.1.5, @radix-ui/react-primitive@npm:^2.1.5":
-  version: 2.1.5
-  resolution: "@radix-ui/react-primitive@npm:2.1.5"
+"@radix-ui/react-primitive@npm:2.1.7, @radix-ui/react-primitive@npm:^2.1.6":
+  version: 2.1.7
+  resolution: "@radix-ui/react-primitive@npm:2.1.7"
   dependencies:
-    "@radix-ui/react-slot": "npm:1.2.5"
+    "@radix-ui/react-slot": "npm:1.3.0"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -8171,16 +8278,16 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/65e3f08f7ecc64508f598944f035ed0c0f1d10842d333370bd7fcd512085526b89217508ee1c396519ab0c31960a53298c07b4d43ec157154481fb1a12a7326b
+  checksum: 10/67b692cdd3cd1fe7f97f84fd3f77376b2edcd9e30b2f07168fd67e723f08a8b6fb5da670c12e039ade3877e08888fcb57b664ea42f9832c26790d961efcbeb30
   languageName: node
   linkType: hard
 
-"@radix-ui/react-progress@npm:1.1.9":
-  version: 1.1.9
-  resolution: "@radix-ui/react-progress@npm:1.1.9"
+"@radix-ui/react-progress@npm:1.1.12":
+  version: 1.1.12
+  resolution: "@radix-ui/react-progress@npm:1.1.12"
   dependencies:
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-primitive": "npm:2.1.7"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -8191,21 +8298,21 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/1e7220a041f2a2fcb4c2f9b31fd999729ba4e9739b88989f3ec1cdd8ffcc7a53ee4f9751150af482a350f538296f7ee3d9db45c6b3c9531954b39aac61e9522b
+  checksum: 10/c0b0f9122a4b23da497d2a61bd4afff5420f25de25325185aa3d6febf3419549d5245d4762de4f33ed0c446d9086f876288956edb10fbf3de30729975abba10d
   languageName: node
   linkType: hard
 
-"@radix-ui/react-radio-group@npm:1.4.0":
-  version: 1.4.0
-  resolution: "@radix-ui/react-radio-group@npm:1.4.0"
+"@radix-ui/react-radio-group@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@radix-ui/react-radio-group@npm:1.4.3"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-direction": "npm:1.1.2"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-roving-focus": "npm:1.1.12"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
+    "@radix-ui/react-roving-focus": "npm:1.1.15"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
     "@radix-ui/react-use-previous": "npm:1.1.2"
     "@radix-ui/react-use-size": "npm:1.1.2"
@@ -8219,23 +8326,25 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/a228df23837090abcd5c9c89d7a80e9dfef0a683e056db698472bb9e6bbbfe9b7045576288f72282f3bd9eccaa75d5b35a3db6de764c0b1a082a43166490fcc5
+  checksum: 10/d604224dd75b3dcc9b61e6883973bf056cb92cbf07478026e5bbe4f68d7bb8bca64d09adebfdaa24dad04e472e875a7b1cd37069ed5379546802455e07068730
   languageName: node
   linkType: hard
 
-"@radix-ui/react-roving-focus@npm:1.1.12":
-  version: 1.1.12
-  resolution: "@radix-ui/react-roving-focus@npm:1.1.12"
+"@radix-ui/react-roving-focus@npm:1.1.15":
+  version: 1.1.15
+  resolution: "@radix-ui/react-roving-focus@npm:1.1.15"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-collection": "npm:1.1.9"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-collection": "npm:1.1.12"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-direction": "npm:1.1.2"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-callback-ref": "npm:1.1.2"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
+    "@radix-ui/react-use-is-hydrated": "npm:0.1.1"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.2"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -8246,21 +8355,21 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/95eef90ab414b422cf7f07901777d83322ec2db5421a5741c00f2ee13bfcabc7845f881e5bd073bb4dd122af7dff99825227fa3cfee58243e36336be7f39e450
+  checksum: 10/3e05860c4b3874f479438e117a8a6d862b38126787a700941f2e4da2d43b28bb4986d16a462f50cd811af0039a67b2a94a35edc2b7e9edb9f5f1f54f19849180
   languageName: node
   linkType: hard
 
-"@radix-ui/react-scroll-area@npm:1.2.11":
-  version: 1.2.11
-  resolution: "@radix-ui/react-scroll-area@npm:1.2.11"
+"@radix-ui/react-scroll-area@npm:1.2.14":
+  version: 1.2.14
+  resolution: "@radix-ui/react-scroll-area@npm:1.2.14"
   dependencies:
     "@radix-ui/number": "npm:1.1.2"
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-direction": "npm:1.1.2"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-callback-ref": "npm:1.1.2"
     "@radix-ui/react-use-layout-effect": "npm:1.1.2"
   peerDependencies:
@@ -8273,34 +8382,34 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/bf6c768d0bb97696d15a186b9e8ed2f3607fcdcfab738872eacd73bc7b038efe8dc4bc13209ed514acb72b065e0dad502ff80eb4da22f229804c01799215cc55
+  checksum: 10/78bc09f6b9c4aa5b8f007da29c27303df2c8aa4a4ee623a8c1d5a928201124d6fe79dc48deec28bc6687ca8966ee580499591b6623e1fbd55c59ca860cf8586f
   languageName: node
   linkType: hard
 
-"@radix-ui/react-select@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@radix-ui/react-select@npm:2.3.0"
+"@radix-ui/react-select@npm:2.3.3":
+  version: 2.3.3
+  resolution: "@radix-ui/react-select@npm:2.3.3"
   dependencies:
     "@radix-ui/number": "npm:1.1.2"
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-collection": "npm:1.1.9"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-collection": "npm:1.1.12"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-direction": "npm:1.1.2"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.12"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.15"
     "@radix-ui/react-focus-guards": "npm:1.1.4"
-    "@radix-ui/react-focus-scope": "npm:1.1.9"
+    "@radix-ui/react-focus-scope": "npm:1.1.12"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-popper": "npm:1.3.0"
-    "@radix-ui/react-portal": "npm:1.1.11"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-slot": "npm:1.2.5"
+    "@radix-ui/react-popper": "npm:1.3.3"
+    "@radix-ui/react-portal": "npm:1.1.13"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
+    "@radix-ui/react-slot": "npm:1.3.0"
     "@radix-ui/react-use-callback-ref": "npm:1.1.2"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
     "@radix-ui/react-use-layout-effect": "npm:1.1.2"
     "@radix-ui/react-use-previous": "npm:1.1.2"
-    "@radix-ui/react-visually-hidden": "npm:1.2.5"
+    "@radix-ui/react-visually-hidden": "npm:1.2.7"
     aria-hidden: "npm:^1.2.4"
     react-remove-scroll: "npm:^2.7.2"
   peerDependencies:
@@ -8313,15 +8422,15 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/88e5c0f587bbb2c2162269ad6481b5dd34f550bce1064955858821ef924653ab7e52f1ff390a45dabffd473b86cf577cc4472d6980c45dcdc89b2c501e29584e
+  checksum: 10/c9bba914208202e30948c66082ec06c881b3a88a8527361eb3934ef587508e4687345934dd3a49e9bba55ed025077d9f9a225d4f17d194c0783311f825e6e083
   languageName: node
   linkType: hard
 
-"@radix-ui/react-separator@npm:1.1.9":
-  version: 1.1.9
-  resolution: "@radix-ui/react-separator@npm:1.1.9"
+"@radix-ui/react-separator@npm:1.1.11":
+  version: 1.1.11
+  resolution: "@radix-ui/react-separator@npm:1.1.11"
   dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.7"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -8332,21 +8441,21 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/18b7c58cda7e1ace8e9a33bdaebb188e6c5c14ef5ef405e8a302356087f8498f03ae7e6238d6d8858ceb26b36f47ab161ded84a088a12ffbc58ec1a2d7f4d774
+  checksum: 10/2b08ce2cd7e087f1955c7077f4a539f4a2a9db328f9012dc1209e7f595ba2011faaf41bb1ee03f9a607b9995f6c718f39373612083ea64a694001c9bae40af7e
   languageName: node
   linkType: hard
 
-"@radix-ui/react-slider@npm:1.4.0":
-  version: 1.4.0
-  resolution: "@radix-ui/react-slider@npm:1.4.0"
+"@radix-ui/react-slider@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@radix-ui/react-slider@npm:1.4.3"
   dependencies:
     "@radix-ui/number": "npm:1.1.2"
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-collection": "npm:1.1.9"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-collection": "npm:1.1.12"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-direction": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
     "@radix-ui/react-use-layout-effect": "npm:1.1.2"
     "@radix-ui/react-use-previous": "npm:1.1.2"
@@ -8361,13 +8470,13 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/6e0699d026d71516fad57917a0aa0f78063966a7dbd05bdc887b9517e5e6dcf258ba71e212b0552f53d1a15fb3942409a296caba8b695c45d2a34b08cea8cafc
+  checksum: 10/b61a4fa73f84b77331533b7f3bdfb5dd8c1ce3665afc43c28a4676ec9e370130dfe67a00f7d0dacacc43774d097c16f9efbbfd6c6808e47b341aae132045a0ec
   languageName: node
   linkType: hard
 
-"@radix-ui/react-slot@npm:1.2.5":
-  version: 1.2.5
-  resolution: "@radix-ui/react-slot@npm:1.2.5"
+"@radix-ui/react-slot@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@radix-ui/react-slot@npm:1.3.0"
   dependencies:
     "@radix-ui/react-compose-refs": "npm:1.1.3"
   peerDependencies:
@@ -8376,18 +8485,18 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/dbc0785979547111ba584e978ae25695f4b6c7dbc2f369a1078910841ece38785ce55a1e1bd5f92c940ed4e48a09ee110714d5e7cf354284b2d92677bb31959d
+  checksum: 10/9426062f8e48377c10c8338f5e8cee9c9318960d588754777aa01fe51c5f251db22e88239796e8edd60a8b2e6551a0a8448650c7ae4167eadcf606e83a11b32e
   languageName: node
   linkType: hard
 
-"@radix-ui/react-switch@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@radix-ui/react-switch@npm:1.3.0"
+"@radix-ui/react-switch@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@radix-ui/react-switch@npm:1.3.3"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
     "@radix-ui/react-use-previous": "npm:1.1.2"
     "@radix-ui/react-use-size": "npm:1.1.2"
@@ -8401,21 +8510,21 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/8c569abf581b6f8bfdf877a6504ae683e16b8ae8026ce686d8661bb9b4337e36966d5ab3d3f014905ed49daed6bea818e7546f5a756e9e77d33f2edfcfbb7424
+  checksum: 10/100b81a62dd8c92af305c15e6dcaab5219d28c1fa8ccafecf6ee9eb5dcc066bba7cac4b7e84135e38f35d5518e0e49ce4a40eac5da218615169fc824021bdc8a
   languageName: node
   linkType: hard
 
-"@radix-ui/react-tabs@npm:1.1.14":
-  version: 1.1.14
-  resolution: "@radix-ui/react-tabs@npm:1.1.14"
+"@radix-ui/react-tabs@npm:1.1.17":
+  version: 1.1.17
+  resolution: "@radix-ui/react-tabs@npm:1.1.17"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-direction": "npm:1.1.2"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-roving-focus": "npm:1.1.12"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
+    "@radix-ui/react-roving-focus": "npm:1.1.15"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
   peerDependencies:
     "@types/react": "*"
@@ -8427,26 +8536,26 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/a9d2f98ed3d3b3376198179aa571ac0b8c9125a7c6a2a99f235d3c323fea580e7aac81183be4fe6522207e57efa0ae7bb49234ed13c418c289d54c5b59cebd25
+  checksum: 10/dcfbe2d3e34d07921f29f059be007126438f1ea50f5bc18e674d1394818fb52811134705ce169af21d6bad9778885f9305a694d6ac87e636836cc5cca2a8063b
   languageName: node
   linkType: hard
 
-"@radix-ui/react-toast@npm:1.2.16":
-  version: 1.2.16
-  resolution: "@radix-ui/react-toast@npm:1.2.16"
+"@radix-ui/react-toast@npm:1.2.19":
+  version: 1.2.19
+  resolution: "@radix-ui/react-toast@npm:1.2.19"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-collection": "npm:1.1.9"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-collection": "npm:1.1.12"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.12"
-    "@radix-ui/react-portal": "npm:1.1.11"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.15"
+    "@radix-ui/react-portal": "npm:1.1.13"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-callback-ref": "npm:1.1.2"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
     "@radix-ui/react-use-layout-effect": "npm:1.1.2"
-    "@radix-ui/react-visually-hidden": "npm:1.2.5"
+    "@radix-ui/react-visually-hidden": "npm:1.2.7"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -8457,20 +8566,20 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/d76ffb9963c85d4cf7a651e9bb8dfca88c0fb2142faa9166f9d8cd9b23854a2c00bcc7640c351809b1c0489861bca84b4a50c5b6ca34e06a45355f42ec07b066
+  checksum: 10/0bb2ae592f41276f33b296e8ee53f667210d4855a6ffa68287b24fc6a06236ed24a88413d02e523be0ff016fa042360518bfbfe83c60b91d6610f0d39b632ffa
   languageName: node
   linkType: hard
 
-"@radix-ui/react-toggle-group@npm:1.1.12":
-  version: 1.1.12
-  resolution: "@radix-ui/react-toggle-group@npm:1.1.12"
+"@radix-ui/react-toggle-group@npm:1.1.15":
+  version: 1.1.15
+  resolution: "@radix-ui/react-toggle-group@npm:1.1.15"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-direction": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-roving-focus": "npm:1.1.12"
-    "@radix-ui/react-toggle": "npm:1.1.11"
+    "@radix-ui/react-primitive": "npm:2.1.7"
+    "@radix-ui/react-roving-focus": "npm:1.1.15"
+    "@radix-ui/react-toggle": "npm:1.1.14"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
   peerDependencies:
     "@types/react": "*"
@@ -8482,16 +8591,16 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/98123f54db604a56432a3e2f2ca4d199edd70c354be3a4487fe9a3fb5e8058e742f1a221f2eb035fa50d1bd893e3c0d39f6a6bc6cc875b676657203b834b80b4
+  checksum: 10/3b1d473fb37e033316a78a931b7a7c4ec2f4297944280038fae52d8687e228d030cf38bcd3d0f78dbd13fc720e8b96f44b8a3bfc48a95afcfa9e2f0c314724ff
   languageName: node
   linkType: hard
 
-"@radix-ui/react-toggle@npm:1.1.11":
-  version: 1.1.11
-  resolution: "@radix-ui/react-toggle@npm:1.1.11"
+"@radix-ui/react-toggle@npm:1.1.14":
+  version: 1.1.14
+  resolution: "@radix-ui/react-toggle@npm:1.1.14"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
   peerDependencies:
     "@types/react": "*"
@@ -8503,21 +8612,21 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/916ba5a90331494173153f7ac7f45175a200a4dfb8004e73da81846a89e4fb8c020a58bbc8ed4ab80c2b9dc43b389f063a0e50053b826720b4e0cf4cf3785ac8
+  checksum: 10/d7826617d70b839e7d790fe861405310ee83653e6bafafd7881b05f44f8a534759846d5e781b9f68bd13edc67a6949c3ba5fc99995353c2550963fcfefd45d74
   languageName: node
   linkType: hard
 
-"@radix-ui/react-toolbar@npm:1.1.12":
-  version: 1.1.12
-  resolution: "@radix-ui/react-toolbar@npm:1.1.12"
+"@radix-ui/react-toolbar@npm:1.1.15":
+  version: 1.1.15
+  resolution: "@radix-ui/react-toolbar@npm:1.1.15"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.0"
     "@radix-ui/react-direction": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-roving-focus": "npm:1.1.12"
-    "@radix-ui/react-separator": "npm:1.1.9"
-    "@radix-ui/react-toggle-group": "npm:1.1.12"
+    "@radix-ui/react-primitive": "npm:2.1.7"
+    "@radix-ui/react-roving-focus": "npm:1.1.15"
+    "@radix-ui/react-separator": "npm:1.1.11"
+    "@radix-ui/react-toggle-group": "npm:1.1.15"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -8528,26 +8637,26 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/59411cde32121483768b353f3ddbe011b0da26a9bdf7c61f27359470cef4b61fca7ba89a9365ee75add3a6d233d7e9df83bac490fc5242a2ce91a9116f765917
+  checksum: 10/97428437d5998327b1692afaf7ec4ec5a9b57e810478d7712464eaa4a32b675243223bde33488b5e03ec471d3bb90ab46fc998aaf1833722cf99f6874c3bad68
   languageName: node
   linkType: hard
 
-"@radix-ui/react-tooltip@npm:1.2.9":
-  version: 1.2.9
-  resolution: "@radix-ui/react-tooltip@npm:1.2.9"
+"@radix-ui/react-tooltip@npm:1.2.12":
+  version: 1.2.12
+  resolution: "@radix-ui/react-tooltip@npm:1.2.12"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.5"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.12"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.15"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-popper": "npm:1.3.0"
-    "@radix-ui/react-portal": "npm:1.1.11"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-slot": "npm:1.2.5"
+    "@radix-ui/react-popper": "npm:1.3.3"
+    "@radix-ui/react-portal": "npm:1.1.13"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
+    "@radix-ui/react-slot": "npm:1.3.0"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
-    "@radix-ui/react-visually-hidden": "npm:1.2.5"
+    "@radix-ui/react-visually-hidden": "npm:1.2.7"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -8558,7 +8667,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/da403d310e56c6b23c09413f0be6ec67ce10648f5cf950077748c2693ebf0c545feeae76917d9287e4f744f7ba7726cd0990009e6bdb83b9aecf04a34e09eb0c
+  checksum: 10/77a6333c938102d3688fb87aeb53139afe481ea16ad178aad91305ad73207a83d12a3ac02b3e713aca54e8b00eb84203e80c2ee65febe0af1399f92843d9cc1c
   languageName: node
   linkType: hard
 
@@ -8575,7 +8684,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-use-controllable-state@npm:1.2.3":
+"@radix-ui/react-use-controllable-state@npm:1.2.3, @radix-ui/react-use-controllable-state@npm:^1.2.3":
   version: 1.2.3
   resolution: "@radix-ui/react-use-controllable-state@npm:1.2.3"
   dependencies:
@@ -8606,7 +8715,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-use-escape-keydown@npm:1.1.2, @radix-ui/react-use-escape-keydown@npm:^1.1.2":
+"@radix-ui/react-use-escape-keydown@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@radix-ui/react-use-escape-keydown@npm:1.1.3"
+  dependencies:
+    "@radix-ui/react-use-callback-ref": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/0a43bb3cc009f3a80eedadb51350fbf58fba16015dda7cf3885fcb37a1cfdec81ee21825c539192bbc04f067ce46051538790a22db50e04fd58a0fc16e7b83f9
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-escape-keydown@npm:^1.1.2":
   version: 1.1.2
   resolution: "@radix-ui/react-use-escape-keydown@npm:1.1.2"
   dependencies:
@@ -8690,11 +8814,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-visually-hidden@npm:1.2.5":
-  version: 1.2.5
-  resolution: "@radix-ui/react-visually-hidden@npm:1.2.5"
+"@radix-ui/react-visually-hidden@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@radix-ui/react-visually-hidden@npm:1.2.7"
   dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.7"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -8705,7 +8829,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/af4c4eb90ac672fe6f1f46b4e9fe8e872427c237defd370a818e4ff1cda43bac291b09c6900541e1464d48120a0e626e80e4091a3d43cffb0855ba57dfbfb060
+  checksum: 10/e8104707449b6fa7f6e0bc2199ab123fdb7f57c6d6ee9f22d36d04305a315f42cebc9c8df9aa687a9816aae20bee93783f5961d23bdf1b81beca842b1c6adf2b
   languageName: node
   linkType: hard
 
@@ -12101,7 +12225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:10.0.0":
+"@types/uuid@npm:10.0.0, @types/uuid@npm:^10.0.0":
   version: 10.0.0
   resolution: "@types/uuid@npm:10.0.0"
   checksum: 10/e3958f8b0fe551c86c14431f5940c3470127293280830684154b91dc7eb3514aeb79fe3216968833cf79d4d1c67f580f054b5be2cd562bebf4f728913e73e944
@@ -12755,21 +12879,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"assistant-cloud@npm:^0.1.32":
-  version: 0.1.32
-  resolution: "assistant-cloud@npm:0.1.32"
+"assistant-cloud@npm:^0.1.34":
+  version: 0.1.34
+  resolution: "assistant-cloud@npm:0.1.34"
   dependencies:
-    assistant-stream: "npm:^0.3.21"
-  checksum: 10/e37841921c575513b5fe31f01bead6ee02efcf9ed20b5ca2185d688bca534f91c7d1ef6c7e8ad6d15b149611249e56e0ff7d98e360e1262aa74e71f69fd48566
+    assistant-stream: "npm:^0.3.24"
+  checksum: 10/711266bfd00451d69c112af4d436c932a691e84eca4f74c1714154f40e96fb8c259dfb72541edb7380b0385a6dcca12d855215f1430749bcb67e024e7d58c214
   languageName: node
   linkType: hard
 
-"assistant-stream@npm:^0.3.21":
-  version: 0.3.21
-  resolution: "assistant-stream@npm:0.3.21"
+"assistant-stream@npm:0.3.24":
+  version: 0.3.24
+  resolution: "assistant-stream@npm:0.3.24"
   dependencies:
     "@standard-schema/spec": "npm:^1.1.0"
-    nanoid: "npm:^5.1.11"
+    nanoid: "npm:^5.1.15"
     secure-json-parse: "npm:^4.1.0"
   peerDependencies:
     ioredis: ^5.10.1
@@ -12779,7 +12903,7 @@ __metadata:
       optional: true
     redis:
       optional: true
-  checksum: 10/65fe61779c743994c71b06da60e4ad22ae3997f5e3c1e31055a1fa92f670b826878c02a0567d25683ec47e6e38a8dcc350a0890ee8539f2d7b37c44be2398c16
+  checksum: 10/550e61db40bdaa6021c4b4774a922ff532ba31c1ac5a830a0a7330bf4f682023bf73a7103d9957ed9fc45ed29abac275e78fc64e4155ef71937efb6866f429e0
   languageName: node
   linkType: hard
 
@@ -14296,6 +14420,13 @@ __metadata:
   version: 1.0.1
   resolution: "commondir@npm:1.0.1"
   checksum: 10/4620bc4936a4ef12ce7dfcd272bb23a99f2ad68889a4e4ad766c9f8ad21af982511934d6f7050d4a8bde90011b1c15d56e61a1b4576d9913efbf697a20172d6c
+  languageName: node
+  linkType: hard
+
+"compare-versions@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "compare-versions@npm:6.1.1"
+  checksum: 10/9325c0fadfba81afa0ec17e6fc2ef823ba785c693089698b8d9374e5460509f1916a88591644d4cb4045c9a58e47fafbcc0724fe8bf446d2a875a3d6eeddf165
   languageName: node
   linkType: hard
 
@@ -16084,6 +16215,13 @@ __metadata:
     merge2: "npm:^1.3.0"
     micromatch: "npm:^4.0.8"
   checksum: 10/dcc6432b269762dd47381d8b8358bf964d8f4f60286ac6aa41c01ade70bda459ff2001b516690b96d5365f68a49242966112b5d5cc9cd82395fa8f9d017c90ad
+  languageName: node
+  linkType: hard
+
+"fast-json-patch@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "fast-json-patch@npm:3.1.1"
+  checksum: 10/3e56304e1c95ad1862a50e5b3f557a74c65c0ff2ba5b15caab983b43e70e86ddbc5bc887e9f7064f0aacfd0f0435a29ab2f000fe463379e72b906486345e6671
   languageName: node
   linkType: hard
 
@@ -20039,12 +20177,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^5.1.11":
-  version: 5.1.11
-  resolution: "nanoid@npm:5.1.11"
+"nanoid@npm:^5.1.15":
+  version: 5.1.16
+  resolution: "nanoid@npm:5.1.16"
   bin:
     nanoid: bin/nanoid.js
-  checksum: 10/d5971a1d39f68bd9845565c70a27733c832ba1bd73caad3c7b999a366c0355b6fcc65064f3b0179bca6cd36b50cacd5747d4482c303f026b58d62ebe31df9868
+  checksum: 10/b1e702e2b7072e74ac2ae880907d0a291853a36617ec5c3d27d81ab04965ebc0d4d0f707cf9220928cf93d5370b1f561c930efee853dc9c1a3facaefdf1a42ee
   languageName: node
   linkType: hard
 
@@ -21827,65 +21965,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"radix-ui@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "radix-ui@npm:1.5.0"
+"radix-ui@npm:^1.6.0":
+  version: 1.6.2
+  resolution: "radix-ui@npm:1.6.2"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
-    "@radix-ui/react-accessible-icon": "npm:1.1.9"
-    "@radix-ui/react-accordion": "npm:1.2.13"
-    "@radix-ui/react-alert-dialog": "npm:1.1.16"
-    "@radix-ui/react-arrow": "npm:1.1.9"
-    "@radix-ui/react-aspect-ratio": "npm:1.1.9"
-    "@radix-ui/react-avatar": "npm:1.1.12"
-    "@radix-ui/react-checkbox": "npm:1.3.4"
-    "@radix-ui/react-collapsible": "npm:1.1.13"
-    "@radix-ui/react-collection": "npm:1.1.9"
+    "@radix-ui/primitive": "npm:1.1.5"
+    "@radix-ui/react-accessible-icon": "npm:1.1.11"
+    "@radix-ui/react-accordion": "npm:1.2.16"
+    "@radix-ui/react-alert-dialog": "npm:1.1.19"
+    "@radix-ui/react-arrow": "npm:1.1.11"
+    "@radix-ui/react-aspect-ratio": "npm:1.1.11"
+    "@radix-ui/react-avatar": "npm:1.2.2"
+    "@radix-ui/react-checkbox": "npm:1.3.7"
+    "@radix-ui/react-collapsible": "npm:1.1.16"
+    "@radix-ui/react-collection": "npm:1.1.12"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-context-menu": "npm:2.3.0"
-    "@radix-ui/react-dialog": "npm:1.1.16"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-context-menu": "npm:2.3.3"
+    "@radix-ui/react-dialog": "npm:1.1.19"
     "@radix-ui/react-direction": "npm:1.1.2"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.12"
-    "@radix-ui/react-dropdown-menu": "npm:2.1.17"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.15"
+    "@radix-ui/react-dropdown-menu": "npm:2.1.20"
     "@radix-ui/react-focus-guards": "npm:1.1.4"
-    "@radix-ui/react-focus-scope": "npm:1.1.9"
-    "@radix-ui/react-form": "npm:0.1.9"
-    "@radix-ui/react-hover-card": "npm:1.1.16"
-    "@radix-ui/react-label": "npm:2.1.9"
-    "@radix-ui/react-menu": "npm:2.1.17"
-    "@radix-ui/react-menubar": "npm:1.1.17"
-    "@radix-ui/react-navigation-menu": "npm:1.2.15"
-    "@radix-ui/react-one-time-password-field": "npm:0.1.9"
-    "@radix-ui/react-password-toggle-field": "npm:0.1.4"
-    "@radix-ui/react-popover": "npm:1.1.16"
-    "@radix-ui/react-popper": "npm:1.3.0"
-    "@radix-ui/react-portal": "npm:1.1.11"
-    "@radix-ui/react-presence": "npm:1.1.6"
-    "@radix-ui/react-primitive": "npm:2.1.5"
-    "@radix-ui/react-progress": "npm:1.1.9"
-    "@radix-ui/react-radio-group": "npm:1.4.0"
-    "@radix-ui/react-roving-focus": "npm:1.1.12"
-    "@radix-ui/react-scroll-area": "npm:1.2.11"
-    "@radix-ui/react-select": "npm:2.3.0"
-    "@radix-ui/react-separator": "npm:1.1.9"
-    "@radix-ui/react-slider": "npm:1.4.0"
-    "@radix-ui/react-slot": "npm:1.2.5"
-    "@radix-ui/react-switch": "npm:1.3.0"
-    "@radix-ui/react-tabs": "npm:1.1.14"
-    "@radix-ui/react-toast": "npm:1.2.16"
-    "@radix-ui/react-toggle": "npm:1.1.11"
-    "@radix-ui/react-toggle-group": "npm:1.1.12"
-    "@radix-ui/react-toolbar": "npm:1.1.12"
-    "@radix-ui/react-tooltip": "npm:1.2.9"
+    "@radix-ui/react-focus-scope": "npm:1.1.12"
+    "@radix-ui/react-form": "npm:0.1.12"
+    "@radix-ui/react-hover-card": "npm:1.1.19"
+    "@radix-ui/react-label": "npm:2.1.11"
+    "@radix-ui/react-menu": "npm:2.1.20"
+    "@radix-ui/react-menubar": "npm:1.1.20"
+    "@radix-ui/react-navigation-menu": "npm:1.2.18"
+    "@radix-ui/react-one-time-password-field": "npm:0.1.12"
+    "@radix-ui/react-password-toggle-field": "npm:0.1.7"
+    "@radix-ui/react-popover": "npm:1.1.19"
+    "@radix-ui/react-popper": "npm:1.3.3"
+    "@radix-ui/react-portal": "npm:1.1.13"
+    "@radix-ui/react-presence": "npm:1.1.7"
+    "@radix-ui/react-primitive": "npm:2.1.7"
+    "@radix-ui/react-progress": "npm:1.1.12"
+    "@radix-ui/react-radio-group": "npm:1.4.3"
+    "@radix-ui/react-roving-focus": "npm:1.1.15"
+    "@radix-ui/react-scroll-area": "npm:1.2.14"
+    "@radix-ui/react-select": "npm:2.3.3"
+    "@radix-ui/react-separator": "npm:1.1.11"
+    "@radix-ui/react-slider": "npm:1.4.3"
+    "@radix-ui/react-slot": "npm:1.3.0"
+    "@radix-ui/react-switch": "npm:1.3.3"
+    "@radix-ui/react-tabs": "npm:1.1.17"
+    "@radix-ui/react-toast": "npm:1.2.19"
+    "@radix-ui/react-toggle": "npm:1.1.14"
+    "@radix-ui/react-toggle-group": "npm:1.1.15"
+    "@radix-ui/react-toolbar": "npm:1.1.15"
+    "@radix-ui/react-tooltip": "npm:1.2.12"
     "@radix-ui/react-use-callback-ref": "npm:1.1.2"
     "@radix-ui/react-use-controllable-state": "npm:1.2.3"
     "@radix-ui/react-use-effect-event": "npm:0.0.3"
-    "@radix-ui/react-use-escape-keydown": "npm:1.1.2"
+    "@radix-ui/react-use-escape-keydown": "npm:1.1.3"
     "@radix-ui/react-use-is-hydrated": "npm:0.1.1"
     "@radix-ui/react-use-layout-effect": "npm:1.1.2"
     "@radix-ui/react-use-size": "npm:1.1.2"
-    "@radix-ui/react-visually-hidden": "npm:1.2.5"
+    "@radix-ui/react-visually-hidden": "npm:1.2.7"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -21896,7 +22034,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10/06b89fa829a1052ae3cf399df5156b63ccfd393741d8bcdf6da46604555b645f872677c6cf4f2fb906ea0d84fbbd20fa3e5a5c01c66cf25078d69c41f204bb76
+  checksum: 10/8cbf1ab070cd676c185ffb3de4f6963f971b197369daefebb1c43c2aa0ae19647773b8730a1b0cca957296b7d88bf2ba9212ea8651eaf635cb6dbfbd81118c2f
   languageName: node
   linkType: hard
 
@@ -22805,6 +22943,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rxjs@npm:7.8.1":
+  version: 7.8.1
+  resolution: "rxjs@npm:7.8.1"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 10/b10cac1a5258f885e9dd1b70d23c34daeb21b61222ee735d2ec40a8685bdca40429000703a44f0e638c27a684ac139e1c37e835d2a0dc16f6fc061a138ae3abb
+  languageName: node
+  linkType: hard
+
 "rxjs@npm:7.8.2":
   version: 7.8.2
   resolution: "rxjs@npm:7.8.2"
@@ -22828,10 +22975,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-content-frame@npm:^0.0.21":
-  version: 0.0.21
-  resolution: "safe-content-frame@npm:0.0.21"
-  checksum: 10/46f8800f5a8f1c0f0caeddc1b45da988f4ed0d544fe914612bf1c10871ea4bf07981e79e87ced0cfdbf700ae574d31c52e39d51c8265d284deffd15de6e070b9
+"safe-content-frame@npm:^0.0.22":
+  version: 0.0.22
+  resolution: "safe-content-frame@npm:0.0.22"
+  checksum: 10/326f437257bee23e27764ab8436f935f7700b8f885f63f6620225333a1ea7376c4482e89953f92070783be6a736c234fe9c2c5b5d24fc1784b34d7c2425d8712
   languageName: node
   linkType: hard
 
@@ -24880,6 +25027,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"untruncate-json@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "untruncate-json@npm:0.0.1"
+  checksum: 10/60fe7e60bff82d512ca1fb7ea4b09caf2dfb0a1fdf6a966a923f55f3cb49618f3bc24843172e6ab6480231327a78c86d2a5a4328f290a5c8819e5b9a4fcce6ab
+  languageName: node
+  linkType: hard
+
 "update-browserslist-db@npm:^1.2.3":
   version: 1.2.3
   resolution: "update-browserslist-db@npm:1.2.3"
@@ -25022,7 +25176,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.2.0, use-sync-external-store@npm:^1.2.2, use-sync-external-store@npm:^1.6.0":
+"use-sync-external-store@npm:^1.2.0, use-sync-external-store@npm:^1.6.0":
   version: 1.6.0
   resolution: "use-sync-external-store@npm:1.6.0"
   peerDependencies:
@@ -25132,6 +25286,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 10/5086c43bbe11e2337d9bb9a3b3a156311e5f5ba5da2de8152da9e00cfd5fbbf626d36e6a2838dde06e2105ac563bc298470acc0e4800c96fa2d50565c5782f8a
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^11.1.0":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 10/16411d3dc12a08d6691616c09a75e66a7f900ba1beef6628a76fe0602f82fae2ee537b564d0b7bc95c24f58d059ca9b58c75a1e806118efb50e17822ff00ddd2
   languageName: node
   linkType: hard
 
@@ -25993,7 +26156,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:3.25.76":
+"zod@npm:3.25.76, zod@npm:^3.22.4":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10/f0c963ec40cd96858451d1690404d603d36507c1fc9682f2dae59ab38b578687d542708a7fdbf645f77926f78c9ed558f57c3d3aa226c285f798df0c4da16995
@@ -26007,27 +26170,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zustand@npm:^4.4.1":
-  version: 4.5.7
-  resolution: "zustand@npm:4.5.7"
-  dependencies:
-    use-sync-external-store: "npm:^1.2.2"
-  peerDependencies:
-    "@types/react": ">=16.8"
-    immer: ">=9.0.6"
-    react: ">=16.8"
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    immer:
-      optional: true
-    react:
-      optional: true
-  checksum: 10/21c47ea1c9bb0363b714a7e371a91b9afaeabc5c9c2f522803a0fb412605b1e037c4f975a7377529de8f2857e60d1f4586e7ade18444168ecc492e38779e605d
-  languageName: node
-  linkType: hard
-
-"zustand@npm:^5.0.14":
+"zustand@npm:5.0.14":
   version: 5.0.14
   resolution: "zustand@npm:5.0.14"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ag-ui/core@npm:^0.0.52":
+  version: 0.0.52
+  resolution: "@ag-ui/core@npm:0.0.52"
+  dependencies:
+    zod: "npm:^3.22.4"
+  checksum: 10/6938253718a7c94eef39d68285d992daf1101f92163342b90a73056f3fa34628f69b61f866ea887ab7e90e857a81cb9dc237bb7507ebf3dbf70478e58d8e44f7
+  languageName: node
+  linkType: hard
+
 "@ag-ui/encoder@npm:0.0.57":
   version: 0.0.57
   resolution: "@ag-ui/encoder@npm:0.0.57"
@@ -5741,6 +5750,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@pikku/ai-tanstack@workspace:*, @pikku/ai-tanstack@workspace:packages/services/ai-tanstack":
+  version: 0.0.0-use.local
+  resolution: "@pikku/ai-tanstack@workspace:packages/services/ai-tanstack"
+  dependencies:
+    "@tanstack/ai": "npm:^0.39.0"
+    "@tanstack/ai-openai": "npm:^0.15.9"
+    typescript: "npm:^5.9"
+    zod: "npm:^4.3.6"
+  peerDependencies:
+    "@pikku/core": ^0.12.35
+  languageName: unknown
+  linkType: soft
+
 "@pikku/ai-vercel@npm:^0.12.7, @pikku/ai-vercel@workspace:*, @pikku/ai-vercel@workspace:packages/services/ai-vercel":
   version: 0.0.0-use.local
   resolution: "@pikku/ai-vercel@workspace:packages/services/ai-vercel"
@@ -6104,6 +6126,7 @@ __metadata:
     "@pikku/addon-console": "workspace:*"
     "@pikku/addon-graph": "workspace:*"
     "@pikku/addon-hmac-signer": "workspace:*"
+    "@pikku/ai-tanstack": "workspace:*"
     "@pikku/ai-vercel": "workspace:*"
     "@pikku/better-auth": "workspace:*"
     "@pikku/cli": "workspace:*"
@@ -11129,10 +11152,79 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/ai-event-client@npm:0.6.8":
+  version: 0.6.8
+  resolution: "@tanstack/ai-event-client@npm:0.6.8"
+  dependencies:
+    "@tanstack/devtools-event-client": "npm:^0.4.1"
+  checksum: 10/534e097bcd24a814ee3a735f2cb32dfcf959c91f165752a53738dab38435f5c660c323f34ecc4c735f8076cdb5e15462d815df498e2f72f711a1d0e8f990f135
+  languageName: node
+  linkType: hard
+
+"@tanstack/ai-openai@npm:^0.15.9":
+  version: 0.15.10
+  resolution: "@tanstack/ai-openai@npm:0.15.10"
+  dependencies:
+    "@tanstack/ai-utils": "npm:0.3.1"
+    "@tanstack/openai-base": "npm:0.9.6"
+    openai: "npm:^6.41.0"
+  peerDependencies:
+    "@tanstack/ai": ^0.39.0
+    zod: ^4.0.0
+  checksum: 10/6d62bf877eaad8cf720229de2834171952e55565c96326ed0b5a52c84d69997c3dc9977af3b3084670cca3d9ecaf3bde485959dbe0b142db2bcef02669481721
+  languageName: node
+  linkType: hard
+
+"@tanstack/ai-utils@npm:0.3.1":
+  version: 0.3.1
+  resolution: "@tanstack/ai-utils@npm:0.3.1"
+  checksum: 10/87ed74118c26acbf4a19028a057dd3769195787a19d181c150b3b6231152cf13315b03660d35e88643542d5a1157981de113765c65fbcbc663706d056db89188
+  languageName: node
+  linkType: hard
+
+"@tanstack/ai@npm:^0.39.0":
+  version: 0.39.1
+  resolution: "@tanstack/ai@npm:0.39.1"
+  dependencies:
+    "@ag-ui/core": "npm:^0.0.52"
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@tanstack/ai-event-client": "npm:0.6.8"
+    "@tanstack/ai-utils": "npm:0.3.1"
+    partial-json: "npm:^0.1.7"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.9.0"
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+  checksum: 10/144e4628d01eb65caf51b60766ff8e2ff6dfdf75f77614722009208b73d87f10e4d1268cdd24de61e5904144b5a3d8eade73016d720cc94af64a392d43647199
+  languageName: node
+  linkType: hard
+
+"@tanstack/devtools-event-client@npm:^0.4.1":
+  version: 0.4.4
+  resolution: "@tanstack/devtools-event-client@npm:0.4.4"
+  bin:
+    intent: ./bin/intent.js
+  checksum: 10/69e0e2d63d5d0d2b1466be0368452e3c76d7d5bcf06b086521124ecbeeac27b57c7a7cbb0f9498eab3152d5dd2a3397bc7d756d7d2728747aab84157d5e5f490
+  languageName: node
+  linkType: hard
+
 "@tanstack/history@npm:1.162.0":
   version: 1.162.0
   resolution: "@tanstack/history@npm:1.162.0"
   checksum: 10/a92f166469b30dfd19ac45847977e8fc6a38770319fdb7d58a44e0bf8073d334fc121d9b886ecb788206f10e3ad2130d6eb500c1dec610a51b0c940fa266cae6
+  languageName: node
+  linkType: hard
+
+"@tanstack/openai-base@npm:0.9.6":
+  version: 0.9.6
+  resolution: "@tanstack/openai-base@npm:0.9.6"
+  dependencies:
+    "@tanstack/ai-utils": "npm:0.3.1"
+    openai: "npm:^6.41.0"
+  peerDependencies:
+    "@tanstack/ai": ^0.39.0
+  checksum: 10/d46cfeefef79267f02ad376d2726acb9dd34e89f67a85cf158be09389f91d681856e85c65b1c2f795c8a0993d1b3c2ccdd834a75c96530b49a4b91584cd55d81
   languageName: node
   linkType: hard
 
@@ -20641,6 +20733,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"openai@npm:^6.41.0":
+  version: 6.46.0
+  resolution: "openai@npm:6.46.0"
+  peerDependencies:
+    "@aws-sdk/credential-provider-node": ">=3.972.0 <4"
+    "@smithy/hash-node": ">=4.3.0 <5"
+    "@smithy/signature-v4": ">=5.4.0 <6"
+    ws: ^8.18.0
+    zod: ^3.25 || ^4.0
+  peerDependenciesMeta:
+    "@aws-sdk/credential-provider-node":
+      optional: true
+    "@smithy/hash-node":
+      optional: true
+    "@smithy/signature-v4":
+      optional: true
+    ws:
+      optional: true
+    zod:
+      optional: true
+  checksum: 10/94c3533c664626505c6f73d8c29dc3735e5f923ab77c2a82b8f255687eec1b22b99fe62771e391350575320e1b24ffd86ff1ef68fcb3b955dc6af244f39997a0
+  languageName: node
+  linkType: hard
+
 "openapi-types@npm:^12.1.3":
   version: 12.1.3
   resolution: "openapi-types@npm:12.1.3"
@@ -20996,6 +21112,13 @@ __metadata:
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
   checksum: 10/407cee8e0a3a4c5cd472559bca8b6a45b82c124e9a4703302326e9ab60fc1081442ada4e02628efef1eb16197ddc7f8822f5a91fd7d7c86b51f530aedb17dfa2
+  languageName: node
+  linkType: hard
+
+"partial-json@npm:^0.1.7":
+  version: 0.1.7
+  resolution: "partial-json@npm:0.1.7"
+  checksum: 10/6fb8d305638e4747fccfc0649b8a8de99314bfafcc4e3136a3a27c0632857c40b62e6e6bb5f17af00472387393f1d8a58a7865242ca20382af31b593a7bb1f89
   languageName: node
   linkType: hard
 
@@ -24772,6 +24895,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.9":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A>=5.9 <7#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
   version: 6.0.3
   resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
@@ -24779,6 +24912,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/22b67a18dafedf9b1468b64ca20d9aa02ea61d449b65413d8aa6552aeb63f52ef369e86beb25b6b4c91a803d9726ee5c196f391a9b64201263263410a4223ee6
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.9#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Stacked on #930** — merge #930 first. This PR now contains **only** the TanStack backend runner; the generic AG-UI client transport (the assistant-ui rewrite, core AG-UI bridge, better-auth fix, TS6 fix) was split out into #930 and merged/reviewed there.

> Base branch is `feat/929-generic-ag-ui-transport` (PR #930), so the diff below is TanStack-only. GitHub will re-target this to `main` automatically once #930 merges.

## What's here
- **`@pikku/ai-tanstack`**: New package implementing `AIAgentRunnerService` with `@tanstack/ai` + `@tanstack/ai-openai`. Throws on provider stream errors (`RUN_ERROR`) so core marks the run failed and fires `onError` — matching the vercel runner on the error path, not just the happy path.
- **e2e**: Runner selected via `PIKKU_AI_RUNNER` (defaults to `tanstack`); `@pikku/ai-vercel` / `@pikku/ai-tanstack` imported lazily.
- **ci**: `@ai` e2e suite runs against both runners via a `[tanstack, vercel]` matrix. The full `@ai` suite passes against both.

## History note
The previous 35-commit branch was rebased: the generic-transport commits became #930, and this branch was reset to `#930 + one TanStack commit` so the two PRs stack cleanly. TanStack unit tests: 7/7 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)