### PR TITLE
fix(cli): pin @pikku/kysely in the bootstrap tree

### DIFF
--- a/packages/cli/build.sh
+++ b/packages/cli/build.sh
@@ -34,7 +34,19 @@ echo "Bootstrapping with published @pikku/cli..."
 : "${PIKKU_BETTER_AUTH_VERSION:=0.12.20}"
 # core is a *peer* of both the CLI and the inspector, which is why it has to be
 # named here to exist at all once peer resolution is off.
-: "${PIKKU_CORE_VERSION:=0.12.74}"
+: "${PIKKU_CORE_VERSION:=0.12.77}"
+# @pikku/kysely is an ordinary *dependency* of the CLI, so unlike the peers above
+# it installs whether or not it is named — and left unnamed it floats on the
+# CLI's `^0.13.7`, which means the newest release wave, not the wave this pin
+# describes. That is not a hypothetical: publishing @pikku/kysely@0.13.10 (the
+# first version to import `createSecretValue`) alongside core 0.12.77 broke every
+# build within the hour, because the floating kysely landed next to the pinned
+# core 0.12.74 that predates the symbol. Every build since had failed with an
+# error naming a package the change never touched.
+#
+# So it is pinned like the rest: 0.13.10 peers on core ^0.12.77, which is why
+# core moved up with it. The whole set moves together or none of it does.
+: "${PIKKU_KYSELY_VERSION:=0.13.10}"
 # The other peer that has to be named: @pikku/better-auth peers on the upstream
 # `better-auth` library and imports it at module load, so without it the
 # bootstrap CLI dies on "Cannot find package 'better-auth'".
@@ -62,12 +74,14 @@ cat > "$_bootstrap_dir/package.json" <<JSON
     "@pikku/inspector": "${PIKKU_INSPECTOR_VERSION}",
     "@pikku/better-auth": "${PIKKU_BETTER_AUTH_VERSION}",
     "@pikku/core": "${PIKKU_CORE_VERSION}",
+    "@pikku/kysely": "${PIKKU_KYSELY_VERSION}",
     "better-auth": "${BETTER_AUTH_LIB_VERSION}"
   },
   "overrides": {
     "@pikku/better-auth": "${PIKKU_BETTER_AUTH_VERSION}",
     "@pikku/inspector": "${PIKKU_INSPECTOR_VERSION}",
     "@pikku/core": "${PIKKU_CORE_VERSION}",
+    "@pikku/kysely": "${PIKKU_KYSELY_VERSION}",
     "better-auth": "${BETTER_AUTH_LIB_VERSION}"
   }
 }


### PR DESCRIPTION
## Symptom

Every build since ~17:29 today fails, on any branch, with an error naming a package the change never touched:

```
Starting Pikku CLI build process...
Bootstrapping with published @pikku/cli...
Failed to run Pikku CLI: The requested module '@pikku/core'
                         does not provide an export named 'createSecretValue'
```

## Cause

`packages/cli/build.sh` pins the bootstrap wave — `@pikku/cli`, `@pikku/inspector`, `@pikku/better-auth`, `@pikku/core` — but **not** `@pikku/kysely`. Kysely is an ordinary *dependency* of the CLI rather than a peer, so it installs whether or not it is named, and unnamed it floats on the CLI's `^0.13.7` — which means the newest release wave, not the wave the pin describes.

Today's release published `@pikku/kysely@0.13.10`, the first version to import `createSecretValue` (0.13.9 does not — I unpacked both). That landed next to the pinned `@pikku/core@0.12.74`, which predates the symbol (added this morning in #1126), so the bootstrap died linking it.

The `--legacy-peer-deps` comment immediately below the manifest already predicted this — *"every release wave drags in a kysely whose peer on @pikku/core has moved ahead of what the registry is serving for this tree"* — but only ever treated it as a resolution cost, never as a version the pin has to own.

This is why `Release` was green on `2a8768b80` at 17:02 and CI on the same tree fails at 18:39: the publish happened in between. It also isn't caught by a merge gate, because the `CI` workflow runs on `branches-ignore: main` and `Release` on main, so main's Build had already gone red with nothing red to look at.

## Fix

Pin `@pikku/kysely` alongside the rest, in both `dependencies` and `overrides`. `0.13.10` peers on `@pikku/core@^0.12.77`, so core moves `0.12.74 → 0.12.77` with it; that still satisfies `@pikku/cli@0.12.96`'s own peer of `^0.12.74`.

## Things ruled out

- **Not the build cache.** First theory was a stale `dist` restored via the `ts-build-` prefix key. Disproved: a run with `Cache not found` — a genuinely cold build — failed identically. Both cache commits were dropped from this branch.
- **Not a bad publish.** `@pikku/core@0.12.77` on npm does export `createSecretValue`.
- **Not the CLI pin itself.** Published `@pikku/cli@0.12.96`'s dist never references the symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)