### PR TITLE
fix(cli): pin the bootstrap install so a release wave cannot stall it

### DIFF
--- a/packages/cli/build.sh
+++ b/packages/cli/build.sh
@@ -27,6 +27,14 @@ echo "Bootstrapping with published @pikku/cli..."
 : "${PIKKU_CLI_VERSION:=0.12.83}"
 : "${PIKKU_INSPECTOR_VERSION:=0.12.43}"
 : "${PIKKU_BETTER_AUTH_VERSION:=0.12.12}"
+# core 0.12.64 went out 40 seconds before cli 0.12.83, so it is the third member
+# of that same wave. It is a *peer* of both the CLI and the inspector, which is
+# why it has to be named here to exist at all once peer resolution is off.
+: "${PIKKU_CORE_VERSION:=0.12.64}"
+# The other peer that has to be named: @pikku/better-auth peers on the upstream
+# `better-auth` library and imports it at module load, so without it the
+# bootstrap CLI dies on "Cannot find package 'better-auth'".
+: "${BETTER_AUTH_LIB_VERSION:=1.6.25}"
 _bootstrap_dir=$(mktemp -d)
 trap 'rm -rf "$_bootstrap_dir"' EXIT
 # The published bootstrap CLI's own auth codegen imports the auth package at
@@ -48,15 +56,29 @@ cat > "$_bootstrap_dir/package.json" <<JSON
   "dependencies": {
     "@pikku/cli": "${PIKKU_CLI_VERSION}",
     "@pikku/inspector": "${PIKKU_INSPECTOR_VERSION}",
-    "@pikku/better-auth": "${PIKKU_BETTER_AUTH_VERSION}"
+    "@pikku/better-auth": "${PIKKU_BETTER_AUTH_VERSION}",
+    "@pikku/core": "${PIKKU_CORE_VERSION}",
+    "better-auth": "${BETTER_AUTH_LIB_VERSION}"
   },
   "overrides": {
     "@pikku/better-auth": "${PIKKU_BETTER_AUTH_VERSION}",
-    "@pikku/inspector": "${PIKKU_INSPECTOR_VERSION}"
+    "@pikku/inspector": "${PIKKU_INSPECTOR_VERSION}",
+    "@pikku/core": "${PIKKU_CORE_VERSION}",
+    "better-auth": "${BETTER_AUTH_LIB_VERSION}"
   }
 }
 JSON
-(cd "$_bootstrap_dir" && npm install --no-save --no-package-lock)
+# --legacy-peer-deps, because this tree is a throwaway runner for one codegen
+# pass and every package it needs is now pinned above. Left on, peer resolution
+# reaches across the whole floating transitive graph — @pikku/cli@0.12.83 depends
+# on `@pikku/kysely: ^0.13.1`, so every release wave drags in a kysely whose peer
+# on @pikku/core has moved ahead of what the registry is serving for this tree.
+# That is not hypothetical: publishing @pikku/kysely@0.13.6 (peer core ^0.12.71)
+# seconds before @pikku/cli@0.12.92 sent npm backtracking for thirty minutes over
+# ~100k ERESOLVE warnings until it aborted, and the CLI was the one package in
+# that release that did not publish. Peers here buy nothing — nothing consumes
+# this tree — and cost the release.
+(cd "$_bootstrap_dir" && npm install --no-save --no-package-lock --legacy-peer-deps)
 "$_bootstrap_dir/node_modules/.bin/pikku"
 rm -rf "$_bootstrap_dir"
 


### PR DESCRIPTION
## The failure this fixes

On the `0.12.92` release, twenty packages published and `@pikku/cli` did not:

```
an error occurred while publishing @pikku/cli: 134 command failed
sh -c yarn build
```

`packages/cli/build.sh` bootstraps by `npm install`ing a pinned published CLI into a temp dir. That install ran for **30 minutes**, emitted ~100k `npm warn ERESOLVE` lines and died with SIGABRT.

## Why

Only `@pikku/cli`, `@pikku/inspector` and `@pikku/better-auth` were pinned — everything else floated, peers included. `@pikku/cli@0.12.83` depends on `@pikku/kysely: ^0.13.1`, so the bootstrap always picks up the newest kysely. During a release, the newest kysely is the one changesets published *seconds earlier*: `@pikku/kysely@0.13.6`, peering on `@pikku/core@^0.12.71`, while the registry was still serving `@pikku/core@0.12.70` for this tree. npm backtracked over that unsatisfiable graph until it OOM'd.

This is structural, not a one-off — it can recur on any release wave where a transitive dependency's peer range moves ahead of what the registry serves.

## The change

- Pin `@pikku/core` to `0.12.64` — the same release wave that produced cli `0.12.83` and inspector `0.12.43` (core `0.12.64` was published 40 seconds before cli `0.12.83`).
- Pin the upstream `better-auth` library.
- Install with `--legacy-peer-deps`.

Both additions are *peers* rather than dependencies, so they have to be named explicitly to exist at all once peer resolution is off — without them the bootstrap CLI dies on `Cannot find package 'better-auth'`. The tree is a throwaway runner for one codegen pass and nothing consumes it, so peer consistency buys nothing here and costs a release when it goes wrong.

Every version stays overridable by env var (`PIKKU_CORE_VERSION`, `BETTER_AUTH_LIB_VERSION`) like the existing pins.

## Verification

Full `./build.sh` run locally, end to end, exit 0 — bootstrap codegen, `tsc -b`, local `pikku` regen, schema copy, console app, and all five native binaries. Bootstrap install drops from ~17s to ~2s; the whole script now takes 16s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CLI build reliability by pinning required dependency versions during bootstrapping.
  * Updated package installation handling to avoid peer-dependency resolution issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->