### PR TITLE
fix(core): default exposeErrors to !isProduction() in fetchData

### DIFF
--- a/.changeset/expose-errors-non-prod.md
+++ b/.changeset/expose-errors-non-prod.md
@@ -1,0 +1,5 @@
+---
+'@pikku/core': patch
+---
+
+`fetchData` now defaults `exposeErrors` to `!isProduction()`, so a non-production HTTP server returns the error `message` and `stack` on unexpected 500s instead of a bare `{ errorId }`. A dev/sandbox RPC that 500s is now debuggable from the response alone; production (NODE_ENV=production) still returns only the errorId.

--- a/packages/core/src/wirings/http/http-runner.ts
+++ b/packages/core/src/wirings/http/http-runner.ts
@@ -35,6 +35,7 @@ import {
 import { PikkuSessionService } from '../../services/user-session-service.js'
 import { getErrorResponse } from '../../errors/error-handler.js'
 import { handleHTTPError } from '../../handle-error.js'
+import { isProduction } from '../../env.js'
 import { pikkuState } from '../../pikku-state.js'
 import { PikkuFetchHTTPResponse } from './pikku-fetch-http-response.js'
 import { PikkuFetchHTTPRequest } from './pikku-fetch-http-request.js'
@@ -549,7 +550,8 @@ export const fetchData = async <In, Out>(
     logWarningsForStatusCodes = [],
     coerceDataFromSchema = true,
     bubbleErrors = false,
-    exposeErrors = false,
+    // Surface the error message + stack on unexpected 500s unless in production.
+    exposeErrors = !isProduction(),
     generateRequestId,
     traceId: externalTraceId,
   }: RunHTTPWiringOptions = {}


### PR DESCRIPTION
A non-production HTTP server returning a bare `{ errorId }` on an unexpected 500 (no message/stack) is undebuggable — a scenario or RPC that 500s tells the caller nothing to fix.

This defaults `exposeErrors` to `!isProduction()` in `fetchData`, so dev/sandbox servers surface the error `message` + `stack` in the 500 body. `handleHTTPError` already re-gates the actual exposure on `!isProduction()`, so a production build (`NODE_ENV=production`) never leaks stacks.

Motivation: Fabric sandbox scenario runs were looping on `actor sign-in failed (500):` with an empty body — the agent had nothing to act on. With this, the 500 carries the real cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Non-production HTTP error responses now include helpful error messages and stack details by default.
  * Production responses continue to protect details by returning only an error ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->