### PR TITLE
feat(fabric): validate that a login screen ships the actor quick login

### DIFF
--- a/.changeset/fabric-validate-actor-quick-login.md
+++ b/.changeset/fabric-validate-actor-quick-login.md
@@ -1,0 +1,19 @@
+---
+'@pikku/cli': patch
+---
+
+`pikku fabric validate` now checks that a frontend with a login screen also ships the
+one-click actor sign-in.
+
+The dev-only "Sign in as …" switcher is what lets anyone open a sandbox and view the app
+as each scenario persona without knowing a password. When a generated app shipped a login
+form and nothing else, the reviewer was locked out of their own project — and nothing
+caught it until someone tried to log in by hand.
+
+The check fires only when the app actually has a login surface, so an app with no auth is
+left alone. It looks for the canonical fingerprints — a rendered `<DevActorSwitcher />`, a
+call to `signInAsActor()`, or a request to `/auth/sign-in/actor` — and reports
+`app-missing-actor-quick-login-<app>` as an error when a login screen exists without any
+of them. Defining the switcher without rendering it does not count.
+
+Next.js apps keep their routes outside `src/`, so `app/` and `pages/` are scanned too.

--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -2,7 +2,7 @@ import { describe, test } from 'node:test'
 import assert from 'node:assert'
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import {
   runValidate,
   renderValidate,
@@ -1268,6 +1268,171 @@ describe('pikku fabric validate', () => {
         const result = await runValidate(tmp)
         // app-not-declared warn fires (no frontends declared), but no crash
         assert.ok(result.findings.some((f) => f.id === 'app-not-declared-web'))
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe('actor quick login', () => {
+    // Writes a React frontend at apps/web. `files` is a map of app-relative
+    // path → contents, so each test only spells out the UI it cares about.
+    async function makeFrontend(
+      root: string,
+      files: Record<string, string>,
+      pkgExtra: Record<string, unknown> = {}
+    ) {
+      const app = join(root, 'apps', 'web')
+      await mkdir(app, { recursive: true })
+      await writeJson(join(app, 'package.json'), {
+        name: 'web',
+        dependencies: { react: '^19.0.0', ...(pkgExtra as any).dependencies },
+        devDependencies: {
+          '@babel/core': '^7.26.0',
+          '@inlang/paraglide-js': '^2.0.0',
+        },
+      })
+      await mkdir(join(app, 'messages'), { recursive: true })
+      await mkdir(join(app, 'project.inlang'), { recursive: true })
+      await writeJson(join(app, 'project.inlang', 'settings.json'), {})
+      for (const [rel, body] of Object.entries(files)) {
+        const full = join(app, rel)
+        await mkdir(dirname(full), { recursive: true })
+        await writeFile(full, body, 'utf8')
+      }
+      return app
+    }
+
+    test('login screen without the actor switcher → error', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        await makeFrontend(tmp, {
+          'src/pages/LoginPage.tsx':
+            'export const LoginPage = () => <form>email + password</form>\n',
+        })
+        const result = await runValidate(tmp)
+        const finding = result.findings.find(
+          (f) => f.id === 'app-missing-actor-quick-login-web'
+        )
+        assert.ok(finding, 'expected app-missing-actor-quick-login-web finding')
+        assert.strictEqual(finding!.severity, 'error')
+        assert.match(finding!.message, /src\/pages\/LoginPage\.tsx/)
+        assert.strictEqual(result.ok, false)
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+
+    test('login screen rendering <DevActorSwitcher /> → no finding', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        await makeFrontend(tmp, {
+          'src/pages/LoginPage.tsx':
+            "import { DevActorSwitcher } from '@/components/DevActorSwitcher'\n" +
+            'export const LoginPage = () => <><form /><DevActorSwitcher /></>\n',
+        })
+        const result = await runValidate(tmp)
+        assert.ok(
+          !result.findings.some(
+            (f) => f.id === 'app-missing-actor-quick-login-web'
+          ),
+          'expected no actor quick-login finding'
+        )
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+
+    test('a DevActorSwitcher that is defined but never rendered still errors', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        await makeFrontend(tmp, {
+          'src/pages/LoginPage.tsx':
+            'export const LoginPage = () => <form>email + password</form>\n',
+          // Definition only — nothing renders it, so the reviewer is still
+          // locked out. `signInAsActor(` here is the declaration, not a call.
+          'src/lib/auth.ts':
+            'export async function signInAsActor(email: string) {\n' +
+            '  return email\n}\n',
+        })
+        const result = await runValidate(tmp)
+        assert.ok(
+          result.findings.some(
+            (f) => f.id === 'app-missing-actor-quick-login-web'
+          ),
+          'expected the finding to survive a definition-only auth helper'
+        )
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+
+    test('a frontend with no login screen is not asked for one', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        await makeFrontend(tmp, {
+          'src/pages/HomePage.tsx': 'export const HomePage = () => <main />\n',
+        })
+        const result = await runValidate(tmp)
+        assert.ok(
+          !result.findings.some(
+            (f) => f.id === 'app-missing-actor-quick-login-web'
+          ),
+          'an app with no auth has nothing to attach the control to'
+        )
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+
+    test('Next.js app/login/page.tsx is scanned even though it is outside src/', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        await makeFrontend(
+          tmp,
+          {
+            'app/login/page.tsx':
+              'export default function Page() { return <form /> }\n',
+          },
+          { dependencies: { next: '^15.0.0' } }
+        )
+        const result = await runValidate(tmp)
+        const finding = result.findings.find(
+          (f) => f.id === 'app-missing-actor-quick-login-web'
+        )
+        assert.ok(finding, 'expected the Next.js route to be scanned')
+        assert.match(finding!.message, /app\/login\/page\.tsx/)
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+
+    test('Next.js login route wired to the actor endpoint → no finding', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        await makeFrontend(
+          tmp,
+          {
+            'app/login/page.tsx':
+              "const signIn = (email: string) => fetch('/auth/sign-in/actor', {\n" +
+              "  method: 'POST', body: JSON.stringify({ email }) })\n" +
+              'export default function Page() { return <button onClick={() => signIn("a@b.c")} /> }\n',
+          },
+          { dependencies: { next: '^15.0.0' } }
+        )
+        const result = await runValidate(tmp)
+        assert.ok(
+          !result.findings.some(
+            (f) => f.id === 'app-missing-actor-quick-login-web'
+          ),
+          'the /auth/sign-in/actor endpoint is a valid quick-login fingerprint'
+        )
       } finally {
         await rm(tmp, { recursive: true, force: true })
       }

--- a/packages/cli/src/fabric/functions/validate.function.ts
+++ b/packages/cli/src/fabric/functions/validate.function.ts
@@ -150,6 +150,26 @@ const SINGLETON_SENSITIVE_PKGS = [
   'react-dom',
 ]
 
+// A file whose name says "this is the login surface". Used to decide whether an
+// app needs the actor quick-login control — an app with no login screen has
+// nothing to attach it to. Matched against the path relative to the app root, so
+// it covers src/pages/LoginPage.tsx as well as Next's app/login/page.tsx.
+const LOGIN_FILE_PATTERN =
+  /(?:^|\/)[\w[\]-]*(?:login|sign-?in)[\w[\]-]*(?:\/|\.)/i
+
+// Fingerprints of the dev-only "Sign in as …" quick login (the actor switcher):
+// one click signs in as a declared scenario persona, no password. Any one of
+// these means the app actually wires actor sign-in — the component's own
+// definition is excluded, since defining it without rendering it locks the
+// reviewer out just as thoroughly.
+// Canonical implementation: starter-template's DevActorSwitcher, rendered from
+// LoginPage and backed by signInAsActor() → POST /auth/sign-in/actor.
+const ACTOR_QUICK_LOGIN_PATTERNS = [
+  /<\s*DevActorSwitcher\b/,
+  /(?<!function\s)\bsignInAsActor\s*\(/,
+  /\/auth\/sign-in\/actor/,
+]
+
 // Minimum @pikku/* versions Fabric requires. The pikku packages are versioned
 // independently (e.g. @pikku/cli moves faster than @pikku/core), so this is a
 // per-package floor map, not a single number. Only listed packages are
@@ -1669,6 +1689,53 @@ export async function runValidate(
                 ? [`  …and ${rawMantineFiles.length - 10} more`]
                 : []),
               'Keep "@mantine/core/styles.css", @mantine/hooks and @mantine/notifications imports as-is.'
+            )
+          )
+        }
+
+        // ── one-click actor sign-in (the "Sign in as …" quick login) ────────
+        // Any frontend that ships a login screen must also ship the dev-only
+        // actor switcher, so the app can be reviewed as each scenario persona
+        // without knowing a password. Without it the reviewer is locked out of
+        // their own sandbox. Only fires when a login surface exists — an app
+        // with no auth has nothing to attach the control to.
+        // Next.js keeps its routes outside src/, so scan app/ and pages/ too.
+        const isNextApp = !!appAllDeps['next']
+        const uiFiles = isNextApp
+          ? [
+              ...srcFiles,
+              ...(await listSourceFiles(join(appPath, 'app'))),
+              ...(await listSourceFiles(join(appPath, 'pages'))),
+            ]
+          : srcFiles
+
+        const loginFiles: string[] = []
+        let hasQuickLogin = false
+        for (const file of uiFiles) {
+          const text = await readTextSafe(file)
+          if (!text) continue
+          const rel = file.slice(appPath.length + 1).replace(/\\/g, '/')
+          if (LOGIN_FILE_PATTERN.test(rel)) loginFiles.push(rel)
+          if (ACTOR_QUICK_LOGIN_PATTERNS.some((p) => p.test(text))) {
+            hasQuickLogin = true
+          }
+        }
+
+        if (loginFiles.length > 0 && !hasQuickLogin) {
+          e(
+            `app-missing-actor-quick-login-${name}`,
+            `apps/${name} has a login screen (${loginFiles[0]}) but no one-click actor sign-in — nobody can view the app as a scenario persona without a password`,
+            join(appPath, loginFiles[0]!),
+            lines(
+              'Add the dev-only "Sign in as …" switcher and render it from the login screen:',
+              '1. lib/auth: devActors() reading the DEV_ACTORS env var, and',
+              '   signInAsActor(email) → POST `${apiUrl()}/auth/sign-in/actor`',
+              '   with { email, secret } and credentials: "include".',
+              '2. components/DevActorSwitcher.tsx: a Menu of the declared actors,',
+              '   each Menu.Item signing in as that persona. Render null when',
+              '   devActors() is empty, so it disappears in production.',
+              `3. Render <DevActorSwitcher /> from ${loginFiles[0]}.`,
+              'Reference: templates/starter-template/apps/app/src/components/DevActorSwitcher.tsx.'
             )
           )
         }


### PR DESCRIPTION
## What

`pikku fabric validate` now checks that a frontend with a login screen also ships the one-click actor sign-in — the dev-only "Sign in as …" switcher.

## Why

That switcher is what lets anyone open a sandbox and view the app as each scenario persona without knowing a password. A generated app that shipped a login form and nothing else locked the reviewer out of their own project, and nothing caught it until someone tried to log in by hand.

The sandbox orchestrator already enforces this at build-complete time; this brings the same gate into `fabric validate`, where it can be run locally before anything is built.

## How

New finding `app-missing-actor-quick-login-<app>` (severity `error`), raised only when the app actually has a login surface — an app with no auth is left alone.

Accepted fingerprints (any one passes):
- a rendered `<DevActorSwitcher />`
- a `signInAsActor()` **call** — the declaration alone does not count, since defining the switcher without rendering it locks the reviewer out just as thoroughly
- a request to `/auth/sign-in/actor`

Next.js keeps its routes outside `src/`, so `app/` and `pages/` are scanned as well as `src/`.

Reference implementation: `templates/starter-template/apps/app/src/components/DevActorSwitcher.tsx` (fabric).

## Tests

6 new cases under `describe('actor quick login')`: missing switcher errors; rendered switcher passes; definition-without-render still errors; no login screen → no finding; Next `app/login/page.tsx` is scanned; Next route wired to `/auth/sign-in/actor` passes.

`packages/cli` suite: 82/82 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)