### PR TITLE
fix(cli): warn instead of silently ignoring unknown long options

### DIFF
--- a/.changeset/cli-warn-unknown-long-option.md
+++ b/.changeset/cli-warn-unknown-long-option.md
@@ -1,0 +1,12 @@
+---
+'@pikku/core': patch
+---
+
+warn instead of silently ignoring unknown long CLI options
+
+An unknown long option (`--sektion functions` or `--sektion=functions`) was parsed
+into the options object and then silently dropped by the command's input schema —
+the command ran with the real option at its default and produced plausible-but-wrong
+output. Unknown long options are still accepted (forward compatibility is preserved),
+but the parser now records a warning that the runner prints to stderr, e.g.
+`Warning: Unknown option: --sektion (ignored) Did you mean --section?`.

--- a/packages/core/src/wirings/cli/cli-runner.ts
+++ b/packages/core/src/wirings/cli/cli-runner.ts
@@ -490,6 +490,10 @@ export async function executeCLI({
       return
     }
 
+    // Non-fatal diagnostics (unknown options are still accepted) go to stderr
+    // so they never pollute a command's machine-readable stdout.
+    parsed.warnings.forEach((warning) => console.error(`Warning: ${warning}`))
+
     if (parsed.errors.length > 0) {
       // Check if any error is about an unknown command
       const hasUnknownCommand = parsed.errors.some(

--- a/packages/core/src/wirings/cli/command-parser.test.ts
+++ b/packages/core/src/wirings/cli/command-parser.test.ts
@@ -270,6 +270,7 @@ describe('Command Parser', () => {
       // Unknown options are allowed (for forward compatibility)
       // They just won't have defaults or validation
       assert.strictEqual(result.options.unknown, true)
+      assert.strictEqual(result.errors.length, 0)
     })
 
     test('should report error for unknown short flag', () => {
@@ -523,6 +524,135 @@ describe('Command Parser', () => {
         result.errors.some((e) => e.includes('--token')),
         'expected a missing --token error'
       )
+    })
+  })
+
+  describe('unknown long options', () => {
+    const listMeta: CLIMeta = {
+      programs: {
+        'test-cli': {
+          program: 'test-cli',
+          options: {},
+          commands: {
+            list: {
+              pikkuFuncId: 'listFunc',
+              positionals: [],
+              options: {
+                section: { description: 'Section to list', default: 'all' },
+                autoApply: {
+                  description: 'Apply automatically',
+                  default: false,
+                },
+              },
+            },
+          },
+        },
+      },
+      renderers: {},
+    }
+
+    test('warns (but does not error) on an unknown --opt value option', () => {
+      const result = parseCLIArguments(
+        ['list', '--sektion', 'functions'],
+        'test-cli',
+        listMeta
+      )
+
+      assert.strictEqual(result.errors.length, 0, 'should stay non-fatal')
+      assert.strictEqual(result.warnings.length, 1)
+      assert.ok(
+        result.warnings[0].startsWith('Unknown option: --sektion (ignored)'),
+        `unexpected warning: ${result.warnings[0]}`
+      )
+      // Forward compatibility: the value is still parsed through
+      assert.strictEqual(result.options.sektion, 'functions')
+      // ...and the real option keeps its default
+      assert.strictEqual(result.options.section, 'all')
+    })
+
+    test('warns on an unknown --opt=value option', () => {
+      const result = parseCLIArguments(
+        ['list', '--sektion=functions'],
+        'test-cli',
+        listMeta
+      )
+
+      assert.strictEqual(result.errors.length, 0)
+      assert.strictEqual(result.warnings.length, 1)
+      assert.ok(
+        result.warnings[0].startsWith('Unknown option: --sektion (ignored)'),
+        `unexpected warning: ${result.warnings[0]}`
+      )
+      assert.strictEqual(result.options.sektion, 'functions')
+    })
+
+    test('suggests a near-miss option name', () => {
+      const result = parseCLIArguments(
+        ['list', '--sektion'],
+        'test-cli',
+        listMeta
+      )
+
+      assert.ok(
+        result.warnings[0].includes('Did you mean --section?'),
+        `expected a suggestion, got: ${result.warnings[0]}`
+      )
+    })
+
+    test('suggests the kebab-case rendering of a camelCase option', () => {
+      const result = parseCLIArguments(
+        ['list', '--auto-aply'],
+        'test-cli',
+        listMeta
+      )
+
+      assert.ok(
+        result.warnings[0].includes('Did you mean --auto-apply?'),
+        `expected a suggestion, got: ${result.warnings[0]}`
+      )
+    })
+
+    test('omits the suggestion when nothing is close', () => {
+      const result = parseCLIArguments(
+        ['list', '--completely-different'],
+        'test-cli',
+        listMeta
+      )
+
+      assert.strictEqual(
+        result.warnings[0],
+        'Unknown option: --completely-different (ignored)'
+      )
+    })
+
+    test('does not warn for a known option (either casing)', () => {
+      const kebab = parseCLIArguments(
+        ['list', '--section', 'functions', '--auto-apply'],
+        'test-cli',
+        listMeta
+      )
+      assert.deepStrictEqual(kebab.warnings, [])
+      assert.strictEqual(kebab.options.section, 'functions')
+
+      const camel = parseCLIArguments(
+        ['list', '--autoApply'],
+        'test-cli',
+        listMeta
+      )
+      assert.deepStrictEqual(camel.warnings, [])
+    })
+
+    test('does not warn for --help', () => {
+      const result = parseCLIArguments(['list', '--help'], 'test-cli', listMeta)
+
+      assert.deepStrictEqual(result.warnings, [])
+    })
+
+    test('unknown short flags still error, not warn', () => {
+      const result = parseCLIArguments(['list', '-x'], 'test-cli', listMeta)
+
+      assert.ok(result.errors.some((e) => e.includes('Unknown option: -x')))
+      assert.deepStrictEqual(result.warnings, [])
     })
   })
 })

--- a/packages/core/src/wirings/cli/command-parser.ts
+++ b/packages/core/src/wirings/cli/command-parser.ts
@@ -18,6 +18,71 @@ function toKebabCase(str: string): string {
   return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
 }
 
+/** Options the runner handles itself — never reported as unknown. */
+const RESERVED_OPTIONS = new Set(['help'])
+
+/** Levenshtein distance, capped-free and dependency-free. Used only to suggest
+ *  a near-miss option name, so the naive O(n*m) implementation is fine. */
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0
+  if (a.length === 0) return b.length
+  if (b.length === 0) return a.length
+
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i)
+  for (let i = 1; i <= a.length; i++) {
+    const row = [i]
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      row[j] = Math.min(row[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost)
+    }
+    prev = row
+  }
+  return prev[b.length]
+}
+
+/** Finds the closest declared option (distance <= 2) to what the user typed.
+ *  Compares against the kebab-case rendering, since that is what is typed. */
+function suggestOption(
+  typed: string,
+  availableOptions: Record<string, CLIOption>
+): string | null {
+  let best: string | null = null
+  let bestDistance = 3
+
+  for (const name of Object.keys(availableOptions)) {
+    const kebab = toKebabCase(name)
+    const distance = Math.min(
+      levenshtein(typed, kebab),
+      levenshtein(typed, name)
+    )
+    if (distance < bestDistance) {
+      bestDistance = distance
+      best = kebab
+    }
+  }
+
+  return best
+}
+
+/** Records a warning that an unknown long option was accepted but ignored.
+ *  Unknown options stay non-fatal for forward compatibility (a newer command
+ *  version may understand them) — they are just no longer silent. */
+function warnUnknownOption(
+  typed: string,
+  availableOptions: Record<string, CLIOption>,
+  result: ParsedCommand
+) {
+  if (RESERVED_OPTIONS.has(toCamelCase(typed))) {
+    return
+  }
+
+  const suggestion = suggestOption(typed, availableOptions)
+  result.warnings.push(
+    `Unknown option: --${typed} (ignored)` +
+      (suggestion ? ` Did you mean --${suggestion}?` : '')
+  )
+}
+
 /**
  * Result of parsing CLI arguments
  */
@@ -27,6 +92,8 @@ export interface ParsedCommand {
   positionals: Record<string, any>
   options: Record<string, any>
   errors: string[]
+  /** Non-fatal diagnostics (e.g. unknown options that were accepted+ignored) */
+  warnings: string[]
 }
 
 /**
@@ -43,6 +110,7 @@ export function parseCLIArguments(
     positionals: {},
     options: {},
     errors: [],
+    warnings: [],
   }
 
   const meta = allMeta.programs[programName]
@@ -148,7 +216,12 @@ export function parseCLIArguments(
         const key = toCamelCase(arg.slice(2, equalIndex))
         const optionDef = availableOptions[key]
 
-        // Unknown options are allowed for forward compatibility
+        // Unknown options are allowed for forward compatibility, but warned
+        // about so they are not silently dropped by the input schema.
+        if (!optionDef) {
+          warnUnknownOption(arg.slice(2, equalIndex), availableOptions, result)
+        }
+
         const value = arg.slice(equalIndex + 1)
         optionArgs[key] = parseOptionValue(value, optionDef)
       } else {
@@ -156,7 +229,12 @@ export function parseCLIArguments(
         const key = toCamelCase(arg.slice(2))
         const optionDef = availableOptions[key]
 
-        // Unknown options are allowed for forward compatibility
+        // Unknown options are allowed for forward compatibility, but warned
+        // about so they are not silently dropped by the input schema.
+        if (!optionDef) {
+          warnUnknownOption(arg.slice(2), availableOptions, result)
+        }
+
         if (optionDef && optionDef.array) {
           // Array option - collect all following non-flag values
           currentIndex++


### PR DESCRIPTION
Fixes half of #999 (the unknown-**option** half; the "did you mean" suggestion for unknown **commands** is intentionally left out of this PR).

## The bug

In `parseCLIArguments` (`packages/core/src/wirings/cli/command-parser.ts`), both long-option branches carried the comment `// Unknown options are allowed for forward compatibility` and did nothing else. So an unknown long option — in either `--opt value` or `--opt=value` form — was parsed into the options object and then silently dropped by the command's input schema.

The practical failure mode: a typo'd option means the command runs with the *real* option at its default and returns plausible-but-wrong output. No error, no warning, nothing to tell the user their flag did nothing.

Unknown **short** flags already pushed `Unknown option: -x` into `errors`, so the two paths were inconsistent.

### Before

```
$ my-cli list --sektion functions
(runs with section='all', prints the wrong thing, exit 0)
```

### After

```
$ my-cli list --sektion functions
Warning: Unknown option: --sektion (ignored) Did you mean --section?
(still runs — exit code unchanged)
```

## What changed

- `ParsedCommand` gains a `warnings: string[]` field for non-fatal diagnostics.
- Both long-option branches record `Unknown option: --<name> (ignored)` when the option isn't declared.
- A small dependency-free Levenshtein (~20 lines, local to the file) appends `Did you mean --section?` when a declared option is within distance 2. The comparison is done against the **kebab-case** rendering (what the user actually types) as well as the raw camelCase key, since option keys are camelCased via `toCamelCase`.
- `cli-runner.ts` prints `parsed.warnings` to **stderr** (`console.error`) before the error handling, so warnings never pollute a command's machine-readable stdout.
- `--help` is excluded from the warning (the runner handles it itself, and it is not a declared option).

## Forward compatibility is preserved

This is deliberately **not** a hard error. Unknown long options are still accepted and still parsed through into `options` exactly as before, so a caller passing an option that a newer version of the command understands keeps working. The only change is that the situation is no longer silent — it emits a warning on stderr and leaves the exit code alone.

## Short flags

Short-flag behaviour is unchanged: `-x` still produces an `Unknown option: -x` **error**. Nothing in the surrounding code indicated the maintainers wanted that relaxed to a warning, so it was left alone; only the message *style* is now consistent between the two (`Unknown option: <flag>`). Happy to make them symmetric in either direction if you'd prefer.

## Tests

Added a `describe('unknown long options')` block to `command-parser.test.ts`, matching the existing `node:test` + `assert` style, covering:

- `--opt value` form warns, does not error, and the value still parses through while the real option keeps its default
- `--opt=value` form warns
- the suggestion path (`--sektion` → `--section`)
- the kebab-case suggestion for a camelCase option key (`--auto-aply` → `--auto-apply`)
- no suggestion when nothing is close
- a **known** option (kebab or camel) produces **no** warning
- `--help` produces no warning
- unknown short flags still error rather than warn

### Verification

- `npx tsc --noEmit` in `packages/core` — clean (exit 0)
- `bash run-tests.sh` in `packages/core` (full package suite) — 1289 pass, 0 fail, 10 skipped
- `node --import tsx --test src/wirings/cli/command-parser.test.ts` — 48 pass, 0 fail
- `npx prettier --write` on the touched files

Changeset included, `patch` for `@pikku/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)