### PR TITLE
fix(console): a read-only console hid the addon catalogue entirely

### DIFF
--- a/.changeset/nervous-donkeys-hear.md
+++ b/.changeset/nervous-donkeys-hear.md
@@ -1,0 +1,12 @@
+---
+'@pikku/console': patch
+---
+
+Let a read-only console browse the addon catalogue
+
+A read-only console (`editable={false}`, e.g. a deployed stage) locked the addons
+view to the `installed` filter and hid the filter control entirely, so the tab
+rendered an empty gallery with no way to reach the catalogue. Read-only means you
+cannot *install* — the catalogue is still worth browsing. The filter now applies
+as chosen and its control always renders; install actions stay gated on
+`editable` in the detail drawer, as before.

--- a/packages/console/src/pages/PackagesPage.tsx
+++ b/packages/console/src/pages/PackagesPage.tsx
@@ -5,7 +5,6 @@ import { Group, TextInput, SegmentedControl } from '@pikku/mantine/core'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { Search } from 'lucide-react'
-import { useConsoleEditable } from '../context/ConsoleEditableContext'
 import { ResizablePanelLayout } from '../components/layout/ResizablePanelLayout'
 import { ListPageHeader } from '../components/layout/PageLayout'
 import { AddonsList } from '../components/packages/AddonsList'
@@ -21,12 +20,7 @@ const PackagesList: React.FC<{
   const [tab, setTab] = useState<MainTab>('addons')
   const [filter, setFilter] = useState<AddonFilter>('all')
   const [searchQuery, setSearchQuery] = useState('')
-  const editable = useConsoleEditable()
   useLocale()
-
-  // A deployed stage is read-only: you can't install into it. Lock the addons
-  // view to what's already wired and point people at a sandbox to add more.
-  const effectiveFilter: AddonFilter = editable ? filter : 'installed'
 
   const handleTabChange = (value: string) => {
     setSearchQuery('')
@@ -65,7 +59,7 @@ const PackagesList: React.FC<{
                 size="xs"
                 style={{ width: 240 }}
               />
-              {tab === 'addons' && editable && (
+              {tab === 'addons' && (
                 <SegmentedControl
                   size="xs"
                   value={filter}
@@ -89,7 +83,7 @@ const PackagesList: React.FC<{
       ) : (
         <AddonsList
           searchQuery={searchQuery}
-          filter={effectiveFilter}
+          filter={filter}
           onSelect={onSelect}
         />
       )}


### PR DESCRIPTION
## Problem

`PackagesPage` treated a read-only console (`editable={false}`) as "can only see what is already installed":

```ts
const effectiveFilter: AddonFilter = editable ? filter : 'installed'
```

It also hid the All/Official/Installed control (`tab === 'addons' && editable`), so there was no way back to the catalogue.

That conflates two different things. `editable` means *you cannot install here* — it should not mean *you cannot look*. On any host that cannot report installed addons, the result is a silently empty gallery: `AddonsList` builds the Installed view as a left join on `console:getInstalledAddons`, so an empty response yields zero rows, and because an empty result under a filter is deliberately not an error state, the user gets a blank page rather than a message.

This is exactly what a Pikku Fabric deployed stage shows today — its console adapter answers `console:getInstalledAddons` with `[]`, and the addons tab renders nothing at all.

## Change

- The chosen `filter` now applies as-is; `effectiveFilter` is gone.
- The addon filter `SegmentedControl` always renders on the addons tab.

## Installs stay blocked

Nothing installable is exposed by this. Install UI already lives only in `AddonDetailDrawer` and is gated on `editable`:

- `AddonDetailDrawer.tsx:376` — the wireAddon namespace input
- `AddonDetailDrawer.tsx:405` — the Install button
- `CommunityGallery.tsx:242` — the publish CTA

`AddonCard` has no install action; a card click only opens the drawer. So a read-only console browses and previews, exactly as intended.

## Verification

`tsc --noEmit` in `packages/console` reports no errors in `PackagesPage.tsx` or `components/packages/`. The remaining errors in that run are pre-existing in a fresh worktree (`Cannot find module '@pikku/core/*'` from unbuilt workspace deps, plus the implicit-anys that follow from them) and are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Read-only consoles can now browse and filter the full addons catalogue.
  * The addons filter control remains available when editing is disabled.
  * Installation actions remain restricted in read-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->