### PR TITLE
fix(openapi-parser): always emit a description for generated addon functions

### DIFF
--- a/.changeset/addon-mcp-descriptions.md
+++ b/.changeset/addon-mcp-descriptions.md
@@ -1,0 +1,5 @@
+---
+'@pikku/openapi-parser': patch
+---
+
+Always emit a description for generated addon functions (and their MCP tools). When an OpenAPI operation omits both `description` and `summary` (common), the generator now synthesizes one — a humanized `operationId` (with the `Controller` segment stripped), else `METHOD /path` — instead of emitting none. This removes the "MCP tool is missing a description" warnings and makes `--mcp`-exposed tools usable.

--- a/packages/openapi-parser/src/codegen.test.ts
+++ b/packages/openapi-parser/src/codegen.test.ts
@@ -780,3 +780,68 @@ describe('camelCase flag', () => {
     )
   })
 })
+
+// ---------------------------------------------------------------------------
+// Function/MCP-tool description synthesis (specs that omit descriptions)
+// ---------------------------------------------------------------------------
+describe('function description synthesis', () => {
+  test('synthesizes a description from operationId when the spec omits one', () => {
+    const spec = makeSpec({
+      operations: [
+        makeOp({
+          operationId: 'contactsControllerGetContacts',
+          method: 'get',
+          path: '/contacts',
+        }),
+      ],
+    })
+
+    const files = generateAddonFromOpenAPI(spec, makeVars(), {
+      oauth: false,
+      secret: false,
+      mcp: true,
+    })
+    const funcFile = files['src/functions/contactsControllerGetContacts.function.ts']
+    assert.ok(funcFile, 'function file should exist')
+    assert.ok(
+      funcFile.includes('description: "Contacts get contacts"'),
+      'humanized operationId (Controller stripped) should be emitted as the description'
+    )
+    assert.ok(funcFile.includes('mcp: true'), 'mcp tool flag should be present')
+  })
+
+  test('falls back to "METHOD /path" when operationId is absent', () => {
+    const spec = makeSpec({
+      operations: [makeOp({ operationId: undefined, method: 'get', path: '/health' })],
+    })
+
+    const files = generateAddonFromOpenAPI(spec, makeVars(), {
+      oauth: false,
+      secret: false,
+    })
+    const key = Object.keys(files).find((k) => k.startsWith('src/functions/'))
+    assert.ok(key, 'a function file should be generated')
+    assert.ok(
+      files[key].includes('description: "GET /health"'),
+      'should fall back to METHOD path when nothing else is available'
+    )
+  })
+
+  test('prefers the spec description over synthesis', () => {
+    const spec = makeSpec({
+      operations: [
+        makeOp({ operationId: 'getPet', description: 'Fetch a single pet by id' }),
+      ],
+    })
+
+    const files = generateAddonFromOpenAPI(spec, makeVars(), {
+      oauth: false,
+      secret: false,
+    })
+    const funcFile = files['src/functions/getPet.function.ts']
+    assert.ok(
+      funcFile.includes('description: "Fetch a single pet by id"'),
+      'the real spec description should win over the synthesized one'
+    )
+  })
+})

--- a/packages/openapi-parser/src/codegen.ts
+++ b/packages/openapi-parser/src/codegen.ts
@@ -69,12 +69,40 @@ function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
-function humanDescription(parsed: ParsedOperation): string | undefined {
+/**
+ * Turn an operationId like `contactsControllerGetContacts` (or snake/kebab
+ * variants) into a readable phrase — split camel/snake/kebab into words, drop
+ * noise segments ("controller"), and capitalize. Returns undefined if nothing
+ * usable remains.
+ */
+function humanizeOperationId(operationId?: string): string | undefined {
+  if (!operationId) return undefined
+  const words = operationId
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .split(/\s+/)
+    .map((w) => w.trim())
+    .filter((w) => w && w.toLowerCase() !== 'controller')
+  if (words.length === 0) return undefined
+  return capitalize(words.join(' ').toLowerCase())
+}
+
+/**
+ * A description for the generated function (and its MCP tool). Prefers the
+ * spec's `description`, then `summary`; when a spec omits both (common), a
+ * synthesized description is still emitted so no function — and no MCP tool —
+ * ships description-less: a humanized operationId, else "METHOD /path".
+ */
+function humanDescription(parsed: ParsedOperation): string {
   const description = parsed.description?.trim()
   if (description && !GENERIC_SUMMARIES.has(description.toLowerCase())) {
     return capitalize(description)
   }
-  return undefined
+  const summary = parsed.summary?.trim()
+  if (summary && !GENERIC_SUMMARIES.has(summary.toLowerCase())) {
+    return capitalize(summary)
+  }
+  return humanizeOperationId(parsed.operationId) ?? `${parsed.method.toUpperCase()} ${parsed.path}`
 }
 
 function getErrorClassesForResponses(


### PR DESCRIPTION
`pikku new addon --openapi <spec> --mcp` exposes every operation as an MCP tool, but the generator only emitted a `description` when the OpenAPI operation had one. Specs frequently omit both `description` and `summary` (e.g. a real 250-operation spec produced 252 `MCP tool '<x>' is missing a description` warnings), leaving description-less tools an AI can't choose between.

Synthesize a description when the spec omits one:
1. `description` (as today)
2. → `summary`
3. → humanized `operationId` (`contactsControllerGetContacts` → "Contacts get contacts", `Controller` segment dropped)
4. → `METHOD /path`

Adds 3 tests; full codegen suite 23/23 green. Changeset: patch (cascades a `@pikku/cli` patch via updateInternalDependencies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated tool descriptions now always fall back to a readable value when an operation has no description or summary, reducing missing-description warnings.
  * Improved description text by using a human-friendly operation name first, then a method-and-path fallback when needed.

* **Tests**
  * Added coverage for description generation when descriptions are missing, explicitly provided, or derived from operation names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->