### PR TITLE
feat: console bearer-token auth via PIKKU_CONSOLE_TOKEN

### DIFF
--- a/.changeset/console-bearer-token.md
+++ b/.changeset/console-bearer-token.md
@@ -1,0 +1,17 @@
+---
+'@pikku/core': patch
+'@pikku/cli': patch
+---
+
+Console: accept `Authorization: Bearer <PIKKU_CONSOLE_TOKEN>`
+
+A console served from another origin cannot carry the session cookie, so
+every `console:*` RPC returned 403. `authBearer` gains a secret-resolved
+token mode (`token: { secretId, userSession }` — resolved through the
+secrets service per request, constant-time compare, no-op while the secret
+is unset), and the auth scaffold wires it with `PIKKU_CONSOLE_TOKEN` when
+`scaffold.console` is enabled — inside the same `addHTTPMiddleware('*')`
+call as the session middleware, since the inspector keys route-middleware
+groups by pattern (pikkujs/pikku#886).
+Set that secret in the server environment and send it as a bearer token to
+authenticate an external console.

--- a/packages/cli/src/functions/wirings/auth/pikku-command-auth.ts
+++ b/packages/cli/src/functions/wirings/auth/pikku-command-auth.ts
@@ -39,7 +39,11 @@ export const pikkuAuth = pikkuSessionlessFunc<{ bootstrap?: boolean }, void>({
           config.ignoreFiles
         ))
       ) {
-        await writeFileInDir(logger, authTypesFile, serializeAuthTypesBootstrap())
+        await writeFileInDir(
+          logger,
+          authTypesFile,
+          serializeAuthTypesBootstrap()
+        )
       }
       return
     }
@@ -56,7 +60,8 @@ export const pikkuAuth = pikkuSessionlessFunc<{ bootstrap?: boolean }, void>({
       authFile,
       typesDeclarationFile,
       packageMappings ?? {},
-      state.auth.hasUserSessionMiddleware ?? false
+      state.auth.hasUserSessionMiddleware ?? false,
+      Boolean(config.scaffold?.console)
     )
     // The secrets file sits alongside authFile so re-inspection rediscovers it.
     // It is kept separate from the wiring file because the CLI forbids Zod

--- a/packages/cli/src/functions/wirings/auth/serialize-auth-gen.test.ts
+++ b/packages/cli/src/functions/wirings/auth/serialize-auth-gen.test.ts
@@ -238,6 +238,43 @@ describe('serializeAuthGen', () => {
     })
   })
 
+  describe('console bearer token (scaffold.console enabled)', () => {
+    const statelessDef = def({ cookieCache: true })
+    const genConsole = (d: AuthDefinition = def()) =>
+      serializeAuthGen(d, ['github'], AUTH_FILE, TYPES_FILE, {}, false, true)
+
+    test('stateless: the middleware file registers authBearer alongside the session verifier', () => {
+      const out = genConsole(statelessDef)
+      assert.ok(out.middleware, 'middleware file should be emitted')
+      const mw = out.middleware!
+      assert.match(mw, /import { authBearer } from '@pikku\/core\/middleware'/)
+      assert.match(
+        mw,
+        /addHTTPMiddleware\('\*', \[\s*betterAuthStatelessSession\(\),\s*authBearer\(\{[\s\S]*?secretId: 'PIKKU_CONSOLE_TOKEN'[\s\S]*?\}\),\s*\]\)/
+      )
+      assert.doesNotMatch(mw, /process\.env/)
+    })
+
+    test('stateful: the wiring file registers authBearer alongside betterAuthSession', () => {
+      const out = genConsole()
+      assert.match(
+        out.wiring,
+        /import { authBearer } from '@pikku\/core\/middleware'/
+      )
+      assert.match(
+        out.wiring,
+        /addHTTPMiddleware\('\*', \[\s*betterAuthSession\(\),\s*authBearer\(\{[\s\S]*?secretId: 'PIKKU_CONSOLE_TOKEN'[\s\S]*?\}\),\s*\]\)/
+      )
+    })
+
+    test('without scaffold.console no authBearer is emitted', () => {
+      const stateful = gen(['github'])
+      const stateless = gen(['github'], statelessDef)
+      assert.doesNotMatch(stateful.wiring, /authBearer/)
+      assert.doesNotMatch(stateless.middleware ?? '', /authBearer/)
+    })
+  })
+
   describe('user-registered global betterAuthSession → CLI steps aside', () => {
     const genSkip = (providers: string[], d: AuthDefinition = def()) =>
       serializeAuthGen(d, providers, AUTH_FILE, TYPES_FILE, {}, true)

--- a/packages/cli/src/functions/wirings/auth/serialize-auth-gen.ts
+++ b/packages/cli/src/functions/wirings/auth/serialize-auth-gen.ts
@@ -60,13 +60,30 @@ export interface AuthGenOutput {
  * wiring, the routes flow through inspection into the deploy manifest (one
  * worker for all auth routes).
  */
+// External consoles (served from another origin) cannot carry the session
+// cookie, so they authenticate with 'Authorization: Bearer <PIKKU_CONSOLE_TOKEN>'.
+// The expected token resolves through the secrets service per request and the
+// middleware is a no-op while the secret is unset. Emitted into the same
+// addHTTPMiddleware('*') call as the session middleware: the inspector keys
+// route-middleware groups by pattern, so a second '*' registration from another
+// file would silently displace this one in deployed units.
+const consoleTokenMiddlewareLines = (): string[] => [
+  `  authBearer({`,
+  `    token: {`,
+  `      secretId: 'PIKKU_CONSOLE_TOKEN',`,
+  `      userSession: { userId: 'pikku-console-token' },`,
+  `    },`,
+  `  }),`,
+]
+
 export const serializeAuthGen = (
   definition: AuthDefinition,
   providers: string[],
   authFile: string,
   typesDeclarationFile: string,
   packageMappings: Record<string, string>,
-  hasUserSessionMiddleware = false
+  hasUserSessionMiddleware = false,
+  includeConsoleToken = false
 ): AuthGenOutput => {
   const known = providers.filter((p) => p in PROVIDER_REGISTRY)
 
@@ -189,6 +206,9 @@ export const serializeAuthGen = (
     emitStatefulSession
       ? `import { createAuthHandler, betterAuthSession } from '@pikku/better-auth'`
       : `import { createAuthHandler } from '@pikku/better-auth'`,
+    ...(emitStatefulSession && includeConsoleToken
+      ? [`import { authBearer } from '@pikku/core/middleware'`]
+      : []),
     `import '${configImportPath}'`,
     '',
     // createAuthHandler is called once at module load; the exported handler is a
@@ -205,7 +225,17 @@ export const serializeAuthGen = (
   if (emitStatefulSession) {
     // Stateful: betterAuthSession calls services.auth(), so it stays here with
     // the auth.wiring import.
-    wiring.push(`addHTTPMiddleware('*', [betterAuthSession()])`, '')
+    if (includeConsoleToken) {
+      wiring.push(
+        `addHTTPMiddleware('*', [`,
+        `  betterAuthSession(),`,
+        ...consoleTokenMiddlewareLines(),
+        `])`,
+        ''
+      )
+    } else {
+      wiring.push(`addHTTPMiddleware('*', [betterAuthSession()])`, '')
+    }
   }
   wiring.push(`wireHTTPRoutes({`, `  routes: {`)
   // One catch-all route per method. `{/*splat}` matches both the bare basePath
@@ -233,8 +263,18 @@ export const serializeAuthGen = (
       '',
       `import { addHTTPMiddleware } from '${pikkuTypesImportPath}'`,
       `import { betterAuthStatelessSession } from '@pikku/better-auth'`,
+      ...(includeConsoleToken
+        ? [`import { authBearer } from '@pikku/core/middleware'`]
+        : []),
       '',
-      `addHTTPMiddleware('*', [betterAuthStatelessSession()])`,
+      ...(includeConsoleToken
+        ? [
+            `addHTTPMiddleware('*', [`,
+            `  betterAuthStatelessSession(),`,
+            ...consoleTokenMiddlewareLines(),
+            `])`,
+          ]
+        : [`addHTTPMiddleware('*', [betterAuthStatelessSession()])`]),
       '',
     ]
     output.middleware = middleware.join('\n')

--- a/packages/core/src/middleware/auth-bearer.test.ts
+++ b/packages/core/src/middleware/auth-bearer.test.ts
@@ -416,6 +416,124 @@ describe('authBearer middleware', () => {
     assert.equal(SessionService.get(), undefined)
   })
 
+  test('should resolve the expected token from the secrets service in secretId mode', async () => {
+    const mockUserSession: CoreUserSession = {
+      userId: 'console-token',
+      role: 'admin',
+    }
+    const SessionService = new PikkuSessionService<CoreUserSession>()
+    const jwtService = {
+      encode: async () => 'token',
+      decode: async () => {
+        assert.fail('JWT decode should not be called in secretId mode')
+        return null
+      },
+    }
+    const secrets = {
+      getSecret: async (secretId: string) => {
+        assert.equal(secretId, 'PIKKU_CONSOLE_TOKEN')
+        return 'secret-token-value'
+      },
+    }
+
+    const middleware = authBearer({
+      token: {
+        secretId: 'PIKKU_CONSOLE_TOKEN',
+        userSession: mockUserSession,
+      },
+    })
+    let nextCalled = false
+
+    await middleware(
+      { jwt: jwtService, secrets } as any,
+      {
+        ...createMiddlewareSessionWireProps(SessionService),
+        http: {
+          request: createMockHTTPRequest({
+            authorization: 'Bearer secret-token-value',
+          }),
+          response: createMockHTTPResponse(),
+        },
+      } as any,
+      async () => {
+        nextCalled = true
+      }
+    )
+
+    assert.equal(nextCalled, true)
+    assert.deepEqual(SessionService.get(), mockUserSession)
+  })
+
+  test('should continue without session when the secret is not configured', async () => {
+    const SessionService = new PikkuSessionService<CoreUserSession>()
+    const secrets = {
+      getSecret: async () => {
+        throw new Error('secret not found')
+      },
+    }
+
+    const middleware = authBearer({
+      token: {
+        secretId: 'PIKKU_CONSOLE_TOKEN',
+        userSession: { userId: 'console-token' },
+      },
+    })
+    let nextCalled = false
+
+    await middleware(
+      { jwt: undefined, secrets } as any,
+      {
+        ...createMiddlewareSessionWireProps(SessionService),
+        http: {
+          request: createMockHTTPRequest({
+            authorization: 'Bearer anything',
+          }),
+          response: createMockHTTPResponse(),
+        },
+      } as any,
+      async () => {
+        nextCalled = true
+      }
+    )
+
+    assert.equal(nextCalled, true)
+    assert.equal(SessionService.get(), undefined)
+  })
+
+  test('should not set session when secret-resolved token does not match', async () => {
+    const SessionService = new PikkuSessionService<CoreUserSession>()
+    const secrets = {
+      getSecret: async () => 'expected-token',
+    }
+
+    const middleware = authBearer({
+      token: {
+        secretId: 'PIKKU_CONSOLE_TOKEN',
+        userSession: { userId: 'console-token' },
+      },
+    })
+    let nextCalled = false
+
+    await middleware(
+      { jwt: undefined, secrets } as any,
+      {
+        ...createMiddlewareSessionWireProps(SessionService),
+        http: {
+          request: createMockHTTPRequest({
+            authorization: 'Bearer wrong-token',
+          }),
+          response: createMockHTTPResponse(),
+        },
+      } as any,
+      async () => {
+        nextCalled = true
+      }
+    )
+
+    assert.equal(nextCalled, true)
+    assert.equal(SessionService.get(), undefined)
+  })
+
   test('should work in static token mode even when jwtService is not available', async () => {
     const mockUserSession: CoreUserSession = { userId: 'static-user' }
     const SessionService = new PikkuSessionService<CoreUserSession>()

--- a/packages/core/src/middleware/auth-bearer.ts
+++ b/packages/core/src/middleware/auth-bearer.ts
@@ -14,11 +14,14 @@ const constantTimeEqual = (a: string, b: string): boolean => {
 /**
  * Bearer token middleware that extracts and validates tokens from the Authorization header.
  *
- * Supports two modes:
+ * Supports three modes:
  * - JWT decoding (default): Decodes bearer tokens using the JWT service
  * - Static token: Provide a `token` object with a value and userSession for simple token validation
+ * - Secret-resolved token: Provide a `token` object with a secretId — the expected
+ *   value is resolved through the secrets service per request, so it works with any
+ *   secret backend and the middleware is a no-op while the secret is unset
  *
- * @param options.token - Optional static token configuration { value: string, userSession: CoreUserSession }
+ * @param options.token - Optional token configuration: { value, userSession } or { secretId, userSession }
  *
  * @example
  * ```typescript
@@ -38,16 +41,35 @@ const constantTimeEqual = (a: string, b: string): boolean => {
  *     }
  *   })
  * ])
+ *
+ * // Secret-resolved token mode
+ * addHTTPMiddleware('*', [
+ *   authBearer({
+ *     token: {
+ *       secretId: 'PIKKU_CONSOLE_TOKEN',
+ *       userSession: { userId: 'pikku-console-token' }
+ *     }
+ *   })
+ * ])
  * ```
  */
 export const authBearer = pikkuMiddlewareFactory<{
-  token?: {
-    value: string
-    userSession: CoreUserSession
-  }
+  token?:
+    | {
+        value: string
+        userSession: CoreUserSession
+      }
+    | {
+        secretId: string
+        userSession: CoreUserSession
+      }
 }>(({ token } = {}) =>
   pikkuMiddleware(
-    async ({ jwt: jwtService }, { http, setSession, session }, next) => {
+    async (
+      { jwt: jwtService, secrets },
+      { http, setSession, session },
+      next
+    ) => {
       if (!http?.request || !setSession || session) {
         return next()
       }
@@ -64,9 +86,20 @@ export const authBearer = pikkuMiddlewareFactory<{
 
         let userSession: CoreUserSession | null = null
 
-        if (token && constantTimeEqual(bearerToken, token.value)) {
-          userSession = token.userSession
-        } else if (jwtService && !token) {
+        if (token) {
+          let expected: string | undefined
+          if ('value' in token) {
+            expected = token.value
+          } else {
+            // An unset secret means the feature is off — never a request error.
+            expected = await secrets
+              ?.getSecret<string>(token.secretId)
+              .catch(() => undefined)
+          }
+          if (expected && constantTimeEqual(bearerToken, expected)) {
+            userSession = token.userSession
+          }
+        } else if (jwtService) {
           userSession = await jwtService.decode(bearerToken)
         }
 


### PR DESCRIPTION
Closes #884

An external console (served from another origin — e.g. a hosted console UI talking to a dev server or sandbox) has no way to authenticate: the scaffolded session middleware only reads the signed session cookie, so `Authorization: Bearer …` is ignored and every `console:*` RPC returns 403.

## Changes

- **`@pikku/core`**: `authBearer` gains a secret-resolved token mode — `token: { secretId, userSession }`. The expected value resolves through the secrets service per request (works with any secret backend), compared constant-time, and the middleware is a no-op while the secret is unset.
- **`@pikku/cli`**: when `scaffold.console` is enabled, the auth scaffold registers `authBearer({ token: { secretId: 'PIKKU_CONSOLE_TOKEN', … } })` **inside the same `addHTTPMiddleware('*')` call** as the session middleware (both the stateful `betterAuthSession` and the split stateless `auth-middleware.gen.ts` paths).

That co-location is load-bearing: the inspector keys route-middleware groups by pattern, so a second `'*'` registration from another file silently displaces the first in deployed units — the deploy-serverless verifier caught exactly that (greet unit lost the stateless session middleware) with the initial console-scaffold placement. Filed as #886.

## Usage

Set `PIKKU_CONSOLE_TOKEN` in the server environment and send it as a bearer token; unset, nothing changes.

## Verification

- TDD: 3 new `authBearer` secretId tests + 3 auth-scaffold serializer tests written first (red), green after.
- Deploy-serverless verifier passes (21/21), including the stateless-session tree-shaking check.
- Live on the e2e app: `console:getAIWorkflows` → 403 without/with wrong bearer, 200 with the token; better-auth cookie sessions (actor sign-in) still work alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)