### PR TITLE
fix(deps): make @pikku/core a peerDependency in the last 6 packages

### DIFF
--- a/.changeset/core-peer-dependency.md
+++ b/.changeset/core-peer-dependency.md
@@ -1,0 +1,16 @@
+---
+'@pikku/cli': patch
+'@pikku/inspector': patch
+'@pikku/console': patch
+'@pikku/kysely-mysql': patch
+'@pikku/kysely-postgres': patch
+'@pikku/kysely-sqlite': patch
+---
+
+Move `@pikku/core` from `dependencies` to `peerDependencies` in the last packages that still declared it as a regular dependency.
+
+`@pikku/core` holds a single `pikkuState` registry and must resolve to exactly one copy at runtime — every wiring (workflows, RPCs, queue workers, middleware) registers into the copy it imports, and the runner reads the copy it imports. 35 packages already declare core as a peer for this reason; these six were the stragglers. Because they carried a regular `@pikku/core` dependency, bumping any one of them could leave a second, older core locked in a consumer's tree, splitting the registry so wirings silently fail to resolve (surfaced as `[PKU717] Multiple @pikku/core versions installed`).
+
+Making core a peer everywhere means the consuming app provides the one copy (the react/react-dom singleton pattern), so duplication is structurally impossible. `@pikku/core` is also kept as a devDependency in each package so it still builds/typechecks standalone.
+
+Backward-compatible for consumers that already list `@pikku/core` directly (every template does). A consumer that only pulled core transitively now gets a loud install-time peer warning instead of a silent runtime split — strictly better.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,6 @@
     "@openapi-contrib/json-schema-to-openapi-schema": "^4.3.1",
     "@pikku/better-auth": "^0.12.15",
     "@pikku/bun-server": "^0.12.4",
-    "@pikku/core": "^0.12.53",
     "@pikku/deploy-cloudflare": "^0.12.8",
     "@pikku/fetch": "^0.12.6",
     "@pikku/inspector": "^0.12.37",
@@ -58,7 +57,11 @@
     "zod": "^4.3.6",
     "zod-to-ts": "^2.1.0"
   },
+  "peerDependencies": {
+    "@pikku/core": "^0.12.53"
+  },
   "devDependencies": {
+    "@pikku/core": "^0.12.53",
     "@types/istanbul-lib-instrument": "^1.7.7",
     "@types/node": "^24.11.0",
     "@types/pg": "^8.11.0",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -43,7 +43,6 @@
     "@mantine/notifications": "^8.3.18",
     "@mantine/spotlight": "^8.3.18",
     "@pikku/assistant-ui": "^0.12.7",
-    "@pikku/core": "^0.12.52",
     "@pikku/fetch": "^0.12.6",
     "@rjsf/core": "^6.3.1",
     "@rjsf/mantine": "^6.3.1",
@@ -74,11 +73,15 @@
     "reactflow": "^11.11.4",
     "remark-gfm": "^4.0.1"
   },
+  "peerDependencies": {
+    "@pikku/core": "^0.12.52"
+  },
   "devDependencies": {
     "@inlang/paraglide-js": "^2.20.0",
     "@mantine/colors-generator": "^8.3.18",
     "@pikku/addon-console": "^0.12.24",
     "@pikku/cli": "^0.12.69",
+    "@pikku/core": "^0.12.52",
     "@pikku/websocket": "^0.12.2",
     "@types/chroma-js": "^3",
     "@types/lodash": "^4",

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "@openapi-contrib/json-schema-to-openapi-schema": "^4.3.1",
-    "@pikku/core": "^0.12.53",
     "openapi-types": "^12.1.3",
     "path-to-regexp": "^8.3.0",
     "ts-json-schema-generator": "2.9.1-next.16",
@@ -44,7 +43,11 @@
     "zod": "^4.3.6",
     "zod-to-ts": "^2.1.0"
   },
+  "peerDependencies": {
+    "@pikku/core": "^0.12.53"
+  },
   "devDependencies": {
+    "@pikku/core": "^0.12.53",
     "@types/node": "^24.11.0"
   },
   "engines": {

--- a/packages/services/kysely-mysql/package.json
+++ b/packages/services/kysely-mysql/package.json
@@ -13,11 +13,14 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "@pikku/core": "^0.12.44",
     "@pikku/kysely": "^0.13.0",
     "kysely": "^0.29.0"
   },
+  "peerDependencies": {
+    "@pikku/core": "^0.12.44"
+  },
   "devDependencies": {
+    "@pikku/core": "^0.12.44",
     "typescript": "^6.0.3"
   },
   "exports": {

--- a/packages/services/kysely-postgres/package.json
+++ b/packages/services/kysely-postgres/package.json
@@ -13,13 +13,16 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "@pikku/core": "^0.12.45",
     "@pikku/kysely": "^0.13.0",
     "kysely": "^0.29.0",
     "kysely-postgres-js": "^3.0.0",
     "postgres": "^3.4.8"
   },
+  "peerDependencies": {
+    "@pikku/core": "^0.12.45"
+  },
   "devDependencies": {
+    "@pikku/core": "^0.12.45",
     "typescript": "^6.0.3"
   },
   "exports": {

--- a/packages/services/kysely-sqlite/package.json
+++ b/packages/services/kysely-sqlite/package.json
@@ -13,11 +13,14 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "@pikku/core": "^0.12.44",
     "@pikku/kysely": "^0.13.0",
     "kysely": "^0.29.0"
   },
+  "peerDependencies": {
+    "@pikku/core": "^0.12.44"
+  },
   "devDependencies": {
+    "@pikku/core": "^0.12.44",
     "typescript": "^6.0.3"
   },
   "exports": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5838,6 +5838,8 @@ __metadata:
     yaml: "npm:^2.8.2"
     zod: "npm:^4.3.6"
     zod-to-ts: "npm:^2.1.0"
+  peerDependencies:
+    "@pikku/core": ^0.12.53
   bin:
     pikku: dist/bin/pikku.js
   languageName: unknown
@@ -5927,6 +5929,8 @@ __metadata:
     remark-gfm: "npm:^4.0.1"
     typescript: "npm:^6.0.3"
     vite: "npm:^8.0.11"
+  peerDependencies:
+    "@pikku/core": ^0.12.52
   languageName: unknown
   linkType: soft
 
@@ -6150,6 +6154,8 @@ __metadata:
     typescript: "npm:^6.0.3"
     zod: "npm:^4.3.6"
     zod-to-ts: "npm:^2.1.0"
+  peerDependencies:
+    "@pikku/core": ^0.12.53
   languageName: unknown
   linkType: soft
 
@@ -6184,6 +6190,8 @@ __metadata:
     "@pikku/kysely": "npm:^0.13.0"
     kysely: "npm:^0.29.0"
     typescript: "npm:^6.0.3"
+  peerDependencies:
+    "@pikku/core": ^0.12.44
   languageName: unknown
   linkType: soft
 
@@ -6212,6 +6220,8 @@ __metadata:
     kysely-postgres-js: "npm:^3.0.0"
     postgres: "npm:^3.4.8"
     typescript: "npm:^6.0.3"
+  peerDependencies:
+    "@pikku/core": ^0.12.45
   languageName: unknown
   linkType: soft
 
@@ -6223,6 +6233,8 @@ __metadata:
     "@pikku/kysely": "npm:^0.13.0"
     kysely: "npm:^0.29.0"
     typescript: "npm:^6.0.3"
+  peerDependencies:
+    "@pikku/core": ^0.12.44
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Problem

`@pikku/core` holds a single `pikkuState` registry and must resolve to **exactly one copy** at runtime — every wiring (workflows, RPCs, queue workers, middleware) registers into the copy it imports, and the runner reads the copy it imports. Two copies ⇒ a split registry ⇒ wirings silently fail to resolve, surfaced as:

```
[PKU717] Multiple @pikku/core versions installed: 0.12.51, 0.12.53.
```

35 packages already declare core as a **peerDependency** for exactly this reason. Six stragglers still declared it as a regular `dependency`:

- `@pikku/cli`
- `@pikku/inspector`
- `@pikku/console`
- `@pikku/kysely-mysql`
- `@pikku/kysely-postgres`
- `@pikku/kysely-sqlite`

Because they carried a regular `@pikku/core` dependency, bumping any one of them could leave a second, older core locked in a consumer's tree (a caret transitive that the resolver doesn't dedupe), splitting the registry. This bit a downstream project when bumping `@pikku/cli` pulled `@pikku/core@0.12.53` while `@pikku/addon-console`'s transitive `@pikku/core@0.12.51` stayed locked.

## Fix

Move `@pikku/core` from `dependencies` → `peerDependencies` in those six packages, matching the existing convention. The consuming app provides the one copy (the `react`/`react-dom` singleton pattern), so duplication is **structurally impossible**. `@pikku/core` is kept as a `devDependency` in each so the package still builds/typechecks standalone.

## Compatibility

- **No change** for consumers that already list `@pikku/core` directly — every template does.
- A consumer that only pulled core **transitively** now gets a loud **install-time peer warning** instead of a silent runtime split — strictly better.

## Verification

- `yarn install` — no unmet peers, single `@pikku/core` resolves.
- `@pikku/inspector` `tsc -b` — clean.
- `yarn build:packages` (full ordered workspace build, incl. cli `build.sh` running `pikku all`) — exit 0.

Changeset: all six at `patch` (per the repo rule that core-adjacent minors auto-major dependents).