### PR TITLE
fix(workflow): thread run wire pikkuUserId onto queued step wires

### DIFF
--- a/.changeset/queued-workflow-step-pikku-userid.md
+++ b/.changeset/queued-workflow-step-pikku-userid.md
@@ -1,0 +1,7 @@
+---
+'@pikku/core': patch
+---
+
+fix(workflow): carry `pikkuUserId` onto queued workflow step wires so authed steps rehydrate their session
+
+A workflow step invoked on the queued (pg-boss) executor received the bare job wire (payload is just `{ runId }`), so `pikkuUserId` was never on the step wire and an authed step (`pikkuFunc`) threw `Authentication required` — even though the run wire persisted the acting user's id and the inline executor worked. `invokeStepRpc` now reads `pikkuUserId` from the persisted run wire and merges it into the step wire override, so authed steps rehydrate their session via the `SessionStore` on both the inline and queued paths.

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -1732,7 +1732,11 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     data: any,
     rpcService: any
   ): Promise<any> {
+    // Carry the run's pikkuUserId onto the step wire so authed steps rehydrate their
+    // session on the queued path too (the bare job wire lacks it; inline already has it).
+    const run = await this.getRun(runId)
     return rpcService.rpcWithWire(rpcName, data, {
+      ...(run?.wire?.pikkuUserId ? { pikkuUserId: run.wire.pikkuUserId } : {}),
       workflowStep: {
         runId,
         stepId: stepState.stepId,

--- a/packages/core/src/wirings/workflow/workflow-step-session.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-step-session.test.ts
@@ -1,0 +1,78 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState } from '../../pikku-state.js'
+
+// A queued workflow step is executed with the bare job wire (payload is just
+// { runId }), so its wire has no `pikkuUserId`. Without threading it from the
+// persisted run wire, an authed step (`pikkuFunc`) sees no session and throws
+// "Authentication required". These tests pin that `invokeStepRpc` merges the
+// run wire's `pikkuUserId` into the step wire override so the session rehydrates.
+
+const silentLogger = { error() {}, info() {}, warn() {}, debug() {} }
+
+// rpcService stand-in whose only job is to capture the wire override it's handed.
+function capturingRpcService(): {
+  service: { rpcWithWire: (n: string, d: any, w: any) => Promise<any> }
+  wire: () => any
+} {
+  let captured: any
+  return {
+    service: {
+      rpcWithWire: async (_rpcName: string, _data: any, wire: any) => {
+        captured = wire
+        return { ok: true }
+      },
+    },
+    wire: () => captured,
+  }
+}
+
+describe('queued workflow steps carry the run wire pikkuUserId', () => {
+  test('invokeStepRpc merges run.wire.pikkuUserId into the step wire override', async () => {
+    pikkuState(null, 'package', 'singletonServices', { logger: silentLogger } as any)
+
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'queue',
+      pikkuUserId: 'user-abc',
+    })
+    await ws.insertStepState(runId, 'deploy', 'deployByStageKind', {})
+    const stepState = await ws.getStepState(runId, 'deploy')
+
+    const rpc = capturingRpcService()
+    await (ws as any).invokeStepRpc(
+      runId,
+      'deploy',
+      stepState,
+      'deployByStageKind',
+      {},
+      rpc.service
+    )
+
+    assert.equal(
+      rpc.wire().pikkuUserId,
+      'user-abc',
+      'the step wire override carries the run wire pikkuUserId so authed steps rehydrate'
+    )
+    assert.ok(rpc.wire().workflowStep, 'workflowStep provenance is still present')
+  })
+
+  test('no pikkuUserId key is injected when the run wire has none', async () => {
+    pikkuState(null, 'package', 'singletonServices', { logger: silentLogger } as any)
+
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('flow', {}, false, 'hash', { type: 'test' })
+    await ws.insertStepState(runId, 'noauth', 'someFn', {})
+    const stepState = await ws.getStepState(runId, 'noauth')
+
+    const rpc = capturingRpcService()
+    await (ws as any).invokeStepRpc(runId, 'noauth', stepState, 'someFn', {}, rpc.service)
+
+    assert.ok(
+      !('pikkuUserId' in rpc.wire()),
+      'no undefined pikkuUserId is added when the run wire lacks one'
+    )
+  })
+})


### PR DESCRIPTION
## Problem

A workflow step invoked on the **queued** (pg-boss) executor is run with the bare job wire — the orchestrator job payload is just `{ runId }` — so `pikkuUserId` is never present on the step wire. When that step is an authed `pikkuFunc`, `resolveSession` finds no `pikkuUserId` (`if (!sessionStore || !pikkuUserId) return`), no session is hydrated, and the step throws `ForbiddenError('Authentication required')` — even though:

- the run wire persisted the acting user's id (`createRun` stores `wire.pikkuUserId`), and
- the **inline** executor works, because there the `rpcService` is the caller's `ContextAwareRPCService`, which already carries `pikkuUserId` on its wire.

The two executors pass different `rpcService` shapes, so the workflow function hydrates (it reads `run.wire.pikkuUserId` directly) but the DSL *step* invocations (`invokeStepRpc`) do not.

This surfaced as every queued workflow with an authed step (e.g. a deploy step) failing with `Authentication required` after `retry_count` exhaustion.

## Fix

`invokeStepRpc` now reads `pikkuUserId` from the persisted run wire and merges it into the step wire **override** (applied after `...this.wire` in `rpcWithWire`, so it always lands), covering both the inline and queued paths. No step signatures change; when the run wire has no `pikkuUserId`, nothing is injected.

## Tests

`workflow-step-session.test.ts`:
- `invokeStepRpc` merges `run.wire.pikkuUserId` into the step wire override (and keeps `workflowStep` provenance).
- no `pikkuUserId` key is injected when the run wire has none.

Full workflow suite: 57/57 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)