### PR TITLE
fix: workspace addon linked into a parent app breaks inspection and tsc

### DIFF
--- a/.changeset/wild-addons-inspect.md
+++ b/.changeset/wild-addons-inspect.md
@@ -1,0 +1,7 @@
+---
+'@pikku/inspector': patch
+'@pikku/openapi-parser': patch
+'@pikku/cli': patch
+---
+
+Fix workspace addon integration: exclude nested pikku projects from inspection (prevents "More than one CoreUserSession/CoreConfig found" when a workspace addon is linked), widen the generated addon service `call()` data param to `unknown` so schema-less function inputs compile, and add `@pikku/inspector` + `@standard-schema/spec` to the generated addon devDependencies so its `.pikku` gen files typecheck.

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -158,6 +158,8 @@ function getAddonFiles(
       devDependencies: {
         '@pikku/cli': '*',
         '@pikku/core': '*',
+        '@pikku/inspector': '*',
+        '@standard-schema/spec': '^1.1.0',
         typescript: '^5.7.2',
         zod: '^4',
       },

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -10,6 +10,7 @@ import type {
 } from './types.js'
 import { getFilesAndMethods } from './utils/get-files-and-methods.js'
 import { findCommonAncestor } from './utils/find-root-dir.js'
+import { createNestedProjectFilter } from './utils/nested-project-filter.js'
 import {
   aggregateRequiredServices,
   stampAuthHandlerServices,
@@ -272,19 +273,24 @@ export const inspect = async (
   const startSourceFiles = performance.now()
   // node_modules under rootDir (e.g. a locally-installed addon) is a
   // dependency, not project source — scanning it double-counts the addon's
-  // own application types (CoreConfig/Services/SingletonServices).
+  // own application types (CoreConfig/Services/SingletonServices). Nested
+  // pikku projects (a workspace addon at packages/<addon>) are the same case:
+  // TS resolves the node_modules symlink to its realpath under rootDir, so
+  // the node_modules check alone misses them.
   // Sort by file name so the sweeps populate state in a stable order. The
   // program's own file order depends on glob + import-graph resolution, which
   // varies run to run — leaving generated meta keys (and anything serialized
   // in insertion order) non-reproducible across identical `pikku all` runs.
   // Safe because function registration is a dedicated pass (visitFunctions)
   // that completes before any order-sensitive wiring resolution in visitRoutes.
+  const isNestedProjectFile = createNestedProjectFilter(rootDir)
   const sourceFiles = program
     .getSourceFiles()
     .filter(
       (sf) =>
         sf.fileName.startsWith(rootDir) &&
-        !sf.fileName.includes('/node_modules/')
+        !sf.fileName.includes('/node_modules/') &&
+        !isNestedProjectFile(sf.fileName)
     )
     .sort((a, b) =>
       a.fileName < b.fileName ? -1 : a.fileName > b.fileName ? 1 : 0

--- a/packages/inspector/src/utils/nested-project-filter.test.ts
+++ b/packages/inspector/src/utils/nested-project-filter.test.ts
@@ -1,0 +1,53 @@
+import { test } from 'node:test'
+import * as assert from 'node:assert'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createNestedProjectFilter } from './nested-project-filter.js'
+
+test('createNestedProjectFilter', async (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'pikku-nested-'))
+  t.after(() => rmSync(root, { recursive: true, force: true }))
+
+  writeFileSync(join(root, 'pikku.config.json'), '{}')
+  mkdirSync(join(root, 'packages/functions/src'), { recursive: true })
+  mkdirSync(join(root, 'packages/addon/src'), { recursive: true })
+  mkdirSync(join(root, 'packages/addon/types'), { recursive: true })
+  writeFileSync(join(root, 'packages/addon/pikku.config.json'), '{}')
+
+  const isNested = createNestedProjectFilter(root)
+
+  await t.test('keeps project source files', () => {
+    assert.strictEqual(
+      isNested(join(root, 'packages/functions/src/auth.ts')),
+      false
+    )
+  })
+
+  await t.test('keeps files directly under rootDir', () => {
+    assert.strictEqual(isNested(join(root, 'services.ts')), false)
+  })
+
+  await t.test('excludes files inside a nested pikku project', () => {
+    assert.strictEqual(
+      isNested(join(root, 'packages/addon/types/application-types.d.ts')),
+      true
+    )
+    assert.strictEqual(
+      isNested(join(root, 'packages/addon/src/index.ts')),
+      true
+    )
+  })
+
+  await t.test('keeps files outside rootDir untouched', () => {
+    assert.strictEqual(isNested('/somewhere/else/file.ts'), false)
+  })
+
+  await t.test('rootDir itself is not treated as nested', () => {
+    const addonScoped = createNestedProjectFilter(join(root, 'packages/addon'))
+    assert.strictEqual(
+      addonScoped(join(root, 'packages/addon/src/index.ts')),
+      false
+    )
+  })
+})

--- a/packages/inspector/src/utils/nested-project-filter.ts
+++ b/packages/inspector/src/utils/nested-project-filter.ts
@@ -1,0 +1,28 @@
+import { existsSync } from 'fs'
+import { dirname, join } from 'path'
+
+export const createNestedProjectFilter = (rootDir: string) => {
+  const cache = new Map<string, boolean>()
+  return (fileName: string): boolean => {
+    const pending: string[] = []
+    let dir = dirname(fileName)
+    let nested = false
+    while (dir.startsWith(rootDir) && dir !== rootDir) {
+      const cached = cache.get(dir)
+      if (cached !== undefined) {
+        nested = cached
+        break
+      }
+      pending.push(dir)
+      if (existsSync(join(dir, 'pikku.config.json'))) {
+        nested = true
+        break
+      }
+      const parent = dirname(dir)
+      if (parent === dir) break
+      dir = parent
+    }
+    for (const d of pending) cache.set(d, nested)
+    return nested
+  }
+}

--- a/packages/openapi-parser/src/codegen.ts
+++ b/packages/openapi-parser/src/codegen.ts
@@ -1397,10 +1397,13 @@ function generateServiceFile(
   lines.push('  async call<T>(')
   lines.push("    method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',")
   lines.push('    path: string,')
-  lines.push('    data?: Record<string, unknown>')
+  lines.push('    data?: unknown')
   lines.push('  ): Promise<T> {')
+  lines.push(
+    '    const input = data as Record<string, unknown> | undefined'
+  )
   if (flags.camelCase) {
-    lines.push('    const rawData = data ? _toSnakeCase(data) : data')
+    lines.push('    const rawData = input ? _toSnakeCase(input) : input')
   }
   lines.push('    const route = ROUTES[`${method} ${path}`]')
   lines.push('    let endpoint = path')
@@ -1416,7 +1419,7 @@ function generateServiceFile(
   lines.push('    }')
   lines.push('')
   // When camelCase flag is on, use rawData (snake_case converted) for route matching
-  const dataVar = flags.camelCase ? 'rawData' : 'data'
+  const dataVar = flags.camelCase ? 'rawData' : 'input'
   lines.push(`    if (${dataVar} && route) {`)
   lines.push('      // Interpolate path params')
   lines.push('      for (const param of route.path) {')


### PR DESCRIPTION
Three fixes for the generated-addon → parent-app integration path (hit by every \`fabric addon\` build):

1. **inspector**: a workspace addon (\`packages/<addon>\` with its own \`pikku.config.json\`) is resolved by TS through the node_modules symlink to its realpath under rootDir, so the existing \`/node_modules/\` filter misses it and its application types are double-counted — fatal \`More than one CoreUserSession/CoreConfig found\`. New \`createNestedProjectFilter\` excludes files inside nested pikku projects.
2. **openapi-parser**: generated service \`call()\` took \`data?: Record<string, unknown>\`, which rejects schema-less function inputs inferred as \`unknown\` (TS2345 in every generated function without an output schema). Now \`data?: unknown\`, narrowed once inside.
3. **cli**: generated addon package.json was missing \`@pikku/inspector\` and \`@standard-schema/spec\` devDependencies — its \`.pikku\` gen files type-import both, so \`tsc\` failed with TS2307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)