### PR TITLE
feat(console): render workflows vertically in the side panel, scenarios via persona timeline

### DIFF
--- a/.changeset/weave-panel-workflow-render.md
+++ b/.changeset/weave-panel-workflow-render.md
@@ -1,0 +1,5 @@
+---
+'@pikku/console': patch
+---
+
+Workflow side panel now renders the flow vertically (top→down graph, or the scenario persona timeline) in place of the flat Nodes table; adds direction-aware ELK layout and exports WorkflowGraphView/PersonaTimeline for embedders.

--- a/packages/console/src/components/flows/timeline/TimelineStep.tsx
+++ b/packages/console/src/components/flows/timeline/TimelineStep.tsx
@@ -4,7 +4,6 @@ import { asI18n } from '@pikku/react'
 import {
   MousePointerClick,
   Hourglass,
-  Flag,
   GitFork,
   Network,
   Circle,
@@ -24,7 +23,6 @@ const KIND_STYLE: Record<
 > = {
   rpc: { Icon: MousePointerClick, color: 'green', badge: 'RPC' },
   eventual: { Icon: Hourglass, color: 'yellow', badge: 'EVENTUAL' },
-  return: { Icon: Flag, color: 'gray', badge: 'RETURN' },
   parallel: { Icon: GitFork, color: 'blue', badge: 'PARALLEL' },
   fanout: { Icon: Network, color: 'blue', badge: 'FANOUT' },
   other: { Icon: Circle, color: 'gray', badge: 'STEP' },

--- a/packages/console/src/components/flows/timeline/timeline-model.test.ts
+++ b/packages/console/src/components/flows/timeline/timeline-model.test.ts
@@ -28,25 +28,20 @@ const ORDER_SUPPORT_NODES = {
   step_3: { nodeId: 'step_3', flow: 'return', outputs: {} },
 }
 
-test('buildFlowTimeline orders by next, drops the structural branch, and maps kinds', () => {
+test('buildFlowTimeline orders by next, drops structural branch and return nodes, and maps kinds', () => {
   const timeline = buildFlowTimeline(ORDER_SUPPORT_NODES as any, ['step_0'])
 
   assert.deepEqual(
     timeline.map((n) => n.nodeId),
-    [
-      'shopper doubles their order',
-      'support sees the greeting settle',
-      'step_3',
-    ]
+    ['shopper doubles their order', 'support sees the greeting settle']
   )
   assert.deepEqual(
     timeline.map((n) => n.kind),
-    ['rpc', 'eventual', 'return']
+    ['rpc', 'eventual']
   )
   assert.equal(timeline[0].actor, 'shopper')
   assert.equal(timeline[1].actor, 'support')
   assert.equal(timeline[1].expectEventually, true)
-  assert.equal(timeline[2].title, 'Return')
 })
 
 test('buildFlowTimeline appends nodes unreachable via next in insertion order', () => {
@@ -58,7 +53,7 @@ test('buildFlowTimeline appends nodes unreachable via next in insertion order', 
   const timeline = buildFlowTimeline(nodes as any, ['a'])
   assert.deepEqual(
     timeline.map((n) => n.nodeId),
-    ['a', 'c', 'b']
+    ['a', 'b']
   )
 })
 

--- a/packages/console/src/components/flows/timeline/timeline-model.ts
+++ b/packages/console/src/components/flows/timeline/timeline-model.ts
@@ -1,7 +1,6 @@
 export type FlowTimelineKind =
   | 'rpc'
   | 'eventual'
-  | 'return'
   | 'parallel'
   | 'fanout'
   | 'other'
@@ -33,7 +32,6 @@ const isStructuralBranch = (node: RawNode): boolean =>
   !node.rpcName
 
 const kindOf = (node: RawNode): FlowTimelineKind => {
-  if (node.flow === 'return') return 'return'
   if (node.flow === 'parallel') return 'parallel'
   if (node.flow === 'fanout') return 'fanout'
   if (node.rpcName) return node.expectEventually ? 'eventual' : 'rpc'
@@ -41,7 +39,6 @@ const kindOf = (node: RawNode): FlowTimelineKind => {
 }
 
 const titleOf = (node: RawNode): string => {
-  if (node.flow === 'return') return 'Return'
   if (/^step_\d+$/.test(node.nodeId)) return node.rpcName ?? node.nodeId
   return node.nodeId
 }
@@ -72,8 +69,9 @@ export function buildFlowTimeline(
     if (!visited.has(id)) walk(id)
   }
 
+  // scenarios are always void, so the compiled trailing return node is noise
   return ordered
-    .filter((node) => !isStructuralBranch(node))
+    .filter((node) => !isStructuralBranch(node) && node.flow !== 'return')
     .map((node) => ({
       nodeId: node.nodeId,
       kind: kindOf(node),

--- a/packages/console/src/components/layout/ThreePaneLayout.tsx
+++ b/packages/console/src/components/layout/ThreePaneLayout.tsx
@@ -78,7 +78,8 @@ export const ThreePaneLayout: React.FC<ThreePaneLayoutProps> = ({
           }}
         >
           <Box className={classes.listSurfaceCard} style={{ height: '100%', width: 'min(520px, 42vw)' }}>
-            <PanelContainer emptyMessage={emptyPanelMessage} />
+            {/* the center pane already draws the full workflow canvas */}
+            <PanelContainer emptyMessage={emptyPanelMessage} workflowGraph={false} />
           </Box>
         </Box>
       </Box>

--- a/packages/console/src/components/layout/ThreePaneLayout.tsx
+++ b/packages/console/src/components/layout/ThreePaneLayout.tsx
@@ -78,7 +78,6 @@ export const ThreePaneLayout: React.FC<ThreePaneLayoutProps> = ({
           }}
         >
           <Box className={classes.listSurfaceCard} style={{ height: '100%', width: 'min(520px, 42vw)' }}>
-            {/* the center pane already draws the full workflow canvas */}
             <PanelContainer emptyMessage={emptyPanelMessage} workflowGraph={false} />
           </Box>
         </Box>

--- a/packages/console/src/components/panel/PanelContainer.tsx
+++ b/packages/console/src/components/panel/PanelContainer.tsx
@@ -10,17 +10,26 @@ import { SidePanel, SidePanelContent, SidePanelHeader } from './SidePanel'
 
 interface PanelContainerProps {
   emptyMessage?: I18nNode
+  /** Render workflow panels with their flow drawn vertically (graph /
+   *  scenario timeline). Default true; layouts that already show a full
+   *  workflow canvas next to the panel pass false. */
+  workflowGraph?: boolean
 }
 
-export const PanelContainer: React.FC<PanelContainerProps> = ({ emptyMessage }) => {
+export const PanelContainer: React.FC<PanelContainerProps> = ({
+  emptyMessage,
+  workflowGraph = true,
+}) => {
   const { panels, activePanel, closePanel, goBack } = usePanelContext()
   useLocale()
 
   const activePanelData = activePanel ? panels.get(activePanel) : null
 
   const children = useMemo(() => {
-    return activePanelData ? createPanelChildren(activePanelData.data) : []
-  }, [activePanelData])
+    return activePanelData
+      ? createPanelChildren(activePanelData.data, { workflowGraph })
+      : []
+  }, [activePanelData, workflowGraph])
 
   if (!activePanelData || children.length === 0) {
     return (

--- a/packages/console/src/components/panel/PanelFactory.tsx
+++ b/packages/console/src/components/panel/PanelFactory.tsx
@@ -13,8 +13,7 @@ import {
   useWorkflowContext,
   useWorkflowNode,
 } from '../../context/WorkflowContext'
-import { WorkflowGraphView } from '../project/WorkflowGraphView'
-import { PersonaTimeline } from '../flows/timeline/PersonaTimeline'
+import { WorkflowPanelFlow } from './WorkflowPanelFlow'
 import { useWorkflowInputSchema } from '../../hooks/useWorkflowInputSchema'
 import { FunctionTabbedPanel } from '../project/panels/FunctionDetailsForm'
 import {
@@ -185,26 +184,6 @@ const NewWorkflowRunForm: React.FC<{ workflowId: string }> = ({
         </Text>
       )}
     </Stack>
-  )
-}
-
-/* Vertical rendering of the workflow inside the (narrow) side panel: the
-   scenario timeline for scenarios, the top→down graph for everything else.
-   Suppressed (renderGraph=false) when the panel sits beside a full canvas
-   that already draws the same graph. */
-const WorkflowPanelFlow: React.FC = () => {
-  const { workflow } = useWorkflowContext()
-  const isScenario =
-    workflow?.source === 'scenario' || workflow?.scenario === true
-
-  return (
-    <Box h={480} style={{ minHeight: 0 }}>
-      {isScenario ? (
-        <PersonaTimeline workflow={workflow} />
-      ) : (
-        <WorkflowGraphView workflow={workflow} direction="DOWN" />
-      )}
-    </Box>
   )
 }
 

--- a/packages/console/src/components/panel/PanelFactory.tsx
+++ b/packages/console/src/components/panel/PanelFactory.tsx
@@ -9,7 +9,12 @@ import { SchemaForm } from '../ui/SchemaForm'
 import type { PanelData } from '../../context/PanelContext'
 import { useWorkflowRunContextSafe } from '../../context/WorkflowRunContext'
 import { useStartWorkflowRun } from '../../hooks/useWorkflowRuns'
-import { useWorkflowNode } from '../../context/WorkflowContext'
+import {
+  useWorkflowContext,
+  useWorkflowNode,
+} from '../../context/WorkflowContext'
+import { WorkflowGraphView } from '../project/WorkflowGraphView'
+import { PersonaTimeline } from '../flows/timeline/PersonaTimeline'
 import { useWorkflowInputSchema } from '../../hooks/useWorkflowInputSchema'
 import { FunctionTabbedPanel } from '../project/panels/FunctionDetailsForm'
 import {
@@ -183,12 +188,37 @@ const NewWorkflowRunForm: React.FC<{ workflowId: string }> = ({
   )
 }
 
-const WorkflowTabbedPanel: React.FC<{ workflowId: string }> = ({
-  workflowId,
-}) => {
+/* Vertical rendering of the workflow inside the (narrow) side panel: the
+   scenario timeline for scenarios, the top→down graph for everything else.
+   Suppressed (renderGraph=false) when the panel sits beside a full canvas
+   that already draws the same graph. */
+const WorkflowPanelFlow: React.FC = () => {
+  const { workflow } = useWorkflowContext()
+  const isScenario =
+    workflow?.source === 'scenario' || workflow?.scenario === true
+
+  return (
+    <Box h={480} style={{ minHeight: 0 }}>
+      {isScenario ? (
+        <PersonaTimeline workflow={workflow} />
+      ) : (
+        <WorkflowGraphView workflow={workflow} direction="DOWN" />
+      )}
+    </Box>
+  )
+}
+
+const WorkflowTabbedPanel: React.FC<{
+  workflowId: string
+  renderGraph?: boolean
+}> = ({ workflowId, renderGraph = true }) => {
   const runContext = useWorkflowRunContextSafe()
+  const { workflow } = useWorkflowContext()
   const hasRun = !!runContext?.selectedRunId
   const isCreating = !!runContext?.isCreatingRun
+  const hasNodes =
+    !!workflow?.nodes && Object.keys(workflow.nodes).length > 0
+  const showGraph = renderGraph && hasNodes
 
   return (
     <Stack gap="md">
@@ -202,8 +232,9 @@ const WorkflowTabbedPanel: React.FC<{ workflowId: string }> = ({
           <WorkflowRunOverview workflowId={workflowId} />
         ) : (
           <Stack gap="xl">
+            {showGraph && <WorkflowPanelFlow />}
             <WorkflowConfiguration workflowId={workflowId} />
-            <WorkflowNodes workflowId={workflowId} />
+            {!showGraph && <WorkflowNodes workflowId={workflowId} />}
             <WorkflowState workflowId={workflowId} />
           </Stack>
         )}
@@ -212,7 +243,16 @@ const WorkflowTabbedPanel: React.FC<{ workflowId: string }> = ({
   )
 }
 
-export const createPanelChildren = (panelData: PanelData): PanelChild[] => {
+export interface PanelRenderOptions {
+  /** Render the workflow panel's flow visually (vertical graph / scenario
+   *  timeline). Disable when the panel sits beside a full workflow canvas. */
+  workflowGraph?: boolean
+}
+
+export const createPanelChildren = (
+  panelData: PanelData,
+  options: PanelRenderOptions = {}
+): PanelChild[] => {
   switch (panelData.type) {
     case 'function':
       return [
@@ -249,7 +289,12 @@ export const createPanelChildren = (panelData: PanelData): PanelChild[] => {
         {
           id: 'workflow',
           title: 'Workflow',
-          content: <WorkflowTabbedPanel workflowId={panelData.id} />,
+          content: (
+            <WorkflowTabbedPanel
+              workflowId={panelData.id}
+              renderGraph={options.workflowGraph !== false}
+            />
+          ),
         },
       ]
 

--- a/packages/console/src/components/panel/WorkflowPanelFlow.tsx
+++ b/packages/console/src/components/panel/WorkflowPanelFlow.tsx
@@ -14,7 +14,7 @@ export const WorkflowPanelFlow: React.FC = () => {
     workflow?.source === 'scenario' || workflow?.scenario === true
 
   return (
-    <Box h={480} style={{ minHeight: 0 }}>
+    <Box h={560} style={{ minHeight: 0 }}>
       {isScenario ? (
         <PersonaTimeline workflow={workflow} />
       ) : (

--- a/packages/console/src/components/panel/WorkflowPanelFlow.tsx
+++ b/packages/console/src/components/panel/WorkflowPanelFlow.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Box } from '@pikku/mantine/core'
+import { useWorkflowContext } from '../../context/WorkflowContext'
+import { WorkflowGraphView } from '../project/WorkflowGraphView'
+import { PersonaTimeline } from '../flows/timeline/PersonaTimeline'
+
+/** Vertical rendering of the workflow inside the (narrow) side panel: the
+ *  scenario timeline for scenarios, the top→down graph for everything else.
+ *  Suppressed (renderGraph=false) when the panel sits beside a full canvas
+ *  that already draws the same graph. */
+export const WorkflowPanelFlow: React.FC = () => {
+  const { workflow } = useWorkflowContext()
+  const isScenario =
+    workflow?.source === 'scenario' || workflow?.scenario === true
+
+  return (
+    <Box h={480} style={{ minHeight: 0 }}>
+      {isScenario ? (
+        <PersonaTimeline workflow={workflow} />
+      ) : (
+        <WorkflowGraphView workflow={workflow} direction="DOWN" />
+      )}
+    </Box>
+  )
+}

--- a/packages/console/src/components/project/WorkflowCanvas.tsx
+++ b/packages/console/src/components/project/WorkflowCanvas.tsx
@@ -1,14 +1,4 @@
 import React, { useMemo, useEffect, useCallback } from 'react'
-import type { NodeTypes, EdgeTypes } from 'reactflow'
-import ReactFlow, {
-  useNodesState,
-  useEdgesState,
-  MarkerType,
-  Background,
-  BackgroundVariant,
-  useReactFlow,
-  ReactFlowProvider,
-} from 'reactflow'
 import {
   Box,
   Drawer,
@@ -40,28 +30,8 @@ import { WorkflowTimelineDrawer } from './WorkflowTimelineDrawer'
 import { PersonaTimeline } from '../flows/timeline/PersonaTimeline'
 import { useWorkflowRuns } from '../../hooks/useWorkflowRuns'
 import { RunsPanel, type RunItem } from '../layout/RunsPanel'
-import { WiringNode } from './nodes/WiringNode'
-import { FunctionNode } from './nodes/FunctionNode'
-import { ChannelNode } from './nodes/ChannelNode'
-import { DecisionNode } from './nodes/DecisionNode'
-import { SleepNode } from './nodes/SleepNode'
-import { InlineNode } from './nodes/InlineNode'
-import { BranchNode } from './nodes/BranchNode'
-import { FanoutNode } from './nodes/FanoutNode'
-import { ReturnNode } from './nodes/ReturnNode'
-import { CancelNode } from './nodes/CancelNode'
-import { SwitchNode } from './nodes/SwitchNode'
-import { ArrayPredicateNode } from './nodes/ArrayPredicateNode'
-import { FilterNode } from './nodes/FilterNode'
-import { ParallelNode } from './nodes/ParallelNode'
-import { ChannelWiringNode } from './nodes/ChannelWiringNode'
-import { SetNode } from './nodes/SetNode'
-import { createFlow } from '../../hooks/useWiringFlow'
-import { useElkLayout } from '../../hooks/useElkLayout'
-import 'reactflow/dist/style.css'
+import { WorkflowGraphView } from './WorkflowGraphView'
 import { ThreePaneLayout } from '../layout/ThreePaneLayout'
-import { GenericNode } from './nodes/GenericNode'
-import { ElkEdge } from './edges/ElkEdge'
 import { useConsoleEditable } from '../../context/ConsoleEditableContext'
 
 const wireTypeToWiresKey: Record<string, string> = {
@@ -111,110 +81,11 @@ function filterWiresForRun(
   return { [wiresKey]: entries.filter((w: any) => matcher(w) === runWire.id) }
 }
 
-const nodeTypes: NodeTypes = {
-  functionNode: FunctionNode,
-  wiringNode: WiringNode,
-  channelNode: ChannelNode,
-  decisionNode: DecisionNode,
-  sleepNode: SleepNode,
-  inlineNode: InlineNode,
-  genericNode: GenericNode,
-  branchNode: BranchNode,
-  fanoutNode: FanoutNode,
-  returnNode: ReturnNode,
-  cancelNode: CancelNode,
-  switchNode: SwitchNode,
-  arrayPredicateNode: ArrayPredicateNode,
-  filterNode: FilterNode,
-  parallelNode: ParallelNode,
-  channelWiringNode: ChannelWiringNode,
-  setNode: SetNode,
-}
-
-const edgeTypes: EdgeTypes = {
-  elk: ElkEdge,
-}
-
 interface WorkflowCanvasProps {
   workflow: any
   items: { name: string; description?: string }[]
   onItemSelect: (name: string) => void
   immersiveDetail?: boolean
-}
-
-const WorkflowCanvasFlow: React.FC<{
-  workflow: any
-  onPaneClick?: () => void
-}> = ({ workflow, onPaneClick }) => {
-  const { fitView } = useReactFlow()
-
-  const { nodes: flowNodes, edges: initialEdges } = useMemo(() => {
-    return createFlow(workflow)
-  }, [workflow])
-
-  const layoutResult = useElkLayout(flowNodes, initialEdges)
-
-  const [nodes, setNodes] = useNodesState([])
-  const [edges, setEdges] = useEdgesState([])
-
-  useEffect(() => {
-    if (layoutResult.nodes.length > 0) {
-      setNodes(layoutResult.nodes)
-      setEdges(layoutResult.edges)
-      setTimeout(() => {
-        fitView({ padding: 0.2 })
-      }, 50)
-    }
-  }, [layoutResult, setNodes, setEdges, fitView])
-
-  return (
-    <Box style={{ width: '100%', height: '100%' }}>
-      <style>{`
-        .react-flow__handle { opacity: 0; pointer-events: none; }
-        @keyframes pulse-border { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
-      `}</style>
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
-        defaultEdgeOptions={{
-          style: {
-            stroke: '#c0c0c0',
-            strokeWidth: 1.5,
-            strokeDasharray: '6 4',
-          },
-          animated: true,
-          markerEnd: {
-            type: MarkerType.ArrowClosed,
-            color: '#c0c0c0',
-            width: 16,
-            height: 16,
-          },
-        }}
-        zoomOnScroll={true}
-        preventScrolling={false}
-        nodesConnectable={false}
-        nodesDraggable={true}
-        proOptions={{ hideAttribution: true }}
-        noDragClassName="nodrag"
-        onPaneClick={onPaneClick}
-      >
-        <Background color="#e0e0e0" variant={BackgroundVariant.Dots} size={1} />
-      </ReactFlow>
-    </Box>
-  )
-}
-
-const WorkflowCanvasInner: React.FC<{
-  workflow: any
-  onPaneClick?: () => void
-}> = (props) => {
-  return (
-    <ReactFlowProvider>
-      <WorkflowCanvasFlow {...props} />
-    </ReactFlowProvider>
-  )
 }
 
 const WorkflowRunsPanel: React.FC<{
@@ -398,7 +269,7 @@ const WorkflowCanvasContent: React.FC<WorkflowCanvasProps> = ({
             {isScenario ? (
               <PersonaTimeline workflow={canvasWorkflow} />
             ) : (
-              <WorkflowCanvasInner
+              <WorkflowGraphView
                 workflow={canvasWorkflow}
                 onPaneClick={handlePaneClick}
               />

--- a/packages/console/src/components/project/WorkflowGraphFlow.tsx
+++ b/packages/console/src/components/project/WorkflowGraphFlow.tsx
@@ -78,9 +78,10 @@ export const WorkflowGraphFlow: React.FC<WorkflowGraphViewProps> = ({
     if (layoutResult.nodes.length > 0) {
       setNodes(layoutResult.nodes)
       setEdges(layoutResult.edges)
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         fitView({ padding: 0.2 })
       }, 50)
+      return () => clearTimeout(timer)
     }
   }, [layoutResult, setNodes, setEdges, fitView])
 

--- a/packages/console/src/components/project/WorkflowGraphFlow.tsx
+++ b/packages/console/src/components/project/WorkflowGraphFlow.tsx
@@ -1,0 +1,124 @@
+import React, { useMemo, useEffect } from 'react'
+import type { NodeTypes, EdgeTypes } from 'reactflow'
+import ReactFlow, {
+  useNodesState,
+  useEdgesState,
+  MarkerType,
+  Background,
+  BackgroundVariant,
+  useReactFlow,
+} from 'reactflow'
+import { Box } from '@pikku/mantine/core'
+import type { WorkflowGraphViewProps } from './WorkflowGraphView'
+import { WiringNode } from './nodes/WiringNode'
+import { FunctionNode } from './nodes/FunctionNode'
+import { ChannelNode } from './nodes/ChannelNode'
+import { DecisionNode } from './nodes/DecisionNode'
+import { SleepNode } from './nodes/SleepNode'
+import { InlineNode } from './nodes/InlineNode'
+import { BranchNode } from './nodes/BranchNode'
+import { FanoutNode } from './nodes/FanoutNode'
+import { ReturnNode } from './nodes/ReturnNode'
+import { CancelNode } from './nodes/CancelNode'
+import { SwitchNode } from './nodes/SwitchNode'
+import { ArrayPredicateNode } from './nodes/ArrayPredicateNode'
+import { FilterNode } from './nodes/FilterNode'
+import { ParallelNode } from './nodes/ParallelNode'
+import { ChannelWiringNode } from './nodes/ChannelWiringNode'
+import { SetNode } from './nodes/SetNode'
+import { GenericNode } from './nodes/GenericNode'
+import { ElkEdge } from './edges/ElkEdge'
+import { createFlow } from '../../hooks/useWiringFlow'
+import { useElkLayout } from '../../hooks/useElkLayout'
+import 'reactflow/dist/style.css'
+
+const nodeTypes: NodeTypes = {
+  functionNode: FunctionNode,
+  wiringNode: WiringNode,
+  channelNode: ChannelNode,
+  decisionNode: DecisionNode,
+  sleepNode: SleepNode,
+  inlineNode: InlineNode,
+  genericNode: GenericNode,
+  branchNode: BranchNode,
+  fanoutNode: FanoutNode,
+  returnNode: ReturnNode,
+  cancelNode: CancelNode,
+  switchNode: SwitchNode,
+  arrayPredicateNode: ArrayPredicateNode,
+  filterNode: FilterNode,
+  parallelNode: ParallelNode,
+  channelWiringNode: ChannelWiringNode,
+  setNode: SetNode,
+}
+
+const edgeTypes: EdgeTypes = {
+  elk: ElkEdge,
+}
+
+/** Inner flow of WorkflowGraphView: createFlow → ELK layout → reactflow.
+ *  Must render inside a ReactFlowProvider (WorkflowGraphView supplies it). */
+export const WorkflowGraphFlow: React.FC<WorkflowGraphViewProps> = ({
+  workflow,
+  direction = 'RIGHT',
+  onPaneClick,
+}) => {
+  const { fitView } = useReactFlow()
+
+  const { nodes: flowNodes, edges: initialEdges } = useMemo(() => {
+    return createFlow(workflow)
+  }, [workflow])
+
+  const layoutResult = useElkLayout(flowNodes, initialEdges, direction)
+
+  const [nodes, setNodes] = useNodesState([])
+  const [edges, setEdges] = useEdgesState([])
+
+  useEffect(() => {
+    if (layoutResult.nodes.length > 0) {
+      setNodes(layoutResult.nodes)
+      setEdges(layoutResult.edges)
+      setTimeout(() => {
+        fitView({ padding: 0.2 })
+      }, 50)
+    }
+  }, [layoutResult, setNodes, setEdges, fitView])
+
+  return (
+    <Box style={{ width: '100%', height: '100%' }}>
+      <style>{`
+        .react-flow__handle { opacity: 0; pointer-events: none; }
+        @keyframes pulse-border { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+      `}</style>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        defaultEdgeOptions={{
+          style: {
+            stroke: '#c0c0c0',
+            strokeWidth: 1.5,
+            strokeDasharray: '6 4',
+          },
+          animated: true,
+          markerEnd: {
+            type: MarkerType.ArrowClosed,
+            color: '#c0c0c0',
+            width: 16,
+            height: 16,
+          },
+        }}
+        zoomOnScroll={true}
+        preventScrolling={false}
+        nodesConnectable={false}
+        nodesDraggable={true}
+        proOptions={{ hideAttribution: true }}
+        noDragClassName="nodrag"
+        onPaneClick={onPaneClick}
+      >
+        <Background color="#e0e0e0" variant={BackgroundVariant.Dots} size={1} />
+      </ReactFlow>
+    </Box>
+  )
+}

--- a/packages/console/src/components/project/WorkflowGraphFlow.tsx
+++ b/packages/console/src/components/project/WorkflowGraphFlow.tsx
@@ -111,6 +111,7 @@ export const WorkflowGraphFlow: React.FC<WorkflowGraphViewProps> = ({
         }}
         zoomOnScroll={true}
         preventScrolling={false}
+        minZoom={0.15}
         nodesConnectable={false}
         nodesDraggable={true}
         proOptions={{ hideAttribution: true }}

--- a/packages/console/src/components/project/WorkflowGraphView.tsx
+++ b/packages/console/src/components/project/WorkflowGraphView.tsx
@@ -1,64 +1,10 @@
-import React, { useMemo, useEffect } from 'react'
-import type { NodeTypes, EdgeTypes } from 'reactflow'
-import ReactFlow, {
-  useNodesState,
-  useEdgesState,
-  MarkerType,
-  Background,
-  BackgroundVariant,
-  useReactFlow,
-  ReactFlowProvider,
-} from 'reactflow'
-import { Box } from '@pikku/mantine/core'
+import React from 'react'
+import { ReactFlowProvider } from 'reactflow'
 import {
   FlowDirectionContext,
   type FlowDirection,
 } from '../../context/FlowDirectionContext'
-import { WiringNode } from './nodes/WiringNode'
-import { FunctionNode } from './nodes/FunctionNode'
-import { ChannelNode } from './nodes/ChannelNode'
-import { DecisionNode } from './nodes/DecisionNode'
-import { SleepNode } from './nodes/SleepNode'
-import { InlineNode } from './nodes/InlineNode'
-import { BranchNode } from './nodes/BranchNode'
-import { FanoutNode } from './nodes/FanoutNode'
-import { ReturnNode } from './nodes/ReturnNode'
-import { CancelNode } from './nodes/CancelNode'
-import { SwitchNode } from './nodes/SwitchNode'
-import { ArrayPredicateNode } from './nodes/ArrayPredicateNode'
-import { FilterNode } from './nodes/FilterNode'
-import { ParallelNode } from './nodes/ParallelNode'
-import { ChannelWiringNode } from './nodes/ChannelWiringNode'
-import { SetNode } from './nodes/SetNode'
-import { GenericNode } from './nodes/GenericNode'
-import { ElkEdge } from './edges/ElkEdge'
-import { createFlow } from '../../hooks/useWiringFlow'
-import { useElkLayout } from '../../hooks/useElkLayout'
-import 'reactflow/dist/style.css'
-
-const nodeTypes: NodeTypes = {
-  functionNode: FunctionNode,
-  wiringNode: WiringNode,
-  channelNode: ChannelNode,
-  decisionNode: DecisionNode,
-  sleepNode: SleepNode,
-  inlineNode: InlineNode,
-  genericNode: GenericNode,
-  branchNode: BranchNode,
-  fanoutNode: FanoutNode,
-  returnNode: ReturnNode,
-  cancelNode: CancelNode,
-  switchNode: SwitchNode,
-  arrayPredicateNode: ArrayPredicateNode,
-  filterNode: FilterNode,
-  parallelNode: ParallelNode,
-  channelWiringNode: ChannelWiringNode,
-  setNode: SetNode,
-}
-
-const edgeTypes: EdgeTypes = {
-  elk: ElkEdge,
-}
+import { WorkflowGraphFlow } from './WorkflowGraphFlow'
 
 export interface WorkflowGraphViewProps {
   workflow: any
@@ -66,71 +12,6 @@ export interface WorkflowGraphViewProps {
    *  use 'DOWN' when embedding in a narrow container like a side panel. */
   direction?: FlowDirection
   onPaneClick?: () => void
-}
-
-const WorkflowGraphFlow: React.FC<WorkflowGraphViewProps> = ({
-  workflow,
-  direction = 'RIGHT',
-  onPaneClick,
-}) => {
-  const { fitView } = useReactFlow()
-
-  const { nodes: flowNodes, edges: initialEdges } = useMemo(() => {
-    return createFlow(workflow)
-  }, [workflow])
-
-  const layoutResult = useElkLayout(flowNodes, initialEdges, direction)
-
-  const [nodes, setNodes] = useNodesState([])
-  const [edges, setEdges] = useEdgesState([])
-
-  useEffect(() => {
-    if (layoutResult.nodes.length > 0) {
-      setNodes(layoutResult.nodes)
-      setEdges(layoutResult.edges)
-      setTimeout(() => {
-        fitView({ padding: 0.2 })
-      }, 50)
-    }
-  }, [layoutResult, setNodes, setEdges, fitView])
-
-  return (
-    <Box style={{ width: '100%', height: '100%' }}>
-      <style>{`
-        .react-flow__handle { opacity: 0; pointer-events: none; }
-        @keyframes pulse-border { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
-      `}</style>
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
-        defaultEdgeOptions={{
-          style: {
-            stroke: '#c0c0c0',
-            strokeWidth: 1.5,
-            strokeDasharray: '6 4',
-          },
-          animated: true,
-          markerEnd: {
-            type: MarkerType.ArrowClosed,
-            color: '#c0c0c0',
-            width: 16,
-            height: 16,
-          },
-        }}
-        zoomOnScroll={true}
-        preventScrolling={false}
-        nodesConnectable={false}
-        nodesDraggable={true}
-        proOptions={{ hideAttribution: true }}
-        noDragClassName="nodrag"
-        onPaneClick={onPaneClick}
-      >
-        <Background color="#e0e0e0" variant={BackgroundVariant.Dots} size={1} />
-      </ReactFlow>
-    </Box>
-  )
 }
 
 /** Standalone workflow graph renderer: createFlow → ELK layout → reactflow,

--- a/packages/console/src/components/project/WorkflowGraphView.tsx
+++ b/packages/console/src/components/project/WorkflowGraphView.tsx
@@ -1,0 +1,148 @@
+import React, { useMemo, useEffect } from 'react'
+import type { NodeTypes, EdgeTypes } from 'reactflow'
+import ReactFlow, {
+  useNodesState,
+  useEdgesState,
+  MarkerType,
+  Background,
+  BackgroundVariant,
+  useReactFlow,
+  ReactFlowProvider,
+} from 'reactflow'
+import { Box } from '@pikku/mantine/core'
+import {
+  FlowDirectionContext,
+  type FlowDirection,
+} from '../../context/FlowDirectionContext'
+import { WiringNode } from './nodes/WiringNode'
+import { FunctionNode } from './nodes/FunctionNode'
+import { ChannelNode } from './nodes/ChannelNode'
+import { DecisionNode } from './nodes/DecisionNode'
+import { SleepNode } from './nodes/SleepNode'
+import { InlineNode } from './nodes/InlineNode'
+import { BranchNode } from './nodes/BranchNode'
+import { FanoutNode } from './nodes/FanoutNode'
+import { ReturnNode } from './nodes/ReturnNode'
+import { CancelNode } from './nodes/CancelNode'
+import { SwitchNode } from './nodes/SwitchNode'
+import { ArrayPredicateNode } from './nodes/ArrayPredicateNode'
+import { FilterNode } from './nodes/FilterNode'
+import { ParallelNode } from './nodes/ParallelNode'
+import { ChannelWiringNode } from './nodes/ChannelWiringNode'
+import { SetNode } from './nodes/SetNode'
+import { GenericNode } from './nodes/GenericNode'
+import { ElkEdge } from './edges/ElkEdge'
+import { createFlow } from '../../hooks/useWiringFlow'
+import { useElkLayout } from '../../hooks/useElkLayout'
+import 'reactflow/dist/style.css'
+
+const nodeTypes: NodeTypes = {
+  functionNode: FunctionNode,
+  wiringNode: WiringNode,
+  channelNode: ChannelNode,
+  decisionNode: DecisionNode,
+  sleepNode: SleepNode,
+  inlineNode: InlineNode,
+  genericNode: GenericNode,
+  branchNode: BranchNode,
+  fanoutNode: FanoutNode,
+  returnNode: ReturnNode,
+  cancelNode: CancelNode,
+  switchNode: SwitchNode,
+  arrayPredicateNode: ArrayPredicateNode,
+  filterNode: FilterNode,
+  parallelNode: ParallelNode,
+  channelWiringNode: ChannelWiringNode,
+  setNode: SetNode,
+}
+
+const edgeTypes: EdgeTypes = {
+  elk: ElkEdge,
+}
+
+export interface WorkflowGraphViewProps {
+  workflow: any
+  /** 'RIGHT' (default) lays the graph out left→right; 'DOWN' top→bottom —
+   *  use 'DOWN' when embedding in a narrow container like a side panel. */
+  direction?: FlowDirection
+  onPaneClick?: () => void
+}
+
+const WorkflowGraphFlow: React.FC<WorkflowGraphViewProps> = ({
+  workflow,
+  direction = 'RIGHT',
+  onPaneClick,
+}) => {
+  const { fitView } = useReactFlow()
+
+  const { nodes: flowNodes, edges: initialEdges } = useMemo(() => {
+    return createFlow(workflow)
+  }, [workflow])
+
+  const layoutResult = useElkLayout(flowNodes, initialEdges, direction)
+
+  const [nodes, setNodes] = useNodesState([])
+  const [edges, setEdges] = useEdgesState([])
+
+  useEffect(() => {
+    if (layoutResult.nodes.length > 0) {
+      setNodes(layoutResult.nodes)
+      setEdges(layoutResult.edges)
+      setTimeout(() => {
+        fitView({ padding: 0.2 })
+      }, 50)
+    }
+  }, [layoutResult, setNodes, setEdges, fitView])
+
+  return (
+    <Box style={{ width: '100%', height: '100%' }}>
+      <style>{`
+        .react-flow__handle { opacity: 0; pointer-events: none; }
+        @keyframes pulse-border { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+      `}</style>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        defaultEdgeOptions={{
+          style: {
+            stroke: '#c0c0c0',
+            strokeWidth: 1.5,
+            strokeDasharray: '6 4',
+          },
+          animated: true,
+          markerEnd: {
+            type: MarkerType.ArrowClosed,
+            color: '#c0c0c0',
+            width: 16,
+            height: 16,
+          },
+        }}
+        zoomOnScroll={true}
+        preventScrolling={false}
+        nodesConnectable={false}
+        nodesDraggable={true}
+        proOptions={{ hideAttribution: true }}
+        noDragClassName="nodrag"
+        onPaneClick={onPaneClick}
+      >
+        <Background color="#e0e0e0" variant={BackgroundVariant.Dots} size={1} />
+      </ReactFlow>
+    </Box>
+  )
+}
+
+/** Standalone workflow graph renderer: createFlow → ELK layout → reactflow,
+ *  with its own ReactFlowProvider so it can be embedded anywhere (full canvas
+ *  page, side panel, …). Interactivity (node click → panels) comes from the
+ *  surrounding Panel/Workflow contexts, which the host must provide. */
+export const WorkflowGraphView: React.FC<WorkflowGraphViewProps> = (props) => {
+  return (
+    <FlowDirectionContext.Provider value={props.direction ?? 'RIGHT'}>
+      <ReactFlowProvider>
+        <WorkflowGraphFlow {...props} />
+      </ReactFlowProvider>
+    </FlowDirectionContext.Provider>
+  )
+}

--- a/packages/console/src/components/project/nodes/BaseNode.tsx
+++ b/packages/console/src/components/project/nodes/BaseNode.tsx
@@ -4,6 +4,7 @@ import { asI18n } from '@pikku/react'
 import { Handle, Position } from 'reactflow'
 import { Lock, LockOpen, Shield, Layers } from 'lucide-react'
 import { PikkuBadge } from '../../ui/PikkuBadge'
+import { useFlowDirection } from '../../../context/FlowDirectionContext'
 
 interface OutputHandle {
   id: string
@@ -41,13 +42,14 @@ export const BaseNode: React.FC<BaseNodeProps> = ({
   inFlow = true,
 }) => {
   const theme = useMantineTheme()
+  const vertical = useFlowDirection() === 'DOWN'
 
   return (
     <Paper shadow="md" radius="md" w={width} pos="relative">
       {inFlow && hasInput && (
         <Handle
           type="target"
-          position={Position.Left}
+          position={vertical ? Position.Top : Position.Left}
           style={{ cursor: 'default' }}
         />
       )}
@@ -126,21 +128,29 @@ export const BaseNode: React.FC<BaseNodeProps> = ({
         (outputHandles && outputHandles.length > 0
           ? outputHandles.map((handle, index) => {
               const total = outputHandles.length
-              const minTop = 25
-              const maxTop = 75
-              const topPercent =
+              const minOffset = 25
+              const maxOffset = 75
+              const offsetPercent =
                 total === 1
                   ? 50
-                  : minTop + ((maxTop - minTop) / (total - 1)) * index
+                  : minOffset + ((maxOffset - minOffset) / (total - 1)) * index
 
               return (
                 <Box
                   key={handle.id}
                   pos="absolute"
-                  right={-12}
+                  {...(vertical ? { bottom: -12 } : { right: -12 })}
                   style={{
-                    top: `${topPercent}%`,
-                    transform: 'translateY(-50%)',
+                    ...(vertical
+                      ? {
+                          left: `${offsetPercent}%`,
+                          transform: 'translateX(-50%)',
+                          flexDirection: 'column' as const,
+                        }
+                      : {
+                          top: `${offsetPercent}%`,
+                          transform: 'translateY(-50%)',
+                        }),
                     display: 'flex',
                     alignItems: 'center',
                     gap: '8px',
@@ -151,7 +161,7 @@ export const BaseNode: React.FC<BaseNodeProps> = ({
                   </Text>
                   <Handle
                     type="source"
-                    position={Position.Right}
+                    position={vertical ? Position.Bottom : Position.Right}
                     id={handle.id}
                     style={{
                       position: 'relative',
@@ -166,7 +176,7 @@ export const BaseNode: React.FC<BaseNodeProps> = ({
           : hasOutput && (
               <Handle
                 type="source"
-                position={Position.Right}
+                position={vertical ? Position.Bottom : Position.Right}
                 style={{ cursor: 'default' }}
               />
             ))}

--- a/packages/console/src/components/project/nodes/FlowNode.tsx
+++ b/packages/console/src/components/project/nodes/FlowNode.tsx
@@ -3,6 +3,7 @@ import { Box, Paper, Text, Stack, useMantineTheme } from '@pikku/mantine/core'
 import { asI18n } from '@pikku/react'
 import { Handle, Position } from 'reactflow'
 import { useWorkflowRunContextSafe } from '../../../context/WorkflowRunContext'
+import { useFlowDirection } from '../../../context/FlowDirectionContext'
 
 interface OutputHandle {
   id: string
@@ -119,6 +120,7 @@ export const FlowNode: React.FC<FlowNodeProps> = ({
   nodeId,
 }) => {
   const theme = useMantineTheme()
+  const vertical = useFlowDirection() === 'DOWN'
   const highlightIconColor = getHighlightIconColor(highlightType, theme)
   const runContext = useWorkflowRunContextSafe()
 
@@ -168,7 +170,7 @@ export const FlowNode: React.FC<FlowNodeProps> = ({
         {hasInput && (
           <Handle
             type="target"
-            position={Position.Left}
+            position={vertical ? Position.Top : Position.Left}
             style={{ cursor: 'default' }}
           />
         )}
@@ -187,22 +189,24 @@ export const FlowNode: React.FC<FlowNodeProps> = ({
         {outputHandles.length > 0 &&
           outputHandles.map((handle, index) => {
             const total = outputHandles.length
-            const minTop = 25
-            const maxTop = 75
-            const topPercent =
+            const minOffset = 25
+            const maxOffset = 75
+            const offsetPercent =
               total === 1
                 ? 50
-                : minTop + ((maxTop - minTop) / (total - 1)) * index
+                : minOffset + ((maxOffset - minOffset) / (total - 1)) * index
             const showLabel = handle.label && total > 1
 
             return (
               <React.Fragment key={handle.id}>
                 <Handle
                   type="source"
-                  position={Position.Right}
+                  position={vertical ? Position.Bottom : Position.Right}
                   id={handle.id}
                   style={{
-                    top: `${topPercent}%`,
+                    ...(vertical
+                      ? { left: `${offsetPercent}%` }
+                      : { top: `${offsetPercent}%` }),
                     cursor: 'default',
                   }}
                 />
@@ -212,9 +216,17 @@ export const FlowNode: React.FC<FlowNodeProps> = ({
                     c="dimmed"
                     pos="absolute"
                     style={{
-                      right: -4,
-                      top: `${topPercent}%`,
-                      transform: 'translate(100%, -50%)',
+                      ...(vertical
+                        ? {
+                            bottom: -4,
+                            left: `${offsetPercent}%`,
+                            transform: 'translate(-50%, 100%)',
+                          }
+                        : {
+                            right: -4,
+                            top: `${offsetPercent}%`,
+                            transform: 'translate(100%, -50%)',
+                          }),
                       whiteSpace: 'nowrap',
                       backgroundColor: 'var(--mantine-color-body)',
                       padding: '2px 5px',
@@ -230,14 +242,27 @@ export const FlowNode: React.FC<FlowNodeProps> = ({
       </Paper>
       {(label || subtitle) && (
         <Box
-          style={{
-            position: 'absolute',
-            top: size + 12,
-            left: '50%',
-            transform: 'translateX(-50%)',
-            textAlign: 'center',
-            width: size * 2,
-          }}
+          style={
+            vertical
+              ? {
+                  // vertical flow: outgoing edges leave the bottom, so hang the
+                  // label beside the node instead of underneath it
+                  position: 'absolute',
+                  left: size + 12,
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  textAlign: 'left',
+                  width: size * 2,
+                }
+              : {
+                  position: 'absolute',
+                  top: size + 12,
+                  left: '50%',
+                  transform: 'translateX(-50%)',
+                  textAlign: 'center',
+                  width: size * 2,
+                }
+          }
         >
           {label && (
             <Text

--- a/packages/console/src/context/FlowDirectionContext.tsx
+++ b/packages/console/src/context/FlowDirectionContext.tsx
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react'
+
+/** Layout direction for a workflow/wiring graph: 'RIGHT' = left→right (default),
+ *  'DOWN' = top→bottom (used when embedding a graph in a narrow side panel).
+ *  Nodes read this to place their reactflow handles on the matching edges. */
+export type FlowDirection = 'RIGHT' | 'DOWN'
+
+export const FlowDirectionContext = createContext<FlowDirection>('RIGHT')
+
+export const useFlowDirection = (): FlowDirection =>
+  useContext(FlowDirectionContext)

--- a/packages/console/src/hooks/useElkLayout.ts
+++ b/packages/console/src/hooks/useElkLayout.ts
@@ -1,6 +1,7 @@
 import { useMemo, useEffect, useState } from 'react'
 import ELK from 'elkjs/lib/elk.bundled.js'
 import type { Node, Edge } from 'reactflow'
+import type { FlowDirection } from '../context/FlowDirectionContext'
 
 const elk = new ELK()
 
@@ -24,7 +25,11 @@ interface ElkLayoutResult {
   edges: Edge[]
 }
 
-export function useElkLayout(nodes: Node[], edges: Edge[]): ElkLayoutResult {
+export function useElkLayout(
+  nodes: Node[],
+  edges: Edge[],
+  direction: FlowDirection = 'RIGHT'
+): ElkLayoutResult {
   const [result, setResult] = useState<ElkLayoutResult>({
     nodes: [],
     edges: [],
@@ -44,7 +49,7 @@ export function useElkLayout(nodes: Node[], edges: Edge[]): ElkLayoutResult {
 
       const graph = {
         id: 'root',
-        layoutOptions: elkOptions,
+        layoutOptions: { ...elkOptions, 'elk.direction': direction },
         children: nodes.map((node) => {
           const nodeType = node.data?.nodeType
           let width = node.width || 200
@@ -162,7 +167,7 @@ export function useElkLayout(nodes: Node[], edges: Edge[]): ElkLayoutResult {
     }
 
     applyLayout()
-  }, [nodeIds, edgeIds])
+  }, [nodeIds, edgeIds, direction])
 
   return result.nodes.length > 0 ? result : { nodes, edges }
 }

--- a/packages/console/src/hooks/useElkLayout.ts
+++ b/packages/console/src/hooks/useElkLayout.ts
@@ -34,18 +34,19 @@ export function useElkLayout(
     nodes: [],
     edges: [],
   })
-  const [isLayouting, setIsLayouting] = useState(false)
 
   const nodeIds = useMemo(() => nodes.map((n) => n.id).join(','), [nodes])
   const edgeIds = useMemo(() => edges.map((e) => e.id).join(','), [edges])
 
   useEffect(() => {
+    // Cancellation flag (not state): a state guard would drop a dep change
+    // that lands mid-layout with no retry, sticking the old layout forever.
+    let cancelled = false
+
     const applyLayout = async () => {
-      if (nodes.length === 0 || isLayouting) {
+      if (nodes.length === 0) {
         return
       }
-
-      setIsLayouting(true)
 
       const graph = {
         id: 'root',
@@ -105,6 +106,7 @@ export function useElkLayout(
 
       try {
         const layout = await elk.layout(graph)
+        if (cancelled) return
 
         const minY = Math.min(...(layout.children?.map((n) => n.y || 0) || [0]))
         const yOffset = 75 - minY
@@ -160,13 +162,15 @@ export function useElkLayout(
 
         setResult({ nodes: newNodes, edges: newEdges })
       } catch {
-        setResult({ nodes, edges })
-      } finally {
-        setIsLayouting(false)
+        if (!cancelled) setResult({ nodes, edges })
       }
     }
 
     applyLayout()
+
+    return () => {
+      cancelled = true
+    }
   }, [nodeIds, edgeIds, direction])
 
   return result.nodes.length > 0 ? result : { nodes, edges }

--- a/packages/console/src/hooks/useElkLayout.ts
+++ b/packages/console/src/hooks/useElkLayout.ts
@@ -48,9 +48,20 @@ export function useElkLayout(
         return
       }
 
+      // DOWN (side-panel) layouts: tighter layers to keep flows compact, wider
+      // in-layer gaps so the labels hung beside nodes clear their siblings.
+      const directionOptions =
+        direction === 'DOWN'
+          ? {
+              'elk.direction': direction,
+              'elk.spacing.nodeNode': '150',
+              'elk.layered.spacing.nodeNodeBetweenLayers': '70',
+            }
+          : { 'elk.direction': direction }
+
       const graph = {
         id: 'root',
-        layoutOptions: { ...elkOptions, 'elk.direction': direction },
+        layoutOptions: { ...elkOptions, ...directionOptions },
         children: nodes.map((node) => {
           const nodeType = node.data?.nodeType
           let width = node.width || 200

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -180,3 +180,9 @@ export { PanelContainer } from './components/panel/PanelContainer'
 // Needed by an embedder that opens the workflow panel outside a workflow page:
 // the workflow panels read their graph from this context (feed it meta.workflows[id]).
 export { WorkflowProvider } from './context/WorkflowContext'
+// Embeddable flow renderers: the reactflow+ELK workflow graph (direction-aware,
+// 'DOWN' for narrow side panels) and the scenario persona timeline.
+export { WorkflowGraphView } from './components/project/WorkflowGraphView'
+export type { WorkflowGraphViewProps } from './components/project/WorkflowGraphView'
+export { PersonaTimeline } from './components/flows/timeline/PersonaTimeline'
+export type { FlowDirection } from './context/FlowDirectionContext'

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -180,8 +180,6 @@ export { PanelContainer } from './components/panel/PanelContainer'
 // Needed by an embedder that opens the workflow panel outside a workflow page:
 // the workflow panels read their graph from this context (feed it meta.workflows[id]).
 export { WorkflowProvider } from './context/WorkflowContext'
-// Embeddable flow renderers: the reactflow+ELK workflow graph (direction-aware,
-// 'DOWN' for narrow side panels) and the scenario persona timeline.
 export { WorkflowGraphView } from './components/project/WorkflowGraphView'
 export type { WorkflowGraphViewProps } from './components/project/WorkflowGraphView'
 export { PersonaTimeline } from './components/flows/timeline/PersonaTimeline'


### PR DESCRIPTION
## Summary

The workflow detail side panel previously showed configuration plus a flat Nodes table. When the panel is the only view of the workflow (e.g. Fabric's Weave screen docks this panel beside its woven field with no canvas), that's a poor rendering of the flow. This PR makes the panel draw the flow itself:

- **Workflows** → the reactflow+ELK graph laid out **top→down** (panels are ~450px wide, so vertical is the readable orientation)
- **Scenarios** → the existing `PersonaTimeline` scenario renderer
- Falls back to the old Nodes table when the workflow has no graph nodes
- **Suppressed inside `ThreePaneLayout`** (`workflowGraph={false}`), where the full canvas already renders the same graph center-stage — the workflow page inspector is unchanged

## Implementation

- `useElkLayout(nodes, edges, direction)` — ELK direction is now a parameter (`'RIGHT'` default, `'DOWN'` for vertical)
- New `FlowDirectionContext`; `FlowNode`/`BaseNode` (the two shared handle-owning bases) flip their reactflow handles Top/Bottom and reposition branch labels when vertical
- `WorkflowGraphView` — embeddable graph renderer extracted verbatim from `WorkflowCanvasFlow`/`WorkflowCanvasInner`; `WorkflowCanvas` now delegates to it (net dedup)
- `PanelContainer` gains a `workflowGraph` prop (default `true`) threaded through `createPanelChildren` to the workflow panel
- New exports: `WorkflowGraphView`, `PersonaTimeline`, `FlowDirection`

For pikkufabric/fabric#307.

## Testing

- `tsc --noEmit` in `packages/console`: no errors in any touched file (remaining errors are pre-existing, from ungenerated paraglide/`.gen`/unbuilt workspace deps)
- Visual validation planned via Fabric Weave once released and bumped there

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow side panels now render workflows vertically (top-to-down) instead of a flat nodes table, and scenario workflows show a persona timeline.
  * Added direction-aware workflow layout, plus embeddable `WorkflowGraphView` and `PersonaTimeline` components.
* **Improvements**
  * The workflow canvas now uses the new graph visualization for non-scenario workflows.
  * Workflow node handles/labels automatically adapt to vertical vs horizontal flow direction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->