### PR TITLE
fix(cli): preserve Postgres array columns in db schema codegen

### DIFF
--- a/.changeset/fix-pg-array-codegen.md
+++ b/.changeset/fix-pg-array-codegen.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Fix `pikku db` schema codegen flattening Postgres array columns to scalar types. `text[]`/`int[]`/`uuid[]` columns now generate as `string[]`/`number[]`/`string[]` in `schema.gen.ts` instead of `string`/`number`. The introspector now captures the array element type from `udt_name` (previously every array column was recorded as the opaque `ARRAY`), and `mapType` preserves the `[]` suffix rather than matching the element substring and dropping the array-ness.

--- a/packages/cli/src/functions/db/db-codegen.test.ts
+++ b/packages/cli/src/functions/db/db-codegen.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { generateSchemaTypes } from './db-codegen.js'
@@ -105,6 +105,29 @@ test('does not warn when a json column has a concrete tsType', async () => {
   assert.ok(
     !hasJsonWarning(result.warnings, 'spec'),
     `expected no json-type warning, got: ${JSON.stringify(result.warnings)}`
+  )
+})
+
+test('array columns keep their array-ness (text[] → string[], int[] → number[])', async () => {
+  const result = await run([
+    col({ name: 'tags', type: 'text[]', notNull: false }),
+    col({ name: 'scores', type: 'int4[]', notNull: false }),
+  ])
+  const schema = readFileSync(result.outFile, 'utf8')
+  assert.match(
+    schema,
+    /Private<string\[\]>/,
+    `text[] should type as string[], got:\n${schema}`
+  )
+  assert.match(
+    schema,
+    /Private<number\[\]>/,
+    `int4[] should type as number[], got:\n${schema}`
+  )
+  assert.doesNotMatch(
+    schema,
+    /tags:[^\n]*Private<string>[^[]/,
+    `text[] must not flatten to a scalar string, got:\n${schema}`
   )
 })
 

--- a/packages/cli/src/functions/db/db-codegen.ts
+++ b/packages/cli/src/functions/db/db-codegen.ts
@@ -26,6 +26,8 @@ type Dialect = 'sqlite' | 'postgres'
 function realKind(dialect: Dialect, sqlType: string): ColumnKind | null {
   if (dialect !== 'postgres') return null
   const u = sqlType.toUpperCase()
+  // Array types carry no scalar kind — an array of timestamps is not a `date`.
+  if (u.endsWith('[]')) return null
   if (u.includes('TIMESTAMP') || u === 'DATE') return 'date'
   if (u === 'BOOLEAN' || u === 'BOOL') return 'bool'
   if (u === 'UUID') return 'uuid'
@@ -61,6 +63,9 @@ function escapeTsString(value: string): string {
 
 function mapType(sqlType: string): string {
   const upper = sqlType.toUpperCase()
+  // Preserve array-ness — map the element type and re-apply the `[]` suffix
+  // rather than letting the element's substring match flatten it to a scalar.
+  if (upper.endsWith('[]')) return `${mapType(sqlType.slice(0, -2))}[]`
   if (upper.includes('INT')) return 'number'
   if (
     upper.includes('CHAR') ||

--- a/packages/cli/src/functions/db/postgres/postgres-introspector.test.ts
+++ b/packages/cli/src/functions/db/postgres/postgres-introspector.test.ts
@@ -1,0 +1,58 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { PostgresIntrospector } from './postgres-introspector.js'
+
+interface PgColumnRow {
+  column_name: string
+  data_type: string
+  udt_name: string
+  is_nullable: string
+  column_default: string | null
+  is_generated: string
+  is_pk: boolean
+}
+
+function row(partial: Partial<PgColumnRow> & { column_name: string }): PgColumnRow {
+  return {
+    data_type: 'text',
+    udt_name: 'text',
+    is_nullable: 'YES',
+    column_default: null,
+    is_generated: 'NEVER',
+    is_pk: false,
+    ...partial,
+  }
+}
+
+function fakeClient(rows: PgColumnRow[]) {
+  return {
+    async query<T = unknown>(): Promise<{ rows: T[] }> {
+      return { rows: rows as unknown as T[] }
+    },
+    async end(): Promise<void> {},
+  }
+}
+
+test('getColumns captures the element type of a text[] array column', async () => {
+  const client = fakeClient([
+    row({ column_name: 'tags', data_type: 'ARRAY', udt_name: '_text' }),
+  ])
+  const cols = await new PostgresIntrospector(client).getColumns('public.widget')
+  assert.equal(cols[0]!.type, 'text[]')
+})
+
+test('getColumns captures the element type of an integer[] array column', async () => {
+  const client = fakeClient([
+    row({ column_name: 'scores', data_type: 'ARRAY', udt_name: '_int4' }),
+  ])
+  const cols = await new PostgresIntrospector(client).getColumns('widget')
+  assert.equal(cols[0]!.type, 'int4[]')
+})
+
+test('getColumns leaves scalar column types unchanged', async () => {
+  const client = fakeClient([
+    row({ column_name: 'name', data_type: 'text', udt_name: 'text' }),
+  ])
+  const cols = await new PostgresIntrospector(client).getColumns('widget')
+  assert.equal(cols[0]!.type, 'text')
+})

--- a/packages/cli/src/functions/db/postgres/postgres-introspector.ts
+++ b/packages/cli/src/functions/db/postgres/postgres-introspector.ts
@@ -21,6 +21,21 @@ interface QueryClient {
   end(): Promise<void>
 }
 
+/**
+ * Resolve the SQL type string for a column, preserving array-ness. Postgres
+ * reports every array column with `data_type = 'ARRAY'`; the element type lives
+ * in `udt_name` as the internal array type name (`_text`, `_int4`, `_uuid`, …).
+ * We strip the leading underscore and re-form it as `<element>[]` so downstream
+ * type mapping keeps the array instead of flattening to the scalar element.
+ */
+function resolveColumnType(dataType: string, udtName: string): string {
+  if (dataType === 'ARRAY') {
+    const element = udtName.startsWith('_') ? udtName.slice(1) : udtName
+    return `${element}[]`
+  }
+  return dataType
+}
+
 export class PostgresIntrospector implements DbIntrospector {
   private client: QueryClient
   private ownsClient: boolean
@@ -94,7 +109,7 @@ export class PostgresIntrospector implements DbIntrospector {
 
     return result.rows.map((r) => ({
       name: r.column_name,
-      type: r.data_type,
+      type: resolveColumnType(r.data_type, r.udt_name),
       udtName: r.udt_name,
       notNull: r.is_nullable === 'NO',
       pk: Boolean(r.is_pk),


### PR DESCRIPTION
Fixes #911

## Problem

Any Postgres array column (`text[]`, `int[]`, `uuid[]`, …) was generated as its scalar element type in `.pikku/db/schema.gen.ts` — `text[]` → `string`, `int[]` → `number`. Round-tripping the real `string[]` value then failed to type-check against the generated Kysely schema, and (worse) writing a scalar into an array column type-checked silently.

Two independent defects, either sufficient on its own:

1. **Introspector dropped the element type.** `PostgresIntrospector.getColumns` recorded `type: r.data_type`, which is the opaque literal `"ARRAY"` for every array column. The element type lives in `udt_name` (`_text`, `_int4`, …) and was never captured.
2. **`mapType()` had no array case.** Given `"ARRAY"` it fell through to `'string'`; given `"text[]"` it matched `includes('TEXT')` → `'string'` and still dropped the array-ness.

## Fix

- **`postgres-introspector.ts`** — new `resolveColumnType(dataType, udtName)`: for `data_type === 'ARRAY'`, strip the leading `_` from `udt_name` and emit `<element>[]`. This also improves `pikku-db-schema.gen.json` (was `"ARRAY"`, now e.g. `"text[]"`).
- **`db-codegen.ts`** — `mapType` preserves a trailing `[]` by mapping the element type and re-applying the suffix (`text[]` → `string[]`, `int4[]` → `number[]`, `bytea[]` → `Buffer[]`). `realKind` returns `null` for array types so an array of timestamps isn't mis-derived as a scalar `Date`.

## Tests (TDD — fail before, pass after)

- `postgres-introspector.test.ts` (new) — element type is captured for `text[]`/`int4[]`; scalars unchanged.
- `db-codegen.test.ts` — asserts `text[]` → `string[]` and `int4[]` → `number[]` in the emitted schema, and that `text[]` never flattens to scalar `string`.

Full `packages/cli` db suite: **54/54 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)