### PR TITLE
fix(cli): make the CLI channel client runtime-agnostic

### DIFF
--- a/.changeset/bun-cli-channel-client.md
+++ b/.changeset/bun-cli-channel-client.md
@@ -1,0 +1,9 @@
+---
+'@pikku/cli': patch
+---
+
+fix(cli): pick the CLI channel client's WebSocket by runtime, and fix the direct-execution check
+
+The generated CLI-over-channel client always reached for the `ws` module when it had credentials to send, because Node's global `WebSocket` reads its second argument as subprotocols and silently drops custom headers. Bun's honours them, so it now uses the native `WebSocket` there and never loads Bun's `ws` compatibility shim. The runtime is detected once, the same way the CLI picks its dev-server runner.
+
+Both generated CLI entrypoints also guarded direct execution by comparing `import.meta.url` against a hand-built `file://` path from `process.argv[1]`. That is false for any CLI invoked through a symlinked `node_modules/.bin/<name>` — Node reports the symlink in argv and the realpath in the URL — so the block never ran. It also failed on paths needing percent-encoding, such as one containing a space. Both now use `import.meta.main`, falling back to a realpath comparison on Node before 24.2.

--- a/packages/cli/src/functions/wirings/cli/serialize-channel-cli-client.test.ts
+++ b/packages/cli/src/functions/wirings/cli/serialize-channel-cli-client.test.ts
@@ -119,4 +119,34 @@ describe('serializeChannelCLIClient', () => {
     const occurrences = out.match(/cardsRenderer/g) ?? []
     assert.strictEqual(occurrences.length, 3)
   })
+
+  test('picks the WebSocket implementation by runtime: native under Bun, the ws module only when Node needs headers', () => {
+    const out = serializeChannelCLIClient(
+      'kanban',
+      programMeta(),
+      clientFile,
+      config,
+      bootstrapFile
+    )
+    // Detected the same way services.ts picks its dev-server runner.
+    assert.match(out, /typeof \(globalThis as \{ Bun\?: unknown \}\)\.Bun/)
+    // Bun's WebSocket honours `headers`, so the ws shim is never loaded there.
+    assert.match(
+      out,
+      /if \(!isBun && \(hasAuth \|\| typeof WebSocket === 'undefined'\)\)/
+    )
+    assert.match(out, /await import\('ws'\)/)
+  })
+
+  test('guards direct execution with the shared entrypoint guard, not a file:// argv comparison', () => {
+    const out = serializeChannelCLIClient(
+      'kanban',
+      programMeta(),
+      clientFile,
+      config,
+      bootstrapFile
+    )
+    assert.match(out, /if \(isDirectExecution\)/)
+    assert.doesNotMatch(out, /file:\/\/\$\{process\.argv/)
+  })
 })

--- a/packages/cli/src/functions/wirings/cli/serialize-channel-cli-client.ts
+++ b/packages/cli/src/functions/wirings/cli/serialize-channel-cli-client.ts
@@ -1,6 +1,7 @@
 import type { CLIProgramMeta, CLICommandMeta } from '@pikku/core/cli'
 import { getFileImportRelativePath } from '../../../utils/file-import-path.js'
 import type { Config } from '../../../../types/application-types.js'
+import { DIRECT_EXECUTION_GUARD } from './serialize-cli-entrypoint-guard.js'
 
 /**
  * Collect all unique renderer names from CLI metadata (populated by inspector)
@@ -193,15 +194,17 @@ export async function ${capitalizedName}CLIClient(
 export default ${capitalizedName}CLIClient
 
 // For direct execution (if this file is run directly)
-if (import.meta.url === \`file://\${process.argv[1]}\`) {
+${DIRECT_EXECUTION_GUARD}
+
+if (isDirectExecution) {
   const url = process.env.PIKKU_WS_URL || 'ws://localhost:4002${finalChannelRoute}'
 
   // Attach credentials so the channel authenticates like any other pikku client.
   // A machine API key (PIKKU_API_KEY -> x-api-key) takes precedence; otherwise
   // the human session token saved by \`pikku login\` (~/.pikku/session.json ->
-  // Authorization: Bearer) is used. This block only runs under Node (direct
-  // execution), so reading the session file and using the 'ws' headers option
-  // is safe — the browser WebSocket cannot set custom headers anyway.
+  // Authorization: Bearer) is used. This block only runs on a server runtime
+  // (direct execution), so reading the session file is safe — a browser could
+  // neither reach it nor set custom headers on its WebSocket.
   const headers: Record<string, string> = {}
   if (process.env.PIKKU_API_KEY) {
     headers['x-api-key'] = process.env.PIKKU_API_KEY
@@ -228,12 +231,26 @@ if (import.meta.url === \`file://\${process.argv[1]}\`) {
   }
   const hasAuth = Object.keys(headers).length > 0
 
-  // Custom headers require the Node 'ws' module — the global/browser WebSocket
-  // cannot set them — so prefer 'ws' whenever we have credentials to send.
+  // Node's global WebSocket reads its second argument as subprotocols and drops
+  // custom headers on the floor, so credentials there need the 'ws' module.
+  // Bun's honours them natively, and reaching for 'ws' under Bun would load its
+  // compatibility shim for nothing. Detected once, the way the CLI picks its
+  // dev-server runner.
+  const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined'
+
+  // Only the header-carrying Bun call needs the cast: the DOM lib types the
+  // second argument as subprotocols, which is what Node implements.
+  type WebSocketWithHeaders = new (
+    url: string,
+    options: { headers: Record<string, string> }
+  ) => WebSocket
+
   let ws: WebSocket
-  if (hasAuth || typeof WebSocket === 'undefined') {
+  if (!isBun && (hasAuth || typeof WebSocket === 'undefined')) {
     const wsModule = await import('ws')
     ws = new wsModule.default(url, { headers }) as unknown as WebSocket
+  } else if (hasAuth) {
+    ws = new (WebSocket as unknown as WebSocketWithHeaders)(url, { headers })
   } else {
     ws = new WebSocket(url)
   }

--- a/packages/cli/src/functions/wirings/cli/serialize-cli-entrypoint-guard.test.ts
+++ b/packages/cli/src/functions/wirings/cli/serialize-cli-entrypoint-guard.test.ts
@@ -1,0 +1,62 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DIRECT_EXECUTION_GUARD } from './serialize-cli-entrypoint-guard.js'
+
+/**
+ * Writes the emitted guard into a module that reports what it decided, and runs
+ * it both directly and through a symlinked bin — the shape every CLI installed
+ * into node_modules/.bin actually takes.
+ */
+const runGuard = (): { direct: string; viaSymlink: string } => {
+  const dir = mkdtempSync(join(tmpdir(), 'pikku-entry-guard-'))
+  const entry = join(dir, 'entry.mjs')
+  writeFileSync(
+    entry,
+    `${DIRECT_EXECUTION_GUARD}\nconsole.log(isDirectExecution)\n`
+  )
+
+  const binDir = join(dir, 'bin')
+  mkdirSync(binDir)
+  const link = join(binDir, 'cli.mjs')
+  symlinkSync(entry, link)
+
+  const run = (script: string) =>
+    execFileSync(process.execPath, [script], { encoding: 'utf8' }).trim()
+
+  return { direct: run(entry), viaSymlink: run(link) }
+}
+
+describe('DIRECT_EXECUTION_GUARD', () => {
+  test('resolves true when the module is the entrypoint, directly and through a symlinked bin', () => {
+    const { direct, viaSymlink } = runGuard()
+    assert.strictEqual(direct, 'true')
+    // The regression: `import.meta.url === \`file://${process.argv[1]}\`` is
+    // false here, because Node puts the symlink in argv and the realpath in the
+    // URL, so the direct-execution block never ran for an installed CLI.
+    assert.strictEqual(viaSymlink, 'true')
+  })
+
+  test('resolves false when the module is imported rather than executed', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pikku-entry-guard-'))
+    const lib = join(dir, 'lib.mjs')
+    writeFileSync(
+      lib,
+      `${DIRECT_EXECUTION_GUARD}\nconsole.log(isDirectExecution)\n`
+    )
+    const main = join(dir, 'main.mjs')
+    writeFileSync(main, `await import('./lib.mjs')\n`)
+
+    const out = execFileSync(process.execPath, [main], {
+      encoding: 'utf8',
+    }).trim()
+    assert.strictEqual(out, 'false')
+  })
+
+  test('does not compare import.meta.url against a hand-built file:// argv path', () => {
+    assert.doesNotMatch(DIRECT_EXECUTION_GUARD, /file:\/\/\$\{process\.argv/)
+  })
+})

--- a/packages/cli/src/functions/wirings/cli/serialize-cli-entrypoint-guard.ts
+++ b/packages/cli/src/functions/wirings/cli/serialize-cli-entrypoint-guard.ts
@@ -1,0 +1,28 @@
+/**
+ * The snippet every generated CLI entrypoint uses to decide whether it is being
+ * run or merely imported. It declares `isDirectExecution`; the caller writes the
+ * `if`.
+ *
+ * `import.meta.url === \`file://${process.argv[1]}\`` — the shape this replaces —
+ * is false for any CLI invoked through a symlinked bin, because Node reports the
+ * symlink in argv and the realpath in the URL, so the block never ran for an
+ * installed `node_modules/.bin/<name>`. It also fails on paths the URL has to
+ * percent-encode, such as one containing a space.
+ */
+export const DIRECT_EXECUTION_GUARD = `const isDirectExecution = await (async () => {
+  if (typeof import.meta.main === 'boolean') {
+    return import.meta.main
+  }
+  // Node exposes import.meta.main from 24.2; earlier 24.x compares realpaths,
+  // which is what it is shorthand for.
+  try {
+    const { fileURLToPath } = await import('node:url')
+    const { realpathSync } = await import('node:fs')
+    return (
+      process.argv[1] !== undefined &&
+      realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)
+    )
+  } catch {
+    return false
+  }
+})()`

--- a/packages/cli/src/functions/wirings/cli/serialize-local-cli-bootstrap.ts
+++ b/packages/cli/src/functions/wirings/cli/serialize-local-cli-bootstrap.ts
@@ -1,5 +1,6 @@
 import { getFileImportRelativePath } from '../../../utils/file-import-path.js'
 import type { Config } from '../../../../types/application-types.js'
+import { DIRECT_EXECUTION_GUARD } from './serialize-cli-entrypoint-guard.js'
 
 /**
  * Serializes the local (in-program) CLI bootstrap code
@@ -69,7 +70,9 @@ ${wireServicesFactory ? '      createWireServices,' : ''}
 export default ${capitalizedName}CLI
 
 // For direct execution (if this file is run directly)
-if (import.meta.url === \`file://\${process.argv[1]}\`) {
+${DIRECT_EXECUTION_GUARD}
+
+if (isDirectExecution) {
   ${capitalizedName}CLI(process.argv.slice(2)).catch(error => {
     console.error('Fatal error:', error.message)
     process.exit(1)

--- a/templates/functions/client/mcp.ts
+++ b/templates/functions/client/mcp.ts
@@ -12,6 +12,8 @@ import {
   ReadResourceResultSchema,
 } from '@modelcontextprotocol/sdk/types.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { realpathSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 
 export class PikkuMCPTestClient {
   private client: Client
@@ -201,7 +203,15 @@ export async function runMCPHTTPClientTest(url: string): Promise<void> {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Comparing `import.meta.url` to a hand-built `file://${process.argv[1]}` looks
+// equivalent but is false whenever the path needs percent-encoding — a space
+// anywhere in the project directory is enough — and whenever the script is
+// reached through a symlink. Either way this block silently never runs.
+const isMain =
+  process.argv[1] !== undefined &&
+  realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (isMain) {
   const client = new PikkuMCPTestClient('yarn', ['run', 'start:mcp:http'])
   try {
     await client.connect()

--- a/templates/mcp-server/client/mcp.ts
+++ b/templates/mcp-server/client/mcp.ts
@@ -12,6 +12,8 @@ import {
   ReadResourceResultSchema,
 } from '@modelcontextprotocol/sdk/types.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { realpathSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 
 export class PikkuMCPTestClient {
   private client: Client
@@ -237,6 +239,14 @@ export async function runMCPHTTPClientTest(url: string): Promise<void> {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Comparing `import.meta.url` to a hand-built `file://${process.argv[1]}` looks
+// equivalent but is false whenever the path needs percent-encoding — a space
+// anywhere in the project directory is enough — and whenever the script is
+// reached through a symlink. Either way this block silently never runs.
+const isMain =
+  process.argv[1] !== undefined &&
+  realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (isMain) {
   await runMCPClientTest('npx', ['tsx', 'src/start.ts'])
 }


### PR DESCRIPTION
Closes #1113.

The generated CLI-over-channel client made two Node-only assumptions. Both are now runtime-agnostic — one generated artifact runs on Node and Bun, with no new config surface.

## 1. WebSocket implementation is picked by runtime

Node's global `WebSocket` reads its second argument as subprotocols and drops custom headers, so the client loaded `ws` whenever it had credentials to send. Bun's honours them natively, and reaching for `ws` there pulls in Bun's compatibility shim for nothing.

The runtime is detected once, the way `packages/cli/src/services.ts:422` picks its dev-server runner:

```ts
const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined'

let ws: WebSocket
if (!isBun && (hasAuth || typeof WebSocket === 'undefined')) {
  const wsModule = await import('ws')
  ws = new wsModule.default(url, { headers }) as unknown as WebSocket
} else if (hasAuth) {
  ws = new (WebSocket as unknown as WebSocketWithHeaders)(url, { headers })
} else {
  ws = new WebSocket(url)
}
```

Node with no credentials still uses the global `WebSocket`, so `ws` stays an optional dependency exactly where it was before.

## 2. The direct-execution guard was broken behind a symlink

Both `serialize-channel-cli-client.ts` and `serialize-local-cli-bootstrap.ts` emitted:

```js
if (import.meta.url === `file://${process.argv[1]}`) { ... }
```

Node puts the symlink in `process.argv[1]` and the realpath in `import.meta.url`, so this is **false** for any CLI invoked through `node_modules/.bin/<name>` — the direct-execution block never ran for an installed CLI. It also fails on paths the URL has to percent-encode, such as one containing a space. Bun happens to resolve it to true, which is why the bug is easy to miss.

Both now share `DIRECT_EXECUTION_GUARD` (new `serialize-cli-entrypoint-guard.ts`), which uses `import.meta.main` and falls back to a realpath comparison on Node before 24.2, where `import.meta.main` is `undefined` and a bare check would fail silently.

## Verification

TDD — the new tests fail on `main` and pass here.

`serialize-cli-entrypoint-guard.test.ts` is behavioural, not a string match: it writes the emitted guard to a temp module and executes it directly, through a symlinked bin, and as an import, asserting `true / true / false`. The symlink case is the regression.

Manually confirmed on node 24.18.1 / bun 1.3.14:

| | Node | Bun |
|---|---|---|
| `new WebSocket(url, { headers })` | headers dropped | **header arrives** (verified against an HTTP upgrade listener: `AUTH_HEADER=Bearer tok-123`) |
| guard direct / symlink / imported | true / true / false | true / true / false |

Also: `packages/cli` suite 783/783 green, `tsc --noEmit -p packages/cli` clean, and the emitted direct-execution block typechecks standalone under `strict` + `nodenext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)