### PR TITLE
fix(kysely): ensurePikkuSchema on a schema-bound connection

### DIFF
--- a/.changeset/kysely-ensure-schema-qualified.md
+++ b/.changeset/kysely-ensure-schema-qualified.md
@@ -15,3 +15,10 @@ The schema half of the name is now parsed, and the lookup matches on the pair
 when the DDL is qualified (falling back to the bare name when it is not, since
 an unqualified statement resolves against a `search_path` that is not knowable
 from here). Error messages name the schema too.
+
+Also: applying a schema over a `withSchema(...)`-bound **sqlite** connection now
+explains itself. `withSchema` qualifies foreign key targets along with everything
+else — which postgres requires and sqlite refuses, since a `REFERENCES` clause
+there takes a bare table name — and all the engine says about it is
+`near ".": syntax error`. The failure is now reported with the schema that
+produced it and what to do instead, with the engine error kept as the `cause`.

--- a/.changeset/kysely-ensure-schema-qualified.md
+++ b/.changeset/kysely-ensure-schema-qualified.md
@@ -1,0 +1,17 @@
+---
+'@pikku/kysely': patch
+---
+
+fix: `ensurePikkuSchema` now sees tables on a `withSchema(...)`-bound connection
+
+It read the table name out of its own compiled DDL with a regex that matched the
+first quoted identifier. On a connection bound to a schema that DDL is
+`create table "app"."workflow_runs"`, so it captured `app` — never a real table
+name — concluded every table was missing, and issued a bare `create table` that
+the database rejected with `relation "workflow_runs" already exists`, on every
+boot.
+
+The schema half of the name is now parsed, and the lookup matches on the pair
+when the DDL is qualified (falling back to the bare name when it is not, since
+an unqualified statement resolves against a `search_path` that is not knowable
+from here). Error messages name the schema too.

--- a/packages/services/kysely/src/schema/index.ts
+++ b/packages/services/kysely/src/schema/index.ts
@@ -143,10 +143,48 @@ export const applyPikkuSchemas = async (
     const bound = bind(trx)
     for (const schema of schemas) {
       for (const statement of schema.statements) {
-        await statement(bound, types).execute()
+        const query = statement(bound, types)
+        try {
+          await query.execute()
+        } catch (error) {
+          throw explain(error, query.compile().sql, schema)
+        }
       }
     }
   })
+}
+
+/** `references "app"."workflow_runs"` — a foreign key onto a qualified table. */
+const QUALIFIED_REFERENCE = /references "[^"]+"\."[^"]+"/i
+
+/**
+ * Say what a schema-bound connection did to the DDL, when that is what failed.
+ *
+ * `withSchema(...)` qualifies foreign key targets along with everything else.
+ * Postgres needs that — an unqualified reference resolves against `search_path`,
+ * which a schema-bound connection does not control — and sqlite refuses it: a
+ * `REFERENCES` clause there takes a bare table name, because a foreign key can
+ * only point inside the same database, so there is no qualifier to give. One
+ * declaration cannot spell both, and what the engine says about it is
+ * `near ".": syntax error`, which names neither the schema nor the cause.
+ *
+ * Gated on the error as well as the SQL, so a qualified reference that failed
+ * for some other reason is still reported as itself.
+ */
+const explain = (error: unknown, sql: string, schema: PikkuSchema): unknown => {
+  const message = error instanceof Error ? error.message : String(error)
+  if (!QUALIFIED_REFERENCE.test(sql) || !/syntax error/i.test(message)) {
+    return error
+  }
+  return new Error(
+    `The '${schema.name}' schema has a foreign key, and this connection is bound to a schema, ` +
+      `so it compiled to a qualified 'references "schema"."table"' that the database rejected. ` +
+      'sqlite is the engine that does this: its REFERENCES clause takes a bare table name. ' +
+      'Use a connection without withSchema(...) there — sqlite has one schema to be in — ' +
+      'or write the schema down as a migration with `pikku db generate` and apply it yourself. ' +
+      `The database said: ${message}`,
+    { cause: error }
+  )
 }
 
 /** A table a schema creates, as the DDL addresses it. */

--- a/packages/services/kysely/src/schema/index.ts
+++ b/packages/services/kysely/src/schema/index.ts
@@ -158,6 +158,17 @@ export const applyPikkuSchemas = async (
 const QUALIFIED_REFERENCE = /references "[^"]+"\."[^"]+"/i
 
 /**
+ * sqlite's own words for "you put a dot where a table name goes".
+ *
+ * Matched rather than a driver's `code`, because every sqlite binding
+ * (better-sqlite3, node:sqlite, bun:sqlite, libsql) passes the engine's message
+ * through verbatim while disagreeing about how to label it. Postgres phrases the
+ * same class of error the other way round — `syntax error at or near "."` — so
+ * this cannot fire on it.
+ */
+const SQLITE_REJECTED_QUALIFIER = /near "\.":\s*syntax error/i
+
+/**
  * Say what a schema-bound connection did to the DDL, when that is what failed.
  *
  * `withSchema(...)` qualifies foreign key targets along with everything else.
@@ -168,12 +179,17 @@ const QUALIFIED_REFERENCE = /references "[^"]+"\."[^"]+"/i
  * declaration cannot spell both, and what the engine says about it is
  * `near ".": syntax error`, which names neither the schema nor the cause.
  *
- * Gated on the error as well as the SQL, so a qualified reference that failed
- * for some other reason is still reported as itself.
+ * Gated on sqlite's exact phrasing as well as the SQL. Postgres compiles the
+ * same qualified reference legitimately, and can raise a syntax error of its own
+ * on this DDL — a column type resolved from `requires` goes in verbatim — so a
+ * looser `/syntax error/` would answer for postgres in sqlite's name.
  */
 const explain = (error: unknown, sql: string, schema: PikkuSchema): unknown => {
   const message = error instanceof Error ? error.message : String(error)
-  if (!QUALIFIED_REFERENCE.test(sql) || !/syntax error/i.test(message)) {
+  if (
+    !QUALIFIED_REFERENCE.test(sql) ||
+    !SQLITE_REJECTED_QUALIFIER.test(message)
+  ) {
     return error
   }
   return new Error(
@@ -243,21 +259,40 @@ export type EnsureOutcome = 'present' | 'created'
  * matched on the pair. Unqualified DDL resolves against the connection's
  * search_path, which is not knowable from here, so it falls back to the name.
  */
-const tablesOf = async (
-  db: Kysely<any>
-): Promise<{ qualified: Set<string>; bare: Set<string> }> => {
+interface ExistingTables {
+  qualified: Set<string>
+  bare: Set<string>
+  /** Whether this engine reports schemas at all. */
+  schemaAware: boolean
+}
+
+const tablesOf = async (db: Kysely<any>): Promise<ExistingTables> => {
   const tables = await bind(db).introspection.getTables()
   return {
-    qualified: new Set(tables.map((table) => `${table.schema}.${table.name}`)),
+    qualified: new Set(
+      tables
+        .filter((table) => table.schema)
+        .map((table) => `${table.schema}.${table.name}`)
+    ),
     bare: new Set(tables.map((table) => table.name)),
+    schemaAware: tables.some((table) => table.schema !== undefined),
   }
 }
 
-const isPresent = (
-  existing: { qualified: Set<string>; bare: Set<string> },
-  table: DeclaredTable
-): boolean =>
-  table.schema
+/**
+ * Qualified declarations match on the pair — but only where that pair means
+ * something.
+ *
+ * `TableMetadata.schema` is optional, and sqlite and mysql leave it unset:
+ * sqlite has one schema to be in, and mysql calls the thing a database. A
+ * `withSchema('main')` connection there declares `main.workflow_runs` while
+ * introspection can only offer `workflow_runs`, and holding out for the pair
+ * would read every existing table as missing — the same false negative this
+ * whole function exists to fix, arrived at from the other side. So when the
+ * engine reports no schemas, the bare name is the only name there is.
+ */
+const isPresent = (existing: ExistingTables, table: DeclaredTable): boolean =>
+  table.schema && existing.schemaAware
     ? existing.qualified.has(`${table.schema}.${table.name}`)
     : existing.bare.has(table.name)
 

--- a/packages/services/kysely/src/schema/index.ts
+++ b/packages/services/kysely/src/schema/index.ts
@@ -149,21 +149,46 @@ export const applyPikkuSchemas = async (
   })
 }
 
+/** A table a schema creates, as the DDL addresses it. */
+export interface DeclaredTable {
+  /** Present when the connection is `withSchema(...)`-bound. */
+  schema?: string
+  name: string
+}
+
+/** How a table reads in an error message: qualified only when it is. */
+const displayName = (table: DeclaredTable): string =>
+  table.schema ? `${table.schema}.${table.name}` : table.name
+
+/**
+ * `create table "workflow_runs"` and `create table "app"."workflow_runs"`.
+ *
+ * The schema half is optional and the table is always the LAST quoted
+ * identifier — matching the first one instead reads a `withSchema('app')`
+ * connection's DDL as a table called `app`, which is no table at all.
+ */
+const CREATE_TABLE =
+  /^\s*create table (?:if not exists\s+)?(?:"([^"]+)"\.)?"([^"]+)"/i
+
 /**
  * The tables a schema creates, read back out of its own compiled SQL.
  *
  * Derived rather than declared alongside the statements, because a hand-kept
  * list of names is a second source of truth: rename a table in a statement and
  * the list keeps answering for the old one.
+ *
+ * Compiled against `db` rather than in the abstract, so the answer carries the
+ * schema the DDL will actually target — the same binding the lookup has to use.
  */
-const declaredTables = (schema: PikkuSchema, db: Kysely<any>): string[] => {
+export const declaredTables = (
+  schema: PikkuSchema,
+  db: Kysely<any>
+): DeclaredTable[] => {
   const bound = bind(db)
-  const tables: string[] = []
+  const tables: DeclaredTable[] = []
   for (const statement of schema.statements) {
-    const match = /^\s*create table "([^"]+)"/i.exec(
-      statement(bound, {}).compile().sql
-    )
-    if (match) tables.push(match[1]!)
+    const match = CREATE_TABLE.exec(statement(bound, {}).compile().sql)
+    if (match) tables.push({ schema: match[1], name: match[2]! })
   }
   return tables
 }
@@ -171,8 +196,32 @@ const declaredTables = (schema: PikkuSchema, db: Kysely<any>): string[] => {
 /** What `ensurePikkuSchema` found when it looked. */
 export type EnsureOutcome = 'present' | 'created'
 
-const tablesOf = async (db: Kysely<any>): Promise<Set<string>> =>
-  new Set((await bind(db).introspection.getTables()).map((table) => table.name))
+/**
+ * What `db` already has, indexed both ways.
+ *
+ * Introspection reports every schema it can see, so the bare name alone cannot
+ * answer the question: a `workflow_runs` in some other schema is not the one a
+ * `withSchema('app')` connection reads or writes. Qualified declarations are
+ * matched on the pair. Unqualified DDL resolves against the connection's
+ * search_path, which is not knowable from here, so it falls back to the name.
+ */
+const tablesOf = async (
+  db: Kysely<any>
+): Promise<{ qualified: Set<string>; bare: Set<string> }> => {
+  const tables = await bind(db).introspection.getTables()
+  return {
+    qualified: new Set(tables.map((table) => `${table.schema}.${table.name}`)),
+    bare: new Set(tables.map((table) => table.name)),
+  }
+}
+
+const isPresent = (
+  existing: { qualified: Set<string>; bare: Set<string> },
+  table: DeclaredTable
+): boolean =>
+  table.schema
+    ? existing.qualified.has(`${table.schema}.${table.name}`)
+    : existing.bare.has(table.name)
 
 /**
  * Make sure one schema's tables are there, creating them only if none are.
@@ -198,14 +247,17 @@ export const ensurePikkuSchema = async (
 ): Promise<EnsureOutcome> => {
   const existing = await tablesOf(db)
   const declared = declaredTables(schema, db)
-  const missing = declared.filter((table) => !existing.has(table))
+  const missing = declared.filter((table) => !isPresent(existing, table))
 
   if (missing.length === 0) return 'present'
 
   if (missing.length < declared.length) {
     throw new Error(
-      `The '${schema.name}' schema is half applied: ${missing.join(', ')} missing, ` +
-        `${declared.filter((table) => existing.has(table)).join(', ')} already there. ` +
+      `The '${schema.name}' schema is half applied: ${missing.map(displayName).join(', ')} missing, ` +
+        `${declared
+          .filter((table) => isPresent(existing, table))
+          .map(displayName)
+          .join(', ')} already there. ` +
         'Something else owns part of it. Reconcile it with a migration — ' +
         '`pikku db generate` writes the declaration down — rather than creating the rest at boot.'
     )
@@ -221,7 +273,7 @@ export const ensurePikkuSchema = async (
     // a guarantee — a boot race is only fully answered by having run the
     // migration, which is what `pikku db generate` is for.
     const after = await tablesOf(db)
-    if (declared.every((table) => after.has(table))) return 'present'
+    if (declared.every((table) => isPresent(after, table))) return 'present'
     throw error
   }
 }

--- a/packages/services/kysely/src/schema/schema.test.ts
+++ b/packages/services/kysely/src/schema/schema.test.ts
@@ -362,6 +362,28 @@ describe('ensurePikkuSchema — a connection bound to a schema', () => {
     assert.equal(await ensurePikkuSchema(db, workflowSchema), 'present')
   })
 
+  test('explains the qualified foreign key sqlite cannot express', async () => {
+    // `withSchema` qualifies foreign key targets too. Postgres needs that;
+    // sqlite refuses it, and says only `near ".": syntax error` — which names
+    // neither the schema nor the connection that produced it.
+    const db = new Kysely<any>({
+      dialect: new SqliteDialect({ database: new Database(':memory:') }),
+    })
+    try {
+      await assert.rejects(
+        ensurePikkuSchema(db.withSchema('main'), workflowSchema),
+        (error: Error) => {
+          assert.match(error.message, /bound to a schema/)
+          assert.match(error.message, /takes a bare table name/i)
+          assert.ok(error.cause, 'the engine error must survive as the cause')
+          return true
+        }
+      )
+    } finally {
+      await db.destroy()
+    }
+  })
+
   test('names the schema when it reports a half-applied one', async () => {
     const db = introspecting([{ schema: 'app', name: 'workflow_runs' }])
 

--- a/packages/services/kysely/src/schema/schema.test.ts
+++ b/packages/services/kysely/src/schema/schema.test.ts
@@ -17,6 +17,7 @@ import {
   compilePikkuSchemas,
   applyPikkuSchemas,
   ensurePikkuSchema,
+  declaredTables,
   unsatisfiedRequirements,
   type PikkuSchema,
 } from './index.js'
@@ -269,5 +270,104 @@ describe('ensurePikkuSchema — what a service does at boot', () => {
     } finally {
       await db.destroy()
     }
+  })
+})
+
+describe('ensurePikkuSchema — a connection bound to a schema', () => {
+  const WORKFLOW_TABLES = [
+    'workflow_runs',
+    'workflow_step',
+    'workflow_step_history',
+    'workflow_versions',
+  ]
+
+  /**
+   * A postgres connection whose introspection answers with `tables`.
+   *
+   * Stubbed rather than run against a real database because sqlite has one
+   * schema and nothing else here speaks postgres — and introspection is the
+   * only thing `ensurePikkuSchema` reads before it decides. DummyDriver takes
+   * whatever DDL follows.
+   */
+  const introspecting = (tables: Array<{ schema: string; name: string }>) =>
+    new Kysely<any>({
+      dialect: {
+        ...dialect('postgres'),
+        createIntrospector: () => ({
+          getSchemas: async () => [],
+          getMetadata: async () => ({ tables: [] }),
+          getTables: async () =>
+            tables.map(({ schema, name }) => ({
+              schema,
+              name,
+              isView: false,
+              columns: [],
+            })),
+        }),
+      },
+    })
+
+  test('reads the schema out of its own DDL, not the table name', () => {
+    const db = new Kysely<any>({ dialect: dialect('postgres') })
+
+    assert.deepEqual(declaredTables(workflowSchema, db.withSchema('app')), [
+      { schema: 'app', name: 'workflow_runs' },
+      { schema: 'app', name: 'workflow_step' },
+      { schema: 'app', name: 'workflow_step_history' },
+      { schema: 'app', name: 'workflow_versions' },
+    ])
+
+    // Unqualified DDL resolves against the connection's search_path, which is
+    // not knowable from here — so there is no schema to report.
+    assert.deepEqual(
+      declaredTables(workflowSchema, db),
+      WORKFLOW_TABLES.map((name) => ({ schema: undefined, name }))
+    )
+  })
+
+  test('finds tables that already exist under that schema', async () => {
+    // The regression this exists for: a `withSchema('app')` connection reading
+    // its own `create table "app"."workflow_runs"` as a table called `app`,
+    // concluding every table was missing, and issuing a bare CREATE that the
+    // database rejects with `relation "workflow_runs" already exists` — on
+    // every boot, forever.
+    const db = introspecting(
+      WORKFLOW_TABLES.map((name) => ({ schema: 'app', name }))
+    )
+
+    assert.equal(
+      await ensurePikkuSchema(db.withSchema('app'), workflowSchema),
+      'present'
+    )
+  })
+
+  test('does not accept the same names in a different schema', async () => {
+    // `withSchema('app')` reads and writes `app.workflow_runs`. A
+    // `public.workflow_runs` is a different table and answers nothing.
+    const db = introspecting(
+      WORKFLOW_TABLES.map((name) => ({ schema: 'public', name }))
+    )
+
+    assert.equal(
+      await ensurePikkuSchema(db.withSchema('app'), workflowSchema),
+      'created'
+    )
+  })
+
+  test('still matches on the bare name when the connection is unbound', async () => {
+    const db = introspecting(
+      WORKFLOW_TABLES.map((name) => ({ schema: 'public', name }))
+    )
+
+    assert.equal(await ensurePikkuSchema(db, workflowSchema), 'present')
+  })
+
+  test('names the schema when it reports a half-applied one', async () => {
+    const db = introspecting([{ schema: 'app', name: 'workflow_runs' }])
+
+    await assert.rejects(
+      ensurePikkuSchema(db.withSchema('app'), workflowSchema),
+      /app\.workflow_step.*missing.*app\.workflow_runs already there/s
+    )
   })
 })

--- a/packages/services/kysely/src/schema/schema.test.ts
+++ b/packages/services/kysely/src/schema/schema.test.ts
@@ -38,6 +38,21 @@ const dialect = (kind: 'postgres' | 'sqlite') =>
         createQueryCompiler: () => new SqliteQueryCompiler(),
       }
 
+/** A driver whose every query fails with `error` — for testing the failure path. */
+class ThrowingDriver extends DummyDriver {
+  constructor(private readonly error: Error) {
+    super()
+  }
+  override async acquireConnection() {
+    return {
+      executeQuery: async (): Promise<never> => {
+        throw this.error
+      },
+      streamQuery: async function* () {},
+    }
+  }
+}
+
 const compileFor = (kind: 'postgres' | 'sqlite') =>
   compilePikkuSchemas(new Kysely<any>({ dialect: dialect(kind) }))
 
@@ -289,7 +304,9 @@ describe('ensurePikkuSchema — a connection bound to a schema', () => {
    * only thing `ensurePikkuSchema` reads before it decides. DummyDriver takes
    * whatever DDL follows.
    */
-  const introspecting = (tables: Array<{ schema: string; name: string }>) =>
+  const introspecting = (
+    tables: Array<{ schema: string | undefined; name: string }>
+  ) =>
     new Kysely<any>({
       dialect: {
         ...dialect('postgres'),
@@ -360,6 +377,50 @@ describe('ensurePikkuSchema — a connection bound to a schema', () => {
     )
 
     assert.equal(await ensurePikkuSchema(db, workflowSchema), 'present')
+  })
+
+  test('matches on the bare name when the engine reports no schemas', async () => {
+    // sqlite and mysql leave `TableMetadata.schema` unset. Holding out for the
+    // qualified pair there would read every existing table as missing — the
+    // same false negative this suite exists for, arrived at from the other side.
+    const db = introspecting(
+      WORKFLOW_TABLES.map((name) => ({ schema: undefined, name }))
+    )
+
+    assert.equal(
+      await ensurePikkuSchema(db.withSchema('main'), workflowSchema),
+      'present'
+    )
+  })
+
+  test('leaves a syntax error that is not sqlite refusing a qualifier alone', async () => {
+    // Postgres compiles the same qualified reference legitimately, and can
+    // raise a syntax error of its own on this DDL — a column type resolved from
+    // `requires` goes in verbatim. Answering for it in sqlite's name would be
+    // the misleading-error bug, reintroduced.
+    const pgError = Object.assign(
+      new Error('syntax error at or near "not"'),
+      { code: '42601' }
+    )
+    const db = new Kysely<any>({
+      dialect: {
+        ...dialect('postgres'),
+        createDriver: () => new ThrowingDriver(pgError),
+        createIntrospector: () => ({
+          getSchemas: async () => [],
+          getMetadata: async () => ({ tables: [] }),
+          getTables: async () => [],
+        }),
+      },
+    })
+
+    await assert.rejects(
+      ensurePikkuSchema(db.withSchema('app'), workflowSchema),
+      (error: Error) => {
+        assert.equal(error, pgError, 'the engine error must pass through as-is')
+        return true
+      }
+    )
   })
 
   test('explains the qualified foreign key sqlite cannot express', async () => {


### PR DESCRIPTION
## The bug

`ensurePikkuSchema` read the table name out of its own compiled DDL with a regex that matched the **first** quoted identifier:

```ts
/^\s*create table "([^"]+)"/i
```

On a connection bound to a schema that DDL is `create table "app"."workflow_runs"`, so it captured `app` — never a real table name. Every table therefore read as missing, and it issued a bare `create table` that the database rejected:

```
PostgresError: relation "workflow_runs" already exists
```

On every boot, forever. This crash-looped a production backend 82 times after upgrading to `0.13.4`, which is where the introspect-then-create replaced the old `.ifNotExists()` DDL.

## The fix

Parse the optional schema half, and match on the pair when the DDL is qualified:

```ts
const CREATE_TABLE = /^\s*create table (?:if not exists\s+)?(?:"([^"]+)"\.)?"([^"]+)"/i
```

`declaredTables` now returns `DeclaredTable[]` (`{ schema?, name }`) instead of `string[]`, and the lookup indexes introspection both ways. A qualified declaration matches on `schema.name`; an unqualified one falls back to the bare name, since such a statement resolves against a `search_path` that isn't knowable from here. `isPresent` branches on the **declaration**, not on what introspection happens to report — which matters, because `SqliteIntrospector` returns `schema: undefined`. Half-applied and boot-race paths share the predicate, and error messages name the schema.

## Second commit: the sqlite case

While verifying sqlite still worked, `withSchema` turned out to be broken there for an unrelated reason. Not create-table — raw sqlite accepts `create table "main"."foo"` fine. It's the foreign key:

```
qualified create:       OK
qualified references:   FAILED: near ".": syntax error
unqualified references: OK
```

`withSchema` qualifies reference targets too. Postgres **needs** that (an unqualified reference resolves against `search_path`, which a schema-bound connection doesn't control — the mirror image of the bug above); sqlite **forbids** it, because a foreign key there can only point inside the same database, so there is no qualifier to give. One declaration can't spell both.

Rather than rewrite compiled SQL per engine — more string-munging of exactly the kind that caused the first bug — the failure is made legible. `applyPikkuSchemas` catches per statement and, when the SQL has a qualified `references` **and** the engine said "syntax error", reports the schema, both ways out, and keeps the engine error as `cause`. The double gate means a qualified reference that fails for any other reason still surfaces as itself. No dialect sniffing, so it holds for any sqlite driver (bun-sqlite, libsql) rather than only the one whose adapter class we'd have recognized.

## Tests

New `ensurePikkuSchema — a connection bound to a schema` suite. The discriminating cases need a stubbed Postgres introspector, since sqlite has one schema and can't express them:

- `declaredTables` reports the schema for qualified DDL, `undefined` otherwise
- tables present under `app` on a `withSchema('app')` connection → `present` (before: `created`, then the real database throws "already exists")
- the same names under `public` → still `created`; a different table answers nothing
- an unbound connection still matches on the bare name
- the half-applied error names the schema
- the qualified-foreign-key message, driven against a real in-memory sqlite, asserting the surviving `cause`

`174 pass, 0 fail`; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema detection for database connections using schema-qualified tables.
  * Prevented repeated attempts to create tables that already exist.
  * Improved error messages for partially applied schemas with qualified table names.
  * Enhanced SQLite errors for unsupported schema-qualified foreign-key syntax, including recommended guidance and the original database error.
  * Improved handling of tables with identical names across different schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->