### PR TITLE
fix(verifiers): use ephemeral ports in standalone deploy verifiers

### DIFF
--- a/verifiers/deploy-standalone/test-deploy-bun.ts
+++ b/verifiers/deploy-standalone/test-deploy-bun.ts
@@ -12,8 +12,28 @@
 
 import { execFileSync, spawn } from 'child_process'
 import { readFileSync, existsSync, readdirSync, statSync, rmSync } from 'fs'
-import { connect } from 'net'
+import { connect, createServer } from 'net'
 import { join } from 'path'
+
+/**
+ * A fixed port collides with whatever happens to be running on the developer's
+ * machine (e.g. a long-lived `pikku serve`), making the probes below hit the
+ * wrong server. Ask the OS for a free ephemeral port instead.
+ */
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer()
+    probe.once('error', reject)
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address()
+      if (typeof address === 'object' && address) {
+        probe.close(() => resolve(address.port))
+      } else {
+        probe.close(() => reject(new Error('Could not allocate a free port')))
+      }
+    })
+  })
+}
 
 const FUNCTIONS_DIR = join(process.cwd(), '..', '..', 'templates', 'functions')
 const REPO_ROOT = join(process.cwd(), '..', '..')
@@ -130,7 +150,7 @@ await check('entry: bootstrap import + main()', () => {
 // Compile to a single executable with bun, then hit endpoints.
 // ---------------------------------------------------------------------------
 
-const port = 4098
+const port = await getFreePort()
 // Probe over loopback; binding stays 0.0.0.0 (HOST below) but fetching
 // 0.0.0.0 as a client target is unreliable on macOS/Windows.
 const clientHost = '127.0.0.1'

--- a/verifiers/deploy-standalone/test-deploy.ts
+++ b/verifiers/deploy-standalone/test-deploy.ts
@@ -7,8 +7,29 @@
 
 import { execSync, spawn } from 'child_process'
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
+import { createServer } from 'net'
 import { join } from 'path'
 import { createHash } from 'crypto'
+
+/**
+ * A fixed port collides with whatever happens to be running on the developer's
+ * machine (e.g. a long-lived `pikku serve`), making the probes below hit the
+ * wrong server. Ask the OS for a free ephemeral port instead.
+ */
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer()
+    probe.once('error', reject)
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address()
+      if (typeof address === 'object' && address) {
+        probe.close(() => resolve(address.port))
+      } else {
+        probe.close(() => reject(new Error('Could not allocate a free port')))
+      }
+    })
+  })
+}
 
 const FUNCTIONS_DIR = join(process.cwd(), '..', '..', 'templates', 'functions')
 const REPO_ROOT = join(process.cwd(), '..', '..')
@@ -279,7 +300,7 @@ check('no infra.json', () => {
 // Runtime test: start bundle, hit endpoints
 // ---------------------------------------------------------------------------
 
-const port = 4099
+const port = await getFreePort()
 
 async function startServer(): Promise<ReturnType<typeof spawn>> {
   const proc = spawn('node', [join(DEPLOY_DIR, unitName, 'bundle.js')], {


### PR DESCRIPTION
Closes #858.

The standalone deploy verifiers hard-coded probe ports (4098/4099). Anything already listening there on the developer's machine — e.g. a long-lived `pikku serve` that binds `*:4098` — receives the verifier's probes instead of the freshly compiled binary, failing the run with confusing 404s and blocking every push through the pre-push hook.

Both verifiers now ask the OS for a free ephemeral port (bind `:0`, read, release) before spawning the server.

**Verification (TDD flow):** with a dev server occupying `*:4098`, `yarn test` in `verifiers/deploy-standalone` failed 4/10 before this change (bun section, all 404s / WS refusals) and passes 10/10 + 15/15 after, with the same server still running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment test reliability by using an available local port at runtime instead of a fixed port.
  * Reduced the chance of flaky failures caused by port conflicts during standalone server checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->