### PR TITLE
fix(cli): work when the CLI runs on bun, not only on node

### DIFF
--- a/.changeset/bun-runtime-compat.md
+++ b/.changeset/bun-runtime-compat.md
@@ -1,0 +1,15 @@
+---
+'@pikku/cli': patch
+---
+
+Make the CLI work when it runs on bun, not just node.
+
+Projects invoke it as `bunx --bun pikku …` so it inherits bun's `node:sqlite`
+(node only ships that unflagged from 24). Under `--bun` the process is bun, where
+`process.loadEnvFile` does not exist — so `.env` silently failed to load with
+`Could not read .env: process.loadEnvFile is not a function`, and every secret in
+it was lost. Parse the file directly when that method is missing.
+
+Also turn the bare `ERR_UNKNOWN_BUILTIN_MODULE: No such built-in module:
+node:sqlite` into a message that names the cause (Node too old) and the two ways
+out (upgrade Node, or run on bun).

--- a/packages/cli/bin/pikku.ts
+++ b/packages/cli/bin/pikku.ts
@@ -20,12 +20,28 @@ const __dirname = dirname(__filename)
  * Cannot be left to the package manager: the CLI has a node shebang, so `bunx
  * pikku dev` execs node and bun's own .env injection never reaches the process.
  * Existing variables win — a real env var must always beat a checked-out file.
+ *
+ * `process.loadEnvFile` is node-only, and the shebang is not a guarantee: under
+ * `bunx --bun pikku …` (which projects use so the CLI gets bun's `node:sqlite`)
+ * the process is bun and that method does not exist. Parse the file ourselves in
+ * that case rather than losing every secret in it.
  */
 function loadEnvFile(): void {
   const envPath = join(process.cwd(), '.env')
   if (!existsSync(envPath)) return
   try {
-    process.loadEnvFile(envPath)
+    if (typeof process.loadEnvFile === 'function') {
+      process.loadEnvFile(envPath)
+      return
+    }
+    for (const line of readFileSync(envPath, 'utf-8').split('\n')) {
+      const match = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/.exec(
+        line
+      )
+      if (!match) continue
+      const value = match[2].trim().replace(/^(['"])(.*)\1$/s, '$2')
+      process.env[match[1]] ??= value
+    }
   } catch (error: any) {
     process.stderr.write(`  Could not read .env: ${error.message}\n`)
   }

--- a/packages/cli/src/functions/db/sqlite/sqlite-runtime-node.ts
+++ b/packages/cli/src/functions/db/sqlite/sqlite-runtime-node.ts
@@ -90,7 +90,22 @@ async function importNodeSqlite(): Promise<NodeSqliteModule> {
   const dynamicImport = new Function(
     'return import("node:sqlite")'
   ) as () => Promise<NodeSqliteModule>
-  return dynamicImport()
+  try {
+    return await dynamicImport()
+  } catch (error: any) {
+    // node ships node:sqlite unflagged only from 24. The raw failure is
+    // ERR_UNKNOWN_BUILTIN_MODULE, which reads like a broken install rather than
+    // a runtime that is simply too old — so say which it is and how to get past it.
+    if (error?.code === 'ERR_UNKNOWN_BUILTIN_MODULE') {
+      throw new Error(
+        `This needs node:sqlite, which Node ${process.versions.node} does not provide ` +
+          `(it is unflagged from Node 24). Either upgrade Node, or run the CLI on bun, ` +
+          `which has it: \`bunx --bun pikku <command>\`.`,
+        { cause: error }
+      )
+    }
+    throw error
+  }
 }
 
 export async function createNodeSqliteRuntime(): Promise<SqliteRuntime> {


### PR DESCRIPTION
## Why

The CLI has a `#!/usr/bin/env node` shebang, so whatever node is on PATH runs it — even under `bunx`. It opens the local SQLite database through `node:sqlite`, which node ships unflagged only from **24**, so on anything older every command dies with:

```
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

The fix on the project side is to invoke it as `bunx --bun pikku …`, which ignores the shebang and runs the CLI on bun (which has that module). That works — but it exposes a second bug.

## The bug it exposes

`process.loadEnvFile` is node-only. Under `--bun` the process is bun, so the `.env` loader added in #1013 fails with:

```
Could not read .env: process.loadEnvFile is not a function
```

and silently drops every secret in the file — precisely the failure that loader exists to prevent (`LocalSecretService` reads `process.env` and nothing else, so sign-up then fails with "Requested secret not found").

## What this changes

- **`.env` loads under bun too.** Parse the file directly when `process.loadEnvFile` is absent. Existing env vars still win over the file, and quoted values / `export FOO=` are handled.
- **The `node:sqlite` failure explains itself.** `ERR_UNKNOWN_BUILTIN_MODULE` reads like a broken install; it now names the cause (node too old) and both ways out — upgrade node, or run on bun.

## Verified

A/B on a real scaffolded project, running `bunx --bun pikku db migrate`:

- unpatched → `Could not read .env: process.loadEnvFile is not a function`
- patched → no warning, `.env` values present

Found while building an app end-to-end from a bare container with no node/bun/npm preinstalled.