### PR TITLE
fix(cli): guard wire.getCredential in generated credential addon

### DIFF
--- a/.changeset/addon-credential-guard.md
+++ b/.changeset/addon-credential-guard.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Guard `wire.getCredential` in the generated per-user credential addon (`new addon --credential`). `getCredential` is optional on the wire services type, so the emitted `src/services.ts` failed `tsc` with "possibly undefined" out of the box; it now checks before calling.

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -240,6 +240,9 @@ import { pikkuAddonWireServices } from '#pikku'
 
 export const createWireServices = pikkuAddonWireServices(
   async ({ variables }, wire) => {
+    if (!wire.getCredential) {
+      throw new Error('Credential resolution is not available in this runtime')
+    }
     const cred = await wire.getCredential<{ ${credField}: string }>('${camelName}')
     if (!cred?.${credField}) {
       throw new Error('Missing ${camelName} credential')


### PR DESCRIPTION
`pikku new addon --openapi <spec> --credential apikey|bearer` emits a `src/services.ts` that calls `wire.getCredential<...>()` unguarded. But `getCredential` is optional on the wire services type, so the generated addon fails `tsc` out of the box:

```
src/services.ts: error TS18048: 'wire.getCredential' is possibly 'undefined'.
```

This blocks every per-user credential addon from building. Guard `wire.getCredential` before calling it (matches how other runtimes treat it as optional, e.g. `ai-agent-prepare.ts`). Verified against a real 250-operation OpenAPI spec: 2 tsc errors → 0 after the guard.

Changeset: patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated credential addons so they no longer fail TypeScript checks when credential lookup isn’t available.
  * Added a clearer runtime error when credential resolution is unsupported, preventing attempts to call a missing service method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->