### PR TITLE
feat(cli): add the pikku-fabric-debug skill

### DIFF
--- a/.changeset/olive-moons-wander.md
+++ b/.changeset/olive-moons-wander.md
@@ -1,0 +1,20 @@
+---
+'@pikku/cli': patch
+---
+
+Add the pikku-fabric-debug skill
+
+`pikku-fabric` covers project layout, database, deploy provider and config, and
+stops at deploy. Nothing covered debugging a stage that is already live, so an
+agent facing a broken deployment had no supported path and would reach for
+whatever it could improvise.
+
+The new skill documents the actual loop over the existing commands —
+`errors` (filtered, carries the traceId) → `trace <traceId>` (the whole request
+across the stage, in order, with per-event durations) → `metrics` (is this one
+request or the whole stage) → `logs` → `status` (is the running gitSha the one
+you think it is).
+
+It also records two behaviours that read as app bugs but are not:
+`pikku fabric logs` accepts `--since` and `--deployment` and ignores both, and
+`--follow` is a 2-second client-side poll rather than a server stream.

--- a/packages/cli/skills/pikku-fabric-debug/SKILL.md
+++ b/packages/cli/skills/pikku-fabric-debug/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: pikku-fabric-debug
+description: 'Debug a deployed Fabric stage from the CLI — read logs, find recent errors, follow a single request end-to-end by traceId, and check request/error/latency metrics. TRIGGER when: a deployed Fabric app is erroring, timing out, or behaving differently than local; the user asks "why is prod failing", "check the logs", "what happened to this request"; or a deploy succeeded but the app misbehaves. DO NOT TRIGGER when: the failure reproduces locally (debug it locally), the deploy itself failed (use pikku-fabric — that is a build/config problem, not a runtime one), or the project is not deployed to Fabric.'
+installGroups: [fabric]
+---
+
+# Debugging a deployed Fabric stage
+
+## Agent Operating Procedure
+
+Use this skill as an execution checklist, not reference material.
+
+1. Reproduce locally first. If it fails locally too, debug it there — the
+   deployed stage adds cost and latency to every iteration.
+2. Start from `errors`, not `logs`. Errors are already filtered and carry the
+   traceId that unlocks the rest.
+3. Follow one trace end-to-end before forming a theory. A single failing request
+   tells you more than a hundred unrelated log lines.
+4. Fix the source cause and redeploy. Never leave the diagnosis at "it is flaky".
+5. Confirm the fix against the same stage — recheck `errors` for the function.
+
+Every command below requires a logged-in CLI and a linked project. Both fail
+with the exact remediation if not:
+
+```
+Not logged in. Run `pikku fabric login` first.
+No fabric project linked. Run `pikku fabric link` first.
+```
+
+## The loop
+
+**1 — What is broken?**
+
+```bash
+pikku fabric errors -b main                 # branch defaults to main
+pikku fabric errors -b main --function createOrder
+```
+
+Prints a `WHEN | FUNCTION | TRACE | MESSAGE` table. The message is **truncated
+to 100 characters** — treat it as a label, not the full error. The TRACE column
+is the input to the next step.
+
+**2 — What happened in that one request?**
+
+```bash
+pikku fabric trace <traceId> -b main
+pikku fabric trace <traceId> -b main --json
+```
+
+`--branch` is **required** here (no default). Each event prints as:
+
+```
+<timestamp> <scriptName> <wireType>:<wireId> <duration>ms — <error|message|outcome>
+```
+
+This is the whole request across the stage — every unit it touched, in order,
+with per-event durations. The last event before the failure is where to look.
+
+**3 — Is it one request or the whole stage?**
+
+```bash
+pikku fabric metrics -b main                       # last 24h
+pikku fabric metrics -b main --hours 2 --function createOrder
+```
+
+Rows are `reqs= err= (rate%) avg= min= max=` per bucket. A single bad request
+with a healthy error rate is a data problem; a climbing error rate is a
+deployment or dependency problem. `--json` additionally returns a `wireTypes`
+breakdown (requests per http/queue/scheduler/…) that the table output omits.
+
+**4 — Wider context around the failure**
+
+```bash
+pikku fabric logs -b main
+pikku fabric logs -b main --level warn
+pikku fabric logs -b main -f              # follow
+```
+
+`--branch` is **required** — `logs` throws `Specify --branch <branch-name>.`
+without it, even though the flag reads as optional.
+
+**5 — Is the running code the code you think it is?**
+
+```bash
+pikku fabric status     # active + in-flight deployment, per stage, with gitSha
+```
+
+Check this *before* deep-diving. A stage still serving an older `gitSha`, or a
+deploy stuck in flight, explains a whole class of "my fix did nothing".
+
+## Known gaps — do not misread these as bugs in your app
+
+- **`pikku fabric logs --since` and `--deployment` are accepted and ignored.**
+  They are declared as options but the command never reads them, so
+  `--since 15m` silently returns the same default window as no flag at all. Do
+  not conclude "nothing happened in the last 15 minutes" from it. Narrow by
+  `--level`, or by `--function` via `errors`, instead.
+- **`--follow` is a 2-second client-side poll, not a server stream.** It
+  dedups against what it already printed, so it behaves like `tail -f`, but new
+  entries can appear up to ~2s late and it holds the process open until killed.
+
+## What NOT to do
+
+- **Do not SSH anywhere or query the telemetry backend directly.** These
+  commands are the supported surface; anything lower-level is Fabric-internal
+  and will not exist for your project.
+- **Do not debug by redeploying with added `console.log`s.** Get the traceId,
+  read the trace. A deploy cycle per hypothesis is the slow path.
+- **Do not read the truncated `errors` message as the full error.** Always
+  confirm against `trace` before changing code.
+- **Do not treat an empty `errors` table as "the app is fine"** — a request that
+  returns a wrong 200 logs nothing. Check `metrics` for the outcome mix.

--- a/packages/cli/src/functions/commands/skills.test.ts
+++ b/packages/cli/src/functions/commands/skills.test.ts
@@ -27,6 +27,7 @@ const KNOWN_INSTALL_GROUPS = new Set(['core', 'fabric'])
 const FABRIC_SKILLS = [
   'pikku-deploy-cloudflare',
   'pikku-fabric',
+  'pikku-fabric-debug',
   'pikku-schema-cfworker',
   'pikku-product-second-opinion',
   'pikku-software-archaeology',


### PR DESCRIPTION
## Why

`pikku-fabric` covers project layout, database, deploy provider and config — and stops at deploy. Nothing in the corpus covered debugging a stage that is **already live**, so an agent facing a broken deployment had no supported path and would improvise (or reach for internal tooling that does not exist for a user's project).

The commands already exist. This documents the loop over them.

## The loop

`errors` (already filtered, carries the traceId) → `trace <traceId>` (the whole request across the stage, in order, with per-event durations) → `metrics` (is this one request or the whole stage) → `logs` (wider context) → `status` (is the running `gitSha` the one you think it is).

Written from the command implementations, so the sharp edges are documented rather than inferred from the flag list:

- `errors` truncates the message to 100 chars — it is a label, not the full error.
- `trace` and `logs` **require** `--branch`; `errors` defaults to `main`.
- `metrics --json` returns a `wireTypes` breakdown the table output omits.

## Two behaviours that read as app bugs but are not

Both are documented in a "Known gaps" section so an agent does not misdiagnose:

- **`pikku fabric logs --since` and `--deployment` are accepted and silently ignored.** They are declared in `FabricLogsInput` but the func destructures only `{ branch, level, json, follow }`, so `--since 15m` returns the same default window as no flag. Concluding "nothing happened in the last 15 minutes" from it would be wrong.
- **`--follow` is a 2-second client-side poll with dedup, not a server stream** — despite the CLI option describing it as SSE. The implementation notes server-side SSE as a planned upgrade.

Worth fixing separately; I documented rather than changed behaviour here.

## Testing

`skills.test.ts` — 19/19 pass. `FABRIC_SKILLS` updated, which is exactly what the `fabric group holds exactly the intended skills` assertion asks for on an intended membership change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)