### PR TITLE
fix(workflow): recover runs stalled by a crash mid-dispatch

### DIFF
--- a/.changeset/stale-pandas-repeat.md
+++ b/.changeset/stale-pandas-repeat.md
@@ -1,0 +1,19 @@
+---
+'@pikku/core': patch
+'@pikku/kysely': patch
+---
+
+Recover workflow runs stalled by a crash mid-dispatch.
+
+Arming a step is two writes to two systems — the step row, then the queue or
+scheduler job — so a process that died between them left a run `running` with
+nothing in flight. It parked on a step that would never complete and never
+error, so the run neither finished nor failed, and nothing swept it up.
+
+`workflowService.recoverStalledRuns()` re-drives those runs through
+`resumeWorkflow`. Replay is memoized per step, so resuming a run that was not
+actually stuck changes nothing; runs mid-sleep or with a step in flight are
+excluded outright. It is not self-starting — call it from a scheduled task.
+
+Stores opt in by overriding `findStalledRunIds`; implemented here for the
+Kysely and in-memory services, and a no-op elsewhere.

--- a/packages/core/src/services/in-memory-workflow-service.ts
+++ b/packages/core/src/services/in-memory-workflow-service.ts
@@ -301,6 +301,35 @@ export class InMemoryWorkflowService
     return newStep
   }
 
+  protected async findStalledRunIds(
+    before: Date,
+    limit: number
+  ): Promise<string[]> {
+    const stalled: string[] = []
+    for (const [runId, run] of this.runs) {
+      if (run.status !== 'running') continue
+      const steps = this.stepHistory.get(runId) ?? []
+      if (
+        steps.some(
+          (step) =>
+            step.status === 'running' ||
+            step.status === 'scheduled' ||
+            step.status === 'suspended'
+        )
+      ) {
+        continue
+      }
+      const lastActivity = steps.reduce(
+        (latest, step) => (step.updatedAt > latest ? step.updatedAt : latest),
+        run.updatedAt
+      )
+      if (lastActivity >= before) continue
+      stalled.push(runId)
+      if (stalled.length >= limit) break
+    }
+    return stalled
+  }
+
   async listRuns(options?: {
     workflowName?: string
     status?: string

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -275,6 +275,12 @@ const WORKFLOW_TERMINAL_STATES: ReadonlySet<string> = new Set([
   'cancelled',
 ])
 
+/** Idle window before a `running` run with nothing in flight is treated as stalled. */
+const DEFAULT_STALLED_RUN_MS = 5 * 60_000
+
+/** Runs re-driven per `recoverStalledRuns` call, so one sweep is bounded. */
+const DEFAULT_STALLED_RUN_LIMIT = 100
+
 const WORKFLOW_POLL_MIN_MS = 10
 
 const WORKFLOW_POLL_FACTOR = 1.6
@@ -906,6 +912,67 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         group: this.getJobGroup(workflowName),
       }
     )
+  }
+
+  /**
+   * Ids of runs that are stalled: still `running`, with no step in a state that
+   * something is expected to complete (`running`, `scheduled`, `suspended`),
+   * and no step activity since `before`.
+   *
+   * Returns nothing by default so a store that cannot express the query keeps
+   * working unchanged; a store that overrides it gains crash recovery through
+   * `recoverStalledRuns`.
+   */
+  protected async findStalledRunIds(
+    _before: Date,
+    _limit: number
+  ): Promise<string[]> {
+    return []
+  }
+
+  /**
+   * Re-drive runs whose next move was lost, and report which were resumed.
+   *
+   * Arming a step is two writes to two systems — the step row, then the queue
+   * or scheduler job — so a process that dies between them leaves a run that is
+   * `running` with nothing in flight. Nothing notices: the run parks on a step
+   * that will never complete and never error, so it neither finishes nor fails.
+   * (Seen on a `workflow.sleep()`: a deploy restart landed between the sleep
+   * step's insert and its timer, parking the run permanently.)
+   *
+   * Replay is the recovery — `resumeWorkflow` re-orchestrates from persisted
+   * step state, and every settled step is memoized, so resuming a run that was
+   * not actually stuck costs an orchestration pass and changes nothing. That
+   * idempotence is what makes an idle-time heuristic safe here; a run that is
+   * legitimately mid-sleep is excluded anyway, since its step is `scheduled`.
+   *
+   * This is not self-starting. Call it from a scheduled task at whatever
+   * interval suits the workload.
+   */
+  public async recoverStalledRuns(options?: {
+    stalledAfterMs?: number
+    limit?: number
+  }): Promise<{ resumed: string[] }> {
+    const before = new Date(
+      Date.now() - (options?.stalledAfterMs ?? DEFAULT_STALLED_RUN_MS)
+    )
+    const runIds = await this.findStalledRunIds(
+      before,
+      options?.limit ?? DEFAULT_STALLED_RUN_LIMIT
+    )
+    const resumed: string[] = []
+    for (const runId of runIds) {
+      try {
+        await this.resumeWorkflow(runId)
+        resumed.push(runId)
+      } catch (err) {
+        // One unresumable run must not stop the sweep from recovering the rest.
+        getSingletonServices()?.logger?.error(
+          `Failed to resume stalled workflow run ${runId}: ${err instanceof Error ? err.message : String(err)}`
+        )
+      }
+    }
+    return { resumed }
   }
 
   protected resolveStepJobOptions(

--- a/packages/core/src/wirings/workflow/workflow-stalled-recovery.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-stalled-recovery.test.ts
@@ -1,0 +1,106 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState } from '../../pikku-state.js'
+
+const silentLogger = { error() {}, info() {}, warn() {}, debug() {} }
+
+/**
+ * `recoverStalledRuns` re-drives a run by putting it back on the orchestrator
+ * queue, so the queue is the observation point.
+ */
+function trackResumes(): { runIds: string[] } {
+  const seen: string[] = []
+  pikkuState(null, 'package', 'singletonServices', {
+    queueService: {
+      add: async (_queue: string, data: { runId: string }) => {
+        seen.push(data.runId)
+      },
+    },
+    logger: silentLogger,
+  } as any)
+  return { runIds: seen }
+}
+
+/** Backdates every persisted timestamp so the run reads as idle. */
+async function backdate(
+  ws: InMemoryWorkflowService,
+  runId: string,
+  ms: number
+): Promise<void> {
+  const past = new Date(Date.now() - ms)
+  const run = await ws.getRun(runId)
+  ;(run as any).updatedAt = past
+  for (const step of await ws.getRunHistory(runId)) {
+    ;(step as any).updatedAt = past
+  }
+}
+
+describe('stalled run recovery', () => {
+  test('resumes a running run left with a pending step and nothing in flight', async () => {
+    const resumes = trackResumes()
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+    // A sleep whose timer was never armed: the step row exists, nothing will
+    // ever complete it.
+    await ws.insertStepState(runId, 'Wait 15s', null, { duration: 15000 })
+    await backdate(ws, runId, 10 * 60_000)
+
+    const { resumed } = await ws.recoverStalledRuns()
+
+    assert.deepEqual(resumed, [runId], 'the orphaned run is resumed')
+    assert.deepEqual(resumes.runIds, [runId], 'it is put back on the queue')
+  })
+
+  test('leaves a run alone while a step is still scheduled', async () => {
+    trackResumes()
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+    const step = await ws.insertStepState(runId, 'Wait 1h', null, {
+      duration: 3_600_000,
+    })
+    await ws.setStepScheduled(step.stepId)
+    await backdate(ws, runId, 10 * 60_000)
+
+    const { resumed } = await ws.recoverStalledRuns()
+
+    assert.deepEqual(
+      resumed,
+      [],
+      'a legitimately sleeping run is not a stalled run'
+    )
+  })
+
+  test('leaves a run alone until it has actually gone idle', async () => {
+    trackResumes()
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+    await ws.insertStepState(runId, 'Wait 15s', null, { duration: 15000 })
+
+    const { resumed } = await ws.recoverStalledRuns()
+
+    assert.deepEqual(resumed, [], 'a run that just moved is not swept')
+  })
+
+  test('leaves a finished run alone', async () => {
+    trackResumes()
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+    await ws.insertStepState(runId, 'Wait 15s', null, { duration: 15000 })
+    await ws.updateRunStatus(runId, 'completed')
+    await backdate(ws, runId, 10 * 60_000)
+
+    const { resumed } = await ws.recoverStalledRuns()
+
+    assert.deepEqual(resumed, [], 'only running runs are swept')
+  })
+})

--- a/packages/services/kysely/src/kysely-workflow-service.ts
+++ b/packages/services/kysely/src/kysely-workflow-service.ts
@@ -600,6 +600,45 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       .execute()
   }
 
+  protected async findStalledRunIds(
+    before: Date,
+    limit: number
+  ): Promise<string[]> {
+    const rows = await this.db
+      .selectFrom('workflowRuns as r')
+      .select('r.workflowRunId')
+      .where('r.status', '=', 'running')
+      .where(({ not, exists, selectFrom }) =>
+        not(
+          exists(
+            selectFrom('workflowStep as s')
+              .select('s.workflowStepId')
+              .whereRef('s.workflowRunId', '=', 'r.workflowRunId')
+              .where('s.status', 'in', ['running', 'scheduled', 'suspended'])
+          )
+        )
+      )
+      // The run row only moves on a status change, so idleness has to hold for
+      // the steps too — expressed as "no step touched since `before`" rather
+      // than max(updated_at) so it stays one index-friendly NOT EXISTS.
+      .where('r.updatedAt', '<', before)
+      .where(({ not, exists, selectFrom }) =>
+        not(
+          exists(
+            selectFrom('workflowStep as s')
+              .select('s.workflowStepId')
+              .whereRef('s.workflowRunId', '=', 'r.workflowRunId')
+              .where('s.updatedAt', '>=', before)
+          )
+        )
+      )
+      .orderBy('r.updatedAt', 'asc')
+      .limit(limit)
+      .execute()
+
+    return rows.map((row) => row.workflowRunId)
+  }
+
   async getRunState(runId: string): Promise<Record<string, unknown>> {
     const row = await this.db
       .selectFrom('workflowRuns')


### PR DESCRIPTION
## The gap

Arming a step is two writes to two systems — the step row, then the queue or scheduler job. A process that dies between them leaves a run `running` with **nothing in flight**: it parks on a step that will never complete and never error, so the run neither finishes nor fails, and nothing sweeps it up.

Pikku already handles the *dispatch-failed* case correctly — the step stays `pending` and re-dispatches on replay (`workflow-dispatch-durability.test.ts`) — but nothing ever **triggers** that replay.

Seen in production on a `workflow.sleep()`: a deploy restart landed between the sleep step's insert and its timer registration, so the wakeup was never armed and the run parked permanently.

## The fix

`workflowService.recoverStalledRuns()` re-drives stalled runs through the existing `resumeWorkflow`.

- Replay is memoized per step, so resuming a run that was not actually stuck costs one orchestration pass and changes nothing. That idempotence is what makes an idle-time heuristic safe here.
- Stalled = `running`, no step in `running`/`scheduled`/`suspended`, no activity since the cutoff. A run legitimately mid-sleep has a `scheduled` step, so it is excluded outright rather than swept every pass.
- **Not self-starting** — apps call it from a scheduled task at whatever interval suits the workload.

Stores opt in by overriding `findStalledRunIds`, which defaults to returning nothing — so this is additive for stores that cannot express the query. Implemented for `@pikku/kysely` and the in-memory service; a no-op for Redis/Mongo/CF-DO.

## Verification

- 4 new tests in `workflow-stalled-recovery.test.ts` (recovers the orphan; leaves a sleeping run, a just-moved run, and a finished run alone)
- Full workflow suite: 206/206 pass
- `@pikku/core` typechecks clean

Changeset: `patch` for `@pikku/core` and `@pikku/kysely`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for workflow runs stalled after a crash.
  * Stalled runs can be detected, requeued, and resumed while respecting active, sleeping, scheduled, recently updated, and completed workflows.
  * Recovery supports configurable inactivity timeouts and processing limits across supported workflow services.

* **Bug Fixes**
  * Prevents orphaned workflow runs from remaining stuck indefinitely.

* **Tests**
  * Added coverage for stalled-run recovery and exclusion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->