### PR TITLE
Point the versions-check hints at a command that exists

### DIFF
--- a/.changeset/versions-check-hint-names-a-real-command.md
+++ b/.changeset/versions-check-hint-names-a-real-command.md
@@ -1,0 +1,14 @@
+---
+'@pikku/cli': patch
+'@pikku/skills': patch
+---
+
+Point the `versions check` hints at a command that exists.
+
+Three different failures told you to run `npx pikku versions-update`. There is
+no such command — `update` is a subcommand of `versions` — so anyone following
+the hint hit "unknown command" at the moment they were trying to repair a
+contract manifest. It now prints `npx pikku versions update`.
+
+The pikku-versioning skill carried a paragraph warning agents the hint was
+wrong; with the hint fixed, that warning is gone.

--- a/packages/cli/src/functions/commands/versions-check.ts
+++ b/packages/cli/src/functions/commands/versions-check.ts
@@ -48,7 +48,7 @@ export const pikkuVersionsCheck = pikkuSessionlessFunc<void, void>({
               `  Set \`version: ${error.nextVersion}\` on the function, then run:`
             )
           }
-          logger.info(`  npx pikku versions-update`)
+          logger.info(`  npx pikku versions update`)
         } else if (
           error.code === ErrorCode.FUNCTION_VERSION_MODIFIED &&
           error.functionKey
@@ -90,7 +90,7 @@ export const pikkuVersionsCheck = pikkuSessionlessFunc<void, void>({
             `  This usually means a merge conflict in versions.pikku.json.`
           )
           logger.info(`  Resolve the conflict, then run:`)
-          logger.info(`  npx pikku versions-update`)
+          logger.info(`  npx pikku versions update`)
         } else if (
           error.code === ErrorCode.VERSION_GAP_NOT_ALLOWED &&
           error.functionKey
@@ -129,7 +129,7 @@ export const pikkuVersionsCheck = pikkuSessionlessFunc<void, void>({
           }
           logger.info(``)
           logger.info(`  The manifest is corrupted. Run:`)
-          logger.info(`  npx pikku versions-update`)
+          logger.info(`  npx pikku versions update`)
         } else {
           logger.info(`[${error.code}] ${error.message}`)
         }

--- a/packages/skills/skills/pikku-versioning/SKILL.md
+++ b/packages/skills/skills/pikku-versioning/SKILL.md
@@ -136,9 +136,6 @@ does **not** capture the hashes of the functions you already have. Run
 never overwrite an immutable record; it reports that as a diagnostic and leaves
 the manifest alone. Fix the contract or bump the version, then run it again.
 
-Some CLI hints print `npx pikku versions-update`. That command does not exist —
-the subcommand form (`pikku versions update`) is the one to run.
-
 **Workflow:**
 
 1. `pikku versions init` then `pikku versions update` — once, to create and


### PR DESCRIPTION
`versions check` told you to run `npx pikku versions-update` on three different failure paths. No such command exists — `update` is a subcommand of `versions`, so the hint sent people to `unknown command` at the moment they were trying to repair a contract manifest. It now prints `npx pikku versions update`.

The pikku-versioning skill carried a paragraph warning agents that the hint was wrong. With the hint fixed that warning is stale, and removing it also clears the `skills-references` test — which flags any `pikku <command>` a skill names, without excepting a mention that exists only to disown it. That test was the sole failure on `main`'s Unit Tests job before this.

Verified locally:

```
✔ every `pikku <command>` a skill tells you to run is a real command (47ms)
✔ every secrets.<method>() a skill documents exists on SecretService (13ms)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected version-check guidance to use the valid `npx pikku versions update` command.
  * Updated remediation instructions for contract, version-conflict, and manifest-integrity errors.

* **Documentation**
  * Removed outdated versioning guidance referencing the obsolete command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->