### PR TITLE
fix(better-auth): narrow fabric() JWT byte helpers to Uint8Array<ArrayBuffer>

### DIFF
--- a/packages/services/better-auth/src/fabric-plugin.ts
+++ b/packages/services/better-auth/src/fabric-plugin.ts
@@ -23,7 +23,7 @@ export interface FabricPluginOptions {
 const fabricEmail = (fabricUserId: string): string =>
   `fabric-${fabricUserId.toLowerCase()}@fabric.internal`
 
-const b64urlToBytes = (s: string): Uint8Array => {
+const b64urlToBytes = (s: string): Uint8Array<ArrayBuffer> => {
   const pad = s + '==='.slice((s.length + 3) % 4)
   const bin = atob(pad.replace(/-/g, '+').replace(/_/g, '/'))
   const out = new Uint8Array(bin.length)
@@ -31,7 +31,7 @@ const b64urlToBytes = (s: string): Uint8Array => {
   return out
 }
 
-const pemToDer = (pem: string): Uint8Array => {
+const pemToDer = (pem: string): Uint8Array<ArrayBuffer> => {
   const body = pem.replace(/-----[^-]+-----/g, '').replace(/\s+/g, '')
   const bin = atob(body)
   const out = new Uint8Array(bin.length)


### PR DESCRIPTION
## Problem
`ded3d084f` (fabric() RS256 refactor) broke the `@pikku/better-auth` build on `main`:

```
src/fabric-plugin.ts(65,7): error TS2769: No overload matches this call.
src/fabric-plugin.ts(79,7): error TS2345: Argument of type 'Uint8Array<ArrayBufferLike>' is not assignable to parameter of type 'BufferSource'.
```

## Cause
`pemToDer`/`b64urlToBytes` were annotated `: Uint8Array`, which TS 5.7+/6.x widen to `Uint8Array<ArrayBufferLike>`. `crypto.subtle.importKey`/`verify` now require an `ArrayBuffer`-backed `BufferSource`, so the widened type is rejected.

## Fix
Annotate both helpers `Uint8Array<ArrayBuffer>` — the exact type `new Uint8Array(n)` already produces. No runtime change.

## Verification
Reproduced the two errors on tsc 6.0.3, then `tsc --noEmit` → **0 errors** with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal type precision for authentication-related utilities.
  * No user-facing behavior, performance, or workflow changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->