### PR TITLE
feat(cli): optional --tsc / --tsc-summary type-check gate for pikku all

### DIFF
--- a/.changeset/pikku-all-tsc-gate.md
+++ b/.changeset/pikku-all-tsc-gate.md
@@ -1,0 +1,21 @@
+---
+"@pikku/cli": patch
+---
+
+Add optional `--tsc` / `--tsc-summary` type-check gate to `pikku all`
+
+`pikku all` previously never ran the TypeScript compiler for type errors — the
+inspector builds a program only for AST traversal (with `skipLibCheck`,
+`types: []`, no `lib`/`paths`) and never requests diagnostics, so real type
+errors were silently ignored by codegen.
+
+Two opt-in flags now run a genuine `tsc --noEmit` over the project's own
+tsconfig after codegen completes (so generated `.pikku` files are included,
+matching a real build) and fail the run on type errors:
+
+- `--tsc` — full diagnostics with code frames.
+- `--tsc-summary` — a compact one-line-per-error render (flattened messages, no
+  code frames, `node_modules` filtered, capped at 50) that's cheap for AI
+  agents and CI logs.
+
+Both are off by default (zero cost on a normal run).

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -130,6 +130,16 @@ wireCLI({
         'Fail the build on critical diagnostics. Always on; accepted for symmetry with --fail-on-error/--fail-on-warn.',
       default: true,
     },
+    tsc: {
+      description:
+        "After codegen, run a real tsc --noEmit over the project's tsconfig and fail on type errors. Prints full diagnostics with code frames. Off by default.",
+      default: false,
+    },
+    tscSummary: {
+      description:
+        'Like --tsc but prints a compact one-line-per-error summary (no code frames, node_modules filtered, capped) — cheap for AI agents / CI. Fails on type errors.',
+      default: false,
+    },
     userSessionType: {
       description:
         'Specify which UserSession type to use (when multiple exist)',

--- a/packages/cli/src/functions/workflows/all.workflow.ts
+++ b/packages/cli/src/functions/workflows/all.workflow.ts
@@ -1,6 +1,12 @@
 import { existsSync } from 'fs'
 import { pikkuWorkflowComplexFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
 import { assertSingleCoreVersion } from '../../utils/assert-single-core-version.js'
+import {
+  PikkuTypecheckFailedError,
+  renderTscFull,
+  renderTscSummary,
+  runProjectTypecheck,
+} from '../../utils/tsc-check.js'
 
 type ScaffoldGenerator =
   | 'pikkuPublicRPC'
@@ -407,5 +413,29 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
 
     await workflow.do('Bootstrap', 'pikkuBootstrap', { allImports })
     await workflow.do('Summary', 'pikkuSummary', null)
+
+    // Opt-in type-check gate (--tsc / --tsc-summary). Runs last, over the
+    // post-codegen project, so generated .pikku files are included — matching a
+    // real build. Printed inside the step; the throw lives in the workflow body
+    // (like assertSingleCoreVersion) so it reliably fails the run.
+    if (config.tsc || config.tscSummary) {
+      const errorCount = await workflow.do('Type check', async () => {
+        const { result, diagnostics, formatHost } = runProjectTypecheck(
+          config.tsconfig,
+          config.rootDir
+        )
+        logger.info(
+          config.tsc
+            ? renderTscFull(diagnostics, config.rootDir, formatHost)
+            : renderTscSummary(result)
+        )
+        return result.errorCount
+      })
+      if (errorCount > 0) {
+        throw new PikkuTypecheckFailedError(
+          `Type check failed: ${errorCount} error${errorCount === 1 ? '' : 's'}`
+        )
+      }
+    }
   },
 })

--- a/packages/cli/src/utils/tsc-check.test.ts
+++ b/packages/cli/src/utils/tsc-check.test.ts
@@ -1,0 +1,159 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import ts from 'typescript'
+import { collectTscDiagnostics, renderTscSummary } from './tsc-check.js'
+
+const ROOT = '/project'
+
+/**
+ * Build a minimal ts.Diagnostic. `fileName` null makes a file-less (global)
+ * diagnostic; otherwise line/character are returned verbatim by a stub
+ * getLineAndCharacterOfPosition so we can assert 1-based conversion.
+ */
+function diag(
+  code: number,
+  message: string,
+  category: ts.DiagnosticCategory,
+  fileName: string | null,
+  line = 0,
+  character = 0
+): ts.Diagnostic {
+  const file =
+    fileName === null
+      ? undefined
+      : ({
+          fileName,
+          getLineAndCharacterOfPosition: () => ({ line, character }),
+        } as unknown as ts.SourceFile)
+  return {
+    file,
+    start: 0,
+    length: 0,
+    code,
+    category,
+    messageText: message,
+  } as ts.Diagnostic
+}
+
+describe('collectTscDiagnostics', () => {
+  test('counts errors/warnings and converts positions to 1-based', () => {
+    const result = collectTscDiagnostics(
+      [
+        diag(
+          2345,
+          'bad arg',
+          ts.DiagnosticCategory.Error,
+          `${ROOT}/src/a.ts`,
+          4,
+          2
+        ),
+        diag(
+          6133,
+          'unused',
+          ts.DiagnosticCategory.Warning,
+          `${ROOT}/src/b.ts`,
+          0,
+          0
+        ),
+      ],
+      ROOT
+    )
+    assert.equal(result.errorCount, 1)
+    assert.equal(result.warningCount, 1)
+    assert.equal(result.fileCount, 2)
+    const first = result.diagnostics.find((d) => d.code === 2345)!
+    assert.equal(first.file, 'src/a.ts')
+    assert.equal(first.line, 5)
+    assert.equal(first.column, 3)
+  })
+
+  test('drops node_modules and out-of-root diagnostics', () => {
+    const result = collectTscDiagnostics(
+      [
+        diag(
+          1,
+          'x',
+          ts.DiagnosticCategory.Error,
+          `${ROOT}/node_modules/dep/index.d.ts`,
+          1,
+          1
+        ),
+        diag(2, 'y', ts.DiagnosticCategory.Error, '/elsewhere/z.ts', 1, 1),
+        diag(
+          3,
+          'keep',
+          ts.DiagnosticCategory.Error,
+          `${ROOT}/src/keep.ts`,
+          1,
+          1
+        ),
+      ],
+      ROOT
+    )
+    assert.equal(result.errorCount, 1)
+    assert.equal(result.diagnostics.length, 1)
+    assert.equal(result.diagnostics[0]!.file, 'src/keep.ts')
+  })
+
+  test('keeps file-less (global) diagnostics under the project label', () => {
+    const result = collectTscDiagnostics(
+      [diag(18003, 'No inputs were found', ts.DiagnosticCategory.Error, null)],
+      ROOT
+    )
+    assert.equal(result.errorCount, 1)
+    assert.equal(result.diagnostics[0]!.file, '(project)')
+    assert.equal(result.diagnostics[0]!.line, 0)
+  })
+})
+
+describe('renderTscSummary', () => {
+  test('returns a passing line when there are no diagnostics', () => {
+    const out = renderTscSummary({
+      errorCount: 0,
+      warningCount: 0,
+      fileCount: 0,
+      diagnostics: [],
+    })
+    assert.match(out, /passed/)
+  })
+
+  test('renders a compact header + one line per diagnostic, no code frames', () => {
+    const result = collectTscDiagnostics(
+      [
+        diag(
+          2345,
+          'Argument bad',
+          ts.DiagnosticCategory.Error,
+          `${ROOT}/src/a.ts`,
+          4,
+          2
+        ),
+      ],
+      ROOT
+    )
+    const out = renderTscSummary(result)
+    const lines = out.split('\n')
+    assert.equal(lines[0], 'Type check: 1 error in 1 file')
+    assert.equal(lines[1], '  src/a.ts:5:3  TS2345  Argument bad')
+    assert.equal(lines.length, 2)
+  })
+
+  test('caps output and reports the remainder', () => {
+    const many = Array.from({ length: 5 }, (_, i) =>
+      diag(
+        1000 + i,
+        `err ${i}`,
+        ts.DiagnosticCategory.Error,
+        `${ROOT}/src/f${i}.ts`,
+        i,
+        0
+      )
+    )
+    const result = collectTscDiagnostics(many, ROOT)
+    const out = renderTscSummary(result, 2)
+    const lines = out.split('\n')
+    // header + 2 shown + 1 "and N more"
+    assert.equal(lines.length, 4)
+    assert.match(lines.at(-1)!, /… and 3 more/)
+  })
+})

--- a/packages/cli/src/utils/tsc-check.ts
+++ b/packages/cli/src/utils/tsc-check.ts
@@ -1,0 +1,199 @@
+import ts from 'typescript'
+import { dirname, isAbsolute, relative } from 'node:path'
+import { PikkuError } from '@pikku/core'
+
+// A type-check failure is expected (the --tsc gate did its job) — throw a
+// PikkuError so the runner logs the message alone, not a stack trace.
+export class PikkuTypecheckFailedError extends PikkuError {}
+
+export interface TscDiagnostic {
+  file: string
+  line: number
+  column: number
+  code: number
+  category: 'error' | 'warning' | 'suggestion' | 'message'
+  message: string
+}
+
+export interface TscCheckResult {
+  errorCount: number
+  warningCount: number
+  fileCount: number
+  diagnostics: TscDiagnostic[]
+}
+
+const CATEGORY: Record<ts.DiagnosticCategory, TscDiagnostic['category']> = {
+  [ts.DiagnosticCategory.Error]: 'error',
+  [ts.DiagnosticCategory.Warning]: 'warning',
+  [ts.DiagnosticCategory.Suggestion]: 'suggestion',
+  [ts.DiagnosticCategory.Message]: 'message',
+}
+
+const MAX_MESSAGE_LENGTH = 200
+const DEFAULT_MAX_LINES = 50
+const NO_FILE = '(project)'
+
+const isProjectFile = (fileName: string, rootDir: string): boolean => {
+  if (fileName.includes('/node_modules/')) return false
+  const rel = relative(rootDir, fileName)
+  return !rel.startsWith('..') && !isAbsolute(rel)
+}
+
+/**
+ * Turn raw tsc diagnostics into a filtered, structured result. Pure — it takes
+ * already-computed diagnostics so it can be unit-tested without a program.
+ * Anything under node_modules or outside the project root is dropped so the
+ * output stays focused on the user's own code (and not lib .d.ts noise).
+ */
+export const collectTscDiagnostics = (
+  diagnostics: readonly ts.Diagnostic[],
+  rootDir: string
+): TscCheckResult => {
+  const files = new Set<string>()
+  const collected: TscDiagnostic[] = []
+  let errorCount = 0
+  let warningCount = 0
+
+  for (const d of diagnostics) {
+    let file = NO_FILE
+    let line = 0
+    let column = 0
+    if (d.file) {
+      if (!isProjectFile(d.file.fileName, rootDir)) continue
+      file = relative(rootDir, d.file.fileName)
+      const lc = d.file.getLineAndCharacterOfPosition(d.start ?? 0)
+      line = lc.line + 1
+      column = lc.character + 1
+    }
+
+    const category = CATEGORY[d.category]
+    if (category === 'error') errorCount++
+    else if (category === 'warning') warningCount++
+
+    let message = ts.flattenDiagnosticMessageText(d.messageText, ' ')
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      message = `${message.slice(0, MAX_MESSAGE_LENGTH - 1)}…`
+    }
+
+    files.add(file)
+    collected.push({ file, line, column, code: d.code, category, message })
+  }
+
+  collected.sort((a, b) =>
+    a.file === b.file ? a.line - b.line : a.file < b.file ? -1 : 1
+  )
+  return {
+    errorCount,
+    warningCount,
+    fileCount: files.size,
+    diagnostics: collected,
+  }
+}
+
+/**
+ * Compact, token-frugal render of a type-check result: a one-line header plus
+ * one line per diagnostic (no code frames), capped. Used by `--tsc-summary` so
+ * AI agents and CI logs get the signal without the flood.
+ */
+export const renderTscSummary = (
+  result: TscCheckResult,
+  maxLines: number = DEFAULT_MAX_LINES
+): string => {
+  if (result.errorCount === 0 && result.warningCount === 0) {
+    return 'Type check passed — no errors.'
+  }
+
+  const counts: string[] = []
+  if (result.errorCount > 0) {
+    counts.push(
+      `${result.errorCount} error${result.errorCount === 1 ? '' : 's'}`
+    )
+  }
+  if (result.warningCount > 0) {
+    counts.push(
+      `${result.warningCount} warning${result.warningCount === 1 ? '' : 's'}`
+    )
+  }
+  const fileLabel = `${result.fileCount} file${result.fileCount === 1 ? '' : 's'}`
+  const lines = [`Type check: ${counts.join(', ')} in ${fileLabel}`]
+
+  const shown = result.diagnostics.slice(0, maxLines)
+  for (const d of shown) {
+    const at = d.line > 0 ? `${d.file}:${d.line}:${d.column}` : d.file
+    lines.push(`  ${at}  TS${d.code}  ${d.message}`)
+  }
+  const remaining = result.diagnostics.length - shown.length
+  if (remaining > 0) {
+    lines.push(
+      `  … and ${remaining} more (run \`pikku all --tsc\` for full output)`
+    )
+  }
+  return lines.join('\n')
+}
+
+/**
+ * Full render: tsc's own formatter with code frames, filtered to project files.
+ */
+export const renderTscFull = (
+  diagnostics: readonly ts.Diagnostic[],
+  rootDir: string,
+  formatHost: ts.FormatDiagnosticsHost
+): string => {
+  const filtered = diagnostics.filter(
+    (d) => !d.file || isProjectFile(d.file.fileName, rootDir)
+  )
+  if (filtered.length === 0) return 'Type check passed — no errors.'
+  return ts.formatDiagnosticsWithColorAndContext(filtered, formatHost)
+}
+
+/**
+ * Run a real `tsc --noEmit` over the project's own tsconfig — the correct
+ * source of truth (lib, paths, strict), unlike the inspector's stripped-down
+ * traversal program. Returns both a structured result and the raw diagnostics
+ * so the caller can pick the compact (`--tsc-summary`) or full (`--tsc`) render.
+ */
+export const runProjectTypecheck = (
+  tsconfigPath: string,
+  rootDir: string
+): {
+  result: TscCheckResult
+  diagnostics: ts.Diagnostic[]
+  formatHost: ts.FormatDiagnosticsHost
+} => {
+  const formatHost: ts.FormatDiagnosticsHost = {
+    getCanonicalFileName: (f) => f,
+    getCurrentDirectory: () => rootDir,
+    getNewLine: () => ts.sys.newLine,
+  }
+
+  const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile)
+  if (configFile.error) {
+    const diagnostics = [configFile.error]
+    return {
+      result: collectTscDiagnostics(diagnostics, rootDir),
+      diagnostics,
+      formatHost,
+    }
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    dirname(tsconfigPath)
+  )
+  const program = ts.createProgram({
+    rootNames: parsed.fileNames,
+    options: {
+      ...parsed.options,
+      noEmit: true,
+      incremental: false,
+      tsBuildInfoFile: undefined,
+    },
+  })
+  const diagnostics = [...parsed.errors, ...ts.getPreEmitDiagnostics(program)]
+  return {
+    result: collectTscDiagnostics(diagnostics, rootDir),
+    diagnostics,
+    formatHost,
+  }
+}

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -388,6 +388,16 @@ export type PikkuCLIInput = {
    */
   security?: boolean
 
+  /**
+   * After codegen, run a real `tsc --noEmit` over the project's tsconfig and
+   * fail on type errors. `tsc` prints full diagnostics with code frames;
+   * `tscSummary` prints a compact one-line-per-error render (no code frames,
+   * capped) that's cheap for AI agents / CI logs. Off by default; enable per
+   * invocation via `pikku all --tsc` / `--tsc-summary`.
+   */
+  tsc?: boolean
+  tscSummary?: boolean
+
   lint?: {
     servicesNotDestructured?: 'off' | 'warn' | 'error'
     wiresNotDestructured?: 'off' | 'warn' | 'error'


### PR DESCRIPTION
Closes #848

## What

`pikku all` never ran the TypeScript compiler for type errors — the inspector builds a `ts.createProgram` purely for AST traversal (`skipLibCheck`, `types: []`, no `lib`/`paths`) and never requests diagnostics, so real type errors were silently ignored by codegen.

This adds two **opt-in, default-off** flags that run a genuine `tsc --noEmit` over the project's **own tsconfig** after codegen completes (generated `.pikku` files included, matching a real build) and fail the run on type errors:

- **`--tsc`** — full diagnostics with code frames.
- **`--tsc-summary`** — compact one-line-per-error render (flattened messages, no code frames, `node_modules` filtered, capped at 50). Cheap for AI agents / CI logs without flooding tokens.

## Why not reuse the inspector's program

The inspector's program is built for AST traversal only (no `lib`, `types: []`, no user `paths`). Running `getPreEmitDiagnostics` on it would emit spurious "cannot find module" / missing-lib noise that doesn't match the real build — the opposite of the goal. So we build from `config.tsconfig`, the actual source of truth.

## Example

```
Type check: 2 errors in 1 file
  src/bad.ts:1:14  TS2322  Type 'string' is not assignable to type 'number'.
  src/bad.ts:2:14  TS2322  Type 'number' is not assignable to type 'string'.
```

## Tests

- Pure `collectTscDiagnostics` / `renderTscSummary` helpers are unit-tested (counts, 1-based positions, node_modules/out-of-root filtering, file-less globals, compact render, cap+remainder). 6/6 pass.
- The real `tsc` path (tsconfig → program → `getPreEmitDiagnostics`) verified against a fixture with deliberate type errors (surfaced 2 errors, correct exit).

Off by default → zero cost on a normal `pikku all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in TypeScript type-check step to `pikku all`.
  * New `--tsc` flag runs `tsc --noEmit` with full diagnostics and code context.
  * New `--tsc-summary` flag runs `tsc --noEmit` and prints a compact, capped one-line-per-error summary.
* **Bug Fixes**
  * When type-checking is enabled, `pikku all` now fails on TypeScript type errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->