### PR TITLE
fix(cli): escape prose in generated code

### DIFF
--- a/.changeset/escape-display-names-in-generated-meta.md
+++ b/.changeset/escape-display-names-in-generated-meta.md
@@ -1,0 +1,9 @@
+---
+'@pikku/cli': patch
+---
+
+Escaped display names and descriptions in generated and scaffolded sources.
+
+A `displayName` is the human-facing label a developer writes — "Stripe's live key" — and it was interpolated raw into a single-quoted string in `pikku-secrets.gen.ts`, `pikku-variables.gen.ts`, and `pikku-credentials.gen.ts`. An apostrophe terminated the literal and the whole generated file stopped parsing, with `tsc` reporting a cascade of syntax errors in generated code rather than anything about the name. The three serializers now emit the value through `JSON.stringify`, which also covers a quote or a backslash — the same treatment the workflow map keys already get.
+
+`pikku new-addon` had the same hole: `--display-name "Bob's CRM"` scaffolded an addon that did not compile before its author had written a line of it. Its prose now goes through the same escaping, composed with the words around it so a message stays one literal, and through a template-literal-aware escape where the scaffolded code interpolates a response status.

--- a/packages/cli/src/functions/commands/new-addon.test.ts
+++ b/packages/cli/src/functions/commands/new-addon.test.ts
@@ -3,7 +3,12 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, test, afterEach } from 'node:test'
-import { resolveAddonDepProtocol } from './new-addon.js'
+import ts from 'typescript'
+import {
+  getAddonFiles,
+  resolveAddonDepProtocol,
+  type AddonVars,
+} from './new-addon.js'
 
 const created: string[] = []
 
@@ -74,5 +79,96 @@ describe('resolveAddonDepProtocol', () => {
     await mkdir(target, { recursive: true })
 
     assert.equal(resolveAddonDepProtocol(target), 'file:..')
+  })
+})
+
+const vars = (displayName: string, description: string): AddonVars => ({
+  name: 'crm',
+  camelName: 'crm',
+  pascalName: 'Crm',
+  screamingName: 'CRM',
+  displayName,
+  description,
+  category: 'General',
+  addonDepProtocol: 'workspace:*',
+})
+
+/** Every flag combination that embeds the prose in a different shape. */
+const flagVariants: Parameters<typeof getAddonFiles>[1][] = [
+  { secret: false, variable: false, oauth: false },
+  { secret: true, variable: true, oauth: false },
+  { secret: false, variable: false, oauth: true },
+  { secret: false, variable: false, oauth: false, credential: 'apikey' },
+  { secret: false, variable: false, oauth: false, credential: 'bearer' },
+  {
+    secret: false,
+    variable: false,
+    oauth: false,
+    credential: 'bearer',
+    delegated: true,
+  },
+  { secret: false, variable: false, oauth: false, credential: 'oauth2' },
+]
+
+const parseErrors = (fileName: string, source: string) => {
+  const file = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true
+  )
+  return (file as unknown as { parseDiagnostics: ts.Diagnostic[] })
+    .parseDiagnostics
+}
+
+const scaffoldErrors = (displayName: string, description: string) => {
+  const errors: string[] = []
+  for (const flags of flagVariants) {
+    const files = getAddonFiles(vars(displayName, description), flags)
+    for (const [path, source] of Object.entries(files)) {
+      if (!path.endsWith('.ts')) {
+        continue
+      }
+      for (const diagnostic of parseErrors(path, source)) {
+        errors.push(`${path}: ${diagnostic.messageText}`)
+      }
+    }
+  }
+  return errors
+}
+
+describe('getAddonFiles', () => {
+  test('scaffolds parseable sources for ordinary prose', () => {
+    assert.deepEqual(scaffoldErrors('Acme CRM', 'Acme CRM integration'), [])
+  })
+
+  /**
+   * `--display-name` and `--description` are free-form prose, and interpolated
+   * raw into a quoted string an apostrophe terminated the literal — the
+   * scaffolded addon did not compile before the user had written a line of it.
+   * A backtick or a `${` does the same inside the generated template literals.
+   */
+  test('scaffolds parseable sources for prose needing escaping', () => {
+    assert.deepEqual(
+      scaffoldErrors(
+        'Bob\'s "Big" CRM \\ Ltd ${escape} `tick`',
+        'Bob\'s "Big" CRM \\ integration'
+      ),
+      []
+    )
+  })
+
+  test('keeps composed prose in a single string literal', () => {
+    const files = getAddonFiles(vars("Bob's CRM", 'desc'), {
+      secret: true,
+      variable: false,
+      oauth: false,
+    })
+
+    assert.match(
+      files['src/crm.secret.ts']!,
+      /describe\("Bob's CRM API key"\)/,
+      'the display name and the words around it are one literal'
+    )
   })
 })

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -123,7 +123,27 @@ function sanitizeAddonName(raw: string): string {
   return name || raw
 }
 
-interface AddonVars {
+/**
+ * `--display-name` and `--description` are free-form prose, so an apostrophe in
+ * them is ordinary — "Bob's CRM". `JSON.stringify` emits a valid, escaped
+ * string literal; interpolating the raw text into a quoted one terminates the
+ * string and the scaffolded file no longer parses. Prose composed with other
+ * words is stringified as a whole, not swapped in place.
+ */
+const literal = (value: string) => JSON.stringify(value)
+
+/**
+ * The same prose inside a generated template literal, where a backtick or a
+ * `${` opens an interpolation rather than ending the string — so the emitted
+ * message keeps its own `\${response.status}` holes.
+ */
+const inTemplate = (value: string) =>
+  value.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${')
+
+/** The same prose on a `//` comment line, where a newline ends the comment. */
+const inComment = (value: string) => value.replace(/\s+/g, ' ').trim()
+
+export interface AddonVars {
   name: string
   camelName: string
   pascalName: string
@@ -134,7 +154,7 @@ interface AddonVars {
   addonDepProtocol: string
 }
 
-function getAddonFiles(
+export function getAddonFiles(
   vars: AddonVars,
   flags: {
     secret: boolean
@@ -266,7 +286,7 @@ ${description}
 `
 
   // src/index.ts
-  files['src/index.ts'] = `// ${displayName} functions
+  files['src/index.ts'] = `// ${inComment(displayName)} functions
 // export { ${camelName}Operation } from './functions/operation.function.js'
 `
 
@@ -286,10 +306,10 @@ export const createWireServices = pikkuAddonWireServices(
     }
     const cred = await wire.getCredential<{ token: string; expiresAt?: number }>('${camelName}')
     if (!cred?.token) {
-      throw new UnauthorizedError('No ${displayName} session — sign in again')
+      throw new UnauthorizedError(${literal(`No ${displayName} session — sign in again`)})
     }
     if (cred.expiresAt && cred.expiresAt * 1000 < Date.now()) {
-      throw new UnauthorizedError('${displayName} session expired — sign in again')
+      throw new UnauthorizedError(${literal(`${displayName} session expired — sign in again`)})
     }
     const ${camelName} = new ${pascalName}Service(cred, variables)
 
@@ -335,7 +355,7 @@ export const createWireServices = pikkuAddonWireServices(
     }
     const cred = await wire.getCredential<{ accessToken: string }>('${camelName}')
     if (!cred?.accessToken) {
-      throw new UnauthorizedError('No ${displayName} connection — connect ${displayName} first')
+      throw new UnauthorizedError(${literal(`No ${displayName} connection — connect ${displayName} first`)})
     }
     const ${camelName} = new ${pascalName}Service(cred, variables)
 
@@ -424,7 +444,7 @@ export class ${pascalName}Service {
 
     if (!response.ok) {
       const errorText = await response.text()
-      throw new Error(\`${displayName} API error (\${response.status}): \${errorText}\`)
+      throw new Error(\`${inTemplate(displayName)} API error (\${response.status}): \${errorText}\`)
     }
 
     return response.json() as Promise<T>
@@ -476,7 +496,7 @@ export class ${pascalName}Service {
 
     if (!response.ok) {
       const errorText = await response.text()
-      throw new Error(\`${displayName} API error (\${response.status}): \${errorText}\`)
+      throw new Error(\`${inTemplate(displayName)} API error (\${response.status}): \${errorText}\`)
     }
 
     return response.json() as Promise<T>
@@ -523,7 +543,7 @@ export class ${pascalName}Service {
 
     if (!response.ok) {
       const errorText = await response.text()
-      throw new Error(\`${displayName} API error (\${response.status}): \${errorText}\`)
+      throw new Error(\`${inTemplate(displayName)} API error (\${response.status}): \${errorText}\`)
     }
 
     return response.json() as Promise<T>
@@ -565,7 +585,7 @@ export class ${pascalName}Service {
 
     if (!response.ok) {
       const errorText = await response.text()
-      throw new Error(\`${displayName} API error (\${response.status}): \${errorText}\`)
+      throw new Error(\`${inTemplate(displayName)} API error (\${response.status}): \${errorText}\`)
     }
 
     return response.json() as Promise<T>
@@ -614,23 +634,23 @@ export interface Services extends CoreServices<SingletonServices> {}
 import { wireCredential } from '@pikku/core/credential'
 
 export const ${camelName}CredentialSchema = z.object({
-  apiKey: z.string().describe('${displayName} API key'),
+  apiKey: z.string().describe(${literal(`${displayName} API key`)}),
 })
 
 wireCredential({
   name: '${camelName}',
-  displayName: '${displayName}',
-  description: '${description}',
+  displayName: ${literal(displayName)},
+  description: ${literal(description)},
   type: 'wire',
   schema: ${camelName}CredentialSchema,
 })
 `
   } else if (flags.credential === 'bearer') {
     const credentialFields = flags.delegated
-      ? `  token: z.string().describe('${displayName} session token captured at delegated sign-in'),
+      ? `  token: z.string().describe(${literal(`${displayName} session token captured at delegated sign-in`)}),
   expiresAt: z.number().optional().describe('Token expiry (epoch seconds)'),
   tenantId: z.string().optional().describe('Upstream tenant id'),`
-      : `  token: z.string().describe('${displayName} bearer token'),`
+      : `  token: z.string().describe(${literal(`${displayName} bearer token`)}),`
     files[`src/${name}.credential.ts`] = `import { z } from 'zod'
 import { wireCredential } from '@pikku/core/credential'
 
@@ -640,8 +660,8 @@ ${credentialFields}
 
 wireCredential({
   name: '${camelName}',
-  displayName: '${displayName}',
-  description: '${description}',
+  displayName: ${literal(displayName)},
+  description: ${literal(description)},
   type: 'wire',
   schema: ${camelName}CredentialSchema,
 })
@@ -658,8 +678,8 @@ export const ${camelName}TokenSchema = z.object({
 
 wireCredential({
   name: '${camelName}',
-  displayName: '${displayName}',
-  description: '${description}',
+  displayName: ${literal(displayName)},
+  description: ${literal(description)},
   type: 'wire',
   schema: ${camelName}TokenSchema,
   oauth2: {
@@ -673,8 +693,8 @@ wireCredential({
 
 wireSecret({
   name: '${camelName}OAuthApp',
-  displayName: '${displayName} OAuth App',
-  description: 'OAuth2 app credentials for ${displayName}',
+  displayName: ${literal(`${displayName} OAuth App`)},
+  description: ${literal(`OAuth2 app credentials for ${displayName}`)},
   secretId: '${screamingName}_OAUTH_APP',
 })
 `
@@ -683,7 +703,7 @@ wireSecret({
 import { wireSecret } from '@pikku/core/secret'
 
 export const ${camelName}SecretsSchema = z.object({
-  apiKey: z.string().describe('${displayName} API key'),
+  apiKey: z.string().describe(${literal(`${displayName} API key`)}),
   // Add other secret fields as needed
 })
 
@@ -691,8 +711,8 @@ export type ${pascalName}Secrets = z.infer<typeof ${camelName}SecretsSchema>
 
 wireSecret({
   name: '${camelName}',
-  displayName: '${displayName} API',
-  description: '${description}',
+  displayName: ${literal(`${displayName} API`)},
+  description: ${literal(description)},
   secretId: '${screamingName}_CREDENTIALS',
   schema: ${camelName}SecretsSchema,
 })
@@ -708,7 +728,7 @@ export const ${camelName}VariableSchema = z.string().optional().describe('TODO: 
 
 wireVariable({
   name: '${camelName}_variable',
-  displayName: '${displayName} Variable',
+  displayName: ${literal(`${displayName} Variable`)},
   description: 'TODO: describe this variable',
   variableId: '${screamingName}_VARIABLE',
   schema: ${camelName}VariableSchema,

--- a/packages/cli/src/functions/wirings/credentials/serialize-credentials-types.test.ts
+++ b/packages/cli/src/functions/wirings/credentials/serialize-credentials-types.test.ts
@@ -1,0 +1,46 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import ts from 'typescript'
+import { serializeCredentialsTypes } from './serialize-credentials-types.js'
+import type { CredentialDefinitions } from '@pikku/core/credential'
+
+const serialize = (definitions: CredentialDefinitions) =>
+  serializeCredentialsTypes({
+    definitions,
+    schemaLookup: new Map(),
+    credentialsFile: '/project/.pikku/credentials/pikku-credentials.gen.ts',
+    packageMappings: {},
+  })
+
+const parseErrors = (source: string) => {
+  const file = ts.createSourceFile(
+    'pikku-credentials.gen.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true
+  )
+  return (file as unknown as { parseDiagnostics: ts.Diagnostic[] })
+    .parseDiagnostics
+}
+
+const credential = (displayName: string): CredentialDefinitions => [
+  { name: 'stripe', displayName, type: 'singleton' },
+]
+
+describe('serializeCredentialsTypes', () => {
+  test('emits a parseable file for an ordinary display name', () => {
+    assert.deepEqual(parseErrors(serialize(credential('Stripe'))), [])
+  })
+
+  /**
+   * A display name is prose written by a human — "Stripe's live key", a Windows
+   * path — and interpolated raw into a quoted string it terminates the literal
+   * and the whole generated file stops parsing.
+   */
+  test('emits a parseable file for a display name needing escaping', () => {
+    assert.deepEqual(
+      parseErrors(serialize(credential(`Stripe's "live" key \\ prod`))),
+      []
+    )
+  })
+})

--- a/packages/cli/src/functions/wirings/credentials/serialize-credentials-types.ts
+++ b/packages/cli/src/functions/wirings/credentials/serialize-credentials-types.ts
@@ -3,6 +3,14 @@ import { validateAndBuildCredentialDefinitionsMeta } from '@pikku/core/credentia
 import type { SchemaRef } from '@pikku/inspector'
 import { getFileImportRelativePath } from '../../../utils/file-import-path.js'
 
+/**
+ * A display name is the human-facing label a developer wrote, so an apostrophe
+ * in it is ordinary. `JSON.stringify` emits a valid, escaped TypeScript string
+ * literal; interpolating the raw text into a quoted one terminates the string
+ * and the generated file stops parsing.
+ */
+const literal = (value: string) => JSON.stringify(value)
+
 export interface SerializeCredentialsOptions {
   definitions: CredentialDefinitions
   schemaLookup: Map<string, SchemaRef>
@@ -47,7 +55,7 @@ export const serializeCredentialsTypes = ({
 
     const metaParts = [
       `name: '${name}'`,
-      `displayName: '${meta.displayName}'`,
+      `displayName: ${literal(meta.displayName)}`,
       `type: '${meta.type}'`,
     ]
     if (meta.oauth2) {

--- a/packages/cli/src/functions/wirings/secrets/serialize-secrets-types.test.ts
+++ b/packages/cli/src/functions/wirings/secrets/serialize-secrets-types.test.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from 'assert'
 import { describe, test } from 'node:test'
+import ts from 'typescript'
 import { serializeSecretsTypes } from './serialize-secrets-types.js'
 import type { SecretDefinitions } from '@pikku/core/secret'
 
@@ -10,6 +11,31 @@ const serialize = (definitions: SecretDefinitions) =>
     secretsFile: '/project/.pikku/secrets/pikku-secrets.gen.ts',
     packageMappings: {},
   })
+
+const parseErrors = (source: string) => {
+  const file = ts.createSourceFile(
+    'pikku-secrets.gen.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true
+  )
+  return (file as unknown as { parseDiagnostics: ts.Diagnostic[] })
+    .parseDiagnostics
+}
+
+const oauth2Secret = (displayName: string): SecretDefinitions => [
+  {
+    name: 'stripe',
+    displayName,
+    secretId: 'STRIPE_KEY',
+    oauth2: {
+      tokenSecretId: 'STRIPE_TOKENS',
+      authorizationUrl: 'https://example.com/authorize',
+      tokenUrl: 'https://example.com/token',
+      scopes: [],
+    },
+  },
+]
 
 describe('serializeSecretsTypes — shipping the declared set', () => {
   // tsc only copies a .json into the build output when something imports it,
@@ -46,6 +72,22 @@ describe('serializeSecretsTypes — shipping the declared set', () => {
     const output = serialize([])
 
     assert.match(output, /pikku-secrets-meta\.gen\.json/)
+  })
+
+  test('emits a parseable file for an ordinary display name', () => {
+    assert.deepEqual(parseErrors(serialize(oauth2Secret('Stripe'))), [])
+  })
+
+  /**
+   * A display name is prose written by a human — "Stripe's live key", a Windows
+   * path — and interpolated raw into a quoted string it terminates the literal
+   * and the whole generated file stops parsing.
+   */
+  test('emits a parseable file for a display name needing escaping', () => {
+    assert.deepEqual(
+      parseErrors(serialize(oauth2Secret(`Stripe's "live" key \\ prod`))),
+      []
+    )
   })
 
   test('still exposes the typed service', () => {

--- a/packages/cli/src/functions/wirings/secrets/serialize-secrets-types.ts
+++ b/packages/cli/src/functions/wirings/secrets/serialize-secrets-types.ts
@@ -3,6 +3,14 @@ import { validateAndBuildSecretDefinitionsMeta } from '@pikku/core/secret'
 import type { SchemaRef } from '@pikku/inspector'
 import { getFileImportRelativePath } from '../../../utils/file-import-path.js'
 
+/**
+ * A display name is the human-facing label a developer wrote, so an apostrophe
+ * in it is ordinary. `JSON.stringify` emits a valid, escaped TypeScript string
+ * literal; interpolating the raw text into a quoted one terminates the string
+ * and the generated file stops parsing.
+ */
+const literal = (value: string) => JSON.stringify(value)
+
 export interface SerializeSecretsOptions {
   definitions: SecretDefinitions
   schemaLookup: Map<string, SchemaRef>
@@ -36,10 +44,10 @@ export const serializeSecretsTypes = ({
       mapEntries.push(`  '${meta.oauth2.tokenSecretId}': OAuth2Token`)
 
       metaEntries.push(
-        `  '${meta.secretId}': { name: '${name}', displayName: '${meta.displayName}', oauth2: { tokenSecretId: '${meta.oauth2.tokenSecretId}' } }`
+        `  '${meta.secretId}': { name: '${name}', displayName: ${literal(meta.displayName)}, oauth2: { tokenSecretId: '${meta.oauth2.tokenSecretId}' } }`
       )
       metaEntries.push(
-        `  '${meta.oauth2.tokenSecretId}': { name: '${name}_tokens', displayName: '${meta.displayName} Tokens' }`
+        `  '${meta.oauth2.tokenSecretId}': { name: '${name}_tokens', displayName: ${literal(`${meta.displayName} Tokens`)} }`
       )
     } else if (meta.schema && typeof meta.schema === 'string') {
       const schemaRef = schemaLookup.get(meta.schema)
@@ -54,7 +62,7 @@ export const serializeSecretsTypes = ({
           `  '${meta.secretId}': z.infer<typeof ${schemaRef.variableName}>`
         )
         metaEntries.push(
-          `  '${meta.secretId}': { name: '${name}', displayName: '${meta.displayName}' }`
+          `  '${meta.secretId}': { name: '${name}', displayName: ${literal(meta.displayName)} }`
         )
       }
     }

--- a/packages/cli/src/functions/wirings/variables/serialize-variables-types.test.ts
+++ b/packages/cli/src/functions/wirings/variables/serialize-variables-types.test.ts
@@ -1,15 +1,53 @@
 import { strict as assert } from 'assert'
 import { describe, test } from 'node:test'
+import ts from 'typescript'
 import { serializeVariablesTypes } from './serialize-variables-types.js'
 import type { VariableDefinitions } from '@pikku/core/variable'
+import type { SchemaRef } from '@pikku/inspector'
 
-const serialize = (definitions: VariableDefinitions) =>
+const serialize = (
+  definitions: VariableDefinitions,
+  schemaLookup: Map<string, SchemaRef> = new Map()
+) =>
   serializeVariablesTypes({
     definitions,
-    schemaLookup: new Map(),
+    schemaLookup,
     variablesFile: '/project/.pikku/variables/pikku-variables.gen.ts',
     packageMappings: {},
   })
+
+const parseErrors = (source: string) => {
+  const file = ts.createSourceFile(
+    'pikku-variables.gen.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true
+  )
+  return (file as unknown as { parseDiagnostics: ts.Diagnostic[] })
+    .parseDiagnostics
+}
+
+/** Only a schema-backed variable reaches the metadata entries. */
+const schemaBackedVariable = (displayName: string) =>
+  serialize(
+    [
+      {
+        name: 'apiUrl',
+        displayName,
+        variableId: 'API_URL',
+        schema: 'ApiUrlSchema',
+      },
+    ],
+    new Map([
+      [
+        'ApiUrlSchema',
+        {
+          variableName: 'ApiUrlSchema',
+          sourceFile: '/project/src/variables.ts',
+        } as SchemaRef,
+      ],
+    ])
+  )
 
 describe('serializeVariablesTypes — shipping the declared set', () => {
   // Same reason as secrets: tsc only copies an imported .json into the build
@@ -41,5 +79,21 @@ describe('serializeVariablesTypes — shipping the declared set', () => {
     const output = serialize([])
 
     assert.match(output, /pikku-variables-meta\.gen\.json/)
+  })
+
+  test('emits a parseable file for an ordinary display name', () => {
+    assert.deepEqual(parseErrors(schemaBackedVariable('API URL')), [])
+  })
+
+  /**
+   * A display name is prose written by a human — "the tenant's API URL", a
+   * Windows path — and interpolated raw into a quoted string it terminates the
+   * literal and the whole generated file stops parsing.
+   */
+  test('emits a parseable file for a display name needing escaping', () => {
+    assert.deepEqual(
+      parseErrors(schemaBackedVariable(`the tenant's "API" URL \\ prod`)),
+      []
+    )
   })
 })

--- a/packages/cli/src/functions/wirings/variables/serialize-variables-types.ts
+++ b/packages/cli/src/functions/wirings/variables/serialize-variables-types.ts
@@ -3,6 +3,14 @@ import { validateAndBuildVariableDefinitionsMeta } from '@pikku/core/variable'
 import type { SchemaRef } from '@pikku/inspector'
 import { getFileImportRelativePath } from '../../../utils/file-import-path.js'
 
+/**
+ * A display name is the human-facing label a developer wrote, so an apostrophe
+ * in it is ordinary. `JSON.stringify` emits a valid, escaped TypeScript string
+ * literal; interpolating the raw text into a quoted one terminates the string
+ * and the generated file stops parsing.
+ */
+const literal = (value: string) => JSON.stringify(value)
+
 export interface SerializeVariablesOptions {
   definitions: VariableDefinitions
   schemaLookup: Map<string, SchemaRef>
@@ -42,7 +50,7 @@ export const serializeVariablesTypes = ({
           `  '${meta.variableId}': z.infer<typeof ${schemaRef.variableName}>`
         )
         metaEntries.push(
-          `  '${meta.variableId}': { name: '${name}', displayName: '${meta.displayName}' }`
+          `  '${meta.variableId}': { name: '${name}', displayName: ${literal(meta.displayName)} }`
         )
       }
     }


### PR DESCRIPTION
Display names, titles and descriptions written by users flow into generated TypeScript as string literals and comments. Unescaped, a quote or a backtick in that prose breaks the generated file.

Covers the four serializers that emit user prose — addon scaffolding, credentials, secrets and variables types — with tests pinning each.

Rebased onto current main; carries its own changeset (`.changeset/escape-display-names-in-generated-meta.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)