### PR TITLE
fix(inspector): report an unresolvable schema type as a resolution failure

### DIFF
--- a/.changeset/schema-vendor-unresolved.md
+++ b/.changeset/schema-vendor-unresolved.md
@@ -1,0 +1,13 @@
+---
+'@pikku/inspector': patch
+---
+
+Distinguish an unresolvable schema type from an unsupported schema library.
+
+Both failures shared one message, so a plain `z.object({...})` whose type TypeScript
+could not resolve — a file outside tsconfig `include`, or a generated file such as
+`.pikku/db/zod.gen.ts` that had not been written yet — was reported as
+"Ensure your schema is imported from a supported validation library". The schema is
+dropped either way (`inputSchemaName: null`, no generated schema file), so the message
+is the only signal that a function has silently lost its input contract, and that
+advice is unactionable when the schema already is zod.

--- a/packages/inspector/src/utils/detect-schema-vendor.test.ts
+++ b/packages/inspector/src/utils/detect-schema-vendor.test.ts
@@ -1,0 +1,123 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import * as ts from 'typescript'
+
+import { detectSchemaVendorOrError } from './detect-schema-vendor.js'
+
+let projectDir: string
+let program: ts.Program
+let checker: ts.TypeChecker
+let sourceFile: ts.SourceFile
+
+const criticals: string[] = []
+const logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+  critical(_code: unknown, message: string) {
+    criticals.push(message)
+  },
+} as any
+
+const initializerIdentifier = (name: string): ts.Identifier => {
+  let found: ts.Identifier | undefined
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name &&
+      node.initializer &&
+      ts.isIdentifier(node.initializer)
+    ) {
+      found = node.initializer
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  assert.ok(found, `no identifier initializer found for '${name}'`)
+  return found
+}
+
+before(() => {
+  projectDir = mkdtempSync(join(tmpdir(), 'pikku-schema-vendor-'))
+  mkdirSync(join(projectDir, 'src'))
+  writeFileSync(
+    join(projectDir, 'src', 'schemas.ts'),
+    [
+      // Imported from a file that does not exist — exactly what a schema built
+      // from an ungenerated '.pikku/db/zod.gen.ts' looks like to the checker.
+      `import { UngeneratedSchema } from './not-written-yet.js'`,
+      `export const unresolved = UngeneratedSchema`,
+      `const plainObject = { a: 1 }`,
+      `export const resolvedButNotASchema = plainObject`,
+      '',
+    ].join('\n')
+  )
+
+  program = ts.createProgram([join(projectDir, 'src', 'schemas.ts')], {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+  })
+  checker = program.getTypeChecker()
+  sourceFile = program.getSourceFile(join(projectDir, 'src', 'schemas.ts'))!
+})
+
+after(() => {
+  rmSync(projectDir, { recursive: true, force: true })
+})
+
+describe('detectSchemaVendorOrError', () => {
+  test('reports a type the checker could not resolve as a resolution failure', () => {
+    criticals.length = 0
+
+    const vendor = detectSchemaVendorOrError(
+      initializerIdentifier('unresolved'),
+      checker,
+      logger,
+      `Function 'createTodo' input`,
+      'src/schemas.ts'
+    )
+
+    assert.equal(vendor, undefined)
+    assert.equal(criticals.length, 1)
+    const [message] = criticals
+    assert.match(message, /could not be TYPED/)
+    assert.match(message, /UngeneratedSchema/)
+    assert.match(message, /pikku db generate/)
+    // The unactionable advice must NOT be given for a type that simply failed
+    // to resolve — the schema may well already be zod.
+    assert.doesNotMatch(
+      message,
+      /Ensure your schema is imported from a supported validation library/
+    )
+  })
+
+  test('still reports a resolvable non-vendor type as an unsupported library', () => {
+    criticals.length = 0
+
+    const vendor = detectSchemaVendorOrError(
+      initializerIdentifier('resolvedButNotASchema'),
+      checker,
+      logger,
+      `Function 'createTodo' input`,
+      'src/schemas.ts'
+    )
+
+    assert.equal(vendor, undefined)
+    assert.equal(criticals.length, 1)
+    const [message] = criticals
+    assert.match(
+      message,
+      /Ensure your schema is imported from a supported validation library/
+    )
+    assert.doesNotMatch(message, /could not be TYPED/)
+  })
+})

--- a/packages/inspector/src/utils/detect-schema-vendor.ts
+++ b/packages/inspector/src/utils/detect-schema-vendor.ts
@@ -1,6 +1,19 @@
-import type * as ts from 'typescript'
+import * as ts from 'typescript'
 import type { SchemaVendor, InspectorLogger } from '../types.js'
 import { ErrorCode } from '../error-codes.js'
+
+/**
+ * Whether the checker could type the identifier at all.
+ *
+ * `any` here is not a schema written in an exotic library — it is TypeScript telling us
+ * it could not resolve the declaration, which happens when the schema comes from a file
+ * outside the program (not matched by tsconfig `include`) or from a generated file that
+ * has not been written yet (`.pikku/db/zod.gen.ts` before `pikku db generate` runs).
+ * The distinction matters because the two have opposite fixes, and conflating them told
+ * users to "import from a supported validation library" about a plain `z.object`.
+ */
+const isUnresolved = (type: ts.Type): boolean =>
+  (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0
 
 /**
  * Detect the schema vendor by tracing the type back to its library origin.
@@ -78,6 +91,23 @@ export const detectSchemaVendorOrError = (
 ): Exclude<SchemaVendor, 'unknown'> | undefined => {
   const vendor = detectSchemaVendor(identifier, checker)
   if (vendor === 'unknown') {
+    // Two different failures used to share one message. Reporting the wrong one is not a
+    // cosmetic problem: the schema is dropped either way (`inputSchemaName: null`, no
+    // generated schema file), so the message is the only thing standing between the user
+    // and a function that silently validates nothing — and "use a supported validation
+    // library" is unactionable when the schema already IS `z.object({...})`.
+    if (isUnresolved(checker.getTypeAtLocation(identifier))) {
+      logger.critical(
+        ErrorCode.INLINE_SCHEMA,
+        `${context} schema '${identifier.text}' could not be TYPED from '${sourceFile}' — ` +
+          `TypeScript resolved it to 'any', so its vendor cannot be traced. This is a ` +
+          `resolution problem, not a schema problem: the file it is imported from is either ` +
+          `outside your tsconfig 'include', or has not been generated yet (a schema built ` +
+          `from '.pikku/db/zod.gen.ts' needs 'pikku db generate' to have run first). ` +
+          `Fix the import so the type resolves, then re-run.`
+      )
+      return undefined
+    }
     logger.critical(
       ErrorCode.INLINE_SCHEMA,
       `${context} schema vendor could not be determined from '${sourceFile}'. ` +


### PR DESCRIPTION
## What

`detectSchemaVendorOrError` reported every `unknown` vendor with the same message:

> Supported vendors: zod, valibot, arktype, @effect/schema. Ensure your schema is imported from a supported validation library.

That message is wrong — and unactionable — for the most common way to hit it: the schema **is** a `z.object({...})`, but TypeScript resolved the identifier to `any`, so the vendor cannot be traced. That happens when the schema is imported from a file the program cannot type:

- a file outside the project's tsconfig `include`, or
- a generated file that has not been written yet — e.g. an input built from `.pikku/db/zod.gen.ts` before `pikku db generate` has run.

Both failures drop the schema silently (`inputSchemaName: null`, `inputs: []`, no `<Name>.schema.json`), so the function ends up validating nothing and the diagnostic is the only signal the user gets.

## Repro

In a project whose input schema derives from the generated db zod:

```ts
import { UserInsertZ } from '#pikku/db/zod.gen.js'
export const CreateUserInput = UserInsertZ.pick({ name: true, email: true })
```

With `.pikku/db/zod.gen.ts` absent, codegen fails with PKU489 blaming the validation library. Verified against `starter-template`; with this change the same run reports the resolution failure and names the identifier.

## Change

Split the branch: when `checker.getTypeAtLocation(identifier)` is `any`/`unknown`, say so and point at the two resolution causes. The unsupported-library message is unchanged for the case it actually describes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema error messages to distinguish unresolved schemas from unsupported validation libraries.
  * Clarified when an input schema may be dropped because its type cannot be resolved.
  * Added guidance for resolving issues involving TypeScript configuration or generated schema files.

* **Documentation**
  * Updated release guidance to explain the impact of missing input contracts and recommended troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->