### PR TITLE
feat(console): expose detail-panel system for embedders + read-only email panel

### DIFF
--- a/.changeset/weave-drawer-panels.md
+++ b/.changeset/weave-drawer-panels.md
@@ -1,0 +1,5 @@
+---
+'@pikku/console': patch
+---
+
+Expose the detail-panel system (`PanelProvider`, `usePanelContext`, `PanelContainer`, `PanelType`, `PanelData`) so an embedder can open the same right-hand configuration panels the console pages use, keyed by wire type + id. Adds a read-only `email` panel (rendered template preview) and an `openEmail` opener.

--- a/packages/console/src/components/panel/PanelFactory.tsx
+++ b/packages/console/src/components/panel/PanelFactory.tsx
@@ -54,6 +54,7 @@ import {
 import { CredentialUserPanel } from '../project/panels/CredentialUserPanel'
 import { AuthProviderPanel } from '../project/panels/AuthProviderPanel'
 import { DbColumnPanel } from '../project/panels/DbColumnPanel'
+import { EmailPreviewPanel } from '../project/panels/EmailPreviewPanel'
 
 interface PanelChild {
   id: string
@@ -529,6 +530,22 @@ export const createPanelChildren = (panelData: PanelData): PanelChild[] => {
           content: (
             <Box px="md">
               <DbColumnPanel metadata={panelData.metadata} />
+            </Box>
+          ),
+        },
+      ]
+
+    case 'email':
+      return [
+        {
+          id: 'preview',
+          title: 'Email',
+          content: (
+            <Box px="md">
+              <EmailPreviewPanel
+                templateName={panelData.id}
+                metadata={panelData.metadata}
+              />
             </Box>
           ),
         },

--- a/packages/console/src/components/project/panels/EmailPreviewPanel.tsx
+++ b/packages/console/src/components/project/panels/EmailPreviewPanel.tsx
@@ -1,0 +1,65 @@
+import React, { useMemo } from 'react'
+import { Box, Center, Loader, Alert, Text } from '@pikku/mantine/core'
+import { AlertTriangle } from 'lucide-react'
+import { asI18n } from '@pikku/react'
+import { useRenderEmailPreview } from '../../../hooks/useWirings'
+
+/**
+ * Read-only rendered preview of an email template — the viewer half of the
+ * EmailsPage, with no locale/variable/source editing. Renders the template's
+ * default locale with empty variables so it works from a detail panel opened by
+ * just the template name.
+ */
+export const EmailPreviewPanel: React.FC<{
+  templateName: string
+  metadata?: any
+}> = ({ templateName, metadata }) => {
+  const locale = useMemo(() => {
+    const locales = metadata?.locales
+      ? Object.keys(metadata.locales)
+      : undefined
+    return metadata?.defaultLocale || locales?.[0] || undefined
+  }, [metadata])
+
+  const preview = useRenderEmailPreview(templateName, locale, {}, !!templateName)
+
+  return (
+    <Box>
+      {preview.isLoading ? (
+        <Center py="xl">
+          <Loader />
+        </Center>
+      ) : null}
+      {preview.error ? (
+        <Alert color="red" icon={<AlertTriangle size={16} />}>
+          {asI18n(
+            preview.error instanceof Error
+              ? preview.error.message
+              : 'Failed to render email preview'
+          )}
+        </Alert>
+      ) : null}
+      {preview.data?.subject ? (
+        <Text fw={600} mb="sm">
+          {asI18n(preview.data.subject)}
+        </Text>
+      ) : null}
+      {preview.data?.html ? (
+        <Box
+          style={{
+            border: '1px solid var(--app-row-border)',
+            borderRadius: 8,
+            overflow: 'hidden',
+            background: '#fff',
+          }}
+        >
+          <iframe
+            title={templateName}
+            srcDoc={preview.data.html}
+            style={{ width: '100%', height: 560, border: 'none' }}
+          />
+        </Box>
+      ) : null}
+    </Box>
+  )
+}

--- a/packages/console/src/context/PanelContext.tsx
+++ b/packages/console/src/context/PanelContext.tsx
@@ -23,6 +23,7 @@ export type PanelType =
   | 'credentialUser'
   | 'authProvider'
   | 'dbColumn'
+  | 'email'
 
 export interface PanelData {
   type: PanelType
@@ -67,6 +68,7 @@ interface PanelContextType {
   openCredentialUser: (userId: string, metadata?: any) => void
   openAuthProvider: (providerId: string, metadata?: any) => void
   openDbColumn: (tableName: string, columnName: string, metadata?: any) => void
+  openEmail: (templateName: string, metadata?: any) => void
   navigateInPanel: (
     type: PanelType,
     id: string,
@@ -277,6 +279,13 @@ export const PanelProvider: React.FC<PanelProviderProps> = ({ children }) => {
     [openPanelGeneric]
   )
 
+  const openEmail = useCallback(
+    (templateName: string, metadata?: any) => {
+      openPanelGeneric('email', templateName, templateName, metadata)
+    },
+    [openPanelGeneric]
+  )
+
   const navigateInPanel = useCallback(
     (type: PanelType, id: string, title: string, metadata?: any) => {
       setPanels((prev) => {
@@ -404,6 +413,7 @@ export const PanelProvider: React.FC<PanelProviderProps> = ({ children }) => {
         openCredentialUser,
         openAuthProvider,
         openDbColumn,
+        openEmail,
         navigateInPanel,
         goBack,
         goBackTo,

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -162,3 +162,11 @@ export type {
 } from './pages/AuthProvidersPage'
 export { NotFoundTitle } from './components/NotFoundTitle'
 export { ConsoleEditableProvider } from './context/ConsoleEditableContext'
+// Detail-panel system: lets an embedder (e.g. a canvas/graph view) open the
+// same right-hand configuration panels the pages use, by wire type + id.
+export { PanelProvider, usePanelContext } from './context/PanelContext'
+export type { PanelType, PanelData } from './context/PanelContext'
+export { PanelContainer } from './components/panel/PanelContainer'
+// Needed by an embedder that opens the workflow panel outside a workflow page:
+// the workflow panels read their graph from this context (feed it meta.workflows[id]).
+export { WorkflowProvider } from './context/WorkflowContext'


### PR DESCRIPTION
## What

Exposes the console's existing detail-panel system so an **embedder** (e.g. a canvas/graph/woven-field view) can open the same right-hand configuration panels the console pages already use, keyed by wire type + id:

- Export `PanelProvider`, `usePanelContext`, `PanelContainer`, and the `PanelType` / `PanelData` types.
- Export `WorkflowProvider` (the workflow panels read their graph from this context; an embedder feeds it `meta.workflows[id]`).
- Add a read-only **`email`** panel — a `EmailPreviewPanel` that renders the template preview (subject + rendered HTML in an iframe) via the existing `useRenderEmailPreview` hook — plus an `openEmail` opener. Email was the only wire type with a page but no panel.

## Why

Fabric's sandbox builder shows a live "woven field" of every function/wire/workflow/etc. while the app is still being built. We want clicking a piece to open its detail on the right — reusing these exact panels rather than rebuilding them. Everything needed already existed internally; this just makes it importable. Read-only is achieved by the consumer via the existing `ConsoleEditableProvider editable={false}`.

No behavior change for existing pages — purely additive exports + one new panel type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening configuration panels in embedded console experiences.
  * Added a new read-only email preview panel, including subject display and rendered template preview.
  * Enabled opening email previews directly from the console with a dedicated action.

* **Bug Fixes**
  * Email panels now render correctly instead of appearing blank when selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->