### PR TITLE
fix(core): stop leaking internal error detail and bound the request body size

### DIFF
--- a/.changeset/core-error-payload-and-body-limit.md
+++ b/.changeset/core-error-payload-and-body-limit.md
@@ -1,0 +1,17 @@
+---
+'@pikku/core': patch
+---
+
+fix: stop leaking internal error detail and bound the request body size
+
+HTTP error responses no longer forward an error's `payload` or its raw `message` for
+registered 5xx errors — those responses carry the registered error message instead, so an
+internal error that happens to hold a `payload` cannot leak it to the client. Errors
+registered with a 4xx status keep their message and payload, and `exposeErrors` still
+surfaces the full detail outside production.
+
+`PikkuFetchHTTPRequest` now caps how much of a request body it buffers, rejecting the
+declared `content-length` up front and measuring the stream as it arrives so a lying or
+absent header cannot exhaust memory. Exceeding the limit throws `PayloadTooLargeError`
+(413). The ceiling defaults to 10MB and is configurable via the new `maxBodySize` option on
+the constructor and on `RunHTTPWiringOptions`.

--- a/packages/core/src/handle-error.test.ts
+++ b/packages/core/src/handle-error.test.ts
@@ -1,11 +1,12 @@
 import { describe, test, beforeEach } from 'node:test'
 import assert from 'node:assert'
 import { handleHTTPError } from './handle-error.js'
-import { addError } from './errors/error-handler.js'
+import { addError, PikkuError } from './errors/error-handler.js'
 import {
   NotFoundError,
   BadRequestError,
   ForbiddenError,
+  MissingScopeError,
 } from './errors/errors.js'
 import { resetPikkuState } from './pikku-state.js'
 
@@ -397,6 +398,112 @@ describe('handleHTTPError', () => {
 
     assert.strictEqual(http._state.statusCode, 500)
     assert.deepStrictEqual(http._state.jsonBody, { errorId: 'tracker-str' })
+  })
+
+  test('should not leak the payload of a registered server error', () => {
+    class LeakyInternalError extends PikkuError {}
+    addError(LeakyInternalError, {
+      status: 500,
+      message: 'Something went wrong',
+    })
+
+    const logger = createMockLogger()
+    const http = createMockHTTP()
+    const error = new LeakyInternalError(
+      'connection to 10.0.0.1 refused'
+    ) as any
+    error.payload = { connectionString: 'postgres://user:hunter2@10.0.0.1' }
+
+    handleHTTPError(
+      error,
+      http as any,
+      'tracker-leak',
+      logger as any,
+      [],
+      true,
+      false
+    )
+
+    assert.strictEqual(http._state.statusCode, 500)
+    assert.strictEqual(http._state.jsonBody.payload, undefined)
+  })
+
+  test('should not leak the raw message of a registered server error', () => {
+    class InternalMessageError extends PikkuError {}
+    addError(InternalMessageError, {
+      status: 500,
+      message: 'Something went wrong',
+    })
+
+    const logger = createMockLogger()
+    const http = createMockHTTP()
+    const error = new InternalMessageError('secret internal detail')
+
+    handleHTTPError(
+      error,
+      http as any,
+      'tracker-msg',
+      logger as any,
+      [],
+      true,
+      false
+    )
+
+    assert.strictEqual(http._state.statusCode, 500)
+    assert.strictEqual(http._state.jsonBody.message, 'Something went wrong')
+  })
+
+  test('should keep the payload of a client facing error', () => {
+    const logger = createMockLogger()
+    const http = createMockHTTP()
+    const error = new MissingScopeError('admin:write')
+
+    handleHTTPError(
+      error,
+      http as any,
+      'tracker-scope',
+      logger as any,
+      [],
+      true,
+      false
+    )
+
+    assert.strictEqual(http._state.statusCode, 403)
+    assert.deepStrictEqual(http._state.jsonBody.payload, {
+      error: 'missing_scope',
+      scope: 'admin:write',
+    })
+    assert.strictEqual(
+      http._state.jsonBody.message,
+      'Missing required scope: admin:write'
+    )
+  })
+
+  test('should expose server error details when exposeErrors is true', () => {
+    class ExposableInternalError extends PikkuError {}
+    addError(ExposableInternalError, {
+      status: 500,
+      message: 'Something went wrong',
+    })
+
+    const logger = createMockLogger()
+    const http = createMockHTTP()
+    const error = new ExposableInternalError('internal detail') as any
+    error.payload = { debug: true }
+
+    handleHTTPError(
+      error,
+      http as any,
+      'tracker-expose-known',
+      logger as any,
+      [],
+      true,
+      false,
+      true
+    )
+
+    assert.strictEqual(http._state.jsonBody.message, 'internal detail')
+    assert.deepStrictEqual(http._state.jsonBody.payload, { debug: true })
   })
 
   test('should handle warning log without trackerId', () => {

--- a/packages/core/src/handle-error.ts
+++ b/packages/core/src/handle-error.ts
@@ -14,6 +14,8 @@ import type { PikkuHTTP } from './wirings/http/http.types.js'
  * @param {number[]} logWarningsForStatusCodes - HTTP status codes to log as warnings
  * @param {boolean} respondWith404 - Whether to respond with 404 for NotFoundError
  * @param {boolean} bubbleError - Whether to throw the error after handling
+ * @param {boolean} exposeErrors - Whether to include internal error details (message, stack and
+ * payload of 5xx errors) in the response body. Ignored in production.
  */
 export const handleHTTPError = (
   e: any,
@@ -33,15 +35,21 @@ export const handleHTTPError = (
   // Get appropriate error response
   const errorResponse = getErrorResponse(e)
   if (errorResponse != null) {
+    const clientFacing =
+      errorResponse.status < 500 || (exposeErrors && !isProduction())
+
     // Set status and response body
     http?.response?.status(errorResponse.status)
     http?.response?.json({
       name: e instanceof Error ? e.name : undefined,
       message:
-        e instanceof Error && e.message && e.message !== 'An error occurred'
+        clientFacing &&
+        e instanceof Error &&
+        e.message &&
+        e.message !== 'An error occurred'
           ? e.message
           : errorResponse.message,
-      payload: (e as any).payload,
+      payload: clientFacing ? (e as any).payload : undefined,
       errorId: traceId,
     })
 

--- a/packages/core/src/wirings/http/http-runner.ts
+++ b/packages/core/src/wirings/http/http-runner.ts
@@ -531,6 +531,7 @@ export const fetchData = async <In, Out>(
     exposeErrors = !isProduction(),
     generateRequestId,
     traceId: externalTraceId,
+    maxBodySize,
   }: RunHTTPWiringOptions = {}
 ): Promise<Out | void> => {
   const singletonServices = getSingletonServices()
@@ -540,7 +541,9 @@ export const fetchData = async <In, Out>(
 
   // Combine the request and response into one wire object
   const pikkuRequest =
-    request instanceof Request ? new PikkuFetchHTTPRequest(request) : request
+    request instanceof Request
+      ? new PikkuFetchHTTPRequest(request, { maxBodySize })
+      : request
 
   // Resolve traceId: external (e.g. CF-Ray) > x-request-id header > generated
   let requestId: string | null = externalTraceId ?? null

--- a/packages/core/src/wirings/http/http.types.ts
+++ b/packages/core/src/wirings/http/http.types.ts
@@ -38,6 +38,8 @@ export type RunHTTPWiringOptions = Partial<{
   generateRequestId: () => string
   /** Pre-resolved trace ID (e.g. CF-Ray). Falls back to x-request-id header or generated ID. */
   traceId: string
+  /** Maximum request body size in bytes, applied when pikku wraps a fetch `Request`. */
+  maxBodySize: number
 }>
 
 /**

--- a/packages/core/src/wirings/http/index.ts
+++ b/packages/core/src/wirings/http/index.ts
@@ -1,4 +1,8 @@
-export { PikkuFetchHTTPRequest } from './pikku-fetch-http-request.js'
+export {
+  PikkuFetchHTTPRequest,
+  DEFAULT_MAX_BODY_SIZE,
+} from './pikku-fetch-http-request.js'
+export type { PikkuFetchHTTPRequestOptions } from './pikku-fetch-http-request.js'
 export { PikkuFetchHTTPResponse } from './pikku-fetch-http-response.js'
 export { logRoutes } from './log-http-routes.js'
 

--- a/packages/core/src/wirings/http/pikku-fetch-http-request.test.ts
+++ b/packages/core/src/wirings/http/pikku-fetch-http-request.test.ts
@@ -221,6 +221,95 @@ test('data() throws on boolean conflict', async () => {
 
 // --- Safe fallback: only one source
 
+// --- Body size limits
+
+const streamedRequest = (chunks) =>
+  new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(new TextEncoder().encode(chunk))
+        }
+        controller.close()
+      },
+    }),
+    duplex: 'half',
+  })
+
+test('arrayBuffer() rejects a body larger than the configured limit', async () => {
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: 'x'.repeat(64),
+  })
+  const pikkuReq = new PikkuFetchHTTPRequest(req, { maxBodySize: 16 })
+  await assert.rejects(async () => await pikkuReq.arrayBuffer(), {
+    name: 'PayloadTooLargeError',
+  })
+})
+
+test('arrayBuffer() rejects an oversized body with no content-length header', async () => {
+  const req = streamedRequest(['x'.repeat(32), 'y'.repeat(32)])
+  assert.equal(req.headers.get('content-length'), null)
+  const pikkuReq = new PikkuFetchHTTPRequest(req, { maxBodySize: 16 })
+  await assert.rejects(async () => await pikkuReq.arrayBuffer(), {
+    name: 'PayloadTooLargeError',
+  })
+})
+
+test('arrayBuffer() rejects a body whose content-length under-reports its size', async () => {
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': '4',
+    },
+    body: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('z'.repeat(128)))
+        controller.close()
+      },
+    }),
+    duplex: 'half',
+  })
+  const pikkuReq = new PikkuFetchHTTPRequest(req, { maxBodySize: 16 })
+  await assert.rejects(async () => await pikkuReq.arrayBuffer(), {
+    name: 'PayloadTooLargeError',
+  })
+})
+
+test('data() surfaces PayloadTooLargeError rather than wrapping it', async () => {
+  const req = createRequest(
+    'POST',
+    'http://localhost',
+    { padding: 'x'.repeat(256) },
+    { 'Content-Type': 'application/json' }
+  )
+  const pikkuReq = new PikkuFetchHTTPRequest(req, { maxBodySize: 16 })
+  await assert.rejects(async () => await pikkuReq.data(), {
+    name: 'PayloadTooLargeError',
+  })
+})
+
+test('data() accepts a body within the configured limit', async () => {
+  const req = createRequest(
+    'POST',
+    'http://localhost',
+    { ok: true },
+    { 'Content-Type': 'application/json' }
+  )
+  const pikkuReq = new PikkuFetchHTTPRequest(req, { maxBodySize: 1024 })
+  assert.deepEqual(await pikkuReq.data(), { ok: true })
+})
+
+test('data() accepts a streamed body within the default limit', async () => {
+  const req = streamedRequest(['{"ok"', ':true}'])
+  const pikkuReq = new PikkuFetchHTTPRequest(req)
+  assert.deepEqual(await pikkuReq.data(), { ok: true })
+})
+
 test('data() works when only body has values', async () => {
   const req = createRequest(
     'POST',

--- a/packages/core/src/wirings/http/pikku-fetch-http-request.ts
+++ b/packages/core/src/wirings/http/pikku-fetch-http-request.ts
@@ -1,7 +1,22 @@
 import { parse as parseQuery } from 'picoquery'
 import { parse as parseCookie } from 'cookie'
 import type { HTTPMethod, PikkuHTTPRequest, PikkuQuery } from './http.types.js'
-import { UnprocessableContentError } from '../../errors/errors.js'
+import {
+  PayloadTooLargeError,
+  UnprocessableContentError,
+} from '../../errors/errors.js'
+
+/**
+ * The largest request body read into memory when no limit is configured. Ample
+ * for JSON APIs and typical uploads while keeping a single request's memory
+ * footprint bounded.
+ */
+export const DEFAULT_MAX_BODY_SIZE = 10 * 1024 * 1024
+
+export type PikkuFetchHTTPRequestOptions = Partial<{
+  /** Maximum request body size in bytes. Defaults to {@link DEFAULT_MAX_BODY_SIZE}. */
+  maxBodySize: number
+}>
 
 /**
  * Abstract class representing a pikku request.
@@ -17,9 +32,14 @@ export class PikkuFetchHTTPRequest<
   #rawBodyText: string | undefined
   #rawBodyBuffer: ArrayBuffer | undefined
   #rawBufferPromise: Promise<ArrayBuffer> | undefined
+  #maxBodySize: number
 
-  constructor(private request: Request) {
+  constructor(
+    private request: Request,
+    { maxBodySize = DEFAULT_MAX_BODY_SIZE }: PikkuFetchHTTPRequestOptions = {}
+  ) {
     this.#url = new URL(request.url)
+    this.#maxBodySize = maxBodySize
   }
 
   public method(): HTTPMethod {
@@ -78,11 +98,70 @@ export class PikkuFetchHTTPRequest<
       )
       return this.#rawBufferPromise
     }
-    this.#rawBufferPromise = this.request.arrayBuffer().then((buf) => {
+    this.#rawBufferPromise = this.#readBoundedBuffer().then((buf) => {
       this.#rawBodyBuffer = buf
       return buf
     })
     return this.#rawBufferPromise
+  }
+
+  /**
+   * Reads the body while refusing to buffer more than `maxBodySize` bytes. The
+   * declared `content-length` is rejected up front so an oversized body is never
+   * transferred, and the stream is measured as it arrives because that header is
+   * both optional and attacker-controlled.
+   */
+  async #readBoundedBuffer(): Promise<ArrayBuffer> {
+    const contentLength = this.request.headers.get('content-length')
+    if (contentLength !== null) {
+      const declaredSize = Number(contentLength)
+      if (Number.isFinite(declaredSize) && declaredSize > this.#maxBodySize) {
+        throw this.#payloadTooLarge()
+      }
+    }
+
+    const stream = this.request.body
+    if (stream === null) {
+      const buffer = await this.request.arrayBuffer()
+      if (buffer.byteLength > this.#maxBodySize) {
+        throw this.#payloadTooLarge()
+      }
+      return buffer
+    }
+
+    const reader = stream.getReader()
+    const chunks: Uint8Array[] = []
+    let size = 0
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) {
+          break
+        }
+        size += value.byteLength
+        if (size > this.#maxBodySize) {
+          await reader.cancel()
+          throw this.#payloadTooLarge()
+        }
+        chunks.push(value)
+      }
+    } finally {
+      reader.releaseLock()
+    }
+
+    const body = new Uint8Array(size)
+    let offset = 0
+    for (const chunk of chunks) {
+      body.set(chunk, offset)
+      offset += chunk.byteLength
+    }
+    return body.buffer as ArrayBuffer
+  }
+
+  #payloadTooLarge(): PayloadTooLargeError {
+    return new PayloadTooLargeError(
+      `Request body exceeds the maximum size of ${this.#maxBodySize} bytes`
+    )
   }
 
   async #readRawText(): Promise<string> {
@@ -214,6 +293,9 @@ export class PikkuFetchHTTPRequest<
         )
       }
     } catch (e) {
+      if (e instanceof PayloadTooLargeError) {
+        throw e
+      }
       throw new UnprocessableContentError(`Error parsing body: ${e}`)
     }
     return body


### PR DESCRIPTION
Two independent hardening fixes in the HTTP path, shipped together because they share `handle-error` and the fetch request wrapper.

### Error detail no longer leaks through 5xx

HTTP error responses no longer forward an error's `payload` or its raw `message` for registered 5xx errors — those responses carry the registered error message instead, so an internal error that happens to hold a `payload` cannot leak it to the client. Errors registered with a 4xx status keep their message and payload, and `exposeErrors` still surfaces full detail outside production.

### Request bodies are bounded

`PikkuFetchHTTPRequest` now caps how much of a request body it buffers: it rejects the declared `content-length` up front and measures the stream as it arrives, so a lying or absent header cannot exhaust memory. Exceeding the limit throws `PayloadTooLargeError` (413). The ceiling defaults to 10MB and is configurable via the new `maxBodySize` option on the constructor and on `RunHTTPWiringOptions`.

Tests cover both; `packages/core` suite passes (60 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)