### PR TITLE
feat(kysely-postgres): PgEventHubService accepts an optional inner transport hub

### DIFF
--- a/.changeset/pg-eventhub-transport-hub.md
+++ b/.changeset/pg-eventhub-transport-hub.md
@@ -1,0 +1,5 @@
+---
+'@pikku/kysely-postgres': patch
+---
+
+PgEventHubService now accepts an optional inner transport hub. When supplied, subscribe/unsubscribe/publish and NOTIFY-relayed events are delivered through it instead of a private LocalEventHubService, so the service can share the SAME hub the server registered its sockets on (e.g. a BunEventHubService). Without an inner hub the behaviour is unchanged.

--- a/packages/services/kysely-postgres/src/pg-eventhub-service.ts
+++ b/packages/services/kysely-postgres/src/pg-eventhub-service.ts
@@ -11,10 +11,21 @@ type ChannelHandler = Parameters<LocalHub['onChannelOpened']>[0]
 /**
  * Multi-instance EventHub backed by Postgres LISTEN/NOTIFY.
  *
- * Each process holds one dedicated LISTEN connection. Publishing fans out
- * locally first (zero extra latency for the publishing instance's own
- * clients) then sends NOTIFY so every other instance delivers the event
- * to its own connected WebSocket clients.
+ * Wraps a `delivery` hub that owns the connected clients and does the in-process
+ * fan-out, then layers Postgres NOTIFY on top so an event published on one
+ * instance also reaches clients connected to every OTHER instance.
+ *
+ * By default the delivery hub is a built-in `LocalEventHubService` (holds
+ * channel handlers and calls `.send()` — the right fit for the Node HTTP
+ * server). Pass an `inner` transport hub to reuse the SAME hub the server holds
+ * its sockets on — e.g. a `BunEventHubService`, whose delivery rides Bun's
+ * native per-socket topic pub/sub. This is REQUIRED on Bun: the server registers
+ * live sockets on its own `BunEventHubService`, so a function's
+ * `eventHub.publish(...)` only reaches them if this service delivers through
+ * that very instance instead of a private `LocalEventHubService` the sockets
+ * were never registered on. The server keeps its direct reference to the inner
+ * hub for the socket lifecycle (`onChannelOpened`/`setServer`); this wrapper
+ * only decorates the subscribe/publish surface plus the NOTIFY backplane.
  *
  * Payload limit: Postgres caps NOTIFY payloads at 8 kB. Keep event data
  * small; for large payloads publish an ID and fetch the full record on
@@ -23,10 +34,20 @@ type ChannelHandler = Parameters<LocalHub['onChannelOpened']>[0]
 export class PgEventHubService<
   Topics extends Record<string, unknown> = {},
 > implements EventHubService<Topics> {
-  private local = new LocalEventHubService<Topics>()
+  // Built-in fallback hub; also backs onChannelOpened/onChannelClosed for the
+  // Node/channel-handler convention when no transport hub is injected.
+  private readonly local = new LocalEventHubService<Topics>()
+  // Where subscribe/unsubscribe/publish and NOTIFY-relayed events are delivered:
+  // the injected transport hub when supplied, otherwise the built-in `local`.
+  private readonly delivery: EventHubService<Topics>
   private sql: postgres.Sql | null = null
 
-  constructor(private readonly connectionString: string) {}
+  constructor(
+    private readonly connectionString: string,
+    inner?: EventHubService<Topics>
+  ) {
+    this.delivery = inner ?? this.local
+  }
 
   async init(): Promise<void> {
     // Dedicated single-connection pool — pooled connections can't hold LISTEN state
@@ -40,10 +61,20 @@ export class PgEventHubService<
       }
       // Skip if this NOTIFY originated from this instance — already fanned out locally in publish()
       if (parsed.instanceId === INSTANCE_ID) return
-      this.local.publish(
-        parsed.topic as keyof Topics,
-        null,
-        parsed.data as Topics[keyof Topics]
+      // Deliver the remote event to THIS instance's connected clients. `delivery`
+      // may be sync (local) or async (transport); normalize so a rejection can't
+      // become an unhandled promise.
+      Promise.resolve(
+        this.delivery.publish(
+          parsed.topic as keyof Topics,
+          null,
+          parsed.data as Topics[keyof Topics]
+        )
+      ).catch((err) =>
+        console.error(
+          `[PgEventHubService] failed delivering relayed event on '${String(parsed.topic)}':`,
+          err
+        )
       )
     })
   }
@@ -53,12 +84,18 @@ export class PgEventHubService<
     this.sql = null
   }
 
-  subscribe<T extends keyof Topics>(topic: T, channelId: string): void {
-    this.local.subscribe(topic, channelId)
+  subscribe<T extends keyof Topics>(
+    topic: T,
+    channelId: string
+  ): Promise<void> | void {
+    return this.delivery.subscribe(topic, channelId)
   }
 
-  unsubscribe<T extends keyof Topics>(topic: T, channelId: string): void {
-    this.local.unsubscribe(topic, channelId)
+  unsubscribe<T extends keyof Topics>(
+    topic: T,
+    channelId: string
+  ): Promise<void> | void {
+    return this.delivery.unsubscribe(topic, channelId)
   }
 
   async publish<T extends keyof Topics>(
@@ -67,8 +104,8 @@ export class PgEventHubService<
     data: Topics[T],
     isBinary?: boolean
   ): Promise<void> {
-    // Fan out to local clients immediately — no network round-trip
-    this.local.publish(topic, channelId, data, isBinary)
+    // Fan out to this instance's own clients immediately — no network round-trip
+    await this.delivery.publish(topic, channelId, data, isBinary)
 
     // Broadcast to all other instances via Postgres NOTIFY (instanceId prevents self-delivery)
     if (this.sql) {


### PR DESCRIPTION
## What

`PgEventHubService` now takes an optional `inner?: EventHubService` in its constructor. When supplied, all delivery operations — `subscribe`/`unsubscribe`/`publish`, and events relayed in over Postgres NOTIFY — are routed through that hub instead of a private `LocalEventHubService`. The Postgres LISTEN/NOTIFY backplane is unchanged and still fans events across instances.

## Why

`PgEventHubService` fans out in-process through a `LocalEventHubService` it creates itself. On a runtime whose server owns the live client sockets on a *different* hub — e.g. `BunEventHubService`, where delivery rides Bun's native per-socket topic pub/sub — a function's `singletonServices.eventHub.publish(...)` lands on a hub the sockets were never registered on, so nothing reaches the clients. Realtime silently degrades.

Passing the server's own transport hub as `inner` makes this service deliver through that very instance, so cross-function publishes reach connected sockets while keeping the multi-instance NOTIFY fan-out.

## Compatibility

Fully backward compatible: with no `inner` argument the delivery hub is the built-in `LocalEventHubService`, identical to today. `onChannelOpened`/`onChannelClosed` continue to target the local hub for the Node channel-handler convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for connecting PostgreSQL event handling to a shared event transport hub.
  - Events can now be delivered through configured transports, including socket-based hubs, for coordinated real-time updates.
  - Existing behavior remains unchanged when no shared hub is configured.

- **Bug Fixes**
  - Improved handling of asynchronous event delivery and relayed notifications to prevent missed or unhandled event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->