### PR TITLE
fix(cucumber): stop failing the page sweep on cancelled requests

### DIFF
--- a/.changeset/shaggy-pugs-shave.md
+++ b/.changeset/shaggy-pugs-shave.md
@@ -1,0 +1,21 @@
+---
+'@pikku/cucumber': patch
+---
+
+fix(cucumber): stop failing the page sweep on cancelled requests
+
+A `net::ERR_ABORTED` means the browser tore a request down in flight — nobody
+ever answered — so it is never on its own evidence of an app bug. A broken
+endpoint answers with a status (already caught as `apiErrors`/`HTTP <status>`)
+and a broken page throws (already caught as `pageErrors`/`consoleErrors`).
+
+The sweep previously exempted aborts only under `node_modules`, on the theory
+that Vite's dep-optimizer was the only source. It isn't: any HMR full-reload
+cancels everything in flight at that instant — app source (`/src/Foo.tsx?t=…`),
+workspace files served through `/@fs/`, and the page's own `/api/…` calls — and
+only the `node_modules` subset was exempt, so every other reload artifact was
+reported as a runtime error.
+
+All aborts are now filtered out of the reported problems and still count as
+transient, so the existing retry re-reads the page and a real error hiding
+behind the reload is reported on the next attempt.

--- a/packages/cucumber/src/browser/pages-sweep.ts
+++ b/packages/cucumber/src/browser/pages-sweep.ts
@@ -34,15 +34,29 @@ export function staticRoutes(repoRoot: string): string[] {
 }
 
 /**
- * A failed request that is just Vite's dev dep-optimizer aborting in-flight
- * pre-bundle module loads (it re-optimizes on first hit of a new route, bumps
- * the `?v=` hash, and full-reloads) — a transient, NOT an app bug.
+ * A CANCELLED request — never on its own evidence of an app bug.
+ *
+ * An abort means nobody ever answered: the browser tore the request down while
+ * it was in flight. A genuinely broken endpoint does the opposite — it answers,
+ * with a status, and that is caught by `apiErrors`/`HTTP <status>`; a broken
+ * page throws, and that is caught by `pageErrors`/`consoleErrors`. So an abort
+ * adds no information those checks don't already carry, and reporting it as a
+ * "runtime error" is the sweep asserting a conclusion it has no evidence for.
+ *
+ * This used to match only aborted requests under `node_modules`, on the theory
+ * that Vite's dep-optimizer was the sole source. It isn't: a dep re-optimize
+ * (or any HMR full-reload) tears down EVERYTHING in flight at that instant —
+ * app source (`/src/Foo.tsx?t=<ts>`), workspace files served via `/@fs/`, and
+ * the page's own `/api/...` calls — and only the `node_modules` subset was
+ * exempt. One sandbox build spent 27 of its 43 `build-complete` refusals on
+ * this: every single failure it was ever shown was an abort, and it kept
+ * "fixing" pages that were fine.
+ *
+ * Aborts still count as transient, so the retry below re-reads the page — if a
+ * real error is hiding behind the reload, the next attempt reports it.
  */
-function isViteDepOptimizerAbort(failedRequest: string): boolean {
-  return (
-    /(?:ERR_ABORTED|net::ERR_FAILED|aborted)/i.test(failedRequest) &&
-    /(?:\/@fs\/[^ ]*node_modules|\/node_modules\/\.vite\/|\/\.vite\/deps\/)/.test(failedRequest)
-  )
+function isAbortedRequest(failedRequest: string): boolean {
+  return /(?:ERR_ABORTED|net::ERR_FAILED|aborted)/i.test(failedRequest)
 }
 
 export async function sweepAllPages(actor: ActorSession, repoRoot: string) {
@@ -82,8 +96,8 @@ export async function sweepAllPages(actor: ActorSession, repoRoot: string) {
       }
 
       const issues = actor.takeIssues()
-      const failedRequests = issues.failedRequests.filter((r) => !isViteDepOptimizerAbort(r))
-      const viteAborts = issues.failedRequests.length - failedRequests.length
+      const failedRequests = issues.failedRequests.filter((r) => !isAbortedRequest(r))
+      const aborts = issues.failedRequests.length - failedRequests.length
       // A GATEWAY error (502/503/504) on an app /api call means the edge
       // couldn't reach the upstream — the dev server is (re)starting. A plain
       // 500 is the server UP but a handler THREW — a real code bug — so it must
@@ -94,11 +108,12 @@ export async function sweepAllPages(actor: ActorSession, repoRoot: string) {
       if (issues.consoleErrors.length) problems.push(`console errors: ${issues.consoleErrors.join(' | ')}`)
       if (failedRequests.length) problems.push(`failed requests: ${failedRequests.join(' | ')}`)
 
-      // Clean read → trust it. If the only disruption was transient (Vite
-      // optimizer, a gateway 502/503/504, or a session-loss /login redirect),
-      // wait for the server to settle and retry; otherwise stop — the problems
-      // are real (a 500, a console/page error, a persistent /login guard).
-      const transient = viteAborts > 0 || gatewayErrors.length > 0 || redirectedToLogin
+      // Clean read → trust it. If the only disruption was transient (a
+      // cancelled request, a gateway 502/503/504, or a session-loss /login
+      // redirect), wait for the server to settle and retry; otherwise stop —
+      // the problems are real (a 500, a console/page error, a persistent
+      // /login guard).
+      const transient = aborts > 0 || gatewayErrors.length > 0 || redirectedToLogin
       if (!transient || attempt === 2) break
       await actor.waitForServerReady()
     }


### PR DESCRIPTION
## The bug

`sweepAllPages` reports any failed request as a page "runtime error". It exempts aborted requests **only when the URL is under `node_modules`**, on the theory that Vite's dep-optimizer is the only thing that cancels requests.

It isn't. Any HMR full-reload tears down *everything* in flight at that instant:

- app source — `/src/components/PageHeader.tsx?t=1784743898760`
- workspace files served through `/@fs/` — `/@fs/…/packages/mantine-theme/active.json?import`
- the page's own API calls — `GET /api/auth/get-session`, `POST /api/rpc/listLots`

None of those match the `node_modules` constraint, so all of them were reported as runtime errors.

## Why an abort is never evidence

`net::ERR_ABORTED` means nobody ever answered — the browser cancelled the request. A genuinely broken endpoint does the opposite: it answers, with a status, and that is already caught by `apiErrors` / `HTTP <status>`. A broken page throws, already caught by `pageErrors` / `consoleErrors`. So an abort carries no information those checks don't already have, and failing on it is the sweep asserting a conclusion it has no evidence for.

## Impact observed

In one 61-minute sandbox build, **every single page failure the agent was ever shown was an abort** — 96 abort lines against 8 real console errors. 27 of its 43 `build-complete` refusals came from this gate, and the agent spent them repeatedly "fixing" pages that were fine (`/app/auctions` was reported 13 times).

## The change

Filter all aborts out of the reported problems. They still count as `transient`, so the existing 3-attempt retry re-reads the page — a real error hiding behind the reload is reported on the next attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page scanning reliability when network requests are cancelled.
  * Cancelled requests are no longer incorrectly reported as application failures.
  * The scan now retries after transient request interruptions and reports only genuine errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->