### PR TITLE
feat(db): let a project declare the extensions its PGlite databases load

### DIFF
--- a/.changeset/pglite-extensions.md
+++ b/.changeset/pglite-extensions.md
@@ -1,0 +1,31 @@
+---
+'@pikku/cli': patch
+---
+
+Let a project declare the Postgres extensions its embedded PGlite databases need
+
+The CLI migrates a PGlite shadow database to type and diff a schema, and PGlite
+only has the extensions it was constructed with — pgcrypto, and nothing else.
+A migration doing `CREATE EXTENSION vector` therefore failed every `db` command
+with `extension "vector" is not available`, whatever the real server had, and
+there was no way to say otherwise.
+
+`createConfig` now takes `pgliteExtensions`. A bare name is one of PGlite's
+bundled contrib extensions and needs no install; anything else is a package the
+project depends on:
+
+```ts
+export const createConfig = async () => ({
+  postgresUrl: process.env.DATABASE_URL,
+  pgliteExtensions: ['@electric-sql/pglite-pgvector', 'hstore'],
+})
+```
+
+They are loaded into both embedded databases — the local dev one and the shadow
+— and resolved from the project before the CLI, so the version the project
+installed is the one that runs. Declared for a `postgresUrl` project too: the
+shadow is PGlite whichever server the app itself talks to.
+
+An extension that is used but not declared now says so, rather than reporting
+Postgres' own message about an unavailable extension with nothing pointing at
+the config that would have loaded it.

--- a/packages/cli/src/functions/commands/db-shared.ts
+++ b/packages/cli/src/functions/commands/db-shared.ts
@@ -5,6 +5,20 @@ import { loadUserModule } from './load-user-project.js'
 export interface UserConfigShape {
   sqliteDb?: string
   postgresUrl?: string
+  /**
+   * Postgres extensions the CLI's embedded PGlite databases must load — the
+   * local dev database, and the shadow one every `db` command migrates to type
+   * and diff a schema.
+   *
+   * A bare name is one of PGlite's bundled contrib extensions (`hstore`,
+   * `citext`, `uuid_ossp`, …) and needs nothing installed. Anything else is a
+   * package the project depends on, such as `@electric-sql/pglite-pgvector`.
+   *
+   * Needed even when `postgresUrl` points at a server that already has the
+   * extension: the shadow database is PGlite regardless, so a `CREATE EXTENSION`
+   * in a migration fails there unless it is declared here.
+   */
+  pgliteExtensions?: string[]
   [key: string]: unknown
 }
 

--- a/packages/cli/src/functions/db/local-db.test.ts
+++ b/packages/cli/src/functions/db/local-db.test.ts
@@ -445,6 +445,130 @@ test('scratch codegen types the postgres migrations without touching the configu
   assert.deepEqual(live.migrate.applied, ['0001-init.sql'])
 })
 
+test('resolveDb carries the declared PGlite extensions onto the postgres descriptor', () => {
+  usePostgresProject()
+
+  const local = resolveDb({ pgliteExtensions: ['hstore'] }, root, root)!
+  assert.equal(local.dialect, 'postgres')
+  if (local.dialect !== 'postgres') throw new Error('expected postgres')
+  assert.deepEqual(local.pgliteExtensions, ['hstore'])
+
+  // A project on a real Postgres server still needs them: the shadow database
+  // the CLI diffs against is PGlite either way.
+  const remote = resolveDb(
+    {
+      postgresUrl: 'postgres://user:pass@localhost:5432/mydb',
+      pgliteExtensions: ['hstore'],
+    },
+    root,
+    root
+  )!
+  if (remote.dialect !== 'postgres') throw new Error('expected postgres')
+  assert.deepEqual(remote.pgliteExtensions, ['hstore'])
+
+  const undeclared = resolveDb({}, root, root)!
+  if (undeclared.dialect !== 'postgres') throw new Error('expected postgres')
+  assert.deepEqual(undeclared.pgliteExtensions, [])
+})
+
+test('a declared extension is available to the scratch database', async () => {
+  usePostgresProject({
+    migrationSql: `CREATE EXTENSION IF NOT EXISTS hstore;
+CREATE TABLE docs (
+  id SERIAL PRIMARY KEY,
+  meta hstore
+);
+`,
+    seedSql: '',
+  })
+
+  const resolved = resolveDb({ pgliteExtensions: ['hstore'] }, root, root)!
+  const scratch = await migrateAndCodegen(resolved, { scratch: true })
+  assert.deepEqual(scratch.migrate.applied, ['0001-init.sql'])
+  assert.match(readFileSync(resolved.schemaFile, 'utf8'), /Docs/)
+})
+
+test('a declared extension is available to the local PGlite database', async () => {
+  usePostgresProject({
+    migrationSql: `CREATE EXTENSION IF NOT EXISTS hstore;
+CREATE TABLE docs (
+  id SERIAL PRIMARY KEY,
+  meta hstore
+);
+`,
+    seedSql: '',
+  })
+
+  const resolved = resolveDb({ pgliteExtensions: ['hstore'] }, root, root)!
+  await migrateAndCodegen(resolved)
+
+  const kysely = await createKysely<{ docs: { id: number } }>(resolved)
+  try {
+    const rows = await kysely.selectFrom('docs').select('id').execute()
+    assert.deepEqual(rows, [])
+  } finally {
+    await kysely.destroy()
+  }
+})
+
+test('an undeclared extension fails with guidance rather than a bare Postgres error', async () => {
+  usePostgresProject({
+    migrationSql: `CREATE EXTENSION IF NOT EXISTS hstore;\n`,
+    seedSql: '',
+  })
+
+  const resolved = resolveDb({}, root, root)!
+  await assert.rejects(
+    () => migrateAndCodegen(resolved, { scratch: true }),
+    (error: Error) => {
+      assert.match(error.message, /hstore/)
+      assert.match(error.message, /pgliteExtensions/)
+      return true
+    }
+  )
+})
+
+test('an unresolvable extension specifier says where it was looked for', async () => {
+  usePostgresProject()
+  const resolved = resolveDb(
+    { pgliteExtensions: ['@not-installed/pglite-nothing'] },
+    root,
+    root
+  )!
+
+  await assert.rejects(
+    () => migrateAndCodegen(resolved, { scratch: true }),
+    (error: Error) => {
+      assert.match(error.message, /@not-installed\/pglite-nothing/)
+      assert.match(error.message, /install/i)
+      return true
+    }
+  )
+})
+
+test('a module that exports no PGlite extension is rejected by name', async () => {
+  usePostgresProject()
+  writeFileSync(
+    join(root, 'not-an-extension.mjs'),
+    'export const nope = { hello: "world" }\n'
+  )
+
+  const resolved = resolveDb(
+    { pgliteExtensions: ['./not-an-extension.mjs'] },
+    root,
+    root
+  )!
+
+  await assert.rejects(
+    () => migrateAndCodegen(resolved, { scratch: true }),
+    (error: Error) => {
+      assert.match(error.message, /not-an-extension\.mjs/)
+      assert.match(error.message, /no PGlite extension/)
+      return true
+    }
+  )
+})
+
 test('scratch codegen types the sqlite migrations without creating the db file', async () => {
   const resolved = resolveDb({}, root, root)!
   assert.equal(resolved.dialect, 'sqlite')

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -8,6 +8,7 @@ import {
 } from 'node:fs'
 import { resolve, isAbsolute, relative, dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
 import { runInNewContext } from 'node:vm'
 import { transformSync } from 'esbuild'
 import { CamelCasePlugin, Kysely, PostgresDialect } from 'kysely'
@@ -72,6 +73,16 @@ export interface ResolvedPostgresDb extends ResolvedDbBase {
   pgliteDir?: string
   runtimeDir: string
   seedFile: string
+  /**
+   * Postgres extensions the embedded PGlite databases must load, as declared by
+   * `pgliteExtensions` in the project's config. See
+   * {@link loadPGliteExtensions}.
+   *
+   * Carried even in `url` mode: the shadow database the CLI migrates and
+   * introspects is PGlite whichever server the project itself runs against, so
+   * a migration that needs an extension needs it here too.
+   */
+  pgliteExtensions: string[]
 }
 
 export type ResolvedDb = ResolvedSqliteDb | ResolvedPostgresDb
@@ -130,6 +141,8 @@ export function resolveDb(
     )
   }
 
+  const pgliteExtensions = userConfig.pgliteExtensions ?? []
+
   if (userConfig.postgresUrl) {
     return {
       dialect: 'postgres',
@@ -137,6 +150,7 @@ export function resolveDb(
       connectionString: userConfig.postgresUrl,
       runtimeDir: resolvedRuntimeDir,
       seedFile: resolveAgainst(rootDir, 'db/postgres-seed.sql'),
+      pgliteExtensions,
       ...base('db/postgres'),
     }
   }
@@ -164,6 +178,7 @@ export function resolveDb(
       pgliteDir: join(resolvedRuntimeDir, 'dev-postgres'),
       runtimeDir: resolvedRuntimeDir,
       seedFile: resolveAgainst(rootDir, 'db/postgres-seed.sql'),
+      pgliteExtensions,
       ...base('db/postgres'),
     }
   }
@@ -213,8 +228,20 @@ async function createPostgresClient(
   }
 
   mkdirSync(dirname(resolved.pgliteDir), { recursive: true })
-  const db = await createEmbeddedPostgres(resolved.pgliteDir)
+  const db = await createEmbeddedPostgres(resolved, resolved.pgliteDir)
   return pgliteAsClient(db)
+}
+
+/**
+ * What an embedded PGlite instance needs beyond its data directory: where to
+ * resolve extension packages from, and which ones to load.
+ *
+ * A `ResolvedPostgresDb` already is one, which is what lets every call site
+ * that has one pass it straight through.
+ */
+export interface PGliteExtensionContext {
+  rootDir: string
+  pgliteExtensions: string[]
 }
 
 interface EmbeddedPostgresWasm {
@@ -261,13 +288,113 @@ async function loadEmbeddedPostgresWasm(): Promise<
   }
 }
 
-async function createEmbeddedPostgres(dataDir?: string): Promise<PGlite> {
+/**
+ * A PGlite extension, as the packages that publish one export it: an object
+ * carrying the `setup` that hands PGlite the WASM bundle, or a URL/string
+ * pointing at a remote one.
+ *
+ * Structural rather than imported from PGlite so a project's extension package
+ * — built against its own copy of `@electric-sql/pglite` — is recognised
+ * whatever the two versions are.
+ */
+type PGliteExtension = { name?: string; setup: (...args: any[]) => unknown }
+
+const isPGliteExtension = (value: unknown): value is PGliteExtension =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as PGliteExtension).setup === 'function'
+
+/**
+ * Turn a declared extension specifier into the module that publishes it.
+ *
+ * A bare name is one of PGlite's own contrib extensions (`hstore`, `citext`,
+ * `uuid_ossp`), which ship with the CLI's copy of PGlite and need nothing
+ * installed. Anything else is a package the project depends on — pgvector, say,
+ * as `@electric-sql/pglite-pgvector` — so it is resolved from the project first
+ * and only then from the CLI, since the project is where a user installs it.
+ */
+async function importPGliteExtensionModule(
+  spec: string,
+  rootDir: string
+): Promise<Record<string, unknown>> {
+  const id =
+    spec.includes('/') || spec.startsWith('@')
+      ? spec
+      : `@electric-sql/pglite/contrib/${spec}`
+
+  for (const from of [join(rootDir, 'package.json'), import.meta.url]) {
+    let resolvedPath: string
+    try {
+      resolvedPath = createRequire(from).resolve(id)
+    } catch {
+      continue
+    }
+    return (await import(pathToFileURL(resolvedPath).href)) as Record<
+      string,
+      unknown
+    >
+  }
+
+  throw new Error(
+    `The PGlite extension '${spec}' could not be resolved as '${id}', ` +
+      `from either the project (${rootDir}) or the pikku CLI. ` +
+      `Install it in your project, or name one of PGlite's bundled contrib ` +
+      `extensions (hstore, citext, uuid_ossp, …), which need no install.`
+  )
+}
+
+/**
+ * Load every extension the project declares, keyed the way PGlite wants them.
+ *
+ * The key is the export name (`vector`, `hstore`), which is also the name the
+ * SQL uses, so `CREATE EXTENSION vector` finds what a declaration of
+ * `@electric-sql/pglite-pgvector` loaded. A module exporting several is fine —
+ * all of them are taken — and a `default` export is used only when it is the
+ * only extension there, so a package that default-exports the same object it
+ * also names is not registered twice.
+ */
+export async function loadPGliteExtensions(
+  rootDir: string,
+  specs: string[]
+): Promise<Record<string, PGliteExtension>> {
+  const extensions: Record<string, PGliteExtension> = {}
+
+  for (const spec of specs) {
+    const module = await importPGliteExtensionModule(spec, rootDir)
+    const found = Object.entries(module).filter(([, value]) =>
+      isPGliteExtension(value)
+    ) as [string, PGliteExtension][]
+    const named = found.filter(([name]) => name !== 'default')
+    const chosen = named.length > 0 ? named : found
+
+    if (chosen.length === 0) {
+      throw new Error(
+        `'${spec}' exports no PGlite extension. A PGlite extension is an ` +
+          `object with a 'setup' function — check that the package is one, ` +
+          `and that its version matches the PGlite the CLI runs.`
+      )
+    }
+
+    for (const [name, extension] of chosen) {
+      extensions[name === 'default' ? (extension.name ?? spec) : name] =
+        extension
+    }
+  }
+
+  return extensions
+}
+
+async function createEmbeddedPostgres(
+  context: PGliteExtensionContext,
+  dataDir?: string
+): Promise<PGlite> {
   embeddedPostgresWasm ??= loadEmbeddedPostgresWasm()
 
-  const [{ PGlite }, { pgcrypto }, wasm] = await Promise.all([
+  const [{ PGlite }, { pgcrypto }, wasm, declared] = await Promise.all([
     import('@electric-sql/pglite'),
     import('@electric-sql/pglite/contrib/pgcrypto'),
     embeddedPostgresWasm,
+    loadPGliteExtensions(context.rootDir, context.pgliteExtensions),
   ])
 
   return new PGlite({
@@ -275,8 +402,37 @@ async function createEmbeddedPostgres(dataDir?: string): Promise<PGlite> {
     ...wasm,
     extensions: {
       pgcrypto,
+      ...declared,
     },
   })
+}
+
+/**
+ * PGlite reports an extension it was never given as a plain
+ * `extension "x" is not available`, which reads as though the SQL is at fault.
+ * It is not: the database is real Postgres, the migration is fine, and the one
+ * thing missing is the declaration that would have loaded the extension into
+ * this particular instance. Say so, since nothing else in the message points
+ * anywhere near the fix.
+ */
+function explainMissingExtension(error: unknown, declared: string[]): unknown {
+  const message = error instanceof Error ? error.message : ''
+  const match = /extension "([^"]+)" is not available/.exec(message)
+  if (!match) return error
+
+  const name = match[1]
+  return new Error(
+    `The embedded PGlite database has no '${name}' extension. ` +
+      `The CLI migrates a PGlite shadow database to type and diff your schema, ` +
+      `so every extension your migrations use has to be declared as ` +
+      `pgliteExtensions in createConfig — e.g. pgliteExtensions: ['${name}'] ` +
+      `for a PGlite contrib extension, or the package that publishes it ` +
+      `('@electric-sql/pglite-pgvector' for pgvector).` +
+      (declared.length > 0
+        ? ` Currently declared: ${declared.join(', ')}.`
+        : ''),
+    { cause: error }
+  )
 }
 
 function pgliteAsClient(db: PGlite): PostgresQueryClient {
@@ -299,6 +455,13 @@ async function withPostgresClient<T>(
   const client = await createPostgresClient(resolved)
   try {
     return await run(client)
+  } catch (error) {
+    // Only the embedded database's missing extensions are the declaration's
+    // doing. On a real server it is the server that lacks the extension, and
+    // pointing at the CLI's config would send the reader the wrong way.
+    throw resolved.mode === 'pglite'
+      ? explainMissingExtension(error, resolved.pgliteExtensions)
+      : error
   } finally {
     await client.end()
   }
@@ -385,9 +548,9 @@ export async function migrateAndCodegen(
   } else {
     const withClient = options.scratch
       ? <T>(
-          _r: ResolvedPostgresDb,
+          r: ResolvedPostgresDb,
           run: (c: PostgresQueryClient) => Promise<T>
-        ) => withScratchPostgresDatabase(run)
+        ) => withScratchPostgresDatabase(r, run)
       : withPostgresClient
     await withClient(resolved, async (client) => {
       const introspector = new PostgresIntrospector(client)
@@ -674,7 +837,7 @@ export async function createKysely<DB>(
 
   mkdirSync(dirname(resolved.pgliteDir), { recursive: true })
   return createPGliteKysely<DB>({
-    db: await createEmbeddedPostgres(resolved.pgliteDir),
+    db: await createEmbeddedPostgres(resolved, resolved.pgliteDir),
     camelCase: resolved.camelCase,
     plugins,
   })
@@ -769,11 +932,14 @@ function isPostgresAuthDatabase(options: {
 // elevated privileges that application roles (correctly) don't have, which made
 // `pikku db migrate` fail against managed/locked-down Postgres (error 42501).
 async function withScratchPostgresDatabase<T>(
+  context: PGliteExtensionContext,
   run: (scratchDb: PostgresQueryClient) => Promise<T>
 ): Promise<T> {
-  const scratchDb = await createEmbeddedPostgres()
+  const scratchDb = await createEmbeddedPostgres(context)
   try {
     return await run(pgliteAsClient(scratchDb))
+  } catch (error) {
+    throw explainMissingExtension(error, context.pgliteExtensions)
   } finally {
     if (!scratchDb.closed) {
       await scratchDb.close()
@@ -794,11 +960,12 @@ async function postgresDatabaseToMap(
 }
 
 async function desiredPostgresAuthSchema(
+  context: PGliteExtensionContext,
   rootDir: string,
   srcDirectories: string[],
   logger: { error: (msg: string) => void }
 ): Promise<DesiredAuthSchema | null> {
-  return withScratchPostgresDatabase(async (scratchDb) => {
+  return withScratchPostgresDatabase(context, async (scratchDb) => {
     // The scratch DB is always an embedded PGlite instance (see
     // withScratchPostgresDatabase), so drive Better Auth's migration codegen
     // through the PGlite-backed Kysely regardless of how the app DB is
@@ -852,7 +1019,12 @@ export async function desiredAuthSchema(
           'Better Auth database.type is postgres, but the resolved app database is not postgres.'
         )
       }
-      return desiredPostgresAuthSchema(rootDir, srcDirectories, logger)
+      return desiredPostgresAuthSchema(
+        resolved,
+        rootDir,
+        srcDirectories,
+        logger
+      )
     }
     const { runMigrations, compileMigrations } =
       await getAuthMigrations(options)
@@ -974,7 +1146,7 @@ export async function desiredRuntimeSchema(
     }
   }
 
-  return withScratchPostgresDatabase(async (db) => {
+  return withScratchPostgresDatabase(resolved, async (db) => {
     const kysely = createPGliteKysely<any>({
       db: db.__pglite!,
       camelCase: true,
@@ -1029,9 +1201,10 @@ async function coveredSqliteSchema(migrationsDir: string): Promise<SchemaMap> {
 }
 
 async function coveredPostgresSchema(
-  migrationsDir: string
+  migrationsDir: string,
+  context: PGliteExtensionContext
 ): Promise<SchemaMap> {
-  return withScratchPostgresDatabase(async (client) => {
+  return withScratchPostgresDatabase(context, async (client) => {
     await migrate(new PostgresMigrationExecutor(client), migrationsDir)
     return postgresDatabaseToMap(client)
   })
@@ -1085,7 +1258,7 @@ export async function computeSchemaDrift(
   const covered =
     resolved.dialect === 'sqlite'
       ? await coveredSqliteSchema(resolved.migrationsDir)
-      : await coveredPostgresSchema(resolved.migrationsDir)
+      : await coveredPostgresSchema(resolved.migrationsDir, resolved)
   const actual = await introspectSchema(resolved)
 
   const { missingTables, missingColumns } = diffSchemas(covered, actual)
@@ -1326,7 +1499,10 @@ const concatMigrations = (migrationsDir: string): string =>
  * happens to be configured against — an addon is published once and consumed by
  * projects on either engine.
  */
-export async function exportSchema(rootDir: string): Promise<SchemaArtifact> {
+export async function exportSchema(
+  rootDir: string,
+  pgliteExtensions: string[] = []
+): Promise<SchemaArtifact> {
   const artifact: SchemaArtifact = {}
 
   const sqliteDir = join(rootDir, 'db', 'sqlite')
@@ -1341,7 +1517,9 @@ export async function exportSchema(rootDir: string): Promise<SchemaArtifact> {
   if (existsSync(postgresDir)) {
     artifact.postgres = {
       sql: concatMigrations(postgresDir),
-      tables: serializeSchemaMap(await coveredPostgresSchema(postgresDir)),
+      tables: serializeSchemaMap(
+        await coveredPostgresSchema(postgresDir, { rootDir, pgliteExtensions })
+      ),
     }
   }
 
@@ -1553,7 +1731,7 @@ export async function generateMigrations(
     const covered =
       resolved.dialect === 'sqlite'
         ? await coveredSqliteSchema(resolved.migrationsDir)
-        : await coveredPostgresSchema(resolved.migrationsDir)
+        : await coveredPostgresSchema(resolved.migrationsDir, resolved)
 
     const { missingTables, missingColumns } = diffSchemas(
       source.desired.tables,


### PR DESCRIPTION
Closes #1104

## The gap

`pikku db check` / `generate` / `migrate --scratch` build a **shadow** database to type and diff a schema against, and that shadow is always PGlite constructed with a hardcoded `extensions: { pgcrypto }`. Any migration doing `CREATE EXTENSION` for anything else died with

```
extension "vector" is not available
```

even when the real Postgres the project runs against has pgvector installed and working. There was no config or env var to change it — `createEmbeddedPostgres` was called unconditionally at all three call sites — and editing the offending migration to tolerate a missing extension is no way out either: it is already applied on dev and production, and the migrator re-hashes every applied file, so it throws `MigrationDriftError` on both databases' next run.

## The fix

`createConfig` now takes `pgliteExtensions`:

```ts
export const createConfig = async () => ({
  postgresUrl: process.env.DATABASE_URL,
  pgliteExtensions: ['@electric-sql/pglite-pgvector', 'hstore'],
})
```

- A **bare name** is one of PGlite's bundled contrib extensions (`hstore`, `citext`, `uuid_ossp`, …) — nothing to install.
- **Anything else** is a package the project depends on, resolved from the project's `node_modules` before the CLI's, so the version the project installed is the one that runs.
- Loaded into **both** embedded databases: the local dev PGlite and the shadow one, so `db check`, `db generate`, scratch codegen and the auth/runtime schema materialization all see them.
- Honoured for a `postgresUrl` project too — the shadow is PGlite whichever server the app itself talks to.

An extension used but not declared now names the declaration that would have loaded it, instead of leaving Postgres' own message pointing nowhere. On a real server that same error is the server's, so it passes through untouched.

## Verification

- 6 new tests in `packages/cli/src/functions/db/local-db.test.ts`, all **red before the change and green after** (re-run against the pre-change file to confirm). Full file 51/51.
- The motivating case end-to-end against the CLI's PGlite: `loadPGliteExtensions` → `{ vector }`, then `CREATE EXTENSION vector`, a `vector(3)` column and an insert/select round-trip. pgvector works with the pinned PGlite, so no version bump is needed here.

## Not in scope

`exportSchema` gained an optional `pgliteExtensions` param, but `db export` still passes none — an *addon* whose own migrations need an extension is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)