### PR TITLE
test: collapse 3x pikku bootstrap to a single run

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -22,36 +22,24 @@ runs:
         start=$SECONDS
         yarn build:packages
         echo "::notice::⏱ Build packages: $((SECONDS - start))s"
-    - name: Generate pikku files
-      shell: bash
-      run: |
-        start=$SECONDS
-        yarn pikku
-        echo "::notice::⏱ Generate pikku files: $((SECONDS - start))s"
     - name: Build addons
       shell: bash
       run: |
         start=$SECONDS
         yarn build:addons
         echo "::notice::⏱ Build addons: $((SECONDS - start))s"
-    - name: Regenerate schemas after bootstrap
-      shell: bash
-      run: |
-        start=$SECONDS
-        yarn pikku
-        echo "::notice::⏱ Regenerate schemas: $((SECONDS - start))s"
     - name: Build function-addon template
       shell: bash
       run: |
         start=$SECONDS
         cd templates/function-addon && yarn pikku && yarn build
         echo "::notice::⏱ Build function-addon template: $((SECONDS - start))s"
-    - name: Final pikku regeneration before template builds
+    - name: Generate pikku files
       shell: bash
       run: |
         start=$SECONDS
         yarn pikku
-        echo "::notice::⏱ Final pikku regeneration: $((SECONDS - start))s"
+        echo "::notice::⏱ Generate pikku files: $((SECONDS - start))s"
     - name: Build templates
       shell: bash
       run: |


### PR DESCRIPTION
Experiment: build packages -> build addons -> build function-addon (its own codegen+build) -> single yarn pikku -> build templates.

Removes the two standalone pre-codegen 'yarn pikku' runs to test whether they are load-bearing. If CI is green, the 3->1 collapse (~46s) is safe; if it fails we learn which run mattered. Test branch only — not for merge.