### PR TITLE
feat(core): per-instance addon credentials via wireAddon overrides

### DIFF
--- a/.changeset/per-instance-addon-credentials.md
+++ b/.changeset/per-instance-addon-credentials.md
@@ -1,0 +1,21 @@
+---
+'@pikku/core': patch
+'@pikku/inspector': patch
+---
+
+`wireAddon` can now install the same addon package as multiple named instances, each bound to its own secret/variable/credential — finishing the previously designed-but-unwired `secretOverrides` / `variableOverrides` / `credentialOverrides` feature.
+
+Previously two `wireAddon({ name, package })` instances of one package resolved distinct RPC namespaces but shared a single set of singleton services and one credential, so the overrides had no runtime effect. Overrides are name-aliases: the KEY is the logical name the addon reads, the VALUE is the actual project secret/variable/credential (the logical name is the default only when no override is given).
+
+**@pikku/core (runtime):**
+
+- `wireAddon` persists the override maps into runtime addon state.
+- Addon singleton services are cached and built per `(package, namespace)` instead of per package, so each instance gets its own services object.
+- `secretOverrides` / `variableOverrides` alias the `secrets` / `variables` services fed to the addon's `createSingletonServices`.
+- `credentialOverrides` alias `wire.getCredential(name)` at invocation time (credentials are per-user and resolved against the project's `credentialService`).
+- The active instance namespace rides on the wire, so intra-addon sibling RPC calls stay in the same instance and workflow-name prefixing uses the exact instance namespace rather than assuming one namespace per package.
+
+**@pikku/inspector (build time):**
+
+- Addon-declared secrets/variables are now surfaced into the project under each instance's **override target** name (one per instance) instead of the addon's shared logical name — e.g. two Slack instances require `slack_marketing_secret` and `slack_support_secret`, not a single shared `slack`. The logical name is used only when an instance provides no override.
+- `validateSecretOverrides` / `validateVariableOverrides` / `validateCredentialOverrides` now validate the override **target** (the real project name) exists, instead of the logical key — matching the runtime resolution direction.

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -16,7 +16,6 @@ import type {
   PermissionMetadata,
   CoreSingletonServices,
   CreateWireServices,
-  CoreConfig,
 } from '../types/core.types.js'
 import type { CorePikkuChannelMiddleware } from '../wirings/channel/channel.types.js'
 import type {
@@ -39,81 +38,9 @@ import {
   type AuditLog,
 } from '../services/audit-service.js'
 import { rpcService } from '../wirings/rpc/rpc-runner.js'
+import { getOrCreatePackageSingletonServices } from '../wirings/rpc/addon-runner.js'
+import type { AddonInstance } from '../wirings/rpc/addon-runner.js'
 import { closeWireServices } from '../utils.js'
-import type { SecretService } from '../services/secret-service.js'
-import type { VariablesService } from '../services/variables-service.js'
-
-/**
- * A single wired addon instance: a namespace (wireAddon `name`) plus the
- * per-instance name-aliases that remap the logical names the addon reads to
- * the actual project secret/variable/credential names.
- */
-export type AddonInstance = {
-  namespace: string
-  secretOverrides?: Record<string, string>
-  variableOverrides?: Record<string, string>
-  credentialOverrides?: Record<string, string>
-}
-
-/**
- * Wrap a SecretService so that the logical secret names an addon reads are
- * remapped to the actual project secret names via the instance's overrides.
- */
-const aliasSecretService = (
-  secrets: SecretService,
-  overrides: Record<string, string>
-): SecretService => {
-  const map = (key: string) => overrides[key] ?? key
-  return {
-    getSecret: <T = string>(key: string) => secrets.getSecret<T>(map(key)),
-    hasSecret: (key: string) => secrets.hasSecret(map(key)),
-    setSecret: (key: string, value: unknown) =>
-      secrets.setSecret(map(key), value),
-    deleteSecret: (key: string) => secrets.deleteSecret(map(key)),
-    getSecrets: async (keys) => {
-      const result = await secrets.getSecrets(keys.map(map))
-      const out: Record<string, unknown> = {}
-      for (const logical of keys) {
-        const real = map(logical)
-        if (real in result)
-          out[logical] = (result as Record<string, unknown>)[real]
-      }
-      return out as never
-    },
-  }
-}
-
-/**
- * Wrap a VariablesService so that the logical variable names an addon reads
- * are remapped to the actual project variable names via the instance's overrides.
- */
-const aliasVariablesService = (
-  variables: VariablesService,
-  overrides: Record<string, string>
-): VariablesService => {
-  const map = (name: string) => overrides[name] ?? name
-  return {
-    get: <T = string>(name: string) => variables.get<T>(map(name)),
-    getVariables: (names) => {
-      const result = variables.getVariables(names.map(map) as never)
-      const remap = (r: Record<string, unknown>) => {
-        const out: Record<string, unknown> = {}
-        for (const logical of names) {
-          const real = map(logical)
-          if (real in r) out[logical] = r[real]
-        }
-        return out
-      }
-      return result instanceof Promise
-        ? (result.then(remap) as never)
-        : (remap(result as Record<string, unknown>) as never)
-    },
-    getAll: () => variables.getAll(),
-    set: (name: string, value: unknown) => variables.set(map(name), value),
-    has: (name: string) => variables.has(map(name)),
-    delete: (name: string) => variables.delete(map(name)),
-  }
-}
 
 async function resolveSession(
   wire: PikkuRawWire,
@@ -142,144 +69,6 @@ async function resolveSession(
     // Seed the sessionService so freezeInitial() returns it instead of undefined.
     sessionService?.setInitial(wire.session as CoreUserSession)
   }
-}
-
-/**
- * Get or create singleton services for an addon package.
- * Services are cached in pikkuState to avoid recreation on each call.
- *
- * @param packageName - The addon package name
- * @param parentServices - The parent/caller's singleton services (used as base)
- * @returns The package's singleton services
- */
-/**
- * Find the consumer-defined namespace (from wireAddon) for a given addon package.
- * Returns null if the package isn't registered as an addon.
- */
-const findAddonNamespaceForPackage = (packageName: string): string | null => {
-  const addons = pikkuState(null, 'addons', 'packages')
-  if (!addons) return null
-  for (const [namespace, cfg] of addons.entries()) {
-    if (cfg?.package === packageName) return namespace
-  }
-  return null
-}
-
-/**
- * Wrap a workflow service so that bare workflow names passed from inside an
- * addon function are auto-prefixed with the addon's consumer-facing namespace.
- * Without this, `runToCompletion('myWorkflow')` from inside an addon misses
- * the workflow registered under the addon's package scope and throws
- * WorkflowNotFoundError — forcing addons to hardcode their consumer-defined
- * namespace, which couples the addon to its caller.
- *
- * Explicit `'ns:name'` and bare names that already exist in root meta are
- * unaffected; only bare names that would otherwise miss resolution get
- * prefixed.
- */
-const wrapWorkflowServiceForPackage = <T extends object>(
-  service: T,
-  packageName: string,
-  namespace: string | null
-): T => {
-  return new Proxy(service, {
-    get(target, prop, receiver) {
-      if (prop === 'startWorkflow' || prop === 'runToCompletion') {
-        const original = Reflect.get(target, prop, receiver) as Function
-        return function (this: any, name: string, ...rest: any[]) {
-          if (typeof name === 'string' && !name.includes(':')) {
-            // Prefer the known instance namespace; fall back to the
-            // package's sole namespace when invoked without an instance.
-            const ns = namespace ?? findAddonNamespaceForPackage(packageName)
-            if (ns) {
-              name = `${ns}:${name}`
-            }
-          }
-          return original.call(this, name, ...rest)
-        }
-      }
-      return Reflect.get(target, prop, receiver)
-    },
-  })
-}
-
-const getOrCreatePackageSingletonServices = async (
-  packageName: string,
-  parentServices: CoreSingletonServices,
-  addonInstance?: AddonInstance
-): Promise<CoreSingletonServices> => {
-  // Singletons are cached per addon INSTANCE (namespace), not per package, so
-  // two wireAddon() instances of the same package each get their own services
-  // built with their own secret/variable overrides. Namespaces are globally
-  // unique, so keying the cache slot by namespace is unambiguous; a bare
-  // package-scoped call (no instance) falls back to per-package caching.
-  const cacheKey = addonInstance?.namespace ?? packageName
-
-  // Check if we already have cached singleton services for this instance
-  const cachedServices = pikkuState(cacheKey, 'package', 'singletonServices')
-  if (cachedServices) {
-    return cachedServices
-  }
-
-  // Get the package's service factories
-  const factories = pikkuState(packageName, 'package', 'factories')
-  if (!factories || !factories.createSingletonServices) {
-    // No factories registered, use parent services
-    return parentServices
-  }
-
-  // Apply this instance's secret/variable overrides by aliasing the resolver
-  // services the addon reads from, so its createSingletonServices resolves
-  // instance-specific secrets/variables.
-  let existingServices = parentServices
-  if (addonInstance?.secretOverrides && parentServices.secrets) {
-    existingServices = {
-      ...existingServices,
-      secrets: aliasSecretService(
-        parentServices.secrets,
-        addonInstance.secretOverrides
-      ),
-    }
-  }
-  if (addonInstance?.variableOverrides && parentServices.variables) {
-    existingServices = {
-      ...existingServices,
-      variables: aliasVariablesService(
-        parentServices.variables,
-        addonInstance.variableOverrides
-      ),
-    }
-  }
-
-  // Create config for the package (use parent config if no factory)
-  let config: CoreConfig = existingServices.config
-  if (factories.createConfig) {
-    config = await factories.createConfig(existingServices.variables)
-  }
-
-  // Create singleton services for the package, passing parent services as existing
-  const packageServices = await factories.createSingletonServices(
-    config,
-    existingServices
-  )
-
-  // Wrap workflowService so that bare names used inside the addon's functions
-  // resolve to workflows registered under the addon's package scope.
-  if (
-    packageServices.workflowService &&
-    typeof packageServices.workflowService === 'object'
-  ) {
-    packageServices.workflowService = wrapWorkflowServiceForPackage(
-      packageServices.workflowService as object,
-      packageName,
-      addonInstance?.namespace ?? null
-    ) as typeof packageServices.workflowService
-  }
-
-  // Cache the services
-  pikkuState(cacheKey, 'package', 'singletonServices', packageServices)
-
-  return packageServices
 }
 
 export const addFunction = (

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -40,6 +40,80 @@ import {
 } from '../services/audit-service.js'
 import { rpcService } from '../wirings/rpc/rpc-runner.js'
 import { closeWireServices } from '../utils.js'
+import type { SecretService } from '../services/secret-service.js'
+import type { VariablesService } from '../services/variables-service.js'
+
+/**
+ * A single wired addon instance: a namespace (wireAddon `name`) plus the
+ * per-instance name-aliases that remap the logical names the addon reads to
+ * the actual project secret/variable/credential names.
+ */
+export type AddonInstance = {
+  namespace: string
+  secretOverrides?: Record<string, string>
+  variableOverrides?: Record<string, string>
+  credentialOverrides?: Record<string, string>
+}
+
+/**
+ * Wrap a SecretService so that the logical secret names an addon reads are
+ * remapped to the actual project secret names via the instance's overrides.
+ */
+const aliasSecretService = (
+  secrets: SecretService,
+  overrides: Record<string, string>
+): SecretService => {
+  const map = (key: string) => overrides[key] ?? key
+  return {
+    getSecret: <T = string>(key: string) => secrets.getSecret<T>(map(key)),
+    hasSecret: (key: string) => secrets.hasSecret(map(key)),
+    setSecret: (key: string, value: unknown) =>
+      secrets.setSecret(map(key), value),
+    deleteSecret: (key: string) => secrets.deleteSecret(map(key)),
+    getSecrets: async (keys) => {
+      const result = await secrets.getSecrets(keys.map(map))
+      const out: Record<string, unknown> = {}
+      for (const logical of keys) {
+        const real = map(logical)
+        if (real in result)
+          out[logical] = (result as Record<string, unknown>)[real]
+      }
+      return out as never
+    },
+  }
+}
+
+/**
+ * Wrap a VariablesService so that the logical variable names an addon reads
+ * are remapped to the actual project variable names via the instance's overrides.
+ */
+const aliasVariablesService = (
+  variables: VariablesService,
+  overrides: Record<string, string>
+): VariablesService => {
+  const map = (name: string) => overrides[name] ?? name
+  return {
+    get: <T = string>(name: string) => variables.get<T>(map(name)),
+    getVariables: (names) => {
+      const result = variables.getVariables(names.map(map) as never)
+      const remap = (r: Record<string, unknown>) => {
+        const out: Record<string, unknown> = {}
+        for (const logical of names) {
+          const real = map(logical)
+          if (real in r) out[logical] = r[real]
+        }
+        return out
+      }
+      return result instanceof Promise
+        ? (result.then(remap) as never)
+        : (remap(result as Record<string, unknown>) as never)
+    },
+    getAll: () => variables.getAll(),
+    set: (name: string, value: unknown) => variables.set(map(name), value),
+    has: (name: string) => variables.has(map(name)),
+    delete: (name: string) => variables.delete(map(name)),
+  }
+}
 
 async function resolveSession(
   wire: PikkuRawWire,
@@ -105,7 +179,8 @@ const findAddonNamespaceForPackage = (packageName: string): string | null => {
  */
 const wrapWorkflowServiceForPackage = <T extends object>(
   service: T,
-  packageName: string
+  packageName: string,
+  namespace: string | null
 ): T => {
   return new Proxy(service, {
     get(target, prop, receiver) {
@@ -113,9 +188,11 @@ const wrapWorkflowServiceForPackage = <T extends object>(
         const original = Reflect.get(target, prop, receiver) as Function
         return function (this: any, name: string, ...rest: any[]) {
           if (typeof name === 'string' && !name.includes(':')) {
-            const namespace = findAddonNamespaceForPackage(packageName)
-            if (namespace) {
-              name = `${namespace}:${name}`
+            // Prefer the known instance namespace; fall back to the
+            // package's sole namespace when invoked without an instance.
+            const ns = namespace ?? findAddonNamespaceForPackage(packageName)
+            if (ns) {
+              name = `${ns}:${name}`
             }
           }
           return original.call(this, name, ...rest)
@@ -128,10 +205,18 @@ const wrapWorkflowServiceForPackage = <T extends object>(
 
 const getOrCreatePackageSingletonServices = async (
   packageName: string,
-  parentServices: CoreSingletonServices
+  parentServices: CoreSingletonServices,
+  addonInstance?: AddonInstance
 ): Promise<CoreSingletonServices> => {
-  // Check if we already have cached singleton services for this package
-  const cachedServices = pikkuState(packageName, 'package', 'singletonServices')
+  // Singletons are cached per addon INSTANCE (namespace), not per package, so
+  // two wireAddon() instances of the same package each get their own services
+  // built with their own secret/variable overrides. Namespaces are globally
+  // unique, so keying the cache slot by namespace is unambiguous; a bare
+  // package-scoped call (no instance) falls back to per-package caching.
+  const cacheKey = addonInstance?.namespace ?? packageName
+
+  // Check if we already have cached singleton services for this instance
+  const cachedServices = pikkuState(cacheKey, 'package', 'singletonServices')
   if (cachedServices) {
     return cachedServices
   }
@@ -143,16 +228,39 @@ const getOrCreatePackageSingletonServices = async (
     return parentServices
   }
 
+  // Apply this instance's secret/variable overrides by aliasing the resolver
+  // services the addon reads from, so its createSingletonServices resolves
+  // instance-specific secrets/variables.
+  let existingServices = parentServices
+  if (addonInstance?.secretOverrides && parentServices.secrets) {
+    existingServices = {
+      ...existingServices,
+      secrets: aliasSecretService(
+        parentServices.secrets,
+        addonInstance.secretOverrides
+      ),
+    }
+  }
+  if (addonInstance?.variableOverrides && parentServices.variables) {
+    existingServices = {
+      ...existingServices,
+      variables: aliasVariablesService(
+        parentServices.variables,
+        addonInstance.variableOverrides
+      ),
+    }
+  }
+
   // Create config for the package (use parent config if no factory)
-  let config: CoreConfig = parentServices.config
+  let config: CoreConfig = existingServices.config
   if (factories.createConfig) {
-    config = await factories.createConfig(parentServices.variables)
+    config = await factories.createConfig(existingServices.variables)
   }
 
   // Create singleton services for the package, passing parent services as existing
   const packageServices = await factories.createSingletonServices(
     config,
-    parentServices
+    existingServices
   )
 
   // Wrap workflowService so that bare names used inside the addon's functions
@@ -163,12 +271,13 @@ const getOrCreatePackageSingletonServices = async (
   ) {
     packageServices.workflowService = wrapWorkflowServiceForPackage(
       packageServices.workflowService as object,
-      packageName
+      packageName,
+      addonInstance?.namespace ?? null
     ) as typeof packageServices.workflowService
   }
 
   // Cache the services
-  pikkuState(packageName, 'package', 'singletonServices', packageServices)
+  pikkuState(cacheKey, 'package', 'singletonServices', packageServices)
 
   return packageServices
 }
@@ -226,6 +335,7 @@ export const runPikkuFunc = async <In = any, Out = any>(
     sessionService,
     credentialWireService,
     packageName = null,
+    addonInstance,
   }: {
     singletonServices: CoreSingletonServices
     createWireServices?: CreateWireServices
@@ -243,6 +353,7 @@ export const runPikkuFunc = async <In = any, Out = any>(
     sessionService?: SessionService<CoreUserSession>
     credentialWireService?: PikkuCredentialWireService
     packageName?: string | null
+    addonInstance?: AddonInstance
   }
 ): Promise<Out> => {
   wire.wireType ??= wireType
@@ -277,7 +388,11 @@ export const runPikkuFunc = async <In = any, Out = any>(
 
   // For addon packages, get or create their singleton services
   const resolvedSingletonServices = packageName
-    ? await getOrCreatePackageSingletonServices(packageName, singletonServices)
+    ? await getOrCreatePackageSingletonServices(
+        packageName,
+        singletonServices,
+        addonInstance
+      )
     : singletonServices
 
   // Get the package's createWireServices if available
@@ -305,8 +420,24 @@ export const runPikkuFunc = async <In = any, Out = any>(
       : wire
 
   // Set up credential wire service early so middleware can use setCredential.
-  // Skip if already set up (e.g. addon functions reuse the parent wire).
-  if (!resolvedWire.getCredentials) {
+  // An addon instance with credentialOverrides always gets a fresh alias-aware
+  // service so its logical credential names resolve to instance-specific ones,
+  // even when a parent credential service is already present on the wire.
+  // Otherwise skip if already set up (e.g. addon functions reuse the parent wire).
+  if (addonInstance?.credentialOverrides) {
+    // Credentials belong to the consuming project, so resolve them via the
+    // project's credentialService (the addon's own singletons may not carry it).
+    const aliasedCredentialWireService = new PikkuCredentialWireService(
+      singletonServices.credentialService ??
+        resolvedSingletonServices.credentialService,
+      resolvedWire,
+      addonInstance.credentialOverrides
+    )
+    Object.assign(
+      resolvedWire,
+      createWireServicesCredentialWireProps(aliasedCredentialWireService)
+    )
+  } else if (!resolvedWire.getCredentials) {
     const resolvedCredentialWireService =
       credentialWireService ??
       new PikkuCredentialWireService(
@@ -323,12 +454,18 @@ export const runPikkuFunc = async <In = any, Out = any>(
   const invocationWire = resolvedWire as PikkuWire
   const previousFunctionId = invocationWire.functionId
   const previousAudit = invocationWire.audit
+  const previousAddonNamespace = invocationWire.addonNamespace
   const previousRpcDescriptor = Object.getOwnPropertyDescriptor(
     invocationWire,
     'rpc'
   )
   invocationWire.functionId = resolvedFunctionId
   invocationWire.audit = resolvedAuditConfig
+  // Track which addon instance is executing so intra-addon sibling calls
+  // resolve the same per-instance singleton services and overrides.
+  if (addonInstance) {
+    invocationWire.addonNamespace = addonInstance.namespace
+  }
 
   // Convert tags to PermissionMetadata and merge with inheritedPermissions
   let mergedInheritedPermissions: PermissionMetadata[]
@@ -507,6 +644,11 @@ export const runPikkuFunc = async <In = any, Out = any>(
         delete (invocationWire as any).audit
       } else {
         invocationWire.audit = previousAudit
+      }
+      if (previousAddonNamespace === undefined) {
+        delete (invocationWire as any).addonNamespace
+      } else {
+        invocationWire.addonNamespace = previousAddonNamespace
       }
     }
   }

--- a/packages/core/src/services/credential-wire-service.ts
+++ b/packages/core/src/services/credential-wire-service.ts
@@ -9,16 +9,22 @@ export class PikkuCredentialWireService {
 
   constructor(
     private credentialService?: CredentialService,
-    private wire?: PikkuRawWire
+    private wire?: PikkuRawWire,
+    private aliases?: Record<string, string>
   ) {}
 
+  private resolveName(name: string): string {
+    return this.aliases?.[name] ?? name
+  }
+
   set(name: string, value: unknown): void {
-    this.credentials[name] = value
+    this.credentials[this.resolveName(name)] = value
   }
 
   get<T = unknown>(name: string): T | null | Promise<T | null> {
-    if (this.loaded) return (this.credentials[name] as T) ?? null
-    return this.lazyLoad().then(() => (this.credentials[name] as T) ?? null)
+    const key = this.resolveName(name)
+    if (this.loaded) return (this.credentials[key] as T) ?? null
+    return this.lazyLoad().then(() => (this.credentials[key] as T) ?? null)
   }
 
   getAll(): Record<string, unknown> | Promise<Record<string, unknown>> {

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -339,6 +339,8 @@ export type PikkuWire<
   traceId: string
   /** Function id for the current invocation */
   functionId: string
+  /** The addon instance namespace (wireAddon name) currently executing, if any */
+  addonNamespace: string
   http: PikkuHTTP<In>
   mcp: PikkuMCP<MCPTools>
   channel: [IsChannel] extends [null]

--- a/packages/core/src/types/state.types.ts
+++ b/packages/core/src/types/state.types.ts
@@ -84,7 +84,18 @@ export interface PikkuPackageState {
   addons: {
     packages: Map<
       string,
-      { package: string; rpcEndpoint?: string; auth?: boolean; tags?: string[] }
+      {
+        package: string
+        rpcEndpoint?: string
+        auth?: boolean
+        tags?: string[]
+        /** Per-instance name-aliases: logical name the addon reads -> actual project secret name */
+        secretOverrides?: Record<string, string>
+        /** Per-instance name-aliases: logical name the addon reads -> actual project variable name */
+        variableOverrides?: Record<string, string>
+        /** Per-instance name-aliases: logical name the addon reads -> actual project credential name */
+        credentialOverrides?: Record<string, string>
+      }
     >
   }
   http: {

--- a/packages/core/src/wirings/rpc/addon-runner.ts
+++ b/packages/core/src/wirings/rpc/addon-runner.ts
@@ -1,0 +1,233 @@
+import { pikkuState } from '../../pikku-state.js'
+import type {
+  CoreConfig,
+  CoreSingletonServices,
+} from '../../types/core.types.js'
+import type { SecretService } from '../../services/secret-service.js'
+import type { VariablesService } from '../../services/variables-service.js'
+
+/**
+ * A single wired addon instance: a namespace (wireAddon `name`) plus the
+ * per-instance name-aliases that remap the logical names the addon reads to
+ * the actual project secret/variable/credential names.
+ */
+export type AddonInstance = {
+  namespace: string
+  secretOverrides?: Record<string, string>
+  variableOverrides?: Record<string, string>
+  credentialOverrides?: Record<string, string>
+}
+
+/**
+ * Wrap a SecretService so that the logical secret names an addon reads are
+ * remapped to the actual project secret names via the instance's overrides.
+ */
+const aliasSecretService = (
+  secrets: SecretService,
+  overrides: Record<string, string>
+): SecretService => {
+  const map = (key: string) => overrides[key] ?? key
+  return {
+    getSecret: <T = string>(key: string) => secrets.getSecret<T>(map(key)),
+    hasSecret: (key: string) => secrets.hasSecret(map(key)),
+    setSecret: (key: string, value: unknown) =>
+      secrets.setSecret(map(key), value),
+    deleteSecret: (key: string) => secrets.deleteSecret(map(key)),
+    getSecrets: async (keys) => {
+      const result = await secrets.getSecrets(keys.map(map))
+      const out: Record<string, unknown> = {}
+      for (const logical of keys) {
+        const real = map(logical)
+        if (real in result)
+          out[logical] = (result as Record<string, unknown>)[real]
+      }
+      return out as never
+    },
+  }
+}
+
+/**
+ * Wrap a VariablesService so that the logical variable names an addon reads
+ * are remapped to the actual project variable names via the instance's overrides.
+ */
+const aliasVariablesService = (
+  variables: VariablesService,
+  overrides: Record<string, string>
+): VariablesService => {
+  const map = (name: string) => overrides[name] ?? name
+  return {
+    get: <T = string>(name: string) => variables.get<T>(map(name)),
+    getVariables: (names) => {
+      const result = variables.getVariables(names.map(map) as never)
+      const remap = (r: Record<string, unknown>) => {
+        const out: Record<string, unknown> = {}
+        for (const logical of names) {
+          const real = map(logical)
+          if (real in r) out[logical] = r[real]
+        }
+        return out
+      }
+      return result instanceof Promise
+        ? (result.then(remap) as never)
+        : (remap(result as Record<string, unknown>) as never)
+    },
+    getAll: () => variables.getAll(),
+    set: (name: string, value: unknown) => variables.set(map(name), value),
+    has: (name: string) => variables.has(map(name)),
+    delete: (name: string) => variables.delete(map(name)),
+  }
+}
+
+/**
+ * Find the consumer-defined namespace (from wireAddon) for a given addon package.
+ * Returns null if the package isn't registered as an addon.
+ */
+const findAddonNamespaceForPackage = (packageName: string): string | null => {
+  const addons = pikkuState(null, 'addons', 'packages')
+  if (!addons) return null
+  for (const [namespace, cfg] of addons.entries()) {
+    if (cfg?.package === packageName) return namespace
+  }
+  return null
+}
+
+/**
+ * Wrap a workflow service so that bare workflow names passed from inside an
+ * addon function are auto-prefixed with the addon's consumer-facing namespace.
+ * Without this, `runToCompletion('myWorkflow')` from inside an addon misses
+ * the workflow registered under the addon's package scope and throws
+ * WorkflowNotFoundError — forcing addons to hardcode their consumer-defined
+ * namespace, which couples the addon to its caller.
+ *
+ * Explicit `'ns:name'` and bare names that already exist in root meta are
+ * unaffected; only bare names that would otherwise miss resolution get
+ * prefixed.
+ */
+const wrapWorkflowServiceForPackage = <T extends object>(
+  service: T,
+  packageName: string,
+  namespace: string | null
+): T => {
+  return new Proxy(service, {
+    get(target, prop, receiver) {
+      if (prop === 'startWorkflow' || prop === 'runToCompletion') {
+        const original = Reflect.get(target, prop, receiver) as Function
+        return function (this: any, name: string, ...rest: any[]) {
+          if (typeof name === 'string' && !name.includes(':')) {
+            // Prefer the known instance namespace; fall back to the
+            // package's sole namespace when invoked without an instance.
+            const ns = namespace ?? findAddonNamespaceForPackage(packageName)
+            if (ns) {
+              name = `${ns}:${name}`
+            }
+          }
+          return original.call(this, name, ...rest)
+        }
+      }
+      return Reflect.get(target, prop, receiver)
+    },
+  })
+}
+
+/**
+ * Get or create singleton services for an addon instance.
+ * Services are cached in pikkuState to avoid recreation on each call.
+ *
+ * @param packageName - The addon package name
+ * @param parentServices - The parent/caller's singleton services (used as base)
+ * @param addonInstance - The wired instance whose overrides shape the services
+ * @returns The instance's singleton services
+ */
+export const getOrCreatePackageSingletonServices = async (
+  packageName: string,
+  parentServices: CoreSingletonServices,
+  addonInstance?: AddonInstance
+): Promise<CoreSingletonServices> => {
+  // Cache per instance (namespace), not per package, so two instances of one
+  // package get separate services built with their own overrides. A bare
+  // package-scoped call (no instance) falls back to per-package caching.
+  const cacheKey = addonInstance?.namespace ?? packageName
+
+  const cachedServices = pikkuState(cacheKey, 'package', 'singletonServices')
+  if (cachedServices) {
+    return cachedServices
+  }
+
+  const factories = pikkuState(packageName, 'package', 'factories')
+  if (!factories || !factories.createSingletonServices) {
+    // No factories registered, use parent services
+    return parentServices
+  }
+
+  // Apply this instance's secret/variable overrides by aliasing the resolver
+  // services the addon reads from, so its createSingletonServices resolves
+  // instance-specific secrets/variables.
+  let existingServices = parentServices
+  if (addonInstance?.secretOverrides && parentServices.secrets) {
+    existingServices = {
+      ...existingServices,
+      secrets: aliasSecretService(
+        parentServices.secrets,
+        addonInstance.secretOverrides
+      ),
+    }
+  }
+  if (addonInstance?.variableOverrides && parentServices.variables) {
+    existingServices = {
+      ...existingServices,
+      variables: aliasVariablesService(
+        parentServices.variables,
+        addonInstance.variableOverrides
+      ),
+    }
+  }
+
+  // Create config for the package (use parent config if no factory)
+  let config: CoreConfig = existingServices.config
+  if (factories.createConfig) {
+    config = await factories.createConfig(existingServices.variables)
+  }
+
+  // Create singleton services for the package, passing parent services as existing
+  const packageServices = await factories.createSingletonServices(
+    config,
+    existingServices
+  )
+
+  // Wrap workflowService so that bare names used inside the addon's functions
+  // resolve to workflows registered under the addon's package scope.
+  if (
+    packageServices.workflowService &&
+    typeof packageServices.workflowService === 'object'
+  ) {
+    packageServices.workflowService = wrapWorkflowServiceForPackage(
+      packageServices.workflowService as object,
+      packageName,
+      addonInstance?.namespace ?? null
+    ) as typeof packageServices.workflowService
+  }
+
+  pikkuState(cacheKey, 'package', 'singletonServices', packageServices)
+
+  return packageServices
+}
+
+/**
+ * Build the addon instance descriptor (namespace + per-instance overrides) for
+ * a bare intra-addon call, using the namespace currently executing on the wire.
+ * Returns undefined unless that namespace maps to the resolved package.
+ */
+export const addonInstanceForNamespace = (
+  namespace: string | undefined,
+  expectedPackage: string
+): AddonInstance | undefined => {
+  if (!namespace) return undefined
+  const cfg = pikkuState(null, 'addons', 'packages').get(namespace)
+  if (!cfg || cfg.package !== expectedPackage) return undefined
+  return {
+    namespace,
+    secretOverrides: cfg.secretOverrides,
+    variableOverrides: cfg.variableOverrides,
+    credentialOverrides: cfg.credentialOverrides,
+  }
+}

--- a/packages/core/src/wirings/rpc/rpc-runner.test.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.test.ts
@@ -9,6 +9,7 @@ import {
   resolveNamespace,
   rpcService,
 } from './rpc-runner.js'
+import { wireAddon } from './wire-addon.js'
 
 const createLogger = () => ({
   debug: () => {},
@@ -489,6 +490,147 @@ describe('ContextAwareRPCService.remote', () => {
     assert.deepEqual(calls, [
       ['remoteFunc', { hi: true }, { userId: 'user-4' }, 'trace-4'],
     ])
+  })
+})
+
+describe('multi-instance addons', () => {
+  const createSecretService = () => ({
+    getSecret: async (key: string) => `secret:${key}`,
+    hasSecret: async () => true,
+    setSecret: async () => {},
+    deleteSecret: async () => {},
+    getSecrets: async () => ({}),
+  })
+
+  test('resolves per-instance secretOverrides and caches singletons per namespace', async () => {
+    const createdServices: any[] = []
+    pikkuState('@addon/slack', 'package', 'factories', {
+      createSingletonServices: async (_config: any, parent: any) => {
+        const token = await parent.secrets.getSecret('slackToken')
+        const svc = { logger: createLogger(), token }
+        createdServices.push(svc)
+        return svc
+      },
+    } as never)
+    registerFunction(
+      'send',
+      async (services: any) => ({ token: services.token }),
+      {
+        packageName: '@addon/slack',
+      }
+    )
+
+    wireAddon({
+      name: 'slack-marketing',
+      package: '@addon/slack',
+      secretOverrides: { slackToken: 'marketing_secret' },
+    })
+    wireAddon({
+      name: 'slack-support',
+      package: '@addon/slack',
+      secretOverrides: { slackToken: 'support_secret' },
+    })
+
+    const service = new ContextAwareRPCService(
+      createServices({ secrets: createSecretService() }),
+      {} as never,
+      { requiresAuth: false }
+    )
+
+    const marketing = await service.rpc('slack-marketing:send', {})
+    const support = await service.rpc('slack-support:send', {})
+
+    assert.deepEqual(marketing, { token: 'secret:marketing_secret' })
+    assert.deepEqual(support, { token: 'secret:support_secret' })
+    assert.equal(createdServices.length, 2)
+    assert.notEqual(createdServices[0], createdServices[1])
+  })
+
+  test('reuses the same per-namespace singleton across intra-addon sibling calls', async () => {
+    let factoryCalls = 0
+    pikkuState('@addon/slack', 'package', 'factories', {
+      createSingletonServices: async (_config: any, parent: any) => {
+        factoryCalls++
+        return {
+          logger: createLogger(),
+          token: await parent.secrets.getSecret('slackToken'),
+        }
+      },
+    } as never)
+
+    registerFunction(
+      'leaf',
+      async (services: any) => ({ token: services.token }),
+      {
+        packageName: '@addon/slack',
+      }
+    )
+    registerFunction(
+      'root',
+      async (_services: any, _data: any, wire: any) =>
+        wire.rpc.invoke('leaf', {}),
+      { packageName: '@addon/slack' }
+    )
+
+    wireAddon({
+      name: 'slack-marketing',
+      package: '@addon/slack',
+      secretOverrides: { slackToken: 'marketing_secret' },
+    })
+
+    const service = new ContextAwareRPCService(
+      createServices({ secrets: createSecretService() }),
+      {} as never,
+      { requiresAuth: false }
+    )
+
+    const result = await service.rpc('slack-marketing:root', {})
+
+    assert.deepEqual(result, { token: 'secret:marketing_secret' })
+    assert.equal(factoryCalls, 1)
+  })
+
+  test('resolves per-instance credentialOverrides via wire.getCredential', async () => {
+    pikkuState('@addon/slack', 'package', 'factories', {
+      createSingletonServices: async () => ({ logger: createLogger() }),
+    } as never)
+    registerFunction(
+      'whoami',
+      async (_services: any, _data: any, wire: any) => ({
+        cred: await wire.getCredential('slack'),
+      }),
+      { packageName: '@addon/slack' }
+    )
+
+    wireAddon({
+      name: 'slack-marketing',
+      package: '@addon/slack',
+      credentialOverrides: { slack: 'marketing_cred' },
+    })
+    wireAddon({
+      name: 'slack-support',
+      package: '@addon/slack',
+      credentialOverrides: { slack: 'support_cred' },
+    })
+
+    const credentialService = {
+      getAll: async (_userId: string) => ({
+        marketing_cred: { token: 'm' },
+        support_cred: { token: 's' },
+      }),
+    }
+
+    const service = new ContextAwareRPCService(
+      createServices({ credentialService }),
+      { pikkuUserId: 'user-1' } as never,
+      { requiresAuth: false }
+    )
+
+    const marketing = await service.rpc('slack-marketing:whoami', {})
+    const support = await service.rpc('slack-support:whoami', {})
+
+    assert.deepEqual(marketing, { cred: { token: 'm' } })
+    assert.deepEqual(support, { cred: { token: 's' } })
   })
 })
 

--- a/packages/core/src/wirings/rpc/rpc-runner.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.ts
@@ -6,6 +6,7 @@ import type {
 import type { SessionService } from '../../services/user-session-service.js'
 import type { CoreUserSession } from '../../types/core.types.js'
 import { runPikkuFunc } from '../../function/function-runner.js'
+import type { AddonInstance } from '../../function/function-runner.js'
 import { pikkuState } from '../../pikku-state.js'
 import { PikkuError, addError } from '../../errors/error-handler.js'
 import type { PikkuRPC, ResolvedFunction } from './rpc-types.js'
@@ -54,6 +55,26 @@ export const resolveNamespace = (
     package: pkgConfig.package,
     function: functionName,
     addonConfig: pkgConfig,
+  }
+}
+
+/**
+ * Build the addon instance descriptor (namespace + per-instance overrides) for
+ * a bare intra-addon call, using the namespace currently executing on the wire.
+ * Returns undefined unless that namespace maps to the resolved package.
+ */
+const addonInstanceForNamespace = (
+  namespace: string | undefined,
+  expectedPackage: string
+): AddonInstance | undefined => {
+  if (!namespace) return undefined
+  const cfg = pikkuState(null, 'addons', 'packages').get(namespace)
+  if (!cfg || cfg.package !== expectedPackage) return undefined
+  return {
+    namespace,
+    secretOverrides: cfg.secretOverrides,
+    variableOverrides: cfg.variableOverrides,
+    credentialOverrides: cfg.credentialOverrides,
   }
 }
 
@@ -164,6 +185,12 @@ export class ContextAwareRPCService {
     // 'namespace:func' boundary via invokeAddonFunction.
     try {
       const resolved = resolvePikkuFunction(funcName, this.packageName)
+      const addonInstance = resolved.packageName
+        ? addonInstanceForNamespace(
+            this.wire.addonNamespace,
+            resolved.packageName
+          )
+        : undefined
       return await runPikkuFunc<In, Out>(
         'rpc',
         funcName,
@@ -174,6 +201,7 @@ export class ContextAwareRPCService {
           data: () => data,
           wire: updatedWire,
           packageName: resolved.packageName,
+          addonInstance,
         }
       )
     } catch (e) {
@@ -228,6 +256,19 @@ export class ContextAwareRPCService {
       ...(funcMeta.tags ?? []),
     ]
 
+    // The namespace is the consumer-facing wireAddon name; it selects the
+    // per-instance singleton services and secret/variable/credential overrides.
+    const namespace = namespacedFunction.slice(
+      0,
+      namespacedFunction.indexOf(':')
+    )
+    const addonInstance: AddonInstance = {
+      namespace,
+      secretOverrides: resolved.addonConfig?.secretOverrides,
+      variableOverrides: resolved.addonConfig?.variableOverrides,
+      credentialOverrides: resolved.addonConfig?.credentialOverrides,
+    }
+
     // Execute the function using runPikkuFunc with the addon package's state
     // We use the parent services (this.services) since addon packages share services
     // Pass the function's tags so tag-based middleware/permissions are applied
@@ -238,6 +279,7 @@ export class ContextAwareRPCService {
       wire,
       packageName: resolved.package,
       tags,
+      addonInstance,
     })
   }
 
@@ -257,12 +299,19 @@ export class ContextAwareRPCService {
 
     try {
       const resolved = resolvePikkuFunction(rpcName, this.packageName)
+      const addonInstance = resolved.packageName
+        ? addonInstanceForNamespace(
+            this.wire.addonNamespace,
+            resolved.packageName
+          )
+        : undefined
       return await runPikkuFunc<In, Out>('rpc', rpcName, resolved.pikkuFuncId, {
         auth: this.options.requiresAuth,
         singletonServices: this.services,
         data: () => data,
         wire: mergedWire,
         packageName: resolved.packageName,
+        addonInstance,
       })
     } catch (e) {
       if (e instanceof RPCNotFoundError && this.services.deploymentService) {

--- a/packages/core/src/wirings/rpc/rpc-runner.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.ts
@@ -6,7 +6,8 @@ import type {
 import type { SessionService } from '../../services/user-session-service.js'
 import type { CoreUserSession } from '../../types/core.types.js'
 import { runPikkuFunc } from '../../function/function-runner.js'
-import type { AddonInstance } from '../../function/function-runner.js'
+import type { AddonInstance } from './addon-runner.js'
+import { addonInstanceForNamespace } from './addon-runner.js'
 import { pikkuState } from '../../pikku-state.js'
 import { PikkuError, addError } from '../../errors/error-handler.js'
 import type { PikkuRPC, ResolvedFunction } from './rpc-types.js'
@@ -55,26 +56,6 @@ export const resolveNamespace = (
     package: pkgConfig.package,
     function: functionName,
     addonConfig: pkgConfig,
-  }
-}
-
-/**
- * Build the addon instance descriptor (namespace + per-instance overrides) for
- * a bare intra-addon call, using the namespace currently executing on the wire.
- * Returns undefined unless that namespace maps to the resolved package.
- */
-const addonInstanceForNamespace = (
-  namespace: string | undefined,
-  expectedPackage: string
-): AddonInstance | undefined => {
-  if (!namespace) return undefined
-  const cfg = pikkuState(null, 'addons', 'packages').get(namespace)
-  if (!cfg || cfg.package !== expectedPackage) return undefined
-  return {
-    namespace,
-    secretOverrides: cfg.secretOverrides,
-    variableOverrides: cfg.variableOverrides,
-    credentialOverrides: cfg.credentialOverrides,
   }
 }
 

--- a/packages/core/src/wirings/rpc/rpc-types.ts
+++ b/packages/core/src/wirings/rpc/rpc-types.ts
@@ -52,5 +52,8 @@ export interface ResolvedFunction {
     auth?: boolean
     tags?: string[]
     rpcEndpoint?: string
+    secretOverrides?: Record<string, string>
+    variableOverrides?: Record<string, string>
+    credentialOverrides?: Record<string, string>
   }
 }

--- a/packages/core/src/wirings/rpc/wire-addon.test.ts
+++ b/packages/core/src/wirings/rpc/wire-addon.test.ts
@@ -27,6 +27,9 @@ describe('wireAddon', () => {
       rpcEndpoint: 'https://rpc.example.com',
       auth: true,
       tags: ['payments', 'billing'],
+      secretOverrides: { apiKey: 'secretName' },
+      variableOverrides: { region: 'eu-west-1' },
+      credentialOverrides: { oauth: 'credentialName' },
     })
   })
 

--- a/packages/core/src/wirings/rpc/wire-addon.test.ts
+++ b/packages/core/src/wirings/rpc/wire-addon.test.ts
@@ -17,9 +17,9 @@ describe('wireAddon', () => {
       auth: true,
       mcp: true,
       tags: ['payments', 'billing'],
-      secretOverrides: { apiKey: 'secretName' },
-      variableOverrides: { region: 'eu-west-1' },
-      credentialOverrides: { oauth: 'credentialName' },
+      secretOverrides: { apiKey: 'STRIPE_API_KEY' },
+      variableOverrides: { region: 'AWS_REGION' },
+      credentialOverrides: { oauth: 'stripeOAuth' },
     })
 
     assert.deepEqual(pikkuState(null, 'addons', 'packages').get('stripe'), {
@@ -27,9 +27,9 @@ describe('wireAddon', () => {
       rpcEndpoint: 'https://rpc.example.com',
       auth: true,
       tags: ['payments', 'billing'],
-      secretOverrides: { apiKey: 'secretName' },
-      variableOverrides: { region: 'eu-west-1' },
-      credentialOverrides: { oauth: 'credentialName' },
+      secretOverrides: { apiKey: 'STRIPE_API_KEY' },
+      variableOverrides: { region: 'AWS_REGION' },
+      credentialOverrides: { oauth: 'stripeOAuth' },
     })
   })
 

--- a/packages/core/src/wirings/rpc/wire-addon.ts
+++ b/packages/core/src/wirings/rpc/wire-addon.ts
@@ -18,5 +18,14 @@ export const wireAddon = (config: WireAddonConfig): void => {
     rpcEndpoint: config.rpcEndpoint,
     auth: config.auth,
     tags: config.tags,
+    ...(config.secretOverrides
+      ? { secretOverrides: config.secretOverrides }
+      : {}),
+    ...(config.variableOverrides
+      ? { variableOverrides: config.variableOverrides }
+      : {}),
+    ...(config.credentialOverrides
+      ? { credentialOverrides: config.credentialOverrides }
+      : {}),
   })
 }

--- a/packages/inspector/src/utils/load-addon-functions-meta.test.ts
+++ b/packages/inspector/src/utils/load-addon-functions-meta.test.ts
@@ -1,0 +1,128 @@
+import { strict as assert } from 'assert'
+import { describe, test, before, after } from 'node:test'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { loadAddonFunctionsMeta } from './load-addon-functions-meta.js'
+import type { InspectorState, InspectorLogger } from '../types.js'
+
+const ADDON = '@addon/slack'
+
+const writeAddonFixture = (rootDir: string) => {
+  writeFileSync(
+    join(rootDir, 'package.json'),
+    JSON.stringify({ name: 'consumer' })
+  )
+  const addonDir = join(rootDir, 'node_modules', ADDON)
+  const pikku = join(addonDir, '.pikku')
+  mkdirSync(join(pikku, 'function'), { recursive: true })
+  mkdirSync(join(pikku, 'secrets'), { recursive: true })
+  mkdirSync(join(pikku, 'variables'), { recursive: true })
+  writeFileSync(join(addonDir, 'package.json'), JSON.stringify({ name: ADDON }))
+  writeFileSync(
+    join(pikku, 'function', 'pikku-functions-meta.gen.json'),
+    JSON.stringify({})
+  )
+  writeFileSync(
+    join(pikku, 'secrets', 'pikku-secrets-meta.gen.json'),
+    JSON.stringify({ slack: { name: 'slack', type: 'string' } })
+  )
+  writeFileSync(
+    join(pikku, 'variables', 'pikku-variables-meta.gen.json'),
+    JSON.stringify({ region: { name: 'region' } })
+  )
+}
+
+const makeState = (
+  rootDir: string,
+  wireAddonDeclarations: Map<string, any>
+): InspectorState =>
+  ({
+    rootDir,
+    rpc: { wireAddonDeclarations },
+    addonFunctions: {},
+    secrets: { definitions: [] },
+    variables: { definitions: [] },
+    mcpEndpoints: { toolsMeta: {} },
+    addonServerlessIncompatible: new Map(),
+    addonRequiredParentServices: [],
+    exportedContracts: { addonHttp: {}, addonCli: {}, addonChannel: {} },
+  }) as unknown as InspectorState
+
+const logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  critical: () => {},
+  diagnostic: () => {},
+} as unknown as InspectorLogger
+
+describe('loadAddonFunctionsMeta — per-instance secret/variable overrides', () => {
+  let rootDir: string
+
+  before(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'pikku-addon-meta-'))
+    writeAddonFixture(rootDir)
+  })
+
+  after(() => {
+    rmSync(rootDir, { recursive: true, force: true })
+  })
+
+  test('registers the override target names, one per instance, not the shared logical name', async () => {
+    const state = makeState(
+      rootDir,
+      new Map<string, any>([
+        [
+          'slack-marketing',
+          {
+            package: ADDON,
+            secretOverrides: { slack: 'slack_marketing_secret' },
+            variableOverrides: { region: 'marketing_region' },
+          },
+        ],
+        [
+          'slack-support',
+          {
+            package: ADDON,
+            secretOverrides: { slack: 'slack_support_secret' },
+          },
+        ],
+      ])
+    )
+
+    await loadAddonFunctionsMeta(logger, state)
+
+    const secretNames = state.secrets.definitions.map((d: any) => d.name).sort()
+    assert.deepEqual(secretNames, [
+      'slack_marketing_secret',
+      'slack_support_secret',
+    ])
+
+    // slack-marketing overrides region; slack-support has no override, so it
+    // falls back to the addon's default variable name.
+    const variableNames = state.variables.definitions
+      .map((d: any) => d.name)
+      .sort()
+    assert.deepEqual(variableNames, ['marketing_region', 'region'])
+  })
+
+  test('falls back to the addon logical name when no override is provided', async () => {
+    const state = makeState(
+      rootDir,
+      new Map<string, any>([['slack-plain', { package: ADDON }]])
+    )
+
+    await loadAddonFunctionsMeta(logger, state)
+
+    assert.deepEqual(
+      state.secrets.definitions.map((d: any) => d.name),
+      ['slack']
+    )
+    assert.deepEqual(
+      state.variables.definitions.map((d: any) => d.name),
+      ['region']
+    )
+  })
+})

--- a/packages/inspector/src/utils/load-addon-functions-meta.ts
+++ b/packages/inspector/src/utils/load-addon-functions-meta.ts
@@ -168,12 +168,19 @@ export async function loadAddonFunctionsMeta(
         const secretsRaw = await readFile(secretsMetaPath, 'utf-8')
         const secretsMeta = JSON.parse(secretsRaw)
         for (const [key, def] of Object.entries<any>(secretsMeta)) {
+          // Each instance's secretOverrides remap the addon's logical secret
+          // name to the real project secret; the logical name is the default
+          // only when no override is provided. Two instances with different
+          // overrides therefore surface two distinct project secrets.
+          const resolvedName = decl.secretOverrides?.[key] ?? key
           const existing = state.secrets.definitions.find(
-            (d: any) => d.name === key
+            (d: any) => d.name === resolvedName
           )
           if (!existing) {
-            state.secrets.definitions.push(def)
-            logger.debug(`Loaded addon secret '${key}' from ${decl.package}`)
+            state.secrets.definitions.push({ ...def, name: resolvedName })
+            logger.debug(
+              `Loaded addon secret '${resolvedName}' from ${decl.package}`
+            )
           }
         }
       } catch {
@@ -188,12 +195,15 @@ export async function loadAddonFunctionsMeta(
         const variablesRaw = await readFile(variablesMetaPath, 'utf-8')
         const variablesMeta = JSON.parse(variablesRaw)
         for (const [key, def] of Object.entries<any>(variablesMeta)) {
+          const resolvedName = decl.variableOverrides?.[key] ?? key
           const existing = state.variables.definitions.find(
-            (d: any) => d.name === key
+            (d: any) => d.name === resolvedName
           )
           if (!existing) {
-            state.variables.definitions.push(def)
-            logger.debug(`Loaded addon variable '${key}' from ${decl.package}`)
+            state.variables.definitions.push({ ...def, name: resolvedName })
+            logger.debug(
+              `Loaded addon variable '${resolvedName}' from ${decl.package}`
+            )
           }
         }
       } catch {

--- a/packages/inspector/src/utils/post-process.test.ts
+++ b/packages/inspector/src/utils/post-process.test.ts
@@ -1,7 +1,55 @@
 import { strict as assert } from 'assert'
 import { describe, test } from 'node:test'
-import { aggregateRequiredServices } from './post-process.js'
-import type { InspectorState } from '../types.js'
+import {
+  aggregateRequiredServices,
+  validateSecretOverrides,
+  validateCredentialOverrides,
+  validateVariableOverrides,
+} from './post-process.js'
+import type { InspectorState, InspectorLogger } from '../types.js'
+
+const makeCriticalLogger = () => {
+  const criticals: { code: string; message: string }[] = []
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    critical: (code: any, message: string) =>
+      criticals.push({ code: String(code), message }),
+    diagnostic: () => {},
+  } as unknown as InspectorLogger
+  return { logger, criticals }
+}
+
+const makeOverrideState = (
+  kind: 'secrets' | 'credentials' | 'variables',
+  declaredNames: string[],
+  overrides: Record<string, string>,
+  overrideKey: 'secretOverrides' | 'credentialOverrides' | 'variableOverrides'
+): Omit<InspectorState, 'typesLookup'> =>
+  ({
+    rpc: {
+      wireAddonDeclarations: new Map([
+        [
+          'slack-marketing',
+          { package: '@addon/slack', [overrideKey]: overrides },
+        ],
+      ]),
+    },
+    secrets: {
+      definitions:
+        kind === 'secrets' ? declaredNames.map((name) => ({ name })) : [],
+    },
+    credentials: {
+      definitions:
+        kind === 'credentials' ? declaredNames.map((name) => ({ name })) : [],
+    },
+    variables: {
+      definitions:
+        kind === 'variables' ? declaredNames.map((name) => ({ name })) : [],
+    },
+  }) as unknown as Omit<InspectorState, 'typesLookup'>
 
 function makeState(
   overrides: {
@@ -250,5 +298,56 @@ describe('aggregateRequiredServices — per-function addon services', () => {
     assert.ok(required.has('aiAgentRunner'))
     assert.ok(!required.has('deploymentService'))
     assert.ok(!required.has('credentialService'))
+  })
+})
+
+describe('override validation resolves the override target (value), not the logical key', () => {
+  test('validateSecretOverrides accepts an override whose value is a declared secret', () => {
+    const { logger, criticals } = makeCriticalLogger()
+    const state = makeOverrideState(
+      'secrets',
+      ['slack_marketing_secret'],
+      { slack: 'slack_marketing_secret' },
+      'secretOverrides'
+    )
+    validateSecretOverrides(logger, state)
+    assert.deepEqual(criticals, [])
+  })
+
+  test('validateSecretOverrides flags an override whose value is not declared', () => {
+    const { logger, criticals } = makeCriticalLogger()
+    const state = makeOverrideState(
+      'secrets',
+      ['slack_marketing_secret'],
+      { slack: 'ghost_secret' },
+      'secretOverrides'
+    )
+    validateSecretOverrides(logger, state)
+    assert.equal(criticals.length, 1)
+    assert.match(criticals[0]!.message, /ghost_secret/)
+  })
+
+  test('validateCredentialOverrides accepts an override whose value is a declared credential', () => {
+    const { logger, criticals } = makeCriticalLogger()
+    const state = makeOverrideState(
+      'credentials',
+      ['marketing_cred'],
+      { slack: 'marketing_cred' },
+      'credentialOverrides'
+    )
+    validateCredentialOverrides(logger, state)
+    assert.deepEqual(criticals, [])
+  })
+
+  test('validateVariableOverrides accepts an override whose value is a declared variable', () => {
+    const { logger, criticals } = makeCriticalLogger()
+    const state = makeOverrideState(
+      'variables',
+      ['marketing_region'],
+      { region: 'marketing_region' },
+      'variableOverrides'
+    )
+    validateVariableOverrides(logger, state)
+    assert.deepEqual(criticals, [])
   })
 })

--- a/packages/inspector/src/utils/post-process.ts
+++ b/packages/inspector/src/utils/post-process.ts
@@ -383,12 +383,14 @@ export function validateSecretOverrides(
   for (const [namespace, addonDecl] of wireAddonDeclarations.entries()) {
     if (!addonDecl.secretOverrides) continue
 
-    for (const secretKey of Object.keys(addonDecl.secretOverrides)) {
-      if (!secretNames.has(secretKey)) {
+    for (const [logicalName, resolvedName] of Object.entries(
+      addonDecl.secretOverrides
+    )) {
+      if (!secretNames.has(resolvedName)) {
         const availableSecrets = Array.from(secretNames)
         logger.critical(
           ErrorCode.INVALID_VALUE,
-          `Secret override '${secretKey}' in addon '${namespace}' (${addonDecl.package}) does not exist. Available secrets: ${availableSecrets.join(', ') || 'none'}`
+          `Secret override '${logicalName}' -> '${resolvedName}' in addon '${namespace}' (${addonDecl.package}) targets a secret that does not exist. Available secrets: ${availableSecrets.join(', ') || 'none'}`
         )
       }
     }
@@ -409,12 +411,14 @@ export function validateCredentialOverrides(
   for (const [namespace, addonDecl] of wireAddonDeclarations.entries()) {
     if (!addonDecl.credentialOverrides) continue
 
-    for (const credentialKey of Object.keys(addonDecl.credentialOverrides)) {
-      if (!credentialNames.has(credentialKey)) {
+    for (const [logicalName, resolvedName] of Object.entries(
+      addonDecl.credentialOverrides
+    )) {
+      if (!credentialNames.has(resolvedName)) {
         const availableCredentials = Array.from(credentialNames)
         logger.critical(
           ErrorCode.INVALID_VALUE,
-          `Credential override '${credentialKey}' in addon '${namespace}' (${addonDecl.package}) does not exist. Available credentials: ${availableCredentials.join(', ') || 'none'}`
+          `Credential override '${logicalName}' -> '${resolvedName}' in addon '${namespace}' (${addonDecl.package}) targets a credential that does not exist. Available credentials: ${availableCredentials.join(', ') || 'none'}`
         )
       }
     }
@@ -433,12 +437,14 @@ export function validateVariableOverrides(
   for (const [namespace, addonDecl] of wireAddonDeclarations.entries()) {
     if (!addonDecl.variableOverrides) continue
 
-    for (const variableKey of Object.keys(addonDecl.variableOverrides)) {
-      if (!variableNames.has(variableKey)) {
+    for (const [logicalName, resolvedName] of Object.entries(
+      addonDecl.variableOverrides
+    )) {
+      if (!variableNames.has(resolvedName)) {
         const availableVariables = Array.from(variableNames)
         logger.critical(
           ErrorCode.INVALID_VALUE,
-          `Variable override '${variableKey}' in addon '${namespace}' (${addonDecl.package}) does not exist. Available variables: ${availableVariables.join(', ') || 'none'}`
+          `Variable override '${logicalName}' -> '${resolvedName}' in addon '${namespace}' (${addonDecl.package}) targets a variable that does not exist. Available variables: ${availableVariables.join(', ') || 'none'}`
         )
       }
     }


### PR DESCRIPTION
Closes #908

`wireAddon` can now install the same addon package as multiple named instances, each bound to its own secret/variable/credential — finishing the previously designed-but-unwired `secretOverrides` / `variableOverrides` / `credentialOverrides` feature.

Previously two `wireAddon({ name, package })` instances of one package resolved distinct RPC namespaces, but everything downstream of namespace resolution was keyed by **package**, so both instances shared one services object and one credential. Overrides are name-aliases: the key is the logical name the addon reads, the value is the actual project secret/variable/credential.

## @pikku/core (runtime)

- `wireAddon` persists the override maps into runtime addon state.
- Addon singleton services are cached and built per `(package, namespace)` instead of per package, so each instance gets its own services object.
- `secretOverrides` / `variableOverrides` alias the `secrets` / `variables` services fed to the addon's `createSingletonServices`.
- `credentialOverrides` alias `wire.getCredential(name)` at invocation time.
- The active instance namespace rides on the wire, so intra-addon sibling RPC calls stay in the same instance and workflow-name prefixing uses the exact instance namespace.

## @pikku/inspector (build time)

- Addon-declared secrets/variables surface into the project under each instance's **override target** name (one per instance) instead of the addon's shared logical name.
- `validateSecretOverrides` / `validateVariableOverrides` / `validateCredentialOverrides` validate the override **target** exists, matching the runtime resolution direction.

## Verification

- Rebased clean onto current main.
- `yarn build` green; `@pikku/core` (1083), `@pikku/inspector` (316), `@pikku/cli` (308) tests all pass.
- The `verifiers/workflows` tsc failure is pre-existing on main (identical error on a clean main checkout) and unrelated to this change.
- New tests: `rpc-runner.test.ts` (+142), `wire-addon.test.ts`, `load-addon-functions-meta.test.ts` (+128), `post-process.test.ts` (+103).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing the same addon package as multiple named instances.
  * Each addon instance can use separate secrets, variables, and credentials through configurable name overrides.
  * Instance-specific services and credentials are now isolated while remaining reusable within the same instance.
  * Addon workflows and functions correctly operate within their active instance namespace.

* **Bug Fixes**
  * Improved validation and registration of overridden addon resources.
  * Added coverage for multi-instance resource and credential resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->