### PR TITLE
feat(core,cli): make AI agents native workflow-graph nodes (#910)

### DIFF
--- a/.changeset/agent-graph-nodes.md
+++ b/.changeset/agent-graph-nodes.md
@@ -1,0 +1,6 @@
+---
+'@pikku/core': patch
+'@pikku/cli': patch
+---
+
+Allow a workflow-graph node's `func` to reference a registered AI agent by name, dispatched as an agent run — exactly like sub-workflows. `executeGraphStep`/`executeGraphNodeInline` now check the agent registry and dispatch matching nodes via the agent-run path (`rpc.agent.run`), so the node's result is the agent's declared output and downstream nodes can `ref()` it. The generated `pikkuWorkflowGraph` wrapper widens its node-func union to also accept `keyof FlattenedWorkflowMap` and `keyof FlattenedAgentMap`, and `ref()` resolves an agent node's output keys.

--- a/packages/cli/src/functions/wirings/workflow/agent-graph-node.compile.test.ts
+++ b/packages/cli/src/functions/wirings/workflow/agent-graph-node.compile.test.ts
@@ -1,0 +1,153 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import ts from 'typescript'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * The graph type machinery emitted by serializeWorkflowTypes, paired with stub
+ * RPC / workflow / agent maps. Kept in lockstep with the emitter — the sibling
+ * serialize-workflow-types.test.ts pins that the emitter still produces these
+ * exact constructs, while this file proves they compile and enforce the union.
+ */
+const MACHINERY = `
+type FlattenedRPCMap = {
+  userCreate: { input: { name: string }; output: { email: string; id: string } }
+  emailSend: { input: { to: string; subject: string; body: string }; output: { sent: boolean } }
+}
+type FlattenedWorkflowMap = {
+  onboardWorkflow: { input: { userId: string }; output: { done: boolean } }
+}
+type FlattenedAgentMap = {
+  readonly summarize: { output: { summary: string; score: number } }
+}
+
+type TypedRef<T> = { $ref: string; path?: string } & { __phantomType?: T }
+type TemplateString = {
+  $template: { parts: string[]; expressions: Array<{ $ref: string; path?: string }> }
+} & { __brand: 'TemplateString' }
+type InputWithRefs<T> = {
+  [K in keyof T]?: T[K] | TypedRef<T[K]> | TypedRef<unknown> | TemplateString
+}
+type NodeInputType<FuncMap extends Record<string, string>, K extends keyof FuncMap> =
+  FuncMap[K] extends keyof FlattenedRPCMap
+    ? InputWithRefs<FlattenedRPCMap[FuncMap[K]]['input']>
+    : FuncMap[K] extends keyof FlattenedWorkflowMap
+      ? InputWithRefs<FlattenedWorkflowMap[FuncMap[K]]['input']>
+      : Record<string, unknown>
+type NodeOutputKeys<FuncMap extends Record<string, string>, N extends string> =
+  N extends keyof FuncMap
+    ? FuncMap[N] extends keyof FlattenedRPCMap
+      ? keyof FlattenedRPCMap[FuncMap[N]]['output'] & string
+      : FuncMap[N] extends keyof FlattenedWorkflowMap
+        ? keyof FlattenedWorkflowMap[FuncMap[N]]['output'] & string
+        : FuncMap[N] extends keyof FlattenedAgentMap
+          ? keyof FlattenedAgentMap[FuncMap[N]]['output'] & string
+          : string
+    : string
+type RefFunction<FuncMap extends Record<string, string>> = {
+  <N extends Extract<keyof FuncMap, string>>(nodeId: N, path: NodeOutputKeys<FuncMap, N>): TypedRef<unknown>
+  (nodeId: 'trigger' | '$item', path?: string): TypedRef<unknown>
+}
+type TemplateFunction = (templateStr: string, refs: TypedRef<unknown>[]) => TemplateString
+type NextConfig<NodeIds extends string> = NodeIds | NodeIds[] | { if: string; then: NodeIds; else?: NodeIds }
+type GraphNodeConfigMap<FuncMap extends Record<string, string>> = {
+  [K in Extract<keyof FuncMap, string>]?: {
+    next?: NextConfig<Extract<keyof FuncMap, string>>
+    input?:
+      | NodeInputType<FuncMap, K>
+      | (() => NodeInputType<FuncMap, K>)
+      | ((ref: RefFunction<FuncMap>, template: TemplateFunction) => NodeInputType<FuncMap, K>)
+    onError?: Extract<keyof FuncMap, string> | Extract<keyof FuncMap, string>[]
+  }
+}
+interface PikkuWorkflowGraphConfig<FuncMap extends Record<string, string>, T> {
+  disabled?: true; name?: string; description?: string; tags?: string[]; nodes: FuncMap; config?: T
+}
+interface PikkuWorkflowGraphResult { __type: 'pikkuWorkflowGraph' }
+declare function pikkuWorkflowGraph<
+  const FuncMap extends Record<
+    string,
+    | (keyof FlattenedRPCMap & string)
+    | (keyof FlattenedWorkflowMap & string)
+    | (keyof FlattenedAgentMap & string)
+  >
+>(config: PikkuWorkflowGraphConfig<FuncMap, GraphNodeConfigMap<FuncMap>>): PikkuWorkflowGraphResult
+`
+
+const typeErrors = (consumer: string): string[] => {
+  const dir = mkdtempSync(join(tmpdir(), 'pikku-agent-graph-'))
+  try {
+    const file = join(dir, 'fixture.ts')
+    writeFileSync(file, `${MACHINERY}\n${consumer}\n`)
+    const program = ts.createProgram([file], {
+      strict: true,
+      noEmit: true,
+      skipLibCheck: true,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ESNext,
+    })
+    return ts
+      .getPreEmitDiagnostics(program)
+      .filter((d) => d.file?.fileName === file)
+      .map((d) => ts.flattenDiagnosticMessageText(d.messageText, ' '))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+describe('pikkuWorkflowGraph agent-name nodes', () => {
+  test('an agent-name node compiles and a downstream node refs its output', () => {
+    const errors = typeErrors(`
+export const g = pikkuWorkflowGraph({
+  nodes: { entry: 'userCreate', classify: 'summarize', notify: 'emailSend' },
+  config: {
+    entry: { next: 'classify' },
+    classify: { next: 'notify', input: (ref) => ({ message: ref('entry', 'email') }) },
+    notify: {
+      input: (ref) => ({
+        to: ref('entry', 'email'),
+        subject: ref('classify', 'summary'),
+        body: 'hi',
+      }),
+    },
+  },
+})
+`)
+    assert.deepEqual(errors, [])
+  })
+
+  test('a sub-workflow name is also accepted as a node func', () => {
+    const errors = typeErrors(
+      `export const g = pikkuWorkflowGraph({ nodes: { a: 'onboardWorkflow' } })`
+    )
+    assert.deepEqual(errors, [])
+  })
+
+  test('an unknown node func name (not an rpc, workflow, or agent) is rejected', () => {
+    const errors = typeErrors(
+      `export const g = pikkuWorkflowGraph({ nodes: { x: 'notARealThing' } })`
+    )
+    assert.ok(
+      errors.some((e) => e.includes('notARealThing')),
+      `expected a rejection mentioning notARealThing, got ${JSON.stringify(errors)}`
+    )
+  })
+
+  test('ref() against a non-existent agent output key is rejected', () => {
+    const errors = typeErrors(`
+export const g = pikkuWorkflowGraph({
+  nodes: { classify: 'summarize', notify: 'emailSend' },
+  config: {
+    notify: { input: (ref) => ({ to: ref('classify', 'nope'), subject: 's', body: 'b' }) },
+  },
+})
+`)
+    assert.ok(
+      errors.length > 0,
+      'expected ref() to reject an unknown agent output key'
+    )
+  })
+})

--- a/packages/cli/src/functions/wirings/workflow/pikku-command-workflow.ts
+++ b/packages/cli/src/functions/wirings/workflow/pikku-command-workflow.ts
@@ -145,6 +145,11 @@ export const pikkuWorkflow = pikkuSessionlessFunc<
       workflowMapDeclarationFile,
       packageMappings
     )
+    const agentMapImportPath = getFileImportRelativePath(
+      workflowTypesFile,
+      config.agentMapDeclarationFile,
+      packageMappings
+    )
 
     await writeFileInDir(
       logger,
@@ -152,7 +157,8 @@ export const pikkuWorkflow = pikkuSessionlessFunc<
       serializeWorkflowTypes(
         functionTypesImportPath,
         rpcMapImportPath,
-        workflowMapImportPath
+        workflowMapImportPath,
+        agentMapImportPath
       )
     )
 

--- a/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.test.ts
+++ b/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.test.ts
@@ -1,0 +1,36 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { serializeWorkflowTypes } from './serialize-workflow-types.js'
+
+describe('serializeWorkflowTypes', () => {
+  const emit = () =>
+    serializeWorkflowTypes(
+      './pikku-function-types.gen.js',
+      './pikku-rpc-map.gen.js',
+      './pikku-workflow-map.gen.js',
+      './pikku-agent-map.gen.js'
+    )
+
+  test('imports the agent map so agent names are known to the graph', () => {
+    const result = emit()
+    assert.match(
+      result,
+      /import type \{ AgentMap as FlattenedAgentMap \} from '\.\/pikku-agent-map\.gen\.js'/
+    )
+  })
+
+  test('pikkuWorkflowGraph node funcs admit RPC, workflow and agent names', () => {
+    const result = emit()
+    assert.match(result, /keyof FlattenedRPCMap & string/)
+    assert.match(result, /keyof FlattenedWorkflowMap & string/)
+    assert.match(result, /keyof FlattenedAgentMap & string/)
+  })
+
+  test('ref() resolves output keys for an agent-name node', () => {
+    const result = emit()
+    assert.match(
+      result,
+      /keyof FlattenedAgentMap\[FuncMap\[N\]\]\['output'\] & string/
+    )
+  })
+})

--- a/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.ts
+++ b/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.ts
@@ -1,7 +1,8 @@
 export const serializeWorkflowTypes = (
   functionTypesImportPath: string,
   rpcMapImportPath: string,
-  workflowMapImportPath: string
+  workflowMapImportPath: string,
+  agentMapImportPath: string
 ) => {
   return `import { WorkflowCancelledException } from '@pikku/core/workflow'
 import { template } from '@pikku/core/workflow'
@@ -16,6 +17,7 @@ export { WorkflowCancelledException }
 import type { PikkuFunctionSessionless, PikkuFunctionConfig } from '${functionTypesImportPath}'
 import type { FlattenedRPCMap } from '${rpcMapImportPath}'
 import type { FlattenedWorkflowMap } from '${workflowMapImportPath}'
+import type { AgentMap as FlattenedAgentMap } from '${agentMapImportPath}'
 
 export { template }
 
@@ -148,13 +150,19 @@ type InputWithRefs<T> = {
 type NodeInputType<FuncMap extends Record<string, string>, K extends keyof FuncMap> =
   FuncMap[K] extends keyof FlattenedRPCMap
     ? InputWithRefs<FlattenedRPCMap[FuncMap[K]]['input']>
-    : Record<string, unknown>
+    : FuncMap[K] extends keyof FlattenedWorkflowMap
+      ? InputWithRefs<FlattenedWorkflowMap[FuncMap[K]]['input']>
+      : Record<string, unknown>
 
 type NodeOutputKeys<FuncMap extends Record<string, string>, N extends string> =
   N extends keyof FuncMap
     ? FuncMap[N] extends keyof FlattenedRPCMap
       ? keyof FlattenedRPCMap[FuncMap[N]]['output'] & string
-      : string
+      : FuncMap[N] extends keyof FlattenedWorkflowMap
+        ? keyof FlattenedWorkflowMap[FuncMap[N]]['output'] & string
+        : FuncMap[N] extends keyof FlattenedAgentMap
+          ? keyof FlattenedAgentMap[FuncMap[N]]['output'] & string
+          : string
     : string
 
 type RefFunction<FuncMap extends Record<string, string>> = {
@@ -181,7 +189,12 @@ type GraphNodeConfigMap<FuncMap extends Record<string, string>> = {
 type NextConfig<NodeIds extends string> = NodeIds | NodeIds[] | { if: string; then: NodeIds; else?: NodeIds }
 
 export function pikkuWorkflowGraph<
-  const FuncMap extends Record<string, keyof FlattenedRPCMap & string>
+  const FuncMap extends Record<
+    string,
+    | (keyof FlattenedRPCMap & string)
+    | (keyof FlattenedWorkflowMap & string)
+    | (keyof FlattenedAgentMap & string)
+  >
 >(
   config: PikkuWorkflowGraphConfig<FuncMap, GraphNodeConfigMap<FuncMap>>
 ): PikkuWorkflowGraphResult {

--- a/packages/core/src/wirings/workflow/graph/graph-runner.test.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.test.ts
@@ -677,6 +677,140 @@ describe('graph-runner bugs', () => {
     delete metaState['testInlineMetaGraph']
   })
 
+  test('executeGraphStep dispatches an agent-name node via the agent-run path and returns its result', async () => {
+    const ws = new InMemoryWorkflowService()
+
+    const agentsMeta = pikkuState(null, 'agent', 'agentsMeta')
+    agentsMeta['summarize'] = {
+      name: 'summarize',
+      inputSchema: null,
+      outputSchema: null,
+      workingMemorySchema: null,
+    } as any
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['testAgentNode'] = {
+      name: 'testAgentNode',
+      pikkuFuncId: 'testAgentNode',
+      source: 'graph',
+      entryNodeIds: ['a'],
+      graphHash: 'agent-node-hash',
+      nodes: {
+        a: { nodeId: 'a', rpcName: 'summarize' },
+      },
+    }
+
+    const runId = await ws.createRun(
+      'testAgentNode',
+      {},
+      false,
+      'agent-node-hash',
+      { type: 'test' }
+    )
+    const agentInput = { message: 'hi', threadId: 't', resourceId: 'r' }
+    const step = await ws.insertStepState(runId, 'a', 'summarize', agentInput)
+
+    let agentRunCall: { name: string; input: any } | null = null
+    const rpcService = {
+      rpcWithWire: async () => {
+        throw new Error('should not invoke rpcWithWire for an agent node')
+      },
+      agent: {
+        run: async (name: string, input: any) => {
+          agentRunCall = { name, input }
+          return {
+            runId: 'agent-run-1',
+            result: { summary: 'done' },
+            usage: { inputTokens: 1, outputTokens: 2 },
+          }
+        },
+      },
+    }
+
+    const result = await executeGraphStep(
+      ws,
+      rpcService,
+      runId,
+      step.stepId,
+      'a',
+      'summarize',
+      agentInput,
+      'testAgentNode'
+    )
+
+    assert.deepEqual(result, { summary: 'done' })
+    assert.deepEqual(agentRunCall, { name: 'summarize', input: agentInput })
+
+    delete metaState['testAgentNode']
+    delete agentsMeta['summarize']
+  })
+
+  test('inline graph dispatches an agent node and a downstream node consumes its result', async () => {
+    const ws = new InMemoryWorkflowService()
+
+    const agentsMeta = pikkuState(null, 'agent', 'agentsMeta')
+    agentsMeta['classifier'] = {
+      name: 'classifier',
+      inputSchema: null,
+      outputSchema: null,
+      workingMemorySchema: null,
+    } as any
+
+    let consumed: any = null
+    const rpcService = {
+      rpcWithWire: async (rpcName: string, data: any) => {
+        if (rpcName === 'consume') {
+          consumed = data
+          return { ok: true }
+        }
+        return {}
+      },
+      agent: {
+        run: async () => ({
+          runId: 'r',
+          result: { category: 'urgent' },
+          usage: { inputTokens: 0, outputTokens: 0 },
+        }),
+      },
+    }
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['testInlineAgentNode'] = {
+      name: 'testInlineAgentNode',
+      pikkuFuncId: 'testInlineAgentNode',
+      source: 'graph',
+      entryNodeIds: ['agentNode'],
+      graphHash: 'inline-agent-hash',
+      nodes: {
+        agentNode: {
+          nodeId: 'agentNode',
+          rpcName: 'classifier',
+          next: 'consume',
+        },
+        consume: {
+          nodeId: 'consume',
+          rpcName: 'consume',
+          input: { category: { $ref: 'agentNode', path: 'category' } },
+        },
+      },
+    }
+
+    const { runId } = await runWorkflowGraph(
+      ws,
+      'testInlineAgentNode',
+      { message: 'x', threadId: 't', resourceId: 'r' },
+      rpcService,
+      true
+    )
+
+    const run = await ws.getRun(runId)
+    assert.equal(run?.status, 'completed')
+    assert.deepEqual(consumed, { category: 'urgent' })
+
+    delete metaState['testInlineAgentNode']
+    delete agentsMeta['classifier']
+  })
+
   test('queueGraphNode forwards node retries to queue attempts and backoff', async () => {
     const ws = new InMemoryWorkflowService()
     const enqueued: Array<{ queueName: string; data: any; options: any }> = []

--- a/packages/core/src/wirings/workflow/graph/graph-runner.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.ts
@@ -621,6 +621,9 @@ export async function executeGraphStep(
     let result: any
 
     const subWorkflowMeta = pikkuState(null, 'workflows', 'meta')[rpcName]
+    const agentMeta = subWorkflowMeta
+      ? undefined
+      : pikkuState(null, 'agent', 'agentsMeta')[rpcName]
     if (subWorkflowMeta) {
       const childWire: WorkflowRunWire = {
         type: 'workflow',
@@ -650,6 +653,9 @@ export async function executeGraphStep(
       } else {
         throw new ChildWorkflowStartedException(runId, stepId, childRunId)
       }
+    } else if (agentMeta) {
+      const agentRun = await rpcService.agent.run(rpcName, data)
+      result = agentRun.result
     } else {
       result = await invokeGraphNodeRpc(
         workflowService,
@@ -760,6 +766,9 @@ async function executeGraphNodeInline(
     let result: any
 
     const subWorkflowMeta = pikkuState(null, 'workflows', 'meta')[rpcName]
+    const agentMeta = subWorkflowMeta
+      ? undefined
+      : pikkuState(null, 'agent', 'agentsMeta')[rpcName]
     if (subWorkflowMeta) {
       const childWire: WorkflowRunWire = {
         type: 'workflow',
@@ -783,6 +792,9 @@ async function executeGraphNodeInline(
         throw new Error('Sub-workflow was cancelled')
       }
       result = childRun?.output
+    } else if (agentMeta) {
+      const agentRun = await rpcService.agent.run(rpcName, input)
+      result = agentRun.result
     } else {
       result = await invokeGraphNodeRpc(
         workflowService,


### PR DESCRIPTION
Closes #910.

## What

Let a `pikkuWorkflowGraph` node's `func` reference a registered AI agent by name, dispatched as an agent run — exactly like sub-workflows already work as graph nodes. Previously agents lived in a separate registry and couldn't be graph nodes, so any graph embedding an agent (e.g. the n8n importer's graph-with-agent shape) could neither type-check nor run.

## How

**Runtime** (`packages/core/.../graph/graph-runner.ts`) — `executeGraphStep` and `executeGraphNodeInline` now check the agent registry (`pikkuState(null, 'agent', 'agentsMeta')[rpcName]`) alongside the existing sub-workflow check, and on a match dispatch the node via the canonical agent-run path (`rpcService.agent.run(rpcName, data)` → `runAIAgent`). The node's result is the agent's declared output (`object ?? text`), so downstream nodes consume it through `ref()`. This mirrors the sub-workflow branch's structure exactly (three-way: sub-workflow → agent → RPC).

**Types** (`packages/cli/.../serialize-workflow-types.ts`) — the generated `pikkuWorkflowGraph` wrapper widens its node-func generic from `keyof FlattenedRPCMap & string` to also accept `keyof FlattenedWorkflowMap` and `keyof FlattenedAgentMap` (agents were never expressible before; sub-workflows worked at runtime but weren't type-checkable as nodes either). `NodeOutputKeys` falls through to the agent map so `ref(agentNode, 'someOutputKey')` resolves the agent's output keys. The agent map is imported via the already-available `config.agentMapDeclarationFile` (empty `AgentMap = {}` for agentless projects, so this is a no-op there).

## Tests (TDD — red before, green after)

- **`graph-runner.test.ts`** (unit): an agent-name node dispatches through the agent-run path and returns the agent's result (queued `executeGraphStep`), and a downstream node consumes an agent node's output via `ref()` (inline `runWorkflowGraph`).
- **`serialize-workflow-types.test.ts`** (codegen): the emitter imports the agent map, admits RPC/workflow/agent names in the node-func generic, and resolves agent output keys.
- **`agent-graph-node.compile.test.ts`** (type/compile): compiles the emitted graph type machinery with the TypeScript API — an agent-name node type-checks, `ref()` enforces the agent's output keys, and unknown func names are rejected. Verified that with the old RPC-only generic the agent/workflow nodes fail to compile, so the test genuinely guards the widening.

Existing sub-workflow + RPC-node graph tests stay green (17/17 in `graph-runner.test.ts`); `@pikku/core` type-checks clean.

## Downstream

Unblocks the n8n importer dropping its agent-as-graph-node stub — graph-with-agent workflows can now reference the agent directly.

## Changeset

`@pikku/core` + `@pikku/cli` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow graphs can now use registered AI agents as node functions.
  * Agent nodes run through the standard agent execution flow and expose their declared outputs to subsequent nodes.
  * References to agent outputs are supported in downstream workflow steps.
  * Workflow typing now recognizes RPCs, sub-workflows, and agents while validating invalid node names and output references.

* **Tests**
  * Added coverage for agent execution, inline workflows, output references, and generated type validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->