### PR TITLE
fix(n8n-import): lower expressions nested inside array/object params

### DIFF
--- a/.changeset/n8n-import-nested-expression-containers.md
+++ b/.changeset/n8n-import-nested-expression-containers.md
@@ -1,0 +1,16 @@
+---
+'@pikku/n8n-import': patch
+---
+
+Lower n8n expressions nested inside array/object parameters instead of emitting them raw
+
+`classifyExpression` only inspects strings, so a parameter holding an expression
+inside a container — `recipients: ["={{ $json.body.email }}"]` — classified as a
+literal and the raw expression string was emitted verbatim into generated code.
+`emitValue` now recurses element-wise into containers that carry an expression,
+lowering each member to `ref()`/`template()`. Containers with no expression
+inside keep the original `safeJson` path, so existing emissions are unchanged.
+
+Also exports the naming helpers (`sanitizeIdentifier`, `integrationRpcName`,
+`codeRpcName`, …) so a second importer normalizing onto the same IR emits
+identical identifiers and can share a project without colliding.

--- a/packages/n8n-import/fixtures/nested-expression-containers.json
+++ b/packages/n8n-import/fixtures/nested-expression-containers.json
@@ -1,0 +1,32 @@
+{
+  "name": "Nested Expr",
+  "nodes": [
+    {
+      "id": "a1",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [0, 0],
+      "parameters": { "path": "nested" }
+    },
+    {
+      "id": "b2",
+      "name": "Send Report",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [200, 0],
+      "parameters": {
+        "operation": "create",
+        "resource": "deal",
+        "recipients": ["={{ $json.body.email }}", "ops@example.com"],
+        "payload": { "dealId": "={{ $json.body.id }}", "source": "webhook" },
+        "greetings": ["=Hello {{ $json.body.name }}"],
+        "tags": ["blue", "green"]
+      },
+      "credentials": { "pipedriveApi": { "id": "1", "name": "Pipedrive account" } }
+    }
+  ],
+  "connections": {
+    "Webhook": { "main": [[{ "node": "Send Report", "type": "main", "index": 0 }]] }
+  }
+}

--- a/packages/n8n-import/src/codegen.test.ts
+++ b/packages/n8n-import/src/codegen.test.ts
@@ -1459,3 +1459,36 @@ test('vectorStore insert becomes a split → ingest pipeline', () => {
   const addons = files['ingestHandbook/ingestHandbook.addons.gen.ts']
   assert.match(addons, /@pikku\/addon-qdrant/)
 })
+
+test('expressions nested inside array/object params are lowered element-wise, not emitted raw', () => {
+  const parsed = parseN8n(loadFixture('nested-expression-containers.json'))
+  const { files } = generateWorkflowFromN8n(parsed)
+
+  const graph = files['nestedExpr/nestedExpr.graph.ts']
+  assert.ok(graph, 'graph file emitted')
+
+  // an expression inside an array element is lowered to a ref, and its
+  // literal siblings survive untouched
+  assert.match(
+    graph,
+    /"recipients": \[ref\("trigger", "body\.email"\), "ops@example\.com"\]/
+  )
+
+  // ...and inside an object value
+  assert.match(
+    graph,
+    /"payload": \{ "dealId": ref\("trigger", "body\.id"\), "source": "webhook" \}/
+  )
+
+  // templates lower inside containers too
+  assert.match(
+    graph,
+    /"greetings": \[template\("Hello \$0", \[ref\("trigger", "body\.name"\)\]\)\]/
+  )
+
+  // an expression-free container keeps the original safeJson path
+  assert.match(graph, /"tags": \["blue","green"\]/)
+
+  // the raw n8n expression must never reach generated code
+  assert.doesNotMatch(graph, /\{\{/)
+})

--- a/packages/n8n-import/src/codegen.ts
+++ b/packages/n8n-import/src/codegen.ts
@@ -151,8 +151,53 @@ function emitRef(ref: RefPart): string {
     : `ref(${q(ref.nodeId)})`
 }
 
+/**
+ * Does this value carry an expression anywhere inside a container?
+ *
+ * n8n almost always holds expressions as scalar parameter values, so classifying
+ * per-value is sufficient for it. Other engines don't: a Make `mapper` routinely
+ * nests refs inside arrays/objects (`to: ["{{1.\`0\`}}"]`). Without this, such a
+ * value classifies as a plain literal and the raw expression string is emitted
+ * verbatim into generated code.
+ *
+ * Deliberately guarded: a container with no expression inside keeps the original
+ * `safeJson` path, so existing n8n emissions stay byte-identical.
+ */
+function containsExpression(value: unknown): boolean {
+  if (typeof value === 'string') return value.startsWith('=')
+  if (Array.isArray(value)) return value.some(containsExpression)
+  if (value && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).some(
+      containsExpression
+    )
+  }
+  return false
+}
+
 /** Render one classified parameter value as a graph-input expression. */
 function emitValue(value: unknown, ctx: ExprContext): string | null {
+  // Lower expressions nested inside a container element-wise.
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    containsExpression(value)
+  ) {
+    if (Array.isArray(value)) {
+      const items = value.map((v) => emitValue(v, ctx))
+      // A transform anywhere inside isn't declaratively expressible — bail the
+      // whole value, exactly as a scalar transform does.
+      if (items.some((i) => i === null)) return null
+      return `[${items.join(', ')}]`
+    }
+    const entries: string[] = []
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      const rendered = emitValue(v, ctx)
+      if (rendered === null) return null
+      entries.push(`${q(k)}: ${rendered}`)
+    }
+    return `{ ${entries.join(', ')} }`
+  }
+
   const classified = classifyExpression(value, ctx)
   if (classified.kind === 'literal') {
     return safeJson(classified.value)

--- a/packages/n8n-import/src/index.ts
+++ b/packages/n8n-import/src/index.ts
@@ -3,6 +3,23 @@ export { buildTopology } from './topology.js'
 export { classifyExpression } from './expressions.js'
 export { generateWorkflowFromN8n } from './codegen.js'
 
+/**
+ * Naming helpers. Engine-agnostic — a second importer that normalizes onto this
+ * IR needs the identical identifier/rpc-name rules, so both can emit into one
+ * project without colliding. First piece of the shared core; see
+ * `@pikku/make-import`.
+ */
+export {
+  sanitizeIdentifier,
+  sanitizeDisplayName,
+  dedupe,
+  integrationRpcName,
+  codeRpcName,
+  toCamelCase,
+  toPascalCase,
+  toKebabCase,
+} from './naming.js'
+
 export type {
   N8nWorkflow,
   N8nNode,


### PR DESCRIPTION
## Problem

`classifyExpression` only inspects strings:

```ts
if (typeof value !== 'string' || !value.startsWith('=')) {
  return { kind: 'literal', value }
}
```

So a parameter holding an expression *inside a container* — `recipients: ["={{ $json.body.email }}"]` — classifies as a literal, and `safeJson` emits the raw expression string verbatim into generated code. It never gets lowered to `ref()`/`template()`.

n8n usually carries expressions as scalar params, so this rarely surfaces there — but it is a real n8n bug, not just a gap for other engines.

## Fix

`emitValue` now recurses element-wise into containers that carry an expression.

- Guarded on `containsExpression`, so a container with **no** expression inside keeps the original `safeJson` path and existing emissions stay byte-identical.
- A transform anywhere inside bails the whole value, matching scalar behaviour.

Also exports the naming helpers (`sanitizeIdentifier`, `integrationRpcName`, `codeRpcName`, …). A second importer normalizing onto this IR needs identical identifier/rpc rules so both can emit into one project without colliding.

## Verification

TDD, per AGENTS.md:

- **Without** the `emitValue` change: `49/50`, generated code contains `"recipients": ["={{ $json.body.email }}","ops@example.com"]` — the raw expression leaking.
- **With** it: `50/50` → `"recipients": [ref("trigger", "body.email"), "ops@example.com"]`

Full suite **154/154 pass**, `tsc --noEmit` clean. The new test also asserts `tags: ["blue","green"]` still takes the `safeJson` path, proving the guard leaves expression-free containers alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)