### PR TITLE
feat(cli): schema types from migrations, and a drift check

### DIFF
--- a/.changeset/mighty-cases-shake.md
+++ b/.changeset/mighty-cases-shake.md
@@ -1,0 +1,11 @@
+---
+'@pikku/cli': minor
+---
+
+Add `pikku db check` — report how the configured database differs from the schema its migrations define.
+
+Answers the question nobody can otherwise answer without going and looking by hand: does this database still match what we wrote down? It applies the migrations to a throwaway database (the same scratch mechanism `db codegen` uses) and diffs that against the real one.
+
+The two halves are deliberately asymmetric. Missing tables and columns mean the database is behind — the fix only ever adds, so the command fails and tells you to run `db migrate`. Tables the migrations never mention are reported but never fail and never dropped: something created them outside the migration history, and no migration can know whether they hold data worth keeping.
+
+Comparison is on the fully-qualified name, so a second copy of a table in the wrong schema (`public.orders` shadowing `app.orders` — what a runtime that forgot to qualify its DDL leaves behind) is reported rather than mistaken for the table the migrations created.

--- a/.changeset/quiet-rules-sniff.md
+++ b/.changeset/quiet-rules-sniff.md
@@ -1,0 +1,9 @@
+---
+'@pikku/cli': minor
+---
+
+Add `pikku db codegen` — regenerate the database types from the migration files without connecting to a database.
+
+`pikku db migrate` can only emit types after migrating the configured database, which forces codegen to run late: on a deploy that means the schema has already moved by the time anything is generated, so a build step that needs the table zod (a function schema built from `#pikku/db/zod.gen.js`) cannot run before it. `db codegen` applies the same migrations to a throwaway database — `:memory:` for SQLite, embedded PGlite for Postgres — and introspects that, so `pikku all` can be handed an accurate schema on a machine with no database reachable.
+
+The generated types describe what the migrations define, which is the contract. Introspecting a live database additionally picks up whatever has drifted into it — tables a runtime bootstrapped at boot, leftovers from a reverted branch — so the two can differ; that difference is the point.

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -19,6 +19,7 @@ import { serve } from './functions/commands/serve.js'
 import { dbMigrate } from './functions/commands/db-migrate.js'
 import { dbGenerate } from './functions/commands/db-generate.js'
 import { dbCodegen } from './functions/commands/db-codegen.js'
+import { dbCheck } from './functions/commands/db-check.js'
 import { dbSeed } from './functions/commands/db-seed.js'
 import { dbReset } from './functions/commands/db-reset.js'
 import { dbAudit } from './functions/commands/db-audit.js'
@@ -388,6 +389,11 @@ wireCLI({
         generate: pikkuCLICommand({
           func: dbGenerate,
           description: 'Generate SQL migrations from detected schema changes',
+        }),
+        check: pikkuCLICommand({
+          func: dbCheck,
+          description:
+            'Report how the configured database differs from the schema its migrations define',
         }),
         codegen: pikkuCLICommand({
           func: dbCodegen,

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -18,6 +18,7 @@ import { dev } from './functions/commands/dev.js'
 import { serve } from './functions/commands/serve.js'
 import { dbMigrate } from './functions/commands/db-migrate.js'
 import { dbGenerate } from './functions/commands/db-generate.js'
+import { dbCodegen } from './functions/commands/db-codegen.js'
 import { dbSeed } from './functions/commands/db-seed.js'
 import { dbReset } from './functions/commands/db-reset.js'
 import { dbAudit } from './functions/commands/db-audit.js'
@@ -387,6 +388,11 @@ wireCLI({
         generate: pikkuCLICommand({
           func: dbGenerate,
           description: 'Generate SQL migrations from detected schema changes',
+        }),
+        codegen: pikkuCLICommand({
+          func: dbCodegen,
+          description:
+            'Regenerate db/schema.gen.ts and db/zod.gen.ts from the migration files, without connecting to a database',
         }),
         seed: pikkuCLICommand({
           func: dbSeed,

--- a/packages/cli/src/functions/commands/db-check.ts
+++ b/packages/cli/src/functions/commands/db-check.ts
@@ -1,0 +1,74 @@
+import { pikkuSessionlessFunc } from '#pikku'
+import { resolveDb, computeSchemaDrift } from '../db/local-db.js'
+import { loadUserConfigForDb } from './db-shared.js'
+
+/**
+ * Report how the configured database differs from the schema its migrations
+ * define.
+ *
+ * Answers the question nobody can otherwise answer without going and looking by
+ * hand: does this database still match what we wrote down? Missing tables and
+ * columns fail the command — the database is behind and a migration has not
+ * been applied. Tables the migrations never mention are reported but never
+ * fail: something created them outside the migration history, which is worth
+ * seeing but is not this command's to fix.
+ */
+export const dbCheck = pikkuSessionlessFunc<{}, void>({
+  remote: true,
+  func: async ({ logger, config }) => {
+    const userConfig = await loadUserConfigForDb({ config, logger })
+    if (!userConfig) return
+
+    const resolved = resolveDb(
+      userConfig,
+      config.rootDir,
+      config.outDir,
+      config.runtimeDir
+    )
+    if (!resolved) {
+      logger.error(
+        'pikku db check: no database configured — set sqliteDb or postgresUrl in your createConfig.'
+      )
+      throw new Error('no database configured')
+    }
+
+    const drift = await computeSchemaDrift(resolved)
+
+    // Table names elide the `public` schema, which reads as ambiguous in a
+    // report whose whole point can be a second copy of `app.orders` sitting in
+    // `public`. Put the schema back for display only.
+    const qualify = (table: string) =>
+      resolved.dialect === 'postgres' && !table.includes('.')
+        ? `public.${table}`
+        : table
+
+    if (drift.extraTables.length) {
+      logger.info(
+        `db check: ${drift.extraTables.length} table(s) in the database that no migration creates:`
+      )
+      for (const table of drift.extraTables) {
+        logger.info(`  ${qualify(table)}`)
+      }
+      logger.info(
+        '  Left alone — a migration cannot know whether these hold data worth keeping.'
+      )
+    }
+
+    if (drift.inSync) {
+      logger.info('db check: the database matches its migrations')
+      return
+    }
+
+    logger.error('db check: the database is behind its migrations:')
+    if (drift.missingTables.length) {
+      logger.error(
+        `  missing tables: ${drift.missingTables.map(qualify).join(', ')}`
+      )
+    }
+    for (const { table, columns } of drift.missingColumns) {
+      logger.error(`  ${qualify(table)} missing columns: ${columns.join(', ')}`)
+    }
+    logger.error('  Run `pikku db migrate` to apply them.')
+    throw new Error('database schema is behind its migrations')
+  },
+})

--- a/packages/cli/src/functions/commands/db-codegen.ts
+++ b/packages/cli/src/functions/commands/db-codegen.ts
@@ -1,0 +1,56 @@
+import { pikkuSessionlessFunc } from '#pikku'
+import { resolveDb, migrateAndCodegen } from '../db/local-db.js'
+import { loadUserConfigForDb } from './db-shared.js'
+
+/**
+ * Regenerate the database types from the migration files alone, without
+ * connecting to the configured database.
+ *
+ * `db migrate` can only emit types after it has migrated the real database,
+ * which forces codegen to run late — after a deploy has already moved the
+ * schema. This command applies the same migrations to a throwaway database and
+ * introspects that, so `pikku all` can be given an accurate table zod on a
+ * machine with no database reachable at all.
+ */
+export const dbCodegen = pikkuSessionlessFunc<{}, void>({
+  remote: true,
+  func: async ({ logger, config }) => {
+    const userConfig = await loadUserConfigForDb({ config, logger })
+    if (!userConfig) return
+
+    const resolved = resolveDb(
+      userConfig,
+      config.rootDir,
+      config.outDir,
+      config.runtimeDir
+    )
+    if (!resolved) {
+      logger.error(
+        'pikku db codegen: no database configured — set sqliteDb or postgresUrl in your createConfig.'
+      )
+      throw new Error('no database configured')
+    }
+
+    const { migrate, codegen, zod } = await migrateAndCodegen(resolved, {
+      scratch: true,
+    })
+
+    for (const warning of codegen.warnings) {
+      logger.diagnostic(warning)
+    }
+
+    logger.info(
+      `db codegen: applied ${migrate.applied.length} migration(s) to a scratch ${resolved.dialect} database`
+    )
+    logger.info(
+      codegen.written
+        ? `db codegen: regenerated ${codegen.outFile} (${codegen.tables.length} tables)`
+        : `db codegen: ${codegen.outFile} unchanged`
+    )
+    logger.info(
+      zod.written
+        ? `db codegen: regenerated ${zod.outFile} (${zod.tables.length} tables)`
+        : `db codegen: ${zod.outFile} unchanged`
+    )
+  },
+})

--- a/packages/cli/src/functions/db/local-db.test.ts
+++ b/packages/cli/src/functions/db/local-db.test.ts
@@ -6,12 +6,14 @@ import {
   writeFileSync,
   rmSync,
   readFileSync,
+  existsSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import {
   resolveDb,
+  type ResolvedSqliteDb,
   parseDatabaseUrl,
   migrateAndCodegen,
   seed as runSeed,
@@ -400,6 +402,32 @@ INSERT INTO todos (title, done) VALUES ('seed from migration', FALSE);
   } finally {
     await kysely.destroy()
   }
+})
+
+test('scratch codegen types the postgres migrations without touching the configured database', async () => {
+  usePostgresProject()
+  const resolved = resolveDb({}, root, root)!
+
+  const scratch = await migrateAndCodegen(resolved, { scratch: true })
+  assert.deepEqual(scratch.migrate.applied, ['0001-init.sql'])
+  assert.match(readFileSync(resolved.zodFile, 'utf8'), /export const TodosZ/)
+
+  // The configured database must be untouched — so a real migrate afterwards
+  // still sees the migration as pending. If the scratch run had recorded state
+  // anywhere real, this would come back skipped and the deploy would never
+  // apply it.
+  const live = await migrateAndCodegen(resolved)
+  assert.deepEqual(live.migrate.applied, ['0001-init.sql'])
+})
+
+test('scratch codegen types the sqlite migrations without creating the db file', async () => {
+  const resolved = resolveDb({}, root, root)!
+  assert.equal(resolved.dialect, 'sqlite')
+
+  const scratch = await migrateAndCodegen(resolved, { scratch: true })
+  assert.deepEqual(scratch.migrate.applied, ['0001-init.sql'])
+  assert.match(readFileSync(resolved.zodFile, 'utf8'), /export const TodosZ/)
+  assert.equal(existsSync((resolved as ResolvedSqliteDb).dbFile), false)
 })
 
 test('postgres PGlite migrate, seed, createKysely, and reset work end-to-end', async () => {

--- a/packages/cli/src/functions/db/local-db.test.ts
+++ b/packages/cli/src/functions/db/local-db.test.ts
@@ -10,10 +10,12 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { sql } from 'kysely'
 
 import {
   resolveDb,
   type ResolvedSqliteDb,
+  computeSchemaDrift,
   parseDatabaseUrl,
   migrateAndCodegen,
   seed as runSeed,
@@ -428,6 +430,73 @@ test('scratch codegen types the sqlite migrations without creating the db file',
   assert.deepEqual(scratch.migrate.applied, ['0001-init.sql'])
   assert.match(readFileSync(resolved.zodFile, 'utf8'), /export const TodosZ/)
   assert.equal(existsSync((resolved as ResolvedSqliteDb).dbFile), false)
+})
+
+test('db check reports a database that is behind its migrations', async () => {
+  const resolved = resolveDb({ sqliteDb: '.pikku-runtime/dev.db' }, root, root)!
+  await migrateAndCodegen(resolved)
+
+  // A migration written after the database was last migrated.
+  writeFileSync(
+    join(root, 'db', 'sqlite', '0002-tags.sql'),
+    `CREATE TABLE tags (id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT NOT NULL);
+ALTER TABLE todos ADD COLUMN priority INTEGER;
+`
+  )
+
+  const drift = await computeSchemaDrift(resolved)
+  assert.equal(drift.inSync, false)
+  assert.deepEqual(drift.missingTables, ['tags'])
+  assert.deepEqual(drift.missingColumns, [
+    { table: 'todos', columns: ['priority'] },
+  ])
+})
+
+test('db check reports tables the migrations never mention, without failing', async () => {
+  const resolved = resolveDb({ sqliteDb: '.pikku-runtime/dev.db' }, root, root)!
+  await migrateAndCodegen(resolved)
+
+  // Something created a table outside the migration history — the shape of the
+  // bug this exists to surface.
+  const runtime = await loadSqliteRuntime()
+  const db = runtime.open((resolved as ResolvedSqliteDb).dbFile)
+  try {
+    db.exec('CREATE TABLE bootstrapped_at_boot (id INTEGER PRIMARY KEY)')
+  } finally {
+    db.close()
+  }
+
+  const drift = await computeSchemaDrift(resolved)
+  assert.deepEqual(drift.extraTables, ['bootstrapped_at_boot'])
+  assert.equal(drift.inSync, true, 'an unrecorded table is reported, not fatal')
+})
+
+test('db check reports a public copy shadowing a schema-qualified table', async () => {
+  usePostgresProject({
+    migrationSql: `CREATE SCHEMA app;
+CREATE TABLE app.orders (
+  id SERIAL PRIMARY KEY,
+  total INTEGER NOT NULL
+);
+`,
+  })
+  const resolved = resolveDb({}, root, root)!
+  await migrateAndCodegen(resolved)
+
+  // A second copy in the default schema — what a runtime that forgot to qualify
+  // its DDL leaves behind, and what matching on the bare name would hide.
+  const kysely = await createKysely<{}>(resolved)
+  try {
+    await sql`CREATE TABLE public.orders (id SERIAL PRIMARY KEY)`.execute(
+      kysely
+    )
+  } finally {
+    await kysely.destroy()
+  }
+
+  const drift = await computeSchemaDrift(resolved)
+  assert.deepEqual(drift.extraTables, ['orders'])
+  assert.deepEqual(drift.missingTables, [], 'app.orders is still accounted for')
 })
 
 test('postgres PGlite migrate, seed, createKysely, and reset work end-to-end', async () => {

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -322,8 +322,10 @@ export async function migrateAndCodegen(
     }
   } else {
     const withClient = options.scratch
-      ? <T,>(r: ResolvedPostgresDb, run: (c: PostgresQueryClient) => Promise<T>) =>
-          withScratchPostgresDatabase(r, 'pikku_codegen', run)
+      ? <T>(
+          r: ResolvedPostgresDb,
+          run: (c: PostgresQueryClient) => Promise<T>
+        ) => withScratchPostgresDatabase(r, 'pikku_codegen', run)
       : withPostgresClient
     await withClient(resolved, async (client) => {
       const introspector = new PostgresIntrospector(client)
@@ -830,6 +832,59 @@ async function coveredPostgresSchema(
       return postgresDatabaseToMap(client)
     }
   )
+}
+
+export interface SchemaDriftResult {
+  /** In the migrations, absent from the database — it is behind. */
+  missingTables: string[]
+  missingColumns: { table: string; columns: string[] }[]
+  /** In the database, absent from the migrations — nobody wrote it down. */
+  extraTables: string[]
+  inSync: boolean
+}
+
+/**
+ * Compare the schema the migration files define against the one the configured
+ * database actually has.
+ *
+ * The two halves are asymmetric and must stay that way. Something missing from
+ * the database is a database that is behind — the fix only ever adds, so it is
+ * safe to automate. Something present in the database but absent from the
+ * migrations is a table nobody wrote down: a runtime that created its own at
+ * boot, or the remains of a reverted branch. Dropping those is how data gets
+ * lost, so they are reported and never acted on.
+ */
+export async function computeSchemaDrift(
+  resolved: ResolvedDb
+): Promise<SchemaDriftResult> {
+  const covered =
+    resolved.dialect === 'sqlite'
+      ? await coveredSqliteSchema(resolved.migrationsDir)
+      : await coveredPostgresSchema(resolved, resolved.migrationsDir)
+  const actual = await introspectSchema(resolved)
+
+  const { missingTables, missingColumns } = diffSchemas(covered, actual)
+
+  // Compare on the full name. A migration that names no schema lands in
+  // whichever one is default, so a BARE covered name still matches a qualified
+  // table — but a QUALIFIED one must match exactly. Relaxing that second case
+  // hides the failure this is here to catch: a second copy of a table in the
+  // wrong schema (`public.orders` shadowing `app.orders`) would otherwise look
+  // like the table the migrations created.
+  const coveredFull = new Set(covered.keys())
+  const coveredBare = new Set(
+    [...covered.keys()].filter((t) => !t.includes('.'))
+  )
+  const extraTables = [...actual.keys()].filter(
+    (t) => !coveredFull.has(t) && !coveredBare.has(t.split('.').pop()!)
+  )
+
+  return {
+    missingTables,
+    missingColumns,
+    extraTables,
+    inSync: missingTables.length === 0 && missingColumns.length === 0,
+  }
 }
 
 export interface AuthDriftResult {

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -264,8 +264,27 @@ export interface MigrateAndCodegenOutcome {
   classificationsJsonWritten: boolean
 }
 
+export interface MigrateAndCodegenOptions {
+  /**
+   * Apply the migrations to a throwaway database and introspect that, instead
+   * of touching the configured one.
+   *
+   * The generated types describe the schema the migrations define, which is the
+   * contract — a live database additionally carries whatever has drifted into
+   * it (tables a runtime bootstrapped, leftovers from a reverted branch), and
+   * introspecting one makes codegen depend on a reachable, already-migrated
+   * server. That ordering is the problem this solves: codegen can now run
+   * before deploy-time migrations, on a machine with no database at all.
+   *
+   * SQLite uses `:memory:`; Postgres uses an embedded PGlite (real Postgres,
+   * and it needs no `CREATEDB` privilege anywhere).
+   */
+  scratch?: boolean
+}
+
 export async function migrateAndCodegen(
-  resolved: ResolvedDb
+  resolved: ResolvedDb,
+  options: MigrateAndCodegenOptions = {}
 ): Promise<MigrateAndCodegenOutcome> {
   let migrateResult!: MigrateResult
   let codegenResult!: CodegenResult
@@ -278,9 +297,11 @@ export async function migrateAndCodegen(
   )
 
   if (resolved.dialect === 'sqlite') {
-    mkdirSync(dirname(resolved.dbFile), { recursive: true })
     const runtime = await loadSqliteRuntime()
-    const db = runtime.open(resolved.dbFile)
+    if (!options.scratch) {
+      mkdirSync(dirname(resolved.dbFile), { recursive: true })
+    }
+    const db = runtime.open(options.scratch ? ':memory:' : resolved.dbFile)
     try {
       const executor = new SqliteMigrationExecutor(db)
       migrateResult = await migrate(executor, resolved.migrationsDir)
@@ -300,7 +321,11 @@ export async function migrateAndCodegen(
       db.close()
     }
   } else {
-    await withPostgresClient(resolved, async (client) => {
+    const withClient = options.scratch
+      ? <T,>(r: ResolvedPostgresDb, run: (c: PostgresQueryClient) => Promise<T>) =>
+          withScratchPostgresDatabase(r, 'pikku_codegen', run)
+      : withPostgresClient
+    await withClient(resolved, async (client) => {
       const introspector = new PostgresIntrospector(client)
       await introspector.connect()
       try {


### PR DESCRIPTION
Two commands, both built on the scratch-database mechanism the CLI already has (`withScratchPostgresDatabase` — in-memory PGlite for Postgres, `:memory:` for SQLite, needing no `CREATEDB` privilege anywhere).

## `pikku db codegen`

Regenerates the database types from the migration files alone, without connecting to a database.

`db migrate` can only emit types *after* it has migrated the real database, which forces codegen to run late. On a deploy that is the wrong order: the build step that needs the table zod (a function schema built from `#pikku/db/zod.gen.js`) runs long before migrations do, so it sees a stale or missing schema and fails on the VM while passing locally. The workaround has been to hand-mirror columns next to a table that already declares them.

`db codegen` applies the same migrations to a throwaway database and introspects that, so `pikku all` can be handed an accurate schema on a machine with no database configured or reachable at all.

The generated types describe what the migrations *define*, which is the contract. Introspecting a live database additionally picks up whatever has drifted into it; that difference is the point, and it is what the second command reports.

## `pikku db check`

Reports how the configured database differs from the schema its migrations define — the question nobody can otherwise answer without going and looking by hand.

The two halves are deliberately asymmetric:

- **Missing** tables/columns mean the database is behind. The fix only ever adds, so this **fails** the command and points at `db migrate`.
- **Extra** tables are reported and never acted on. Something created them outside the migration history, and no migration can know whether they hold data worth keeping.

Comparison is on the fully-qualified name, so a second copy of a table in the wrong schema (`public.orders` shadowing `app.orders` — what a runtime that forgot to qualify its DDL leaves behind) is reported rather than mistaken for the table the migrations created.

## Verification

Run against a real project with 76 migrations:

- `db codegen` with **no database configured**: applied all 76 to a scratch Postgres and regenerated `schema.gen.ts` + `zod.gen.ts` (84 tables). Output is byte-identical to the live-database run for every migration-defined table.
- `db check` against that project's live Postgres correctly identified 4 tables a runtime bootstraps at boot and 5 unqualified duplicates sitting in `public` alongside their `app.` originals — a real bug the project did not know it had.

442 tests pass, including four new ones covering scratch codegen on both dialects, a database behind its migrations, an unrecorded table, and the schema-shadow case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pikku db codegen` to generate database types and schemas from migrations without connecting to the configured database.
  * Added `pikku db check` to compare the configured database with migration-defined schemas.
  * Reports missing tables or columns and recommends running `pikku db migrate`.
  * Reports extra database tables without failing or removing them.
* **Documentation**
  * Clarified database schema comparison, migration behavior, and release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->