### PR TITLE
feat: pikku dev/serve --coverage — in-process V8 precise coverage with per-scenario attribution

### DIFF
--- a/.changeset/dev-coverage-v8.md
+++ b/.changeset/dev-coverage-v8.md
@@ -1,0 +1,13 @@
+---
+'@pikku/core': patch
+'@pikku/inspector': patch
+'@pikku/cli': patch
+'@pikku/addon-console': patch
+---
+
+Add in-process V8 precise coverage (`pikku dev --coverage` / `pikku serve --coverage`) with per-scenario attribution.
+
+- `@pikku/core`: new `V8CoverageService` (node:inspector precise coverage with snapshot + reset), exposed as the optional `coverageService` singleton service.
+- `@pikku/inspector`: function meta now records `bodyStart`/`bodyEnd` body spans (verbose meta only) so coverage can be mapped without a runtime TypeScript dependency.
+- `@pikku/cli`: `--coverage` on `pikku dev` and `pikku serve` starts the collector in-process; `pikku scenario run --coverage` resets/snapshots the server between flows and writes `.pikku/coverage/scenario-coverage.json` with per-scenario function coverage.
+- `@pikku/addon-console`: new exposed `takeLiveCoverage` / `resetLiveCoverage` RPCs; V8 ranges are mapped through inline source maps to original TypeScript lines (offset-based, so esbuild/tsx single-line output keeps full resolution).

--- a/e2e/packages/functions/src/workflows/order-support.scenario.ts
+++ b/e2e/packages/functions/src/workflows/order-support.scenario.ts
@@ -1,10 +1,5 @@
 import { pikkuScenario } from '#pikku/workflow/pikku-workflow-types.gen.js'
 
-/**
- * UI-fixture scenario: gives the console a scenario with two actors so the
- * Workflows page's Scenarios / Personas views have something to render.
- * Runnable via `pikku scenario run` too — the steps are plain exposed RPCs.
- */
 export const orderSupportScenario = pikkuScenario<
   { value?: number },
   { doubled: number; message: string }

--- a/e2e/tests/features/scenario-run.feature
+++ b/e2e/tests/features/scenario-run.feature
@@ -11,3 +11,8 @@ Feature: Scenario runs
   Scenario: a failing scenario surfaces a non-zero exit code
     When I run the "failingScenario" scenario against the "local" environment
     Then the scenario run exits non-zero
+
+  Scenario: scenario run attributes coverage per scenario
+    When I run the "orderSupportScenario" scenario with coverage against the "local" environment
+    Then the scenario run reports all flows passed
+    And the scenario run reports coverage for "orderSupportScenario"

--- a/e2e/tests/steps/scenario-run.steps.ts
+++ b/e2e/tests/steps/scenario-run.steps.ts
@@ -13,13 +13,14 @@ let lastRun: ScenarioRunResult | undefined
 
 const runScenario = (
   environment: string,
-  flow: string
+  flow: string,
+  extraArgs: string[] = []
 ): Promise<ScenarioRunResult> =>
   new Promise((resolvePromise) => {
     const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
     const child = spawn(
       'npx',
-      ['pikku', 'scenario', 'run', environment, '--flows', flow],
+      ['pikku', 'scenario', 'run', environment, '--flows', flow, ...extraArgs],
       { cwd: projectDir, env: { ...process.env } }
     )
     let output = ''
@@ -38,6 +39,27 @@ When(
     lastRun = await runScenario(environment, flow)
   }
 )
+
+When(
+  'I run the {string} scenario with coverage against the {string} environment',
+  async function (flow: string, environment: string) {
+    lastRun = await runScenario(environment, flow, ['--coverage'])
+  }
+)
+
+Then('the scenario run reports coverage for {string}', function (flow: string) {
+  assert.ok(lastRun, 'no scenario run recorded')
+  assert.match(
+    lastRun.output,
+    new RegExp(`coverage: [1-9]\\d*/\\d+ functions exercised by '${flow}'`),
+    `expected per-scenario coverage attribution in output:\n${lastRun.output}`
+  )
+  assert.match(
+    lastRun.output,
+    /Scenario coverage → .*scenario-coverage\.json/,
+    `expected scenario-coverage.json to be written:\n${lastRun.output}`
+  )
+})
 
 Then('the scenario run reports all flows passed', function () {
   assert.ok(lastRun, 'no scenario run recorded')

--- a/e2e/tests/support/hooks.ts
+++ b/e2e/tests/support/hooks.ts
@@ -27,7 +27,7 @@ BeforeAll(async function () {
 
   backendProcess = spawn(
     'npx',
-    ['pikku', 'serve', '--port', backendPort, '--console', '--coverage'],
+    ['pikku', 'dev', '--port', backendPort, '--coverage'],
     {
       cwd: projectDir,
       env: { ...process.env, API_URL: config.apiUrl },

--- a/e2e/tests/support/hooks.ts
+++ b/e2e/tests/support/hooks.ts
@@ -27,7 +27,7 @@ BeforeAll(async function () {
 
   backendProcess = spawn(
     'npx',
-    ['pikku', 'serve', '--port', backendPort, '--console'],
+    ['pikku', 'serve', '--port', backendPort, '--console', '--coverage'],
     {
       cwd: projectDir,
       env: { ...process.env, API_URL: config.apiUrl },

--- a/packages/addon/pikku-console/package.json
+++ b/packages/addon/pikku-console/package.json
@@ -47,6 +47,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
+    "@jridgewell/trace-mapping": "^0.3.25",
     "json-schema": "^0.4.0",
     "open": "^10.0.0"
   }

--- a/packages/addon/pikku-console/src/functions/reset-live-coverage.function.ts
+++ b/packages/addon/pikku-console/src/functions/reset-live-coverage.function.ts
@@ -1,0 +1,13 @@
+import { pikkuFunc } from '#pikku'
+
+export const resetLiveCoverage = pikkuFunc<null, { enabled: boolean }>({
+  title: 'Reset Live Coverage',
+  description:
+    'Clears V8 precise-coverage call counts so the next takeLiveCoverage snapshot is attributable to a single scenario run. Reports enabled: false when the server was not started with coverage enabled.',
+  expose: true,
+  func: async ({ coverageService }) => {
+    if (!coverageService) return { enabled: false }
+    await coverageService.reset()
+    return { enabled: true }
+  },
+})

--- a/packages/addon/pikku-console/src/functions/take-live-coverage.function.ts
+++ b/packages/addon/pikku-console/src/functions/take-live-coverage.function.ts
@@ -1,0 +1,38 @@
+import { pikkuFunc } from '#pikku'
+import type { FunctionCoverageReport } from './get-function-coverage.function.js'
+import {
+  mapPreciseCoverage,
+  type CoverageFunctionMeta,
+} from '../lib/precise-coverage-map.js'
+
+export const takeLiveCoverage = pikkuFunc<null, FunctionCoverageReport | null>({
+  title: 'Take Live Coverage',
+  description:
+    'Snapshots the V8 precise coverage collected since the server started (or since the last resetLiveCoverage) and maps it onto function body spans. Returns null unless the server was started with coverage enabled (pikku dev --coverage).',
+  expose: true,
+  func: async ({ coverageService, metaService }) => {
+    if (!coverageService || !metaService?.basePath) return null
+    const { readFile } = await import('node:fs/promises')
+    const { join } = await import('node:path')
+    let functionsMeta: Record<string, CoverageFunctionMeta>
+    try {
+      const content = await readFile(
+        join(
+          metaService.basePath,
+          'function',
+          'pikku-functions-meta-verbose.gen.json'
+        ),
+        'utf-8'
+      )
+      functionsMeta = JSON.parse(content)
+    } catch {
+      return null
+    }
+    const scripts = await coverageService.takeCoverage()
+    return mapPreciseCoverage(
+      scripts,
+      (scriptId) => coverageService.getScriptSource(scriptId),
+      functionsMeta
+    )
+  },
+})

--- a/packages/addon/pikku-console/src/functions/take-live-coverage.function.ts
+++ b/packages/addon/pikku-console/src/functions/take-live-coverage.function.ts
@@ -2,13 +2,14 @@ import { pikkuFunc } from '#pikku'
 import type { FunctionCoverageReport } from './get-function-coverage.function.js'
 import {
   mapPreciseCoverage,
+  mapLineHitsToReport,
   type CoverageFunctionMeta,
 } from '../lib/precise-coverage-map.js'
 
 export const takeLiveCoverage = pikkuFunc<null, FunctionCoverageReport | null>({
   title: 'Take Live Coverage',
   description:
-    'Snapshots the V8 precise coverage collected since the server started (or since the last resetLiveCoverage) and maps it onto function body spans. Returns null unless the server was started with coverage enabled (pikku dev --coverage).',
+    'Snapshots the live coverage collected since the server started (or since the last resetLiveCoverage) — V8 precise coverage on Node, istanbul instrumentation on Bun — and maps it onto function body spans. Returns null unless the server was started with coverage enabled (pikku dev --coverage).',
   expose: true,
   func: async ({ coverageService, metaService }) => {
     if (!coverageService || !metaService?.basePath) return null
@@ -28,10 +29,13 @@ export const takeLiveCoverage = pikkuFunc<null, FunctionCoverageReport | null>({
     } catch {
       return null
     }
-    const scripts = await coverageService.takeCoverage()
+    const snapshot = await coverageService.takeCoverage()
+    if (snapshot.kind === 'line-hits') {
+      return mapLineHitsToReport(snapshot.lineHits, functionsMeta)
+    }
     return mapPreciseCoverage(
-      scripts,
-      (scriptId) => coverageService.getScriptSource(scriptId),
+      snapshot.scripts,
+      snapshot.getScriptSource,
       functionsMeta
     )
   },

--- a/packages/addon/pikku-console/src/lib/precise-coverage-map.test.ts
+++ b/packages/addon/pikku-console/src/lib/precise-coverage-map.test.ts
@@ -100,4 +100,22 @@ describe('mapPreciseCoverage', () => {
     const ghost = report.functions.find((f) => f.name === 'ghostFn')
     assert.equal(ghost?.status, 'unknown')
   })
+
+  test('cross-file handlers read hits from bodySourceFile, not the wiring file', async () => {
+    const report = await mapPreciseCoverage(scripts, async () => source, {
+      importedFn: {
+        name: 'importedFn',
+        sourceFile: '/proj/src/wirings.ts',
+        bodySourceFile: '/proj/src/things.function.ts',
+        exportedName: 'importedFn',
+        expose: true,
+        description: null,
+        bodyStart: 2,
+        bodyEnd: 2,
+      },
+    } as any)
+    const imported = report.functions.find((f) => f.name === 'importedFn')
+    assert.equal(imported?.status, 'covered')
+    assert.equal(imported?.ratio, 1)
+  })
 })

--- a/packages/addon/pikku-console/src/lib/precise-coverage-map.test.ts
+++ b/packages/addon/pikku-console/src/lib/precise-coverage-map.test.ts
@@ -1,0 +1,103 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mapPreciseCoverage } from './precise-coverage-map.js'
+
+// A plain-JS "transpiled" script (no source map → identity line mapping).
+// Offsets are byte positions into this exact string.
+const lines = [
+  'function coveredFn(n) {', // line 1
+  '  return n * 2', // 2
+  '}', // 3
+  'function missedFn(n) {', // 4
+  '  return n + 1', // 5
+  '}', // 6
+  'coveredFn(1)', // 7
+]
+const source = lines.join('\n')
+const offsetOf = (line: number) =>
+  lines.slice(0, line - 1).join('\n').length + (line > 1 ? 1 : 0)
+
+const scriptUrl = 'file:///proj/src/things.function.ts'
+
+const scripts = [
+  {
+    scriptId: '1',
+    url: scriptUrl,
+    functions: [
+      {
+        functionName: 'coveredFn',
+        isBlockCoverage: true,
+        ranges: [{ startOffset: 0, endOffset: offsetOf(3) + 1, count: 1 }],
+      },
+      {
+        functionName: 'missedFn',
+        isBlockCoverage: true,
+        ranges: [
+          {
+            startOffset: offsetOf(4),
+            endOffset: offsetOf(6) + 1,
+            count: 0,
+          },
+        ],
+      },
+    ],
+  },
+]
+
+const meta = {
+  coveredFn: {
+    name: 'coveredFn',
+    sourceFile: '/proj/src/things.function.ts',
+    exportedName: 'coveredFn',
+    expose: true,
+    description: null,
+    bodyStart: 2,
+    bodyEnd: 2,
+  },
+  missedFn: {
+    name: 'missedFn',
+    sourceFile: '/proj/src/things.function.ts',
+    exportedName: 'missedFn',
+    expose: true,
+    description: null,
+    bodyStart: 5,
+    bodyEnd: 5,
+  },
+}
+
+describe('mapPreciseCoverage', () => {
+  test('maps V8 script coverage onto function body spans', async () => {
+    const report = await mapPreciseCoverage(
+      scripts,
+      async () => source,
+      meta as any
+    )
+    const covered = report.functions.find((f) => f.name === 'coveredFn')
+    const missed = report.functions.find((f) => f.name === 'missedFn')
+    assert.ok(covered && missed)
+    assert.equal(covered.status, 'covered')
+    assert.equal(covered.ratio, 1)
+    assert.equal(missed.status, 'uncovered')
+    assert.deepEqual(missed.missedLines, [5])
+    assert.equal(report.summary.total, 2)
+    assert.equal(report.summary.covered, 1)
+    assert.equal(report.summary.uncovered, 1)
+  })
+
+  test('functions whose source never appears in coverage are unknown', async () => {
+    const report = await mapPreciseCoverage(scripts, async () => source, {
+      ...meta,
+      ghostFn: {
+        name: 'ghostFn',
+        sourceFile: '/proj/src/ghost.function.ts',
+        exportedName: 'ghostFn',
+        expose: true,
+        description: null,
+        bodyStart: 2,
+        bodyEnd: 3,
+      },
+    } as any)
+    const ghost = report.functions.find((f) => f.name === 'ghostFn')
+    assert.equal(ghost?.status, 'unknown')
+  })
+})

--- a/packages/addon/pikku-console/src/lib/precise-coverage-map.test.ts
+++ b/packages/addon/pikku-console/src/lib/precise-coverage-map.test.ts
@@ -118,4 +118,53 @@ describe('mapPreciseCoverage', () => {
     assert.equal(imported?.status, 'covered')
     assert.equal(imported?.ratio, 1)
   })
+
+  test('relative sourcemap sources resolve against sourceRoot before matching meta', async () => {
+    // Single-line generated output (esbuild-style) with an inline map whose
+    // sources entry is relative; sourceRoot supplies the absolute prefix.
+    const generated = 'function coveredFn(n){return n*2}coveredFn(1);'
+    const map = {
+      version: 3,
+      sourceRoot: 'file:///proj/src/',
+      sources: ['things.function.ts'],
+      names: [],
+      // every generated column maps to line 2 of the original source
+      mappings: 'AACA,kBAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC',
+    }
+    const inlined =
+      generated +
+      '\n//# sourceMappingURL=data:application/json;base64,' +
+      Buffer.from(JSON.stringify(map)).toString('base64')
+    const report = await mapPreciseCoverage(
+      [
+        {
+          scriptId: '9',
+          url: 'file:///proj/dist/things.function.js',
+          functions: [
+            {
+              functionName: 'coveredFn',
+              isBlockCoverage: true,
+              ranges: [
+                { startOffset: 0, endOffset: generated.length, count: 1 },
+              ],
+            },
+          ],
+        },
+      ],
+      async () => inlined,
+      {
+        coveredFn: {
+          name: 'coveredFn',
+          sourceFile: '/proj/src/things.function.ts',
+          exportedName: 'coveredFn',
+          expose: true,
+          description: null,
+          bodyStart: 2,
+          bodyEnd: 2,
+        },
+      } as any
+    )
+    const covered = report.functions.find((f) => f.name === 'coveredFn')
+    assert.equal(covered?.status, 'covered')
+  })
 })

--- a/packages/addon/pikku-console/src/lib/precise-coverage-map.ts
+++ b/packages/addon/pikku-console/src/lib/precise-coverage-map.ts
@@ -1,15 +1,6 @@
-/**
- * Maps raw V8 precise coverage (from the core CoverageService) onto pikku
- * function body spans, producing the same FunctionCoverageReport shape the
- * console has always consumed.
- *
- * V8 range offsets are translated to original source lines through the
- * script's inline source map (tsx/esbuild transpiled TypeScript). Istanbul's
- * line-based statement maps can't be used here: esbuild emits the whole
- * module on a single generated line, which collapses every statement onto
- * line 1. Mapping each range's start/end offset through the source map keeps
- * per-line resolution regardless of the generated layout.
- */
+// Offsets are mapped through the inline source map rather than line-based
+// statement maps: esbuild emits the whole module on one generated line, which
+// would collapse every statement onto line 1.
 import { fileURLToPath } from 'node:url'
 import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'
 import type {
@@ -138,9 +129,7 @@ async function scriptToLineCoverage(
   }
 
   for (const fn of script.functions) {
-    // V8 lists a function's whole span first, then progressively narrower
-    // sub-ranges. Applying them in order means inner ranges overwrite the
-    // outer count, matching V8's override semantics.
+    // Inner ranges overwrite the outer count (V8 override semantics).
     for (const range of fn.ranges) {
       const start = mapOffset(range.startOffset)
       const end = mapOffset(Math.max(range.startOffset, range.endOffset - 1))

--- a/packages/addon/pikku-console/src/lib/precise-coverage-map.ts
+++ b/packages/addon/pikku-console/src/lib/precise-coverage-map.ts
@@ -157,7 +157,13 @@ export async function mapPreciseCoverage(
   for (const script of scripts) {
     await scriptToLineCoverage(script, getScriptSource, lineHits)
   }
+  return mapLineHitsToReport(lineHits, functionsMeta)
+}
 
+export function mapLineHitsToReport(
+  lineHits: Map<string, Map<number, number>>,
+  functionsMeta: Record<string, CoverageFunctionMeta>
+): FunctionCoverageReport {
   const functions: FunctionCoverageEntry[] = Object.values(functionsMeta)
     .filter((m) => m.sourceFile && !m.sourceFile.endsWith('.gen.ts'))
     .map((m) => {

--- a/packages/addon/pikku-console/src/lib/precise-coverage-map.ts
+++ b/packages/addon/pikku-console/src/lib/precise-coverage-map.ts
@@ -1,0 +1,225 @@
+/**
+ * Maps raw V8 precise coverage (from the core CoverageService) onto pikku
+ * function body spans, producing the same FunctionCoverageReport shape the
+ * console has always consumed.
+ *
+ * V8 range offsets are translated to original source lines through the
+ * script's inline source map (tsx/esbuild transpiled TypeScript). Istanbul's
+ * line-based statement maps can't be used here: esbuild emits the whole
+ * module on a single generated line, which collapses every statement onto
+ * line 1. Mapping each range's start/end offset through the source map keeps
+ * per-line resolution regardless of the generated layout.
+ */
+import { fileURLToPath } from 'node:url'
+import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'
+import type {
+  FunctionCoverageEntry,
+  FunctionCoverageReport,
+} from '../functions/get-function-coverage.function.js'
+
+interface CoverageRange {
+  startOffset: number
+  endOffset: number
+  count: number
+}
+
+interface FunctionCoverage {
+  functionName: string
+  isBlockCoverage: boolean
+  ranges: CoverageRange[]
+}
+
+export interface ScriptCoverageInput {
+  scriptId: string
+  url: string
+  functions: FunctionCoverage[]
+}
+
+export interface CoverageFunctionMeta {
+  name: string
+  sourceFile: string
+  exportedName?: string
+  expose?: boolean
+  description?: string | null
+  bodyStart?: number
+  bodyEnd?: number
+}
+
+const INLINE_SOURCE_MAP =
+  /\/\/# sourceMappingURL=data:application\/json[^,]*;base64,([A-Za-z0-9+/=]+)/
+
+function extractInlineSourceMap(source: string) {
+  const match = source.match(INLINE_SOURCE_MAP)
+  if (!match) return undefined
+  try {
+    return JSON.parse(Buffer.from(match[1], 'base64').toString('utf-8'))
+  } catch {
+    return undefined
+  }
+}
+
+function computeLineStarts(source: string): number[] {
+  const starts = [0]
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === '\n') starts.push(i + 1)
+  }
+  return starts
+}
+
+function offsetToGeneratedPosition(offset: number, lineStarts: number[]) {
+  let low = 0
+  let high = lineStarts.length - 1
+  while (low < high) {
+    const mid = (low + high + 1) >> 1
+    if (lineStarts[mid] <= offset) low = mid
+    else high = mid - 1
+  }
+  return { line: low + 1, column: offset - lineStarts[low] }
+}
+
+function normalizeSourcePath(source: string): string {
+  if (source.startsWith('file://')) {
+    try {
+      return fileURLToPath(source)
+    } catch {
+      return source
+    }
+  }
+  return source
+}
+
+async function scriptToLineCoverage(
+  script: ScriptCoverageInput,
+  getScriptSource: (scriptId: string) => Promise<string>,
+  lineHits: Map<string, Map<number, number>>
+): Promise<void> {
+  let scriptPath: string
+  try {
+    scriptPath = fileURLToPath(script.url)
+  } catch {
+    return
+  }
+  let source: string
+  try {
+    source = await getScriptSource(script.scriptId)
+  } catch {
+    return
+  }
+  const sourcemap = extractInlineSourceMap(source)
+  let tracer: TraceMap | undefined
+  if (sourcemap) {
+    try {
+      tracer = new TraceMap(sourcemap)
+    } catch {
+      tracer = undefined
+    }
+  }
+  const lineStarts = computeLineStarts(source)
+
+  const mapOffset = (
+    offset: number
+  ): { file: string; line: number } | undefined => {
+    const generated = offsetToGeneratedPosition(offset, lineStarts)
+    if (!tracer) return { file: scriptPath, line: generated.line }
+    const original = originalPositionFor(tracer, generated)
+    if (original.source == null || original.line == null) return undefined
+    return { file: normalizeSourcePath(original.source), line: original.line }
+  }
+
+  const setHits = (file: string, from: number, to: number, count: number) => {
+    let hits = lineHits.get(file)
+    if (!hits) {
+      hits = new Map()
+      lineHits.set(file, hits)
+    }
+    for (let line = from; line <= to; line++) {
+      hits.set(line, count)
+    }
+  }
+
+  for (const fn of script.functions) {
+    // V8 lists a function's whole span first, then progressively narrower
+    // sub-ranges. Applying them in order means inner ranges overwrite the
+    // outer count, matching V8's override semantics.
+    for (const range of fn.ranges) {
+      const start = mapOffset(range.startOffset)
+      const end = mapOffset(Math.max(range.startOffset, range.endOffset - 1))
+      if (!start && !end) continue
+      const file = (start ?? end)!.file
+      const from = start?.line ?? end!.line
+      const to = end && end.file === file ? Math.max(end.line, from) : from
+      setHits(file, from, to, range.count)
+    }
+  }
+}
+
+export async function mapPreciseCoverage(
+  scripts: ScriptCoverageInput[],
+  getScriptSource: (scriptId: string) => Promise<string>,
+  functionsMeta: Record<string, CoverageFunctionMeta>
+): Promise<FunctionCoverageReport> {
+  const lineHits = new Map<string, Map<number, number>>()
+  for (const script of scripts) {
+    await scriptToLineCoverage(script, getScriptSource, lineHits)
+  }
+
+  const functions: FunctionCoverageEntry[] = Object.values(functionsMeta)
+    .filter((m) => m.sourceFile && !m.sourceFile.endsWith('.gen.ts'))
+    .map((m) => {
+      const hits = lineHits.get(m.sourceFile)
+      const covered: number[] = []
+      const missed: number[] = []
+      if (hits && m.bodyStart !== undefined && m.bodyEnd !== undefined) {
+        for (const [line, count] of hits) {
+          if (line < m.bodyStart || line > m.bodyEnd) continue
+          if (count > 0) covered.push(line)
+          else missed.push(line)
+        }
+      }
+      const total = covered.length + missed.length
+      const ratio = total ? covered.length / total : 0
+      const status =
+        total === 0
+          ? ('unknown' as const)
+          : covered.length === 0
+            ? ('uncovered' as const)
+            : missed.length === 0
+              ? ('covered' as const)
+              : ('partial' as const)
+      return {
+        name: m.name,
+        sourceFile: m.sourceFile,
+        exposed: m.expose !== false,
+        description: m.description ?? null,
+        coveredLines: covered.length,
+        totalLines: total,
+        missedLines: missed.sort((a, b) => a - b),
+        ratio: Number(ratio.toFixed(3)),
+        status,
+      }
+    })
+    .sort((a, b) => a.ratio - b.ratio || a.name.localeCompare(b.name))
+
+  const summary = {
+    total: functions.length,
+    covered: 0,
+    partial: 0,
+    uncovered: 0,
+    unknown: 0,
+    overallRatio: 0,
+  }
+  for (const f of functions) summary[f.status]++
+  summary.overallRatio = functions.length
+    ? Number(
+        (functions.reduce((a, f) => a + f.ratio, 0) / functions.length).toFixed(
+          3
+        )
+      )
+    : 0
+
+  return {
+    generatedAt: new Date().toISOString(),
+    summary,
+    functions,
+  }
+}

--- a/packages/addon/pikku-console/src/lib/precise-coverage-map.ts
+++ b/packages/addon/pikku-console/src/lib/precise-coverage-map.ts
@@ -29,6 +29,7 @@ export interface ScriptCoverageInput {
 export interface CoverageFunctionMeta {
   name: string
   sourceFile: string
+  bodySourceFile?: string
   exportedName?: string
   expose?: boolean
   description?: string | null
@@ -114,7 +115,12 @@ async function scriptToLineCoverage(
     if (!tracer) return { file: scriptPath, line: generated.line }
     const original = originalPositionFor(tracer, generated)
     if (original.source == null || original.line == null) return undefined
-    return { file: normalizeSourcePath(original.source), line: original.line }
+    const sourceIndex = tracer.sources.indexOf(original.source)
+    const resolved =
+      sourceIndex >= 0
+        ? (tracer.resolvedSources[sourceIndex] ?? original.source)
+        : original.source
+    return { file: normalizeSourcePath(resolved), line: original.line }
   }
 
   const setHits = (file: string, from: number, to: number, count: number) => {
@@ -155,7 +161,7 @@ export async function mapPreciseCoverage(
   const functions: FunctionCoverageEntry[] = Object.values(functionsMeta)
     .filter((m) => m.sourceFile && !m.sourceFile.endsWith('.gen.ts'))
     .map((m) => {
-      const hits = lineHits.get(m.sourceFile)
+      const hits = lineHits.get(m.bodySourceFile ?? m.sourceFile)
       const covered: number[] = []
       const missed: number[] = []
       if (hits && m.bodyStart !== undefined && m.bodyEnd !== undefined) {

--- a/packages/addon/pikku-console/src/services.ts
+++ b/packages/addon/pikku-console/src/services.ts
@@ -22,6 +22,7 @@ export const createSingletonServices = pikkuAddonServices(
       aiRunState,
       deploymentService,
       credentialService,
+      coverageService,
     }
   ) => {
     if (!existingMetaService) {
@@ -74,6 +75,7 @@ export const createSingletonServices = pikkuAddonServices(
       aiAgentRunner,
       schedulerService,
       credentialService,
+      coverageService,
       codeEditService,
       stateDiffService,
       dbSchemaService,

--- a/packages/cli/build.sh
+++ b/packages/cli/build.sh
@@ -155,7 +155,9 @@ ENTRY
   for target in bun-linux-x64 bun-linux-arm64 bun-darwin-x64 bun-darwin-arm64 bun-windows-x64; do
     suffix="${target#bun-}"
     echo "  → $target"
-    bun build --compile "--target=$target" "--outfile=release/binaries/pikku-$suffix" dist/bin/pikku-bin.mjs
+    # istanbul-lib-instrument (babel) uses dynamic requires bun can't bundle;
+    # it's only needed for dev --coverage under bun, where node_modules exists.
+    bun build --compile "--target=$target" --external istanbul-lib-instrument "--outfile=release/binaries/pikku-$suffix" dist/bin/pikku-bin.mjs
   done
 
   echo "Native binaries written to release/binaries/"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
     "chalk": "^5.6.2",
     "chokidar": "^4.0.3",
     "esbuild": "~0.27.0",
+    "istanbul-lib-instrument": "^6.0.3",
     "open": "^10.2.0",
     "openapi-types": "^12.1.3",
     "path-to-regexp": "^8.3.0",
@@ -58,6 +59,7 @@
     "zod-to-ts": "^2.1.0"
   },
   "devDependencies": {
+    "@types/istanbul-lib-instrument": "^1.7.7",
     "@types/node": "^24.11.0",
     "@types/pg": "^8.11.0",
     "@types/ws": "^8"

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -271,6 +271,11 @@ wireCLI({
           description: 'Enable hot module reload',
           default: true,
         },
+        coverage: {
+          description:
+            'Collect V8 precise coverage in-process; snapshot/reset via the console coverage RPCs',
+          default: false,
+        },
       },
     }),
     serve: pikkuCLICommand({
@@ -285,6 +290,11 @@ wireCLI({
         },
         console: {
           description: 'Also serve the Pikku Console same-origin at /console',
+          default: false,
+        },
+        coverage: {
+          description:
+            'Collect V8 precise coverage in-process; snapshot/reset via the console coverage RPCs',
           default: false,
         },
       },
@@ -412,6 +422,11 @@ wireCLI({
             tags: {
               description: 'Comma-separated tags — run flows matching any',
               short: 't',
+            },
+            coverage: {
+              description:
+                'Reset/snapshot server coverage per scenario (target must run with --coverage); writes coverage/scenario-coverage.json',
+              default: false,
             },
           },
         }),

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -292,11 +292,6 @@ wireCLI({
           description: 'Also serve the Pikku Console same-origin at /console',
           default: false,
         },
-        coverage: {
-          description:
-            'Collect V8 precise coverage in-process; snapshot/reset via the console coverage RPCs',
-          default: false,
-        },
       },
     }),
     login: pikkuCLICommand({

--- a/packages/cli/src/functions/commands/bun-coverage-loader.ts
+++ b/packages/cli/src/functions/commands/bun-coverage-loader.ts
@@ -1,0 +1,65 @@
+import { readFile } from 'node:fs/promises'
+
+export interface BunCoverageLoaderOptions {
+  rootDir: string
+}
+
+interface BunPluginBuild {
+  onLoad(
+    constraints: { filter: RegExp },
+    callback: (args: {
+      path: string
+    }) => Promise<{ contents: string; loader: 'ts' | 'tsx' } | undefined>
+  ): void
+}
+
+interface BunGlobal {
+  plugin(plugin: { name: string; setup(build: BunPluginBuild): void }): void
+}
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const shouldInstrument = (path: string) =>
+  !path.includes('/node_modules/') &&
+  !path.includes('/.pikku/') &&
+  !/\.(gen|test|d)\.tsx?$/.test(path)
+
+/**
+ * Registers a Bun loader plugin that runs istanbul-lib-instrument over the
+ * project's TypeScript sources so `__coverage__` counters exist at runtime.
+ * Bun has no V8 precise coverage (`node:inspector` throws "Coverage APIs are
+ * not supported"), so instrumentation at load time is the coverage backend
+ * there. Must be called before the user bootstrap is imported.
+ */
+export async function registerBunCoverageLoader({
+  rootDir,
+}: BunCoverageLoaderOptions): Promise<void> {
+  const bun = (globalThis as { Bun?: BunGlobal }).Bun
+  if (!bun) {
+    throw new Error('registerBunCoverageLoader called outside Bun')
+  }
+  const { createInstrumenter } = await import('istanbul-lib-instrument')
+  const instrumenter = createInstrumenter({
+    esModules: true,
+    compact: false,
+    parserPlugins: [
+      'typescript',
+      'importAttributes',
+      'topLevelAwait',
+      'decorators-legacy',
+    ],
+  })
+  const filter = new RegExp(`^${escapeRegExp(rootDir)}/.*\\.tsx?$`)
+  bun.plugin({
+    name: 'pikku-istanbul-coverage',
+    setup(build) {
+      build.onLoad({ filter }, async (args) => {
+        if (!shouldInstrument(args.path)) return undefined
+        const source = await readFile(args.path, 'utf-8')
+        const contents = instrumenter.instrumentSync(source, args.path)
+        return { contents, loader: args.path.endsWith('.tsx') ? 'tsx' : 'ts' }
+      })
+    },
+  })
+}

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -10,6 +10,7 @@ import {
   InMemoryWorkflowService,
   InMemoryTriggerService,
   InMemoryAIRunStateService,
+  V8CoverageService,
 } from '@pikku/core/services'
 import {
   KyselyAIStorageService,
@@ -35,16 +36,23 @@ import { createDevAIAgentRunner } from './dev-ai-runner.js'
 import { resolveConsoleMount } from './serve-console.js'
 
 export const dev = pikkuSessionlessFunc<
-  { port?: string; watch?: boolean; hmr?: boolean },
+  { port?: string; watch?: boolean; hmr?: boolean; coverage?: boolean },
   void
 >({
   remote: true,
   func: async (
     { logger, config, getInspectorState, variables, devServerRunner },
-    { port, watch, hmr },
+    { port, watch, hmr, coverage },
     { rpc }
   ) => {
     process.env.PIKKU_DEV_QUICK_LOGIN ??= 'true'
+    const coverageService = coverage ? new V8CoverageService() : undefined
+    if (coverageService) {
+      await coverageService.start()
+      logger.info(
+        'V8 precise coverage enabled — snapshot via console:takeLiveCoverage, reset via console:resetLiveCoverage'
+      )
+    }
     const resolvedPort = parseInt(port || '3000', 10)
     const hostname = 'localhost'
     // Bind on IPv4 loopback explicitly. Under Bun, hostname 'localhost' resolves
@@ -267,6 +275,7 @@ export const dev = pikkuSessionlessFunc<
       ...(aiAgentRunner ? { aiAgentRunner } : {}),
       emailService: new LocalEmailService(),
       metaService: new LocalMetaService(pikkuDir),
+      ...(coverageService ? { coverageService } : {}),
       schedulerService,
       queueService: new InMemoryQueueService(),
       workflowService,
@@ -284,7 +293,11 @@ export const dev = pikkuSessionlessFunc<
       ...inMemoryServices,
       getInspectorState,
     })
-    const resolvedServices = { ...singletonServices, getInspectorState }
+    const resolvedServices = {
+      ...singletonServices,
+      getInspectorState,
+      ...(coverageService ? { coverageService } : {}),
+    }
     pikkuState(null, 'package', 'singletonServices', resolvedServices)
     resolvedServices.workflowService?.wireQueueWorkers?.()
 

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -10,7 +10,6 @@ import {
   InMemoryWorkflowService,
   InMemoryTriggerService,
   InMemoryAIRunStateService,
-  V8CoverageService,
 } from '@pikku/core/services'
 import {
   KyselyAIStorageService,
@@ -32,6 +31,7 @@ import {
   type ResolvedDb,
 } from '../db/local-db.js'
 import { loadUserBootstrap, loadUserModule } from './load-user-project.js'
+import { startCoverageService } from './start-coverage.js'
 import { createDevAIAgentRunner } from './dev-ai-runner.js'
 import { resolveConsoleMount } from './serve-console.js'
 
@@ -46,20 +46,9 @@ export const dev = pikkuSessionlessFunc<
     { rpc }
   ) => {
     process.env.PIKKU_DEV_QUICK_LOGIN ??= 'true'
-    let coverageService = coverage ? new V8CoverageService() : undefined
-    if (coverageService) {
-      try {
-        await coverageService.start()
-        logger.info(
-          'V8 precise coverage enabled — snapshot via console:takeLiveCoverage, reset via console:resetLiveCoverage'
-        )
-      } catch (e) {
-        logger.warn(
-          `V8 precise coverage is not supported on this runtime — continuing without coverage: ${e instanceof Error ? e.message : e}`
-        )
-        coverageService = undefined
-      }
-    }
+    const coverageService = coverage
+      ? await startCoverageService(logger, config.rootDir)
+      : undefined
     const resolvedPort = parseInt(port || '3000', 10)
     const hostname = 'localhost'
     // Bind on IPv4 loopback explicitly. Under Bun, hostname 'localhost' resolves

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -46,12 +46,19 @@ export const dev = pikkuSessionlessFunc<
     { rpc }
   ) => {
     process.env.PIKKU_DEV_QUICK_LOGIN ??= 'true'
-    const coverageService = coverage ? new V8CoverageService() : undefined
+    let coverageService = coverage ? new V8CoverageService() : undefined
     if (coverageService) {
-      await coverageService.start()
-      logger.info(
-        'V8 precise coverage enabled — snapshot via console:takeLiveCoverage, reset via console:resetLiveCoverage'
-      )
+      try {
+        await coverageService.start()
+        logger.info(
+          'V8 precise coverage enabled — snapshot via console:takeLiveCoverage, reset via console:resetLiveCoverage'
+        )
+      } catch (e) {
+        logger.warn(
+          `V8 precise coverage is not supported on this runtime — continuing without coverage: ${e instanceof Error ? e.message : e}`
+        )
+        coverageService = undefined
+      }
     }
     const resolvedPort = parseInt(port || '3000', 10)
     const hostname = 'localhost'

--- a/packages/cli/src/functions/commands/scenario.ts
+++ b/packages/cli/src/functions/commands/scenario.ts
@@ -1,4 +1,5 @@
-import { resolve } from 'path'
+import { resolve, join } from 'node:path'
+import { mkdirSync, writeFileSync } from 'node:fs'
 
 import { pikkuSessionlessFunc } from '#pikku'
 import {
@@ -40,12 +41,12 @@ export const scenarioList = pikkuSessionlessFunc<{}, void>({
 })
 
 export const scenarioRun = pikkuSessionlessFunc<
-  { environment: string; flows?: string; tags?: string },
+  { environment: string; flows?: string; tags?: string; coverage?: boolean },
   void
 >({
   func: async (
     { logger, config, getInspectorState, variables },
-    { environment, flows, tags }
+    { environment, flows, tags, coverage }
   ) => {
     const state = await getInspectorState(true)
 
@@ -132,8 +133,43 @@ export const scenarioRun = pikkuSessionlessFunc<
       error?: string
     }> = []
 
+    // --- per-scenario coverage attribution (server must run with --coverage).
+    // The reset/take RPCs are invoked through an actor's authenticated client
+    // like any other exposed RPC; when the server has no collector (or the
+    // console addon isn't wired) coverage is disabled with a warning.
+    const coverageActor = coverage ? Object.values(actors)[0] : undefined
+    let coverageActive = Boolean(coverageActor)
+    if (coverage && !coverageActor) {
+      logger.warn(
+        '--coverage requires at least one configured actor — skipping coverage.'
+      )
+    }
+    const scenarioCoverage: Record<string, unknown> = {}
+    const invokeCoverage = async (rpcName: string): Promise<any> => {
+      if (!coverageActive || !coverageActor) return null
+      try {
+        return await coverageActor.invoke(rpcName, null)
+      } catch (e: any) {
+        coverageActive = false
+        logger.warn(
+          `Coverage disabled — '${rpcName}' failed against '${environment}': ${e?.message ?? e}. ` +
+            `Is the server running with --coverage and the console addon wired?`
+        )
+        return null
+      }
+    }
+
     for (const flow of selected) {
       const startedAt = Date.now()
+      if (coverageActive) {
+        const reset = await invokeCoverage('console:resetLiveCoverage')
+        if (reset && reset.enabled === false) {
+          coverageActive = false
+          logger.warn(
+            `Coverage disabled — '${environment}' is not collecting (start the server with --coverage).`
+          )
+        }
+      }
       try {
         const { runId } = await workflowService.startWorkflow(
           flow.name,
@@ -166,6 +202,40 @@ export const scenarioRun = pikkuSessionlessFunc<
           error: e?.message ?? String(e),
         })
       }
+      if (coverageActive) {
+        const report = await invokeCoverage('console:takeLiveCoverage')
+        if (report) {
+          scenarioCoverage[flow.name] = report
+          const covered = report.functions?.filter(
+            (f: any) => f.status === 'covered' || f.status === 'partial'
+          )
+          logger.info(
+            `  coverage: ${covered?.length ?? 0}/${report.summary?.total ?? 0} functions exercised by '${flow.name}'`
+          )
+        }
+      }
+    }
+
+    if (coverage && Object.keys(scenarioCoverage).length > 0) {
+      const coverageDir = join(
+        resolve(config.rootDir, config.outDir),
+        'coverage'
+      )
+      mkdirSync(coverageDir, { recursive: true })
+      const outFile = join(coverageDir, 'scenario-coverage.json')
+      writeFileSync(
+        outFile,
+        JSON.stringify(
+          {
+            generatedAt: new Date().toISOString(),
+            environment,
+            scenarios: scenarioCoverage,
+          },
+          null,
+          2
+        ) + '\n'
+      )
+      logger.info(`Scenario coverage → ${outFile}`)
     }
 
     // --- report ---

--- a/packages/cli/src/functions/commands/scenario.ts
+++ b/packages/cli/src/functions/commands/scenario.ts
@@ -50,7 +50,6 @@ export const scenarioRun = pikkuSessionlessFunc<
   ) => {
     const state = await getInspectorState(true)
 
-    // --- resolve the target environment ---
     const environments = config.scenarios?.environments ?? {}
     const env = environments[environment]
     if (!env) {
@@ -63,7 +62,6 @@ export const scenarioRun = pikkuSessionlessFunc<
       )
     }
 
-    // --- select flows ---
     let selected = listScenarios(state)
     if (flows) {
       const names = new Set(flows.split(',').map((f) => f.trim()))
@@ -87,7 +85,6 @@ export const scenarioRun = pikkuSessionlessFunc<
       return
     }
 
-    // --- actors: registry from config, secret STRICTLY from env ---
     const secret = await variables.get('SCENARIO_ACTOR_SECRET')
     if (!secret) {
       throw new Error(
@@ -103,10 +100,6 @@ export const scenarioRun = pikkuSessionlessFunc<
       rpcPath: env.rpcPath,
     })
 
-    // --- load the project's generated bootstrap so flows are registered.
-    // Deliberately NO user services: flows may only use logger/config
-    // (inspector-enforced), and internal rpc dispatch is refused below so a
-    // run against staging/production can never touch local services.
     await loadUserBootstrap(resolve(config.rootDir, config.outDir))
     const workflowService = new InMemoryWorkflowService()
     pikkuState(null, 'package', 'singletonServices', {
@@ -124,7 +117,6 @@ export const scenarioRun = pikkuSessionlessFunc<
       },
     }
 
-    // --- run sequentially: flows are stories; parallel actors would share cookie jars ---
     const results: Array<{
       name: string
       status: 'passed' | 'failed'
@@ -133,10 +125,6 @@ export const scenarioRun = pikkuSessionlessFunc<
       error?: string
     }> = []
 
-    // --- per-scenario coverage attribution (server must run with --coverage).
-    // The reset/take RPCs are invoked through an actor's authenticated client
-    // like any other exposed RPC; when the server has no collector (or the
-    // console addon isn't wired) coverage is disabled with a warning.
     const coverageActor = coverage ? Object.values(actors)[0] : undefined
     let coverageActive = Boolean(coverageActor)
     if (coverage && !coverageActor) {
@@ -238,7 +226,6 @@ export const scenarioRun = pikkuSessionlessFunc<
       logger.info(`Scenario coverage → ${outFile}`)
     }
 
-    // --- report ---
     const failed = results.filter((r) => r.status === 'failed')
     for (const r of results) {
       if (r.status === 'passed') {

--- a/packages/cli/src/functions/commands/serve.ts
+++ b/packages/cli/src/functions/commands/serve.ts
@@ -43,12 +43,19 @@ export const serve = pikkuSessionlessFunc<
     { port, console: serveConsole, coverage }
   ) => {
     process.env.PIKKU_DEV_QUICK_LOGIN ??= 'true'
-    const coverageService = coverage ? new V8CoverageService() : undefined
+    let coverageService = coverage ? new V8CoverageService() : undefined
     if (coverageService) {
-      await coverageService.start()
-      logger.info(
-        'V8 precise coverage enabled — snapshot via console:takeLiveCoverage, reset via console:resetLiveCoverage'
-      )
+      try {
+        await coverageService.start()
+        logger.info(
+          'V8 precise coverage enabled — snapshot via console:takeLiveCoverage, reset via console:resetLiveCoverage'
+        )
+      } catch (e) {
+        logger.warn(
+          `V8 precise coverage is not supported on this runtime — continuing without coverage: ${e instanceof Error ? e.message : e}`
+        )
+        coverageService = undefined
+      }
     }
     const resolvedPort = parseInt(port || '3000', 10)
     const hostname = 'localhost'

--- a/packages/cli/src/functions/commands/serve.ts
+++ b/packages/cli/src/functions/commands/serve.ts
@@ -8,7 +8,6 @@ import {
   InMemoryWorkflowService,
   InMemoryTriggerService,
   InMemoryAIRunStateService,
-  V8CoverageService,
 } from '@pikku/core/services'
 import {
   KyselyAIStorageService,
@@ -34,29 +33,15 @@ import { createDevAIAgentRunner } from './dev-ai-runner.js'
 import { resolveConsoleMount } from './serve-console.js'
 
 export const serve = pikkuSessionlessFunc<
-  { port?: string; console?: boolean; coverage?: boolean },
+  { port?: string; console?: boolean },
   void
 >({
   remote: true,
   func: async (
     { logger, config, getInspectorState, variables, devServerRunner },
-    { port, console: serveConsole, coverage }
+    { port, console: serveConsole }
   ) => {
     process.env.PIKKU_DEV_QUICK_LOGIN ??= 'true'
-    let coverageService = coverage ? new V8CoverageService() : undefined
-    if (coverageService) {
-      try {
-        await coverageService.start()
-        logger.info(
-          'V8 precise coverage enabled — snapshot via console:takeLiveCoverage, reset via console:resetLiveCoverage'
-        )
-      } catch (e) {
-        logger.warn(
-          `V8 precise coverage is not supported on this runtime — continuing without coverage: ${e instanceof Error ? e.message : e}`
-        )
-        coverageService = undefined
-      }
-    }
     const resolvedPort = parseInt(port || '3000', 10)
     const hostname = 'localhost'
     const bindHostname = '127.0.0.1'
@@ -150,7 +135,6 @@ export const serve = pikkuSessionlessFunc<
       ...(aiAgentRunner ? { aiAgentRunner } : {}),
       emailService: new LocalEmailService(),
       metaService: new LocalMetaService(pikkuDir),
-      ...(coverageService ? { coverageService } : {}),
       schedulerService,
       queueService: new InMemoryQueueService(),
       workflowService,
@@ -171,7 +155,6 @@ export const serve = pikkuSessionlessFunc<
     const resolvedServices = {
       ...singletonServices,
       getInspectorState,
-      ...(coverageService ? { coverageService } : {}),
     }
     pikkuState(null, 'package', 'singletonServices', resolvedServices)
     resolvedServices.workflowService?.wireQueueWorkers?.()

--- a/packages/cli/src/functions/commands/serve.ts
+++ b/packages/cli/src/functions/commands/serve.ts
@@ -8,6 +8,7 @@ import {
   InMemoryWorkflowService,
   InMemoryTriggerService,
   InMemoryAIRunStateService,
+  V8CoverageService,
 } from '@pikku/core/services'
 import {
   KyselyAIStorageService,
@@ -33,15 +34,22 @@ import { createDevAIAgentRunner } from './dev-ai-runner.js'
 import { resolveConsoleMount } from './serve-console.js'
 
 export const serve = pikkuSessionlessFunc<
-  { port?: string; console?: boolean },
+  { port?: string; console?: boolean; coverage?: boolean },
   void
 >({
   remote: true,
   func: async (
     { logger, config, getInspectorState, variables, devServerRunner },
-    { port, console: serveConsole }
+    { port, console: serveConsole, coverage }
   ) => {
     process.env.PIKKU_DEV_QUICK_LOGIN ??= 'true'
+    const coverageService = coverage ? new V8CoverageService() : undefined
+    if (coverageService) {
+      await coverageService.start()
+      logger.info(
+        'V8 precise coverage enabled — snapshot via console:takeLiveCoverage, reset via console:resetLiveCoverage'
+      )
+    }
     const resolvedPort = parseInt(port || '3000', 10)
     const hostname = 'localhost'
     const bindHostname = '127.0.0.1'
@@ -135,6 +143,7 @@ export const serve = pikkuSessionlessFunc<
       ...(aiAgentRunner ? { aiAgentRunner } : {}),
       emailService: new LocalEmailService(),
       metaService: new LocalMetaService(pikkuDir),
+      ...(coverageService ? { coverageService } : {}),
       schedulerService,
       queueService: new InMemoryQueueService(),
       workflowService,
@@ -152,7 +161,11 @@ export const serve = pikkuSessionlessFunc<
       ...inMemoryServices,
       getInspectorState,
     })
-    const resolvedServices = { ...singletonServices, getInspectorState }
+    const resolvedServices = {
+      ...singletonServices,
+      getInspectorState,
+      ...(coverageService ? { coverageService } : {}),
+    }
     pikkuState(null, 'package', 'singletonServices', resolvedServices)
     resolvedServices.workflowService?.wireQueueWorkers?.()
 

--- a/packages/cli/src/functions/commands/start-coverage.ts
+++ b/packages/cli/src/functions/commands/start-coverage.ts
@@ -1,0 +1,46 @@
+import {
+  V8CoverageService,
+  IstanbulCoverageService,
+  type CoverageService,
+} from '@pikku/core/services'
+import { registerBunCoverageLoader } from './bun-coverage-loader.js'
+
+interface CoverageLogger {
+  info(message: string): void
+  warn(message: string): void
+}
+
+const isBunRuntime = (): boolean =>
+  typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined'
+
+/**
+ * Starts the coverage backend for `pikku dev --coverage`: V8 precise coverage
+ * on Node, istanbul load-time instrumentation on Bun. Must run before the
+ * user bootstrap is imported so the Bun loader plugin sees every module.
+ * Returns undefined (with a warning) when no backend is available.
+ */
+export async function startCoverageService(
+  logger: CoverageLogger,
+  rootDir: string
+): Promise<CoverageService | undefined> {
+  if (isBunRuntime()) {
+    await registerBunCoverageLoader({ rootDir })
+    logger.info(
+      'Istanbul coverage enabled (Bun) — snapshot via console:takeLiveCoverage, reset via console:resetLiveCoverage'
+    )
+    return new IstanbulCoverageService()
+  }
+  const coverageService = new V8CoverageService()
+  try {
+    await coverageService.start()
+    logger.info(
+      'V8 precise coverage enabled — snapshot via console:takeLiveCoverage, reset via console:resetLiveCoverage'
+    )
+    return coverageService
+  } catch (e) {
+    logger.warn(
+      `V8 precise coverage is not supported on this runtime — continuing without coverage: ${e instanceof Error ? e.message : e}`
+    )
+    return undefined
+  }
+}

--- a/packages/cli/src/functions/wirings/workflow/serialize-scenario-actors.ts
+++ b/packages/cli/src/functions/wirings/workflow/serialize-scenario-actors.ts
@@ -1,19 +1,10 @@
 import type { PikkuCLIConfig } from '../../../../types/config.js'
 
-/**
- * Generate the typed scenario actor registry from pikku.config.json's
- * `scenarios.actors`. Apps wire the result as the `actors` singleton service:
- *
- *   actors: createScenarioActors({ apiUrl, secret })
- */
 export const serializeScenarioActors = (
   actors: NonNullable<NonNullable<PikkuCLIConfig['scenarios']>['actors']>,
   agentMapImportPath: string
 ) => {
-  return `/**
- * Scenario actors declared in pikku.config.json (\`scenarios.actors\`).
- * Any scenario can impersonate any actor.
- */
+  return `/** Scenario actors declared in pikku.config.json (\`scenarios.actors\`) */
 import {
   createHttpScenarioActors,
   type HttpScenarioActorsConfig,
@@ -26,17 +17,12 @@ export const scenarioActorConfigs = ${JSON.stringify(actors, null, 2)} as const 
 
 export type ScenarioActorName = keyof typeof scenarioActorConfigs
 
-/** \`actor.converse({ agent })\` is constrained to the project's agent names. */
 export type AgentName = keyof AgentMap & string
 export type TypedScenarioActors = Record<
   ScenarioActorName,
   ScenarioActor<AgentName>
 >
 
-/**
- * Build the injected \`actors\` service: one lazy HTTP actor per registry
- * entry, signing in via the Better Auth actor plugin on first invoke.
- */
 export const createScenarioActors = (
   options: Omit<HttpScenarioActorsConfig, 'actors'>
 ): TypedScenarioActors =>

--- a/packages/cli/src/utils/strip-verbose-meta.ts
+++ b/packages/cli/src/utils/strip-verbose-meta.ts
@@ -31,6 +31,8 @@ const VERBOSE_FIELDS = new Set([
   'wires',
   'sourceFile',
   'exportedName',
+  'bodyStart',
+  'bodyEnd',
 ])
 
 /**

--- a/packages/cli/src/utils/strip-verbose-meta.ts
+++ b/packages/cli/src/utils/strip-verbose-meta.ts
@@ -31,6 +31,7 @@ const VERBOSE_FIELDS = new Set([
   'wires',
   'sourceFile',
   'exportedName',
+  'bodySourceFile',
   'bodyStart',
   'bodyEnd',
 ])

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -307,11 +307,7 @@ export type PikkuCLIInput = {
   }
 
   scenarios?: {
-    /**
-     * Global scenario actor registry — any scenario can impersonate any
-     * actor. Generates a typed `createScenarioActors` factory (see
-     * `scenarioActorsFile`) and surfaces the personas in the console.
-     */
+    /** Global scenario actor registry — any scenario can impersonate any actor */
     actors?: Record<
       string,
       {
@@ -321,12 +317,7 @@ export type PikkuCLIInput = {
         personality?: string
       }
     >
-    /**
-     * Environments `pikku scenario run <environment>` can target. `apiUrl`
-     * includes the HTTP prefix (e.g. https://app.example.com/api). The actor
-     * secret is NEVER configured here — it comes from the
-     * SCENARIO_ACTOR_SECRET environment variable at run time.
-     */
+    /** Environments `pikku scenario run <environment>` can target; the actor secret comes from SCENARIO_ACTOR_SECRET, never config */
     environments?: Record<
       string,
       {

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -157,7 +157,10 @@ export type {
 export {
   V8CoverageService,
   type CoverageService,
+  type CoverageSnapshot,
+  type LineHits,
   type ScriptCoverage,
   type FunctionCoverage,
   type CoverageRange,
 } from './v8-coverage-service.js'
+export { IstanbulCoverageService } from './istanbul-coverage-service.js'

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -154,3 +154,10 @@ export type {
   EmailTemplateLocaleMeta,
   EmailTemplateAssets,
 } from './meta-service.js'
+export {
+  V8CoverageService,
+  type CoverageService,
+  type ScriptCoverage,
+  type FunctionCoverage,
+  type CoverageRange,
+} from './v8-coverage-service.js'

--- a/packages/core/src/services/istanbul-coverage-service.test.ts
+++ b/packages/core/src/services/istanbul-coverage-service.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { IstanbulCoverageService } from './istanbul-coverage-service.js'
+
+const FILE = '/proj/src/things.function.ts'
+
+const seedCoverage = () => {
+  ;(globalThis as any).__coverage__ = {
+    [FILE]: {
+      path: FILE,
+      statementMap: {
+        '0': { start: { line: 2, column: 2 }, end: { line: 2, column: 20 } },
+        '1': { start: { line: 3, column: 4 }, end: { line: 3, column: 30 } },
+        '2': { start: { line: 5, column: 2 }, end: { line: 6, column: 18 } },
+      },
+      s: { '0': 3, '1': 0, '2': 3 },
+      branchMap: {},
+      b: {},
+      fnMap: {},
+      f: {},
+    },
+  }
+}
+
+afterEach(() => {
+  delete (globalThis as any).__coverage__
+})
+
+describe('IstanbulCoverageService', () => {
+  test('takeCoverage converts __coverage__ statement counts into line hits', async () => {
+    seedCoverage()
+    const service = new IstanbulCoverageService()
+    await service.start()
+    const snapshot = await service.takeCoverage()
+    assert.equal(snapshot.kind, 'line-hits')
+    if (snapshot.kind !== 'line-hits') return
+    const hits = snapshot.lineHits.get(FILE)
+    assert.ok(hits, 'file should have line hits')
+    assert.equal(hits.get(2), 3)
+    assert.equal(hits.get(3), 0)
+    assert.equal(hits.get(5), 3)
+    assert.equal(
+      hits.get(6),
+      undefined,
+      'counts attach to statement start lines only'
+    )
+  })
+
+  test('reset zeroes counters so per-scenario attribution is possible', async () => {
+    seedCoverage()
+    const service = new IstanbulCoverageService()
+    await service.reset()
+    const snapshot = await service.takeCoverage()
+    if (snapshot.kind !== 'line-hits') return assert.fail('expected line-hits')
+    const hits = snapshot.lineHits.get(FILE)
+    assert.equal(hits?.get(2), 0)
+    assert.equal(hits?.get(5), 0)
+  })
+
+  test('takeCoverage with no __coverage__ global returns an empty snapshot', async () => {
+    const service = new IstanbulCoverageService()
+    const snapshot = await service.takeCoverage()
+    if (snapshot.kind !== 'line-hits') return assert.fail('expected line-hits')
+    assert.equal(snapshot.lineHits.size, 0)
+  })
+})

--- a/packages/core/src/services/istanbul-coverage-service.ts
+++ b/packages/core/src/services/istanbul-coverage-service.ts
@@ -1,0 +1,65 @@
+import type {
+  CoverageService,
+  CoverageSnapshot,
+  LineHits,
+} from './v8-coverage-service.js'
+
+interface IstanbulStatementLocation {
+  start: { line: number }
+  end: { line: number }
+}
+
+interface IstanbulFileCoverage {
+  path: string
+  statementMap: Record<string, IstanbulStatementLocation>
+  s: Record<string, number>
+  b: Record<string, number[]>
+  f: Record<string, number>
+}
+
+type IstanbulCoverageGlobal = Record<string, IstanbulFileCoverage>
+
+const getCoverageGlobal = (): IstanbulCoverageGlobal | undefined =>
+  (globalThis as { __coverage__?: IstanbulCoverageGlobal }).__coverage__
+
+/**
+ * Reads istanbul-instrumented counters from the `__coverage__` global —
+ * the coverage backend for runtimes without V8 precise coverage (e.g. Bun,
+ * where source files are instrumented at load time by a Bun loader plugin).
+ */
+export class IstanbulCoverageService implements CoverageService {
+  async start(): Promise<void> {}
+
+  async takeCoverage(): Promise<CoverageSnapshot> {
+    const coverage = getCoverageGlobal()
+    const lineHits: LineHits = new Map()
+    for (const file of Object.values(coverage ?? {})) {
+      let hits = lineHits.get(file.path)
+      if (!hits) {
+        hits = new Map()
+        lineHits.set(file.path, hits)
+      }
+      // istanbul line semantics: a statement's count belongs to its start
+      // line only, so an enclosing multi-line statement never masks an
+      // unexecuted inner statement (e.g. a throw inside a taken if).
+      for (const [id, location] of Object.entries(file.statementMap)) {
+        const count = file.s[id] ?? 0
+        const line = location.start.line
+        hits.set(line, Math.max(hits.get(line) ?? 0, count))
+      }
+    }
+    return { kind: 'line-hits', lineHits }
+  }
+
+  async reset(): Promise<void> {
+    for (const file of Object.values(getCoverageGlobal() ?? {})) {
+      for (const id of Object.keys(file.s)) file.s[id] = 0
+      for (const id of Object.keys(file.f)) file.f[id] = 0
+      for (const id of Object.keys(file.b)) {
+        file.b[id] = file.b[id]!.map(() => 0)
+      }
+    }
+  }
+
+  async stop(): Promise<void> {}
+}

--- a/packages/core/src/services/scenario-actors-service.ts
+++ b/packages/core/src/services/scenario-actors-service.ts
@@ -3,14 +3,7 @@ import type {
   ActorFlowVerdict,
 } from '../wirings/actor-flow/actor-flow.types.js'
 
-/**
- * A scenario actor: a synthetic user (a normal user row flagged `actor`) that
- * workflow steps can run as. Passed to `workflow.do(step, rpc, data, { actor })`
- * — the step then goes through the actor's authenticated client over the REAL
- * transport (auth middleware, permissions, serialization all exercised),
- * never through internal dispatch. Login is lazy: the first `invoke` signs the
- * actor in and the session is cached for the actor's lifetime.
- */
+/** A synthetic user (a user row flagged `actor`) that workflow steps run as over the real transport */
 export interface ScenarioActor<TAgentName extends string = string> {
   /** Stable actor name (the key in pikku.config.json's actor registry). */
   readonly name: string
@@ -18,22 +11,11 @@ export interface ScenarioActor<TAgentName extends string = string> {
   readonly email: string
   /** Invoke an exposed RPC as this actor over the real transport. */
   invoke(rpcName: string, data: unknown): Promise<unknown>
-  /**
-   * Hold a dynamic conversation with a target Pikku AI agent, in THIS actor's
-   * persona (personality/jobTitle). Drives the target over the real transport
-   * as the signed-in actor, answers its tool-approval requests in-persona, and
-   * returns the actor's verdict on whether the task was met. Deterministic
-   * checks are the caller's job — use `invoke` afterwards. In a typed project
-   * `agent` is constrained to the generated union of agent names.
-   */
+  /** Converse with a Pikku AI agent in this actor's persona and return its verdict */
   converse(options: ConverseOptions<TAgentName>): Promise<ActorFlowVerdict>
 }
 
-/**
- * Display/config metadata for an actor (from pikku.config.json). The email
- * identifies the actor's user row; personality/jobTitle exist for the console
- * screen and for agent-driven flows (the agent plays the persona).
- */
+/** Display/config metadata for an actor (from pikku.config.json) */
 export interface ScenarioActorConfig {
   email: string
   name?: string

--- a/packages/core/src/services/v8-coverage-service.test.ts
+++ b/packages/core/src/services/v8-coverage-service.test.ts
@@ -17,8 +17,12 @@ describe('V8CoverageService', () => {
     await service.start()
     coveredProbe(21)
 
-    const scripts = await service.takeCoverage()
-    const own = scripts.find((s) => s.url.includes('v8-coverage-service.test'))
+    const snapshot = await service.takeCoverage()
+    assert.equal(snapshot.kind, 'v8-scripts')
+    if (snapshot.kind !== 'v8-scripts') return
+    const own = snapshot.scripts.find((s) =>
+      s.url.includes('v8-coverage-service.test')
+    )
     assert.ok(own, 'own test script should appear in precise coverage')
     const probe = own.functions.find((f) =>
       f.functionName.includes('coveredProbe')
@@ -33,8 +37,11 @@ describe('V8CoverageService', () => {
   test('reset clears call counts so attribution per run is possible', async () => {
     coveredProbe(1)
     await service.reset()
-    const scripts = await service.takeCoverage()
-    const own = scripts.find((s) => s.url.includes('v8-coverage-service.test'))
+    const snapshot = await service.takeCoverage()
+    if (snapshot.kind !== 'v8-scripts') return assert.fail('expected scripts')
+    const own = snapshot.scripts.find((s) =>
+      s.url.includes('v8-coverage-service.test')
+    )
     const probe = own?.functions.find((f) =>
       f.functionName.includes('coveredProbe')
     )
@@ -47,10 +54,13 @@ describe('V8CoverageService', () => {
   })
 
   test('getScriptSource returns the executed source for mapping', async () => {
-    const scripts = await service.takeCoverage()
-    const own = scripts.find((s) => s.url.includes('v8-coverage-service.test'))
+    const snapshot = await service.takeCoverage()
+    if (snapshot.kind !== 'v8-scripts') return assert.fail('expected scripts')
+    const own = snapshot.scripts.find((s) =>
+      s.url.includes('v8-coverage-service.test')
+    )
     assert.ok(own)
-    const source = await service.getScriptSource(own.scriptId)
+    const source = await snapshot.getScriptSource(own.scriptId)
     assert.ok(
       source.includes('coveredProbe'),
       'script source should contain the probe function'

--- a/packages/core/src/services/v8-coverage-service.test.ts
+++ b/packages/core/src/services/v8-coverage-service.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { V8CoverageService } from './v8-coverage-service.js'
+
+const service = new V8CoverageService()
+
+function coveredProbe(n: number): number {
+  return n * 2
+}
+
+describe('V8CoverageService', () => {
+  after(async () => {
+    await service.stop()
+  })
+
+  test('start + takeCoverage reports call counts for functions invoked after start', async () => {
+    await service.start()
+    coveredProbe(21)
+
+    const scripts = await service.takeCoverage()
+    const own = scripts.find((s) => s.url.includes('v8-coverage-service.test'))
+    assert.ok(own, 'own test script should appear in precise coverage')
+    const probe = own.functions.find((f) =>
+      f.functionName.includes('coveredProbe')
+    )
+    assert.ok(probe, 'coveredProbe should be tracked')
+    assert.ok(
+      probe.ranges[0].count >= 1,
+      `coveredProbe should have been counted, got ${probe.ranges[0].count}`
+    )
+  })
+
+  test('reset clears call counts so attribution per run is possible', async () => {
+    coveredProbe(1)
+    await service.reset()
+    const scripts = await service.takeCoverage()
+    const own = scripts.find((s) => s.url.includes('v8-coverage-service.test'))
+    const probe = own?.functions.find((f) =>
+      f.functionName.includes('coveredProbe')
+    )
+    const count = probe?.ranges[0].count ?? 0
+    assert.equal(
+      count,
+      0,
+      `after reset coveredProbe count should be 0, got ${count}`
+    )
+  })
+
+  test('getScriptSource returns the executed source for mapping', async () => {
+    const scripts = await service.takeCoverage()
+    const own = scripts.find((s) => s.url.includes('v8-coverage-service.test'))
+    assert.ok(own)
+    const source = await service.getScriptSource(own.scriptId)
+    assert.ok(
+      source.includes('coveredProbe'),
+      'script source should contain the probe function'
+    )
+  })
+})

--- a/packages/core/src/services/v8-coverage-service.ts
+++ b/packages/core/src/services/v8-coverage-service.ts
@@ -1,0 +1,113 @@
+/**
+ * In-process V8 precise-coverage collector for `pikku dev --coverage`.
+ *
+ * Wraps a `node:inspector` session: `start()` begins precise coverage with
+ * call counts, `takeCoverage()` snapshots per-script coverage, `reset()`
+ * clears counts so callers can attribute coverage to a single scenario run,
+ * and `getScriptSource()` fetches the executed (transpiled) source whose
+ * inline source map lets consumers translate offsets back to TypeScript.
+ *
+ * `node:inspector` is imported lazily inside `start()` so this module stays
+ * loadable on runtimes without it (e.g. Cloudflare Workers) as long as
+ * coverage is never started there.
+ */
+
+export interface CoverageRange {
+  startOffset: number
+  endOffset: number
+  count: number
+}
+
+export interface FunctionCoverage {
+  functionName: string
+  isBlockCoverage: boolean
+  ranges: CoverageRange[]
+}
+
+export interface ScriptCoverage {
+  scriptId: string
+  url: string
+  functions: FunctionCoverage[]
+}
+
+export interface CoverageService {
+  start(): Promise<void>
+  takeCoverage(): Promise<ScriptCoverage[]>
+  getScriptSource(scriptId: string): Promise<string>
+  reset(): Promise<void>
+  stop(): Promise<void>
+}
+
+type InspectorSession = {
+  connect(): void
+  disconnect(): void
+  post(
+    method: string,
+    params?: unknown,
+    callback?: (err: Error | null, result?: any) => void
+  ): void
+}
+
+export class V8CoverageService implements CoverageService {
+  private session: InspectorSession | null = null
+
+  private post<T>(method: string, params?: unknown): Promise<T> {
+    const session = this.session
+    if (!session) {
+      throw new Error('V8CoverageService not started — call start() first')
+    }
+    return new Promise<T>((resolve, reject) => {
+      session.post(method, params, (err, result) =>
+        err ? reject(err) : resolve(result as T)
+      )
+    })
+  }
+
+  async start(): Promise<void> {
+    if (this.session) return
+    const inspector = await import('node:inspector')
+    this.session = new inspector.Session() as unknown as InspectorSession
+    this.session.connect()
+    await this.post('Profiler.enable')
+    await this.post('Debugger.enable')
+    await this.post('Profiler.startPreciseCoverage', {
+      callCount: true,
+      detailed: true,
+    })
+  }
+
+  async takeCoverage(): Promise<ScriptCoverage[]> {
+    const { result } = await this.post<{ result: ScriptCoverage[] }>(
+      'Profiler.takePreciseCoverage'
+    )
+    return result.filter((script) => script.url.startsWith('file://'))
+  }
+
+  async getScriptSource(scriptId: string): Promise<string> {
+    const { scriptSource } = await this.post<{ scriptSource: string }>(
+      'Debugger.getScriptSource',
+      { scriptId }
+    )
+    return scriptSource
+  }
+
+  async reset(): Promise<void> {
+    await this.post('Profiler.stopPreciseCoverage')
+    await this.post('Profiler.startPreciseCoverage', {
+      callCount: true,
+      detailed: true,
+    })
+  }
+
+  async stop(): Promise<void> {
+    if (!this.session) return
+    try {
+      await this.post('Profiler.stopPreciseCoverage')
+      await this.post('Profiler.disable')
+      await this.post('Debugger.disable')
+    } finally {
+      this.session.disconnect()
+      this.session = null
+    }
+  }
+}

--- a/packages/core/src/services/v8-coverage-service.ts
+++ b/packages/core/src/services/v8-coverage-service.ts
@@ -39,6 +39,7 @@ type InspectorSession = {
 
 export class V8CoverageService implements CoverageService {
   private session: InspectorSession | null = null
+  private startPromise: Promise<void> | null = null
 
   private post<T>(method: string, params?: unknown): Promise<T> {
     const session = this.session
@@ -52,8 +53,12 @@ export class V8CoverageService implements CoverageService {
     })
   }
 
-  async start(): Promise<void> {
-    if (this.session) return
+  start(): Promise<void> {
+    this.startPromise ??= this.doStart()
+    return this.startPromise
+  }
+
+  private async doStart(): Promise<void> {
     const inspector = await import('node:inspector')
     this.session = new inspector.Session() as unknown as InspectorSession
     this.session.connect()
@@ -97,6 +102,7 @@ export class V8CoverageService implements CoverageService {
     } finally {
       this.session.disconnect()
       this.session = null
+      this.startPromise = null
     }
   }
 }

--- a/packages/core/src/services/v8-coverage-service.ts
+++ b/packages/core/src/services/v8-coverage-service.ts
@@ -1,16 +1,5 @@
-/**
- * In-process V8 precise-coverage collector for `pikku dev --coverage`.
- *
- * Wraps a `node:inspector` session: `start()` begins precise coverage with
- * call counts, `takeCoverage()` snapshots per-script coverage, `reset()`
- * clears counts so callers can attribute coverage to a single scenario run,
- * and `getScriptSource()` fetches the executed (transpiled) source whose
- * inline source map lets consumers translate offsets back to TypeScript.
- *
- * `node:inspector` is imported lazily inside `start()` so this module stays
- * loadable on runtimes without it (e.g. Cloudflare Workers) as long as
- * coverage is never started there.
- */
+// node:inspector is imported lazily inside start() so this module stays
+// loadable on runtimes without it (e.g. Cloudflare Workers).
 
 export interface CoverageRange {
   startOffset: number

--- a/packages/core/src/services/v8-coverage-service.ts
+++ b/packages/core/src/services/v8-coverage-service.ts
@@ -19,10 +19,19 @@ export interface ScriptCoverage {
   functions: FunctionCoverage[]
 }
 
+export type LineHits = Map<string, Map<number, number>>
+
+export type CoverageSnapshot =
+  | {
+      kind: 'v8-scripts'
+      scripts: ScriptCoverage[]
+      getScriptSource: (scriptId: string) => Promise<string>
+    }
+  | { kind: 'line-hits'; lineHits: LineHits }
+
 export interface CoverageService {
   start(): Promise<void>
-  takeCoverage(): Promise<ScriptCoverage[]>
-  getScriptSource(scriptId: string): Promise<string>
+  takeCoverage(): Promise<CoverageSnapshot>
   reset(): Promise<void>
   stop(): Promise<void>
 }
@@ -70,11 +79,15 @@ export class V8CoverageService implements CoverageService {
     })
   }
 
-  async takeCoverage(): Promise<ScriptCoverage[]> {
+  async takeCoverage(): Promise<CoverageSnapshot> {
     const { result } = await this.post<{ result: ScriptCoverage[] }>(
       'Profiler.takePreciseCoverage'
     )
-    return result.filter((script) => script.url.startsWith('file://'))
+    return {
+      kind: 'v8-scripts',
+      scripts: result.filter((script) => script.url.startsWith('file://')),
+      getScriptSource: (scriptId) => this.getScriptSource(scriptId),
+    }
   }
 
   async getScriptSource(scriptId: string): Promise<string> {

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -151,6 +151,8 @@ export type FunctionMeta = FunctionRuntimeMeta &
       isDirectFunction: boolean
       sourceFile: string
       exportedName: string
+      /** File containing the handler body when it differs from sourceFile (imported handlers) */
+      bodySourceFile?: string
       /** 1-indexed first line of the handler body (verbose meta; coverage mapping) */
       bodyStart: number
       /** 1-indexed last line of the handler body (verbose meta; coverage mapping) */

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -38,6 +38,7 @@ import type { WorkflowRunService } from '../wirings/workflow/workflow.types.js'
 import type { CredentialService } from '../services/credential-service.js'
 import type { EmailService } from '../services/email-service.js'
 import type { MetaService } from '../services/meta-service.js'
+import type { CoverageService } from '../services/v8-coverage-service.js'
 import type { SessionStore } from '../services/session-store.js'
 import type {
   AuditDurability,
@@ -150,6 +151,10 @@ export type FunctionMeta = FunctionRuntimeMeta &
       isDirectFunction: boolean
       sourceFile: string
       exportedName: string
+      /** 1-indexed first line of the handler body (verbose meta; coverage mapping) */
+      bodyStart: number
+      /** 1-indexed last line of the handler body (verbose meta; coverage mapping) */
+      bodyEnd: number
     } & CommonWireMeta
   >
 
@@ -293,6 +298,8 @@ export interface CoreSingletonServices<Config extends CoreConfig = CoreConfig> {
   emailService?: EmailService
   /** Meta service for reading .pikku metadata files (filesystem on Node, R2/KV on CF) */
   metaService?: MetaService
+  /** V8 precise-coverage collector (`pikku dev --coverage` only) */
+  coverageService?: CoverageService
   /** Audit service for durable or staged audit event capture */
   audit?: AuditService
   /**

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -1105,12 +1105,6 @@ export abstract class PikkuWorkflowService implements WorkflowService {
    * @param options.inline - If true, execute workflow directly without queue service
    * @param options.startNode - Starting node ID for graph workflows (from wire config)
    */
-  /**
-   * Start a new workflow run
-   * Automatically detects workflow type (DSL or graph) from meta and executes accordingly
-   * @param options.inline - If true, execute workflow directly without queue service
-   * @param options.startNode - Starting node ID for graph workflows (from wire config)
-   */
   public async startWorkflow<I>(
     name: string,
     input: I,

--- a/packages/inspector/src/add/add-functions.ts
+++ b/packages/inspector/src/add/add-functions.ts
@@ -1023,6 +1023,10 @@ export const addFunctions: AddWiring = (
   })
 
   const handlerSourceFile = handler.getSourceFile()
+  const bodySourceFile =
+    handlerSourceFile.fileName !== sourceFile
+      ? handlerSourceFile.fileName
+      : undefined
   const lineOf = (pos: number) =>
     handlerSourceFile.getLineAndCharacterOfPosition(pos).line + 1
   const handlerBody = handler.body
@@ -1074,6 +1078,7 @@ export const addFunctions: AddWiring = (
     permissions,
     isDirectFunction,
     sourceFile,
+    bodySourceFile,
     exportedName: exportedName || undefined,
     ...bodySpan,
   }

--- a/packages/inspector/src/add/add-functions.ts
+++ b/packages/inspector/src/add/add-functions.ts
@@ -1022,6 +1022,25 @@ export const addFunctions: AddWiring = (
     isDirectFunction,
   })
 
+  const handlerSourceFile = handler.getSourceFile()
+  const lineOf = (pos: number) =>
+    handlerSourceFile.getLineAndCharacterOfPosition(pos).line + 1
+  const handlerBody = handler.body
+  const bodySpan =
+    ts.isBlock(handlerBody) && handlerBody.statements.length > 0
+      ? {
+          bodyStart: lineOf(
+            handlerBody.statements[0].getStart(handlerSourceFile)
+          ),
+          bodyEnd: lineOf(
+            handlerBody.statements[handlerBody.statements.length - 1].getEnd()
+          ),
+        }
+      : {
+          bodyStart: lineOf(handlerBody.getStart(handlerSourceFile)),
+          bodyEnd: lineOf(handlerBody.getEnd()),
+        }
+
   state.functions.meta[pikkuFuncId] = {
     pikkuFuncId,
     functionType: 'user',
@@ -1056,6 +1075,7 @@ export const addFunctions: AddWiring = (
     isDirectFunction,
     sourceFile,
     exportedName: exportedName || undefined,
+    ...bodySpan,
   }
 
   // Populate node metadata if node config is present

--- a/packages/inspector/src/add/add-workflow.ts
+++ b/packages/inspector/src/add/add-workflow.ts
@@ -316,8 +316,6 @@ export const addWorkflow: AddWiring = (logger, node, checker, state) => {
     return
   }
 
-  // expectEventually is a scenario-only assertion primitive — regular
-  // workflows must stay free of test/eval semantics.
   if (
     wrapperType !== 'scenario' &&
     containsExpectEventuallyCall(resolvedFunc)

--- a/packages/inspector/src/add/function-body-span.test.ts
+++ b/packages/inspector/src/add/function-body-span.test.ts
@@ -1,0 +1,50 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { inspect } from '../inspector.js'
+import type { InspectorLogger } from '../types.js'
+
+const logger: InspectorLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  diagnostic: () => {},
+  critical: () => {},
+  hasCriticalErrors: () => false,
+}
+
+describe('function body spans in meta', () => {
+  test('meta records 1-indexed bodyStart/bodyEnd lines of the handler body', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'pikku-span-'))
+    const file = join(rootDir, 'my.function.ts')
+    await writeFile(
+      file,
+      [
+        "import { pikkuSessionlessFunc } from '@pikku/core'", // line 1
+        '', // 2
+        'export const spanProbe = pikkuSessionlessFunc({', // 3
+        '  func: async ({ logger }, data: { n: number }) => {', // 4
+        '    const doubled = data.n * 2', // 5
+        '    return { doubled }', // 6
+        '  },', // 7
+        '})', // 8
+      ].join('\n')
+    )
+    try {
+      const state = await inspect(logger, [file], { rootDir })
+      const meta = (state.functions.meta as any).spanProbe
+      assert.ok(meta, 'spanProbe should be inspected')
+      assert.equal(
+        meta.bodyStart,
+        5,
+        `bodyStart should be 5, got ${meta.bodyStart}`
+      )
+      assert.equal(meta.bodyEnd, 6, `bodyEnd should be 6, got ${meta.bodyEnd}`)
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/inspector/src/add/function-body-span.test.ts
+++ b/packages/inspector/src/add/function-body-span.test.ts
@@ -47,4 +47,50 @@ describe('function body spans in meta', () => {
       await rm(rootDir, { recursive: true, force: true })
     }
   })
+
+  test('meta records bodySourceFile when the handler is imported from another file', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'pikku-span-'))
+    const handlerFile = join(rootDir, 'handlers.ts')
+    const wiringFile = join(rootDir, 'my.function.ts')
+    await writeFile(
+      handlerFile,
+      [
+        'export const importedHandler = async (', // line 1
+        '  { logger }: any,', // 2
+        '  data: { n: number }', // 3
+        ') => {', // 4
+        '  const doubled = data.n * 2', // 5
+        '  return { doubled }', // 6
+        '}', // 7
+      ].join('\n')
+    )
+    await writeFile(
+      wiringFile,
+      [
+        "import { pikkuSessionlessFunc } from '@pikku/core'",
+        "import { importedHandler } from './handlers.js'",
+        '',
+        'export const importedProbe = pikkuSessionlessFunc({',
+        '  func: importedHandler,',
+        '})',
+      ].join('\n')
+    )
+    try {
+      const state = await inspect(logger, [wiringFile, handlerFile], {
+        rootDir,
+      })
+      const meta = (state.functions.meta as any).importedProbe
+      assert.ok(meta, 'importedProbe should be inspected')
+      assert.equal(meta.sourceFile, wiringFile)
+      assert.equal(
+        meta.bodySourceFile,
+        handlerFile,
+        `bodySourceFile should be the handler file, got ${meta.bodySourceFile}`
+      )
+      assert.equal(meta.bodyStart, 5)
+      assert.equal(meta.bodyEnd, 6)
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/services/better-auth/src/actor-plugin.ts
+++ b/packages/services/better-auth/src/actor-plugin.ts
@@ -4,12 +4,7 @@ import { setSessionCookie } from 'better-auth/cookies'
 import type { BetterAuthPlugin } from 'better-auth'
 
 export interface ActorPluginOptions {
-  /**
-   * The server-held impersonation secret (e.g. from a wired
-   * `SCENARIO_ACTOR_SECRET`). Sign-in only ever works for user rows flagged
-   * `actor: true`, so knowing the secret never impersonates real users. A
-   * missing/empty secret disables the endpoint entirely.
-   */
+  /** Impersonation secret; only `actor: true` rows can sign in, missing/empty disables the endpoint */
   secret:
     | string
     | undefined
@@ -28,14 +23,7 @@ const secretsEqual = (a: string, b: string): boolean => {
   return diff === 0
 }
 
-/**
- * Better Auth plugin for scenario actors: synthetic users (an `actor`
- * boolean column on `user`) that pikkuScenario signs in via
- * `POST /sign-in/actor` with `{ email, secret }`. Actor rows are auto-created
- * on first sign-in; sign-in for a NON-actor user is always refused. The
- * `actor` flag rides on the user (and from there into the pikku core
- * session), so audits and analytics can address synthetic traffic.
- */
+/** Better Auth plugin for scenario actors: `POST /sign-in/actor` with `{ email, secret }`, actor rows auto-created, non-actor sign-in refused */
 export const actor = (options: ActorPluginOptions): BetterAuthPlugin => {
   return {
     id: 'actor',

--- a/packages/services/better-auth/src/stamp-actor-flag.ts
+++ b/packages/services/better-auth/src/stamp-actor-flag.ts
@@ -1,10 +1,6 @@
 import type { CoreUserSession } from '@pikku/core'
 
-/**
- * Propagate the better-auth `actor` user column (see the actor plugin) into
- * the pikku core session, so synthetic scenario traffic is addressable in
- * audits/analytics even when a custom mapSession doesn't copy it.
- */
+/** Propagate the better-auth `actor` user column into the pikku session */
 export const stampActorFlag = <S extends CoreUserSession>(
   session: S,
   user: { actor?: boolean | null } | undefined

--- a/verifiers/workflows/src/tests/scenario.assert.ts
+++ b/verifiers/workflows/src/tests/scenario.assert.ts
@@ -1,12 +1,3 @@
-/**
- * Verifies pikkuScenario end-to-end through real codegen:
- * - inspector meta: source 'scenario', actor + internal + expectEventually steps
- * - runtime: the flow runs with injected actors; actor steps go through the
- *   actor (never internal dispatch), internal steps still hit the real function
- *
- * Expects: pikku has been run first to generate .pikku/ files
- */
-
 import { readFile } from 'fs/promises'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
@@ -48,7 +39,6 @@ const fakeActor = (
     calls,
     invoke: async (rpcName: string, data: any) => {
       calls.push({ rpcName, data })
-      // Order-shaped response, as the deployed app would return over HTTP
       return {
         id: data.orderId,
         customerId: 'customer-1',
@@ -66,7 +56,6 @@ describe('pikkuScenario verification', () => {
     const meta = await loadMeta('orderHealthScenario')
     assert.equal(meta.source, 'scenario')
 
-    // Nodes are keyed by step name
     const nodes: Record<string, any> = meta.nodes || {}
     assert.ok(
       nodes['customer fetches the order'],
@@ -114,7 +103,6 @@ describe('pikkuScenario verification', () => {
       false
     )
 
-    // Actors ride startWorkflow options → the run's wire, never services
     const { runId } = await workflowService.startWorkflow(
       'orderHealthScenario',
       { orderId: 'order-7' },

--- a/verifiers/workflows/src/workflows/scenario/order-health.scenario.ts
+++ b/verifiers/workflows/src/workflows/scenario/order-health.scenario.ts
@@ -1,11 +1,3 @@
-/**
- * Scenario: drives the order API the way users do. A scenario is a pure
- * story of remote RPCs — the func may only use logger/config from services
- * (inspector-enforced); actors arrive on the WIRE, supplied per run by the
- * runner (`pikku scenario run <environment>` or startWorkflow options).
- * Runtime friendly — no state reset, safe as a staged/production health check.
- */
-
 import { pikkuScenario } from '../../../.pikku/workflow/pikku-workflow-types.gen.js'
 
 export const orderHealthScenario = pikkuScenario<
@@ -22,7 +14,6 @@ export const orderHealthScenario = pikkuScenario<
     }
     logger.debug(`order-health flow starting for ${data.orderId}`)
 
-    // The customer reads their order through their authenticated client
     const order = await workflow.do(
       'customer fetches the order',
       'orderGet',
@@ -30,13 +21,10 @@ export const orderHealthScenario = pikkuScenario<
       { actor: actors.customer }
     )
 
-    // A plain internal step still works when the runner provides an rpc
-    // service (the `pikku scenario run` command refuses these on purpose)
     const internal = await workflow.do('internal re-read', 'orderGet', {
       orderId: data.orderId,
     })
 
-    // Ops polls until the order reports a status (async-effect primitive)
     const settled = await workflow.expectEventually(
       'ops sees the order settle',
       'orderGet',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2103,7 +2103,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.23.7, @babel/core@npm:^7.28.5":
+"@babel/core@npm:^7.23.7, @babel/core@npm:^7.23.9, @babel/core@npm:^7.28.5":
   version: 7.29.7
   resolution: "@babel/core@npm:7.29.7"
   dependencies:
@@ -2257,7 +2257,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.23.6, @babel/parser@npm:^7.28.5, @babel/parser@npm:^7.29.7":
+"@babel/parser@npm:^7.23.6, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.28.5, @babel/parser@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/parser@npm:7.29.7"
   dependencies:
@@ -5817,6 +5817,7 @@ __metadata:
     "@pikku/schedule": "npm:^0.12.3"
     "@pikku/ws": "npm:^0.12.3"
     "@types/cookie": "npm:^1.0.0"
+    "@types/istanbul-lib-instrument": "npm:^1.7.7"
     "@types/json-schema": "npm:^7.0.15"
     "@types/node": "npm:^24.11.0"
     "@types/pg": "npm:^8.11.0"
@@ -5824,6 +5825,7 @@ __metadata:
     chalk: "npm:^5.6.2"
     chokidar: "npm:^4.0.3"
     esbuild: "npm:~0.27.0"
+    istanbul-lib-instrument: "npm:^6.0.3"
     open: "npm:^10.2.0"
     openapi-types: "npm:^12.1.3"
     path-to-regexp: "npm:^8.3.0"
@@ -11375,6 +11377,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/babel-generator@npm:*":
+  version: 6.25.8
+  resolution: "@types/babel-generator@npm:6.25.8"
+  dependencies:
+    "@types/babel-types": "npm:*"
+  checksum: 10/8b8eb3101ff2bdb5969ac43f5948f190dbd4ee4da0cd58c67d3a72a29a370e1b7467afe30186181704cb14d3527ad058cb09f025349ff898b87aa839370621b6
+  languageName: node
+  linkType: hard
+
+"@types/babel-types@npm:*":
+  version: 7.0.16
+  resolution: "@types/babel-types@npm:7.0.16"
+  checksum: 10/86aa375bd2eeb8c37dd53308ff10e390f88ff88363b66eac1df0b83c8366da69a48e7d2f0c789223000bf358bd1073372c01754eaa7d930149428b580252075e
+  languageName: node
+  linkType: hard
+
 "@types/better-sqlite3@npm:^7.0.0, @types/better-sqlite3@npm:^7.6.13":
   version: 7.6.13
   resolution: "@types/better-sqlite3@npm:7.6.13"
@@ -11829,10 +11847,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/istanbul-lib-coverage@npm:^2.0.1":
+"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.1":
   version: 2.0.6
   resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
   checksum: 10/3feac423fd3e5449485afac999dcfcb3d44a37c830af898b689fadc65d26526460bedb889db278e0d4d815a670331796494d073a10ee6e3a6526301fe7415778
+  languageName: node
+  linkType: hard
+
+"@types/istanbul-lib-instrument@npm:^1.7.7":
+  version: 1.7.8
+  resolution: "@types/istanbul-lib-instrument@npm:1.7.8"
+  dependencies:
+    "@types/babel-generator": "npm:*"
+    "@types/babel-types": "npm:*"
+    "@types/istanbul-lib-coverage": "npm:*"
+    source-map: "npm:^0.6.1"
+  checksum: 10/3aac6be409d85fba8d7631989b67bfa20f9365cb80209579f4e93e616e803801d9b8a44058573b31ce050b4dc4b73798f3dc328b1c67cfff494a2e9b577d2a99
   languageName: node
   linkType: hard
 
@@ -17743,6 +17773,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"istanbul-lib-instrument@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "istanbul-lib-instrument@npm:6.0.3"
+  dependencies:
+    "@babel/core": "npm:^7.23.9"
+    "@babel/parser": "npm:^7.23.9"
+    "@istanbuljs/schema": "npm:^0.1.3"
+    istanbul-lib-coverage: "npm:^3.2.0"
+    semver: "npm:^7.5.4"
+  checksum: 10/aa5271c0008dfa71b6ecc9ba1e801bf77b49dc05524e8c30d58aaf5b9505e0cd12f25f93165464d4266a518c5c75284ecb598fbd89fec081ae77d2c9d3327695
+  languageName: node
+  linkType: hard
+
 "istanbul-lib-report@npm:^3.0.0, istanbul-lib-report@npm:^3.0.1":
   version: 3.0.1
   resolution: "istanbul-lib-report@npm:3.0.1"
@@ -22882,7 +22925,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.6.2":
+"semver@npm:^7.5.4, semver@npm:^7.6.2":
   version: 7.8.5
   resolution: "semver@npm:7.8.5"
   bin:
@@ -23442,7 +23485,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.6.0, source-map@npm:~0.6.1":
+"source-map@npm:^0.6.0, source-map@npm:^0.6.1, source-map@npm:~0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 10/59ef7462f1c29d502b3057e822cdbdae0b0e565302c4dd1a95e11e793d8d9d62006cdc10e0fd99163ca33ff2071360cf50ee13f90440806e7ed57d81cba2f7ff

--- a/yarn.lock
+++ b/yarn.lock
@@ -4723,7 +4723,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.28":
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25, @jridgewell/trace-mapping@npm:^0.3.28":
   version: 0.3.31
   resolution: "@jridgewell/trace-mapping@npm:0.3.31"
   dependencies:
@@ -5581,6 +5581,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/addon-console@workspace:packages/addon/pikku-console"
   dependencies:
+    "@jridgewell/trace-mapping": "npm:^0.3.25"
     "@pikku/cli": "npm:^0.12.69"
     "@pikku/core": "npm:^0.12.52"
     json-schema: "npm:^0.4.0"


### PR DESCRIPTION
Closes #863. **Stacked on #866** (the userflow→scenario rename) — merge that first, then retarget/merge this onto `main`.

## What

Adds live, in-process code coverage to the dev servers and wires it into the scenario runner so each scenario run reports exactly which pikku functions it exercised.

- **@pikku/core** — new `V8CoverageService`: lazy `node:inspector` session running `Profiler.startPreciseCoverage({ callCount, detailed })`, with `takeCoverage()` snapshots, `reset()` (stop+start), and `Debugger.getScriptSource` access. Registered as the optional `coverageService` singleton service.
- **@pikku/inspector** — function meta gains `bodyStart`/`bodyEnd` (1-indexed body statement span, verbose meta only), so runtime mapping needs no TypeScript dependency.
- **@pikku/cli** — `--coverage` on `pikku dev` and `pikku serve` starts the collector in the CLI process and injects it into resolved services. `pikku scenario run --coverage` calls `console:resetLiveCoverage` before and `console:takeLiveCoverage` after each flow (through a scenario actor, over real HTTP), logs `coverage: N/M functions exercised by '<flow>'`, and writes `.pikku/coverage/scenario-coverage.json`. Degrades gracefully (warn + disable) when the target isn't collecting.
- **@pikku/addon-console** — exposed `takeLiveCoverage` / `resetLiveCoverage` RPCs plus the V8→source mapping. V8 range offsets are mapped through the script's inline source map via `@jridgewell/trace-mapping` — **not** v8-to-istanbul, whose line-based statement maps collapse to a single line on esbuild/tsx single-line output.

## Verification (TDD)

- `packages/core` `v8-coverage-service.test.ts` — call counts, reset semantics, script source (red before service existed).
- `packages/inspector` `function-body-span.test.ts` — body span emission (red before).
- `packages/addon/pikku-console` `precise-coverage-map.test.ts` — offset→line mapping onto body spans (red before).
- e2e `scenario-run.feature`: new scenario asserts a **non-zero** `coverage: N/M functions exercised by 'orderSupportScenario'` line + report file — this failed against the pre-fix code (all functions `unknown` under istanbul, and again when the console addon didn't forward `coverageService`) and now passes: `orderSupportScenario` attributes exactly `doubleValue` + `formatMessage`.

Suites: core 1058 ✓, inspector 308 ✓, cli 279 ✓, addon-console 74 ✓, e2e @scenario 3/3 ✓. The only e2e tsc error (`instructions` missing from generated `AIAgentConfig`) reproduces on origin/main with a fresh regen — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional V8 precise coverage collection for `dev`, `serve`, and `scenario run`, with per-scenario/per-flow attribution.
  * Scenario runs now reset/snapshot coverage between scenarios and write `coverage/scenario-coverage.json`.
  * The console can now take and reset live coverage snapshots during runs.
* **Bug Fixes**
  * Improved coverage mapping accuracy so results are attributed back to original source lines and handler ranges more reliably.
  * Added reliable reset support to prevent coverage from mixing across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->