### PR TITLE
feat(console): scopes admin UI — roles, vocabulary, per-user grants

### DIFF
--- a/.changeset/scopes-console-ui.md
+++ b/.changeset/scopes-console-ui.md
@@ -1,0 +1,21 @@
+---
+'@pikku/console': patch
+---
+
+Add a Scopes admin surface to the console.
+
+A new **Scopes** page (beside Users) with two tabs:
+
+- **Roles** — list the admin-composed roles and edit each one in a drawer that
+  composes it from the declared scope vocabulary. Create and delete roles.
+- **Scopes** — a read-only view of the vocabulary declared in code via
+  `wireScope`, flagging any scope that is stored but no longer declared (inert,
+  and what `pikku scopes prune` removes).
+
+The **Users** page gains a per-row **Roles** action opening a drawer to grant
+and revoke a user's roles, with the resolved scope union shown read-only.
+
+All backed by the console addon's scope RPCs (`scopeListRoles`,
+`scopeListDeclared`, `scopeListUserRoles`, `scopeCreateRole`,
+`scopeSetRoleScopes`, `scopeDeleteRole`, `scopeAddUserToRole`,
+`scopeRemoveUserFromRole`).

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -19,6 +19,7 @@ import { OAuthCallbackPage } from './pages/OAuthCallbackPage'
 import { PackagesPage } from './pages/PackagesPage'
 import { CredentialsPage } from './pages/CredentialsPage'
 import { AdminUsersPage } from './pages/AdminUsersPage'
+import { ScopesPage } from './pages/ScopesPage'
 import { RenderWorkflowPage } from './pages/RenderWorkflowPage'
 import { ChangesPage } from './pages/ChangesPage'
 import { ScenariosPage } from './pages/ScenariosPage'
@@ -60,6 +61,7 @@ export const App: React.FC = () => {
         <Route path="/config" element={<Navigate to="/secrets" replace />} />
         <Route path="/credentials" element={<CredentialsPage />} />
         <Route path="/users" element={<AdminUsersPage />} />
+        <Route path="/scopes" element={<ScopesPage />} />
         <Route path="/auth-providers" element={<AuthProvidersPage />} />
         <Route path="/addons" element={<PackagesPage />} />
         <Route path="*" element={<NotFoundTitle />} />

--- a/packages/console/src/components/project/Sidebar.tsx
+++ b/packages/console/src/components/project/Sidebar.tsx
@@ -39,6 +39,7 @@ import {
   Moon,
   UserCog,
   ShieldCheck,
+  Shield,
 } from 'lucide-react'
 import { useState } from 'react'
 import { spotlight } from '@mantine/spotlight'
@@ -96,6 +97,7 @@ export function useDefaultNavSections(): NavSection[] {
       title: m.nav_users(),
       items: [
         { label: m.nav_users(), href: '/users', icon: Users, matchPrefix: '/users' },
+        { label: asI18n('Scopes'), href: '/scopes', icon: Shield, matchPrefix: '/scopes' },
         { label: m.nav_oauth(), href: '/auth-providers', icon: KeyRound, matchPrefix: '/auth-providers' },
         { label: m.nav_credentials(), href: '/credentials', icon: KeyRound, matchPrefix: '/credentials' },
       ],

--- a/packages/console/src/components/scopes/RoleEditorDrawer.tsx
+++ b/packages/console/src/components/scopes/RoleEditorDrawer.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from 'react'
+import {
+  Box,
+  Button,
+  Divider,
+  Drawer,
+  Group,
+  Stack,
+  Text,
+  TextInput,
+  Textarea,
+} from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+import { Trash2 } from 'lucide-react'
+import type { DeclaredScope } from './scope-tree'
+import { ScopeTreeSelector } from './ScopeTreeSelector'
+import {
+  useCreateRole,
+  useDeleteRole,
+  useSetRoleScopes,
+} from '../../hooks/useScopes'
+
+export type EditableRole = {
+  name: string
+  description?: string
+  scopes: string[]
+}
+
+type RoleEditorDrawerProps = {
+  opened: boolean
+  onClose: () => void
+  /** The role being edited, or `null` to create a new one. */
+  role: EditableRole | null
+  declaredScopes: DeclaredScope[]
+}
+
+/**
+ * Right drawer for composing a role from the declared scope vocabulary. Creates
+ * a new role or edits an existing one — the name is immutable once created, so
+ * it is read-only in edit mode.
+ */
+export const RoleEditorDrawer: React.FC<RoleEditorDrawerProps> = ({
+  opened,
+  onClose,
+  role,
+  declaredScopes,
+}) => {
+  const isNew = role === null
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [selected, setSelected] = useState<string[]>([])
+
+  const createRole = useCreateRole()
+  const setRoleScopes = useSetRoleScopes()
+  const deleteRole = useDeleteRole()
+
+  useEffect(() => {
+    if (opened) {
+      setName(role?.name ?? '')
+      setDescription(role?.description ?? '')
+      setSelected(role?.scopes ?? [])
+    }
+  }, [opened, role])
+
+  const toggle = (id: string) =>
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]
+    )
+
+  const pending =
+    createRole.isPending || setRoleScopes.isPending || deleteRole.isPending
+
+  const save = async () => {
+    if (isNew) {
+      await createRole.mutateAsync({
+        name: name.trim(),
+        description: description.trim() || undefined,
+        scopes: selected,
+      })
+    } else {
+      await setRoleScopes.mutateAsync({ name: role.name, scopes: selected })
+    }
+    onClose()
+  }
+
+  const remove = async () => {
+    if (isNew) return
+    await deleteRole.mutateAsync(role.name)
+    onClose()
+  }
+
+  const error = (
+    createRole.error ||
+    setRoleScopes.error ||
+    deleteRole.error
+  ) as Error | null
+
+  return (
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      position="right"
+      size={480}
+      title={isNew ? asI18n('Create role') : asI18n(`Edit ${role.name}`)}
+    >
+      <Stack gap="md">
+        <TextInput
+          label={asI18n('Name')}
+          placeholder={asI18n('billing-admin')}
+          value={name}
+          onChange={(e) => setName(e.currentTarget.value)}
+          disabled={!isNew}
+          data-autofocus={isNew}
+        />
+        <Textarea
+          label={asI18n('Description')}
+          placeholder={asI18n('What this role is for')}
+          value={description}
+          onChange={(e) => setDescription(e.currentTarget.value)}
+          autosize
+          minRows={1}
+        />
+        <Divider label={asI18n('Scopes in this role')} labelPosition="left" />
+        <Box mah={360} style={{ overflowY: 'auto' }}>
+          <ScopeTreeSelector
+            scopes={declaredScopes}
+            selected={selected}
+            onToggle={toggle}
+          />
+        </Box>
+        {error && (
+          <Text c="red" size="sm">
+            {asI18n(error.message)}
+          </Text>
+        )}
+        <Group justify="space-between" mt="sm">
+          {!isNew ? (
+            <Button
+              color="red"
+              variant="subtle"
+              leftSection={<Trash2 size={14} />}
+              onClick={remove}
+              loading={deleteRole.isPending}
+            >
+              {asI18n('Delete role')}
+            </Button>
+          ) : (
+            <span />
+          )}
+          <Button
+            onClick={save}
+            loading={pending && !deleteRole.isPending}
+            disabled={isNew && name.trim().length === 0}
+          >
+            {asI18n('Save')}
+          </Button>
+        </Group>
+      </Stack>
+    </Drawer>
+  )
+}

--- a/packages/console/src/components/scopes/RolesTab.tsx
+++ b/packages/console/src/components/scopes/RolesTab.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import { Badge, Button, Text } from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+import { Plus, UsersRound } from 'lucide-react'
+import { TableListPage } from '../layout/TableListPage'
+import { RoleEditorDrawer, type EditableRole } from './RoleEditorDrawer'
+import { useRoles, useDeclaredScopes } from '../../hooks/useScopes'
+
+const DOCS_HREF = 'https://pikku.dev/docs/authentication/scopes'
+
+/**
+ * The Roles surface: a list of admin-composed roles, each editable in a drawer
+ * that composes it from the declared scope vocabulary.
+ */
+export const RolesTab: React.FC = () => {
+  const rolesQuery = useRoles()
+  const declaredQuery = useDeclaredScopes()
+  const [editing, setEditing] = useState<EditableRole | null>(null)
+  const [drawerOpen, setDrawerOpen] = useState(false)
+
+  const roles = rolesQuery.data?.roles ?? []
+  const declaredScopes = declaredQuery.data?.scopes ?? []
+
+  const open = (role: EditableRole | null) => {
+    setEditing(role)
+    setDrawerOpen(true)
+  }
+
+  return (
+    <>
+      <TableListPage
+        icon={UsersRound}
+        title={asI18n('Roles')}
+        docsHref={DOCS_HREF}
+        data={roles}
+        getKey={(role) => role.name}
+        onRowClick={(role) => open(role)}
+        loading={rolesQuery.isLoading}
+        searchPlaceholder={asI18n('Search roles…')}
+        searchFilter={(role, q) =>
+          role.name.toLowerCase().includes(q) ||
+          (role.description ?? '').toLowerCase().includes(q)
+        }
+        emptyTitle={asI18n('No roles yet')}
+        emptyDescription={asI18n(
+          'Create a role to group scopes and grant them to users.'
+        )}
+        headerRight={
+          <Button
+            size="sm"
+            leftSection={<Plus size={14} />}
+            onClick={() => open(null)}
+          >
+            {asI18n('Create role')}
+          </Button>
+        }
+        columns={[
+          {
+            key: 'name',
+            header: asI18n('Role'),
+            render: (role) => (
+              <Text size="sm" fw={500}>
+                {asI18n(role.name)}
+              </Text>
+            ),
+          },
+          {
+            key: 'description',
+            header: asI18n('Description'),
+            render: (role) => (
+              <Text size="sm" c="dimmed">
+                {asI18n(role.description || '—')}
+              </Text>
+            ),
+          },
+          {
+            key: 'scopes',
+            header: asI18n('Scopes'),
+            align: 'right',
+            width: 100,
+            render: (role) => (
+              <Badge variant="light" color="gray" size="sm">
+                {role.scopes.length}
+              </Badge>
+            ),
+          },
+        ]}
+      />
+      <RoleEditorDrawer
+        opened={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        role={editing}
+        declaredScopes={declaredScopes}
+      />
+    </>
+  )
+}

--- a/packages/console/src/components/scopes/ScopeTreeSelector.tsx
+++ b/packages/console/src/components/scopes/ScopeTreeSelector.tsx
@@ -1,0 +1,63 @@
+import { Box, Checkbox, Group, Stack, Text } from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+import { toScopeTreeRows, type DeclaredScope } from './scope-tree'
+
+type ScopeTreeSelectorProps = {
+  scopes: DeclaredScope[]
+  selected: string[]
+  onToggle: (id: string) => void
+}
+
+/**
+ * Renders the declared scope vocabulary as an indented list of checkboxes.
+ * Each node is independently grantable — ticking a parent does not tick its
+ * children, matching the runtime, where a role holds an explicit set of ids
+ * rather than a collapsed subtree.
+ */
+export const ScopeTreeSelector: React.FC<ScopeTreeSelectorProps> = ({
+  scopes,
+  selected,
+  onToggle,
+}) => {
+  const rows = toScopeTreeRows(scopes)
+  const held = new Set(selected)
+
+  if (rows.length === 0) {
+    return (
+      <Text c="dimmed" size="sm" py="sm">
+        {asI18n('No scopes are declared. Add wireScope declarations in code.')}
+      </Text>
+    )
+  }
+
+  return (
+    <Stack gap={2}>
+      {rows.map((row) => (
+        <Box key={row.id} pl={row.depth * 20}>
+          <Checkbox
+            checked={held.has(row.id)}
+            onChange={() => onToggle(row.id)}
+            disabled={!row.declared}
+            label={
+              <Group gap={8} wrap="nowrap">
+                <Text size="sm" fw={row.hasChildren ? 600 : 400}>
+                  {asI18n(row.segment)}
+                </Text>
+                {row.description && (
+                  <Text size="xs" c="dimmed">
+                    {asI18n(row.description)}
+                  </Text>
+                )}
+                {!row.declared && (
+                  <Text size="xs" c="orange">
+                    {asI18n('stale')}
+                  </Text>
+                )}
+              </Group>
+            }
+          />
+        </Box>
+      ))}
+    </Stack>
+  )
+}

--- a/packages/console/src/components/scopes/ScopesVocabularyTab.tsx
+++ b/packages/console/src/components/scopes/ScopesVocabularyTab.tsx
@@ -1,0 +1,82 @@
+import { Badge, Group, Text } from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+import { Shield } from 'lucide-react'
+import { TableListPage } from '../layout/TableListPage'
+import { toScopeTreeRows } from './scope-tree'
+import { useDeclaredScopes } from '../../hooks/useScopes'
+
+const DOCS_HREF = 'https://pikku.dev/docs/authentication/scopes'
+
+/**
+ * Read-only view of the scope vocabulary declared in code via wireScope. A row
+ * flagged stale is still stored but no longer declared — it grants nothing and
+ * is what `pikku scopes prune` removes.
+ */
+export const ScopesVocabularyTab: React.FC = () => {
+  const declaredQuery = useDeclaredScopes()
+  const rows = toScopeTreeRows(declaredQuery.data?.scopes ?? [])
+
+  return (
+    <TableListPage
+      icon={Shield}
+      title={asI18n('Scopes')}
+      docsHref={DOCS_HREF}
+      data={rows}
+      getKey={(row) => row.id}
+      onRowClick={() => {}}
+      loading={declaredQuery.isLoading}
+      searchPlaceholder={asI18n('Search scopes…')}
+      searchFilter={(row, q) =>
+        row.id.toLowerCase().includes(q) ||
+        (row.description ?? '').toLowerCase().includes(q)
+      }
+      emptyTitle={asI18n('No scopes declared')}
+      emptyDescription={asI18n(
+        'Declare scopes in code with wireScope, then run pikku all.'
+      )}
+      columns={[
+        {
+          key: 'id',
+          header: asI18n('Scope'),
+          render: (row) => (
+            <Text
+              size="sm"
+              ff="monospace"
+              fw={row.hasChildren ? 600 : 400}
+              c={row.declared ? undefined : 'dimmed'}
+            >
+              {asI18n(row.id)}
+            </Text>
+          ),
+        },
+        {
+          key: 'description',
+          header: asI18n('Description'),
+          render: (row) => (
+            <Text size="sm" c="dimmed">
+              {asI18n(row.description || '—')}
+            </Text>
+          ),
+        },
+        {
+          key: 'state',
+          header: asI18n('State'),
+          align: 'right',
+          width: 120,
+          render: (row) =>
+            row.declared ? (
+              <Group justify="flex-end" gap={6}>
+                <Badge variant="dot" color="green" size="sm">
+                  {asI18n('declared')}
+                </Badge>
+              </Group>
+            ) : (
+              <Badge variant="light" color="orange" size="sm">
+                {asI18n('stale')}
+              </Badge>
+            ),
+        },
+      ]}
+    />
+  )
+}

--- a/packages/console/src/components/scopes/scope-tree.test.ts
+++ b/packages/console/src/components/scopes/scope-tree.test.ts
@@ -1,0 +1,55 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { toScopeTreeRows } from './scope-tree.js'
+
+const SCOPES = [
+  { id: 'admin', declared: true },
+  { id: 'admin:invoices', description: 'Invoice Management', declared: true },
+  { id: 'admin:invoices:create', declared: true },
+  { id: 'billing:read', declared: false },
+]
+
+describe('toScopeTreeRows', () => {
+  test('depth counts the colon separators', () => {
+    const rows = toScopeTreeRows(SCOPES)
+    assert.deepEqual(
+      rows.map((r) => r.depth),
+      [0, 1, 2, 1]
+    )
+  })
+
+  test('segment is the last id fragment', () => {
+    const rows = toScopeTreeRows(SCOPES)
+    assert.deepEqual(
+      rows.map((r) => r.segment),
+      ['admin', 'invoices', 'create', 'read']
+    )
+  })
+
+  test('hasChildren is set only for a scope that others nest under', () => {
+    const rows = toScopeTreeRows(SCOPES)
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r.hasChildren]))
+    assert.equal(byId['admin'], true)
+    assert.equal(byId['admin:invoices'], true)
+    assert.equal(byId['admin:invoices:create'], false)
+    assert.equal(byId['billing:read'], false)
+  })
+
+  test('a prefix that is not colon-delimited does not count as a child', () => {
+    const rows = toScopeTreeRows([
+      { id: 'admin', declared: true },
+      { id: 'administrator', declared: true },
+    ])
+    assert.equal(rows.find((r) => r.id === 'admin')!.hasChildren, false)
+  })
+
+  test('input order and passthrough fields are preserved', () => {
+    const rows = toScopeTreeRows(SCOPES)
+    assert.deepEqual(
+      rows.map((r) => r.id),
+      SCOPES.map((s) => s.id)
+    )
+    assert.equal(rows[1]!.description, 'Invoice Management')
+    assert.equal(rows[3]!.declared, false)
+  })
+})

--- a/packages/console/src/components/scopes/scope-tree.ts
+++ b/packages/console/src/components/scopes/scope-tree.ts
@@ -1,0 +1,31 @@
+export type DeclaredScope = {
+  id: string
+  description?: string
+  declared: boolean
+}
+
+export type ScopeTreeRow = DeclaredScope & {
+  /** Nesting depth, i.e. the number of `:` separators in the id. */
+  depth: number
+  /** The last colon-delimited segment — what a row shows as its label. */
+  segment: string
+  /** True when another declared scope nests beneath this one. */
+  hasChildren: boolean
+}
+
+/**
+ * Turns the flat declared-scope list into rows carrying the depth, leaf segment
+ * and has-children flag the tree view renders from. Input order is preserved
+ * (the backend already sorts by id, so parents precede their descendants).
+ */
+export const toScopeTreeRows = (scopes: DeclaredScope[]): ScopeTreeRow[] =>
+  scopes.map((scope) => {
+    const segments = scope.id.split(':')
+    const prefix = `${scope.id}:`
+    return {
+      ...scope,
+      depth: segments.length - 1,
+      segment: segments[segments.length - 1]!,
+      hasChildren: scopes.some((other) => other.id.startsWith(prefix)),
+    }
+  })

--- a/packages/console/src/components/users/UserRolesDrawer.tsx
+++ b/packages/console/src/components/users/UserRolesDrawer.tsx
@@ -1,0 +1,152 @@
+import {
+  Badge,
+  Box,
+  Center,
+  Divider,
+  Drawer,
+  Group,
+  Loader,
+  Menu,
+  Button,
+  Stack,
+  Text,
+} from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+import { Plus, X } from 'lucide-react'
+import {
+  useRoles,
+  useUserRoles,
+  useAddUserToRole,
+  useRemoveUserFromRole,
+} from '../../hooks/useScopes'
+
+type UserRolesDrawerProps = {
+  opened: boolean
+  onClose: () => void
+  userId: string | undefined
+  userLabel: string
+}
+
+/**
+ * Right drawer for granting and revoking a user's roles. The resolved scopes
+ * are shown read-only — they are the union the user's session will carry, and
+ * change only by editing the roles above.
+ */
+export const UserRolesDrawer: React.FC<UserRolesDrawerProps> = ({
+  opened,
+  onClose,
+  userId,
+  userLabel,
+}) => {
+  const userRolesQuery = useUserRoles(userId, opened)
+  const allRolesQuery = useRoles()
+  const addRole = useAddUserToRole()
+  const removeRole = useRemoveUserFromRole()
+
+  const held = userRolesQuery.data?.roles ?? []
+  const scopes = userRolesQuery.data?.scopes ?? []
+  const available = (allRolesQuery.data?.roles ?? [])
+    .map((r) => r.name)
+    .filter((name) => !held.includes(name))
+
+  const busy = addRole.isPending || removeRole.isPending
+
+  return (
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      position="right"
+      size={420}
+      title={asI18n(`Roles — ${userLabel}`)}
+    >
+      {userRolesQuery.isLoading ? (
+        <Center py="xl">
+          <Loader />
+        </Center>
+      ) : (
+        <Stack gap="md">
+          <Text size="sm" fw={500}>
+            {asI18n('Roles')}
+          </Text>
+          {held.length === 0 ? (
+            <Text size="sm" c="dimmed">
+              {asI18n('This user holds no roles.')}
+            </Text>
+          ) : (
+            <Group gap={8}>
+              {held.map((role) => (
+                <Badge
+                  key={role}
+                  variant="light"
+                  size="lg"
+                  rightSection={
+                    <X
+                      size={12}
+                      style={{ cursor: 'pointer' }}
+                      onClick={() =>
+                        userId &&
+                        !busy &&
+                        removeRole.mutate({ userId, role })
+                      }
+                    />
+                  }
+                >
+                  {asI18n(role)}
+                </Badge>
+              ))}
+            </Group>
+          )}
+
+          <Menu position="bottom-start" disabled={available.length === 0}>
+            <Menu.Target>
+              <Button
+                variant="light"
+                size="sm"
+                leftSection={<Plus size={14} />}
+                disabled={available.length === 0 || busy}
+                w="fit-content"
+              >
+                {asI18n('Add role')}
+              </Button>
+            </Menu.Target>
+            <Menu.Dropdown>
+              {available.map((role) => (
+                <Menu.Item
+                  key={role}
+                  onClick={() =>
+                    userId && addRole.mutate({ userId, role })
+                  }
+                >
+                  {asI18n(role)}
+                </Menu.Item>
+              ))}
+            </Menu.Dropdown>
+          </Menu>
+
+          <Divider label={asI18n('Resolved scopes')} labelPosition="left" />
+          {scopes.length === 0 ? (
+            <Text size="sm" c="dimmed">
+              {asI18n('No scopes — these roles grant nothing yet.')}
+            </Text>
+          ) : (
+            <Box>
+              <Group gap={6}>
+                {scopes.map((scope) => (
+                  <Badge
+                    key={scope}
+                    variant="outline"
+                    color="gray"
+                    size="sm"
+                    styles={{ label: { fontFamily: 'monospace' } }}
+                  >
+                    {asI18n(scope)}
+                  </Badge>
+                ))}
+              </Group>
+            </Box>
+          )}
+        </Stack>
+      )}
+    </Drawer>
+  )
+}

--- a/packages/console/src/hooks/useScopes.ts
+++ b/packages/console/src/hooks/useScopes.ts
@@ -1,0 +1,104 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { usePikkuRPC } from '../context/PikkuRpcProvider'
+import type { DeclaredScope } from '../components/scopes/scope-tree'
+
+export type Role = {
+  name: string
+  description?: string
+  scopes: string[]
+}
+
+const ROLES_KEY = ['scope-roles']
+const DECLARED_KEY = ['scope-declared']
+const userRolesKey = (userId: string) => ['scope-user-roles', userId]
+
+export function useDeclaredScopes() {
+  const rpc = usePikkuRPC()
+  return useQuery({
+    queryKey: DECLARED_KEY,
+    queryFn: async () =>
+      (await rpc.invoke('console:scopeListDeclared')) as {
+        scopes: DeclaredScope[]
+      },
+  })
+}
+
+export function useRoles() {
+  const rpc = usePikkuRPC()
+  return useQuery({
+    queryKey: ROLES_KEY,
+    queryFn: async () =>
+      (await rpc.invoke('console:scopeListRoles')) as { roles: Role[] },
+  })
+}
+
+export function useUserRoles(userId: string | undefined, enabled: boolean) {
+  const rpc = usePikkuRPC()
+  return useQuery({
+    queryKey: userRolesKey(userId ?? ''),
+    queryFn: async () =>
+      (await rpc.invoke('console:scopeListUserRoles', {
+        userId: userId!,
+      })) as { roles: string[]; scopes: string[] },
+    enabled: !!userId && enabled,
+  })
+}
+
+export function useCreateRole() {
+  const rpc = usePikkuRPC()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: {
+      name: string
+      description?: string
+      scopes: string[]
+    }) => rpc.invoke('console:scopeCreateRole', input),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ROLES_KEY }),
+  })
+}
+
+export function useSetRoleScopes() {
+  const rpc = usePikkuRPC()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { name: string; scopes: string[] }) =>
+      rpc.invoke('console:scopeSetRoleScopes', input),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ROLES_KEY }),
+  })
+}
+
+export function useDeleteRole() {
+  const rpc = usePikkuRPC()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (name: string) =>
+      rpc.invoke('console:scopeDeleteRole', { name }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ROLES_KEY }),
+  })
+}
+
+export function useAddUserToRole() {
+  const rpc = usePikkuRPC()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { userId: string; role: string }) =>
+      rpc.invoke('console:scopeAddUserToRole', input),
+    onSuccess: (_data, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: userRolesKey(variables.userId),
+      }),
+  })
+}
+
+export function useRemoveUserFromRole() {
+  const rpc = usePikkuRPC()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { userId: string; role: string }) =>
+      rpc.invoke('console:scopeRemoveUserFromRole', input),
+    onSuccess: (_data, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: userRolesKey(variables.userId),
+      }),
+  })
+}

--- a/packages/console/src/pages/AdminUsersPage.tsx
+++ b/packages/console/src/pages/AdminUsersPage.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Text, Button, Center, Loader, Alert } from '@pikku/mantine/core'
+import { Text, Button, Center, Loader, Alert, Group } from '@pikku/mantine/core'
 import { useDebouncedValue } from '@mantine/hooks'
-import { AlertTriangle, UserCog } from 'lucide-react'
+import { AlertTriangle, UserCog, ShieldCheck } from 'lucide-react'
 import { PageContainer, ListPageHeader } from '../components/layout/PageLayout'
 import { UsersTable } from '../components/users/UsersTable'
+import { UserRolesDrawer } from '../components/users/UserRolesDrawer'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { asI18n } from '@pikku/react'
@@ -17,6 +18,9 @@ export const AdminUsersPage: React.FC = () => {
   const { setTarget, target } = useImpersonation()
   const [search, setSearch] = useState('')
   const [debounced] = useDebouncedValue(search, 250)
+  const [rolesFor, setRolesFor] = useState<{ id: string; label: string } | null>(
+    null
+  )
 
   const usersQuery = useQuery({
     queryKey: ['admin-users', debounced],
@@ -64,31 +68,52 @@ export const AdminUsersPage: React.FC = () => {
             banned: m.users_banned(),
           }}
           renderActions={(u) => {
-            if (u.id === currentUser?.id) return null
             const full = users.find((x) => x.id === u.id) ?? null
-            return target?.id === u.id ? (
-              <Button
-                size="compact-sm"
-                variant="light"
-                color="yellow"
-                leftSection={<UserCog size={14} />}
-                onClick={() => setTarget(null)}
-              >
-                {m.impersonate_stop()}
-              </Button>
-            ) : (
-              <Button
-                size="compact-sm"
-                variant="subtle"
-                leftSection={<UserCog size={14} />}
-                onClick={() => setTarget(full)}
-              >
-                {m.impersonate_button()}
-              </Button>
+            const isSelf = u.id === currentUser?.id
+            return (
+              <Group gap={6} justify="flex-end" wrap="nowrap">
+                <Button
+                  size="compact-sm"
+                  variant="subtle"
+                  leftSection={<ShieldCheck size={14} />}
+                  onClick={() =>
+                    setRolesFor({ id: u.id, label: u.email ?? u.id })
+                  }
+                >
+                  {asI18n('Roles')}
+                </Button>
+                {!isSelf &&
+                  (target?.id === u.id ? (
+                    <Button
+                      size="compact-sm"
+                      variant="light"
+                      color="yellow"
+                      leftSection={<UserCog size={14} />}
+                      onClick={() => setTarget(null)}
+                    >
+                      {m.impersonate_stop()}
+                    </Button>
+                  ) : (
+                    <Button
+                      size="compact-sm"
+                      variant="subtle"
+                      leftSection={<UserCog size={14} />}
+                      onClick={() => setTarget(full)}
+                    >
+                      {m.impersonate_button()}
+                    </Button>
+                  ))}
+              </Group>
             )
           }}
         />
       )}
+      <UserRolesDrawer
+        opened={rolesFor !== null}
+        onClose={() => setRolesFor(null)}
+        userId={rolesFor?.id}
+        userLabel={rolesFor?.label ?? ''}
+      />
     </PageContainer>
   )
 }

--- a/packages/console/src/pages/ScopesPage.tsx
+++ b/packages/console/src/pages/ScopesPage.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { SegmentedControl } from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+import { PageContainer, ListPageHeader } from '../components/layout/PageLayout'
+import { RolesTab } from '../components/scopes/RolesTab'
+import { ScopesVocabularyTab } from '../components/scopes/ScopesVocabularyTab'
+import { useLocale } from '@/i18n/config'
+
+type Tab = 'roles' | 'scopes'
+
+export const ScopesPage: React.FC = () => {
+  useLocale()
+  const [tab, setTab] = useState<Tab>('roles')
+
+  return (
+    <PageContainer
+      header={
+        <ListPageHeader
+          title={asI18n('Scopes')}
+          description={asI18n(
+            tab === 'roles'
+              ? 'Roles composed from the declared scope vocabulary.'
+              : 'The scope vocabulary, declared in code via wireScope.'
+          )}
+          docsHref="https://pikku.dev/docs/authentication/scopes"
+          filters={
+            <SegmentedControl
+              size="sm"
+              value={tab}
+              onChange={(v) => setTab(v as Tab)}
+              data={[
+                { label: asI18n('Roles') as string, value: 'roles' },
+                { label: asI18n('Scopes') as string, value: 'scopes' },
+              ]}
+            />
+          }
+        />
+      }
+    >
+      {tab === 'roles' ? <RolesTab /> : <ScopesVocabularyTab />}
+    </PageContainer>
+  )
+}


### PR DESCRIPTION
Console UI for the scopes feature (#956). Stacks on #960 (the backend) — base is `feat/956-scopes` and retargets to `main` once #960 merges.

## What's here

A new **Scopes** page beside Users, plus per-user role assignment on the Users page.

**Scopes → Roles tab** — list of admin-composed roles; row-click opens a drawer that composes the role from the declared scope vocabulary (checkbox tree). Create and delete roles. Backed by `scopeListRoles` / `scopeCreateRole` / `scopeSetRoleScopes` / `scopeDeleteRole`.

**Scopes → Scopes tab** — read-only view of the `wireScope` vocabulary, flagging any scope that's stored but no longer declared (inert; what `pikku scopes prune` removes). From `scopeListDeclared`.

**Users → Roles action** — each row gets a **Roles** button opening a drawer to grant/revoke that user's roles, with the resolved scope union shown read-only. From `scopeListUserRoles` / `scopeAddUserToRole` / `scopeRemoveUserFromRole`.

## Notes for review

- **Scope tree is a flat Set, not a collapsed subtree** — ticking a parent doesn't tick its children, matching the runtime where a role holds explicit ids. The flat-ids → depth/segment/has-children derivation is a pure helper (`scope-tree.ts`) with unit coverage.
- **RPC boundary is typed locally** (`useScopes.ts`) rather than leaning on cross-package generated-map resolution — the scope keys still come from the addon map, but outputs are cast so the console tsc is stable regardless of regen state.
- **One component per file**, `React.FC` + `asI18n` for all copy (new strings are inlined via `asI18n`, matching the existing `Scenarios` nav item — no message-catalog churn).
- The console is excluded from the repo's CI build/test/verifier jobs, so validation here is `tsc --noEmit` (clean) + the `scope-tree` unit test. Reviewers may want to click through locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
