### PR TITLE
fix(cucumber): share one remote-CDP (Steel) browser connection across scenarios

### DIFF
--- a/.changeset/cucumber-steel-shared-conn.md
+++ b/.changeset/cucumber-steel-shared-conn.md
@@ -1,0 +1,11 @@
+---
+'@pikku/cucumber': patch
+---
+
+browser world: share one remote-CDP (Steel) connection across all scenarios in a
+run instead of reconnecting per scenario. Cucumber builds a fresh world per
+scenario, so the previous per-world connect + closeAll teardown recycled the
+shared remote browser every scenario and raced its session recycling, timing out
+the next `connectOverCDP`. Now: connect once, each scenario gets its own context,
+`closeAll` disposes only contexts on the CDP path, and a dropped connection
+reconnects on the next scenario.

--- a/packages/cucumber/src/browser/world.ts
+++ b/packages/cucumber/src/browser/world.ts
@@ -8,6 +8,16 @@ import {
 } from './config.js'
 
 /**
+ * A single shared connection to the remote CDP browser, reused across EVERY
+ * scenario/world in this cucumber process. Cucumber builds a fresh world per
+ * scenario, so a per-world connection would reconnect (and, via closeAll, tear
+ * down) the shared remote browser on every scenario — racing its session
+ * recycling and timing out the next connect. Connect once; scenarios get their
+ * own contexts; the socket drops at process exit.
+ */
+let sharedCdpBrowser: Promise<Browser> | undefined
+
+/**
  * BrowserWorld — one scenario's browser plus its actors.
  *
  * Actors are personas driving the app in their OWN browser context (own
@@ -101,7 +111,13 @@ export class BrowserWorld<Clients = unknown> {
     }
     this.actors.clear()
     this.last = undefined
-    await this.browser?.close()
+    // On the remote CDP path the browser is a shared, process-lifetime
+    // connection (see launchBrowser) — dispose only the contexts above; closing
+    // it would recycle the shared remote browser and stall the next scenario's
+    // connect. The socket drops when the cucumber process exits.
+    if (!this.config.cdpUrl) {
+      await this.browser?.close()
+    }
     this.browser = undefined
   }
 
@@ -116,10 +132,20 @@ export class BrowserWorld<Clients = unknown> {
     // chromium in a CPU/RAM-capped sandbox. The remote browser reaches the app at
     // its PUBLIC edge via real DNS, so we do NOT add the host-resolver 127.0.0.1
     // mapping (that's only for a local browser hitting the in-container loopback
-    // edge). browser.close() on a connected browser only clears the contexts this
-    // connection created and disconnects — it never kills the shared browser.
+    // edge). One connection is shared across all scenarios (each gets its own
+    // context via ActorSession); if it drops, the next scenario reconnects.
     if (this.config.cdpUrl) {
-      this.browser = await chromium.connectOverCDP(await resolveCdpWsUrl(this.config.cdpUrl))
+      if (!sharedCdpBrowser) {
+        const cdpUrl = this.config.cdpUrl
+        sharedCdpBrowser = resolveCdpWsUrl(cdpUrl).then(async (ws) => {
+          const browser = await chromium.connectOverCDP(ws)
+          browser.on('disconnected', () => {
+            sharedCdpBrowser = undefined
+          })
+          return browser
+        })
+      }
+      this.browser = await sharedCdpBrowser
       return this.browser
     }
     this.browser = await chromium.launch({


### PR DESCRIPTION
Follow-up to #875. Validation surfaced intermittent `connectOverCDP: Timeout 30000ms exceeded` on some scenarios (retries masked it).

## Cause
Cucumber builds a **fresh world per scenario**, and the `After` hook runs `closeAll()`, which called `browser.close()`. On the remote-CDP path that recycled the **shared** remote (Steel) browser after every scenario — so the next scenario's `connectOverCDP` raced Steel's session recycling and timed out.

## Fix
- **Connect once per cucumber process** (module-level shared connection), reused across every scenario/world.
- Each scenario/actor still opens its **own `browser.newContext()`** — isolated cookies/storage/session. Multi-actor and sequential scenarios are unaffected; this is the standard one-`Browser`→many-`BrowserContext` model.
- `closeAll()` disposes only the contexts on the CDP path (never closes the shared browser).
- If the shared connection drops mid-run, the next scenario reconnects (`disconnected` handler clears the singleton).

No behaviour change on the local-chromium path (`cdpUrl`/`XBROWSER_CDP_URL` unset). Patch changeset included.