### PR TITLE
fix(workflow): relay steps whose dispatch was lost

### DIFF
--- a/.changeset/curly-donkeys-shake.md
+++ b/.changeset/curly-donkeys-shake.md
@@ -1,6 +1,8 @@
 ---
 '@pikku/core': patch
 '@pikku/kysely': patch
+'@pikku/kysely-postgres': patch
+'@pikku/kysely-mysql': patch
 ---
 
 Add `relayUndispatchedSteps()`, which re-drives steps whose queue or scheduler
@@ -13,8 +15,10 @@ durable row nothing will ever pick up. The run then neither finishes nor fails.
 The step row is the outbox record and this is the relay. It is safe to
 re-dispatch a step that already has a live job because `executeWorkflowStepInner`
 claims the step under `withStepLock` before invoking anything: the loser reads
-`running` and returns. Stores opt in by overriding `findUndispatchedSteps`
-(implemented for Kysely and in-memory); the default returns nothing, so a store
-without an atomic step lock gains no re-dispatches.
+`running` and returns. Stores opt in by overriding `findUndispatchedSteps`; the
+default returns nothing, so a store without an atomic step lock gains no
+re-dispatches. Opted in: `kysely-postgres` and `kysely-mysql` (real locks) and
+in-memory (inline, single-process, no queues). Not opted in: `mongodb` and
+`kysely-sqlite`, whose `withStepLock` is a pass-through.
 
 Not self-starting — call it from a scheduled task.

--- a/.changeset/curly-donkeys-shake.md
+++ b/.changeset/curly-donkeys-shake.md
@@ -1,0 +1,20 @@
+---
+'@pikku/core': patch
+'@pikku/kysely': patch
+---
+
+Add `relayUndispatchedSteps()`, which re-drives steps whose queue or scheduler
+dispatch was lost.
+
+Arming a step is two writes to two systems — the step row lands `pending`, then
+a job is published — and nothing spans both, so a crash in between leaves a
+durable row nothing will ever pick up. The run then neither finishes nor fails.
+
+The step row is the outbox record and this is the relay. It is safe to
+re-dispatch a step that already has a live job because `executeWorkflowStepInner`
+claims the step under `withStepLock` before invoking anything: the loser reads
+`running` and returns. Stores opt in by overriding `findUndispatchedSteps`
+(implemented for Kysely and in-memory); the default returns nothing, so a store
+without an atomic step lock gains no re-dispatches.
+
+Not self-starting — call it from a scheduled task.

--- a/packages/core/src/services/in-memory-workflow-service.ts
+++ b/packages/core/src/services/in-memory-workflow-service.ts
@@ -301,6 +301,23 @@ export class InMemoryWorkflowService
     return newStep
   }
 
+  protected async findUndispatchedSteps(
+    before: Date,
+    limit: number
+  ): Promise<Array<{ runId: string; stepId: string }>> {
+    const undispatched: Array<{ runId: string; stepId: string }> = []
+    for (const [runId, run] of this.runs) {
+      if (run.status !== 'running') continue
+      for (const step of this.stepHistory.get(runId) ?? []) {
+        if (step.status !== 'pending') continue
+        if (step.updatedAt >= before) continue
+        undispatched.push({ runId, stepId: step.stepId })
+        if (undispatched.length >= limit) return undispatched
+      }
+    }
+    return undispatched
+  }
+
   protected async findStalledRunIds(
     before: Date,
     limit: number

--- a/packages/core/src/services/in-memory-workflow-service.ts
+++ b/packages/core/src/services/in-memory-workflow-service.ts
@@ -301,6 +301,12 @@ export class InMemoryWorkflowService
     return newStep
   }
 
+  /**
+   * Safe to opt in despite the pass-through `withStepLock`: this service wires
+   * no queues and runs every step inline in one process, so the relay's
+   * redundant dispatch has no second holder to race with. See
+   * knowledge: decisions/internals/the-in-memory-workflow-service-is-inline-only-and-single-process.md
+   */
   protected async findUndispatchedSteps(
     before: Date,
     limit: number

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -1000,10 +1000,12 @@ export abstract class PikkuWorkflowService implements WorkflowService {
    *
    * Returns nothing by default so a store that cannot express the query keeps
    * working unchanged — and, because it does not opt in, gains no re-dispatches
-   * either. A store must have an atomic `withStepLock` (or an atomic claim)
-   * before overriding this: the relay makes duplicate dispatch routine, and the
-   * claim in `executeWorkflowStepInner` is what keeps a duplicate from becoming
-   * a second execution.
+   * either. A store must have an atomic `withStepLock` before overriding this,
+   * or no concurrency for one to exclude: the relay makes duplicate dispatch
+   * routine, and the claim in `executeWorkflowStepInner` is what keeps a
+   * duplicate from becoming a second execution. `kysely-postgres` and
+   * `kysely-mysql` qualify on the lock, `in-memory` on being inline and
+   * single-process; `mongodb` and `kysely-sqlite` qualify on neither.
    */
   protected async findUndispatchedSteps(
     _before: Date,
@@ -1050,14 +1052,18 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       options?.limit ?? DEFAULT_UNDISPATCHED_STEP_LIMIT
     )
 
+    // Backoff is keyed by run, not step, because the run is the unit of
+    // re-drive: `resumeWorkflow` replays the whole run and re-dispatches every
+    // step still owed a job. Holding off a single step while resuming its run
+    // would not suppress anything.
     const now = Date.now()
     const runIds = new Set<string>()
-    for (const { runId, stepId } of steps) {
-      const eligibleAt = this.redispatchBackoff.get(stepId)
+    for (const { runId } of steps) {
+      const eligibleAt = this.redispatchBackoff.get(runId)
       if (eligibleAt !== undefined && eligibleAt > now) {
         continue
       }
-      this.noteRedispatch(stepId, now)
+      this.noteRedispatch(runId, now)
       runIds.add(runId)
     }
 
@@ -1076,17 +1082,19 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     return { redispatched }
   }
 
-  /** Advisory, per-process record of when a step may next be re-dispatched. */
+  /** Advisory, per-process record of when a run may next be re-dispatched. */
   private readonly redispatchBackoff = new Map<string, number>()
 
-  private noteRedispatch(stepId: string, now: number): void {
-    const previous = this.redispatchDelays.get(stepId)
+  private readonly redispatchDelays = new Map<string, number>()
+
+  private noteRedispatch(runId: string, now: number): void {
+    const previous = this.redispatchDelays.get(runId)
     const delay = Math.min(
       previous === undefined ? REDISPATCH_BACKOFF_MS : previous * 2,
       REDISPATCH_BACKOFF_MAX_MS
     )
-    // A step that settles is never returned again, so entries are only evicted
-    // by this bound — oldest first, which is also least recently re-dispatched.
+    // A run that settles is never returned again, so entries are only evicted by
+    // this bound — oldest first, which is also least recently re-dispatched.
     if (this.redispatchBackoff.size >= REDISPATCH_BACKOFF_MAX_ENTRIES) {
       const oldest = this.redispatchBackoff.keys().next()
       if (!oldest.done) {
@@ -1094,11 +1102,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         this.redispatchDelays.delete(oldest.value)
       }
     }
-    this.redispatchDelays.set(stepId, delay)
-    this.redispatchBackoff.set(stepId, now + delay)
+    this.redispatchDelays.set(runId, delay)
+    this.redispatchBackoff.set(runId, now + delay)
   }
-
-  private readonly redispatchDelays = new Map<string, number>()
 
   protected resolveStepJobOptions(
     stepOptions?: WorkflowStepOptions

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -281,6 +281,25 @@ const DEFAULT_STALLED_RUN_MS = 5 * 60_000
 /** Runs re-driven per `recoverStalledRuns` call, so one sweep is bounded. */
 const DEFAULT_STALLED_RUN_LIMIT = 100
 
+/**
+ * How long a step may sit `pending` before the relay assumes its dispatch was
+ * lost. This is a bet that no healthy queue takes this long to move a job from
+ * `pending` to `running`; set it above the observed p99 of that latency.
+ */
+const DEFAULT_UNDISPATCHED_STEP_MS = 30_000
+
+/** Steps re-driven per `relayUndispatchedSteps` call, so one tick is bounded. */
+const DEFAULT_UNDISPATCHED_STEP_LIMIT = 100
+
+/** First wait before a step already re-dispatched once is re-dispatched again. */
+const REDISPATCH_BACKOFF_MS = 30_000
+
+/** Ceiling on the doubling backoff, so a permanently stuck step still gets swept. */
+const REDISPATCH_BACKOFF_MAX_MS = 10 * 60_000
+
+/** Bound on the in-process backoff map, so a long-lived process cannot grow it without bound. */
+const REDISPATCH_BACKOFF_MAX_ENTRIES = 10_000
+
 const WORKFLOW_POLL_MIN_MS = 10
 
 const WORKFLOW_POLL_FACTOR = 1.6
@@ -974,6 +993,112 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     }
     return { resumed }
   }
+
+  /**
+   * Runs holding a step that has sat `pending` since before `before`, paired
+   * with the step that flagged them.
+   *
+   * Returns nothing by default so a store that cannot express the query keeps
+   * working unchanged — and, because it does not opt in, gains no re-dispatches
+   * either. A store must have an atomic `withStepLock` (or an atomic claim)
+   * before overriding this: the relay makes duplicate dispatch routine, and the
+   * claim in `executeWorkflowStepInner` is what keeps a duplicate from becoming
+   * a second execution.
+   */
+  protected async findUndispatchedSteps(
+    _before: Date,
+    _limit: number
+  ): Promise<Array<{ runId: string; stepId: string }>> {
+    return []
+  }
+
+  /**
+   * Re-drive steps whose dispatch was lost, and report which runs were nudged.
+   *
+   * Arming a step is two writes to two systems: the step row lands `pending`,
+   * then a queue or scheduler job is published. Nothing spans both, so a crash
+   * in between leaves a durable row that nothing will ever pick up — the run
+   * neither finishes nor fails. (Seen on a `workflow.sleep()`: a deploy restart
+   * landed between the sleep step's insert and its timer.)
+   *
+   * The row is the outbox record and this is the relay. Age is the only signal
+   * available — a step `pending` because its dispatch was lost is
+   * indistinguishable from one whose job is merely still queued — so a step
+   * past `undispatchedAfterMs` is re-dispatched regardless, and correctness
+   * rests on the claim rather than on the guess being right. A redundant
+   * dispatch costs one queue message: the loser reads `running` and returns
+   * without invoking anything.
+   *
+   * Re-dispatches back off per step (doubling from 30s, capped at 10m) so a
+   * genuine queue backlog is not amplified by a tick that keeps firing at the
+   * steps the backlog is already delaying. The backoff is per process and
+   * advisory — losing it on restart costs extra dispatches, never correctness.
+   *
+   * This is not self-starting. Call it from a scheduled task; ~30s suits a
+   * queue whose `pending`→`running` latency is well under that.
+   */
+  public async relayUndispatchedSteps(options?: {
+    undispatchedAfterMs?: number
+    limit?: number
+  }): Promise<{ redispatched: string[] }> {
+    const before = new Date(
+      Date.now() -
+        (options?.undispatchedAfterMs ?? DEFAULT_UNDISPATCHED_STEP_MS)
+    )
+    const steps = await this.findUndispatchedSteps(
+      before,
+      options?.limit ?? DEFAULT_UNDISPATCHED_STEP_LIMIT
+    )
+
+    const now = Date.now()
+    const runIds = new Set<string>()
+    for (const { runId, stepId } of steps) {
+      const eligibleAt = this.redispatchBackoff.get(stepId)
+      if (eligibleAt !== undefined && eligibleAt > now) {
+        continue
+      }
+      this.noteRedispatch(stepId, now)
+      runIds.add(runId)
+    }
+
+    const redispatched: string[] = []
+    for (const runId of runIds) {
+      try {
+        await this.resumeWorkflow(runId)
+        redispatched.push(runId)
+      } catch (err) {
+        // One unresumable run must not stop the tick from relaying the rest.
+        getSingletonServices()?.logger?.error(
+          `Failed to re-dispatch workflow run ${runId}: ${err instanceof Error ? err.message : String(err)}`
+        )
+      }
+    }
+    return { redispatched }
+  }
+
+  /** Advisory, per-process record of when a step may next be re-dispatched. */
+  private readonly redispatchBackoff = new Map<string, number>()
+
+  private noteRedispatch(stepId: string, now: number): void {
+    const previous = this.redispatchDelays.get(stepId)
+    const delay = Math.min(
+      previous === undefined ? REDISPATCH_BACKOFF_MS : previous * 2,
+      REDISPATCH_BACKOFF_MAX_MS
+    )
+    // A step that settles is never returned again, so entries are only evicted
+    // by this bound — oldest first, which is also least recently re-dispatched.
+    if (this.redispatchBackoff.size >= REDISPATCH_BACKOFF_MAX_ENTRIES) {
+      const oldest = this.redispatchBackoff.keys().next()
+      if (!oldest.done) {
+        this.redispatchBackoff.delete(oldest.value)
+        this.redispatchDelays.delete(oldest.value)
+      }
+    }
+    this.redispatchDelays.set(stepId, delay)
+    this.redispatchBackoff.set(stepId, now + delay)
+  }
+
+  private readonly redispatchDelays = new Map<string, number>()
 
   protected resolveStepJobOptions(
     stepOptions?: WorkflowStepOptions

--- a/packages/core/src/wirings/workflow/workflow-dispatch-relay.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-dispatch-relay.test.ts
@@ -1,0 +1,128 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState } from '../../pikku-state.js'
+
+const silentLogger = { error() {}, info() {}, warn() {}, debug() {} }
+
+/**
+ * `relayUndispatchedSteps` re-drives a run by putting it back on the
+ * orchestrator queue, so the queue is the observation point.
+ */
+function trackResumes(): { runIds: string[] } {
+  const seen: string[] = []
+  pikkuState(null, 'package', 'singletonServices', {
+    queueService: {
+      add: async (_queue: string, data: { runId: string }) => {
+        seen.push(data.runId)
+      },
+    },
+    logger: silentLogger,
+  } as any)
+  return { runIds: seen }
+}
+
+/** Backdates a step's timestamp so it reads as undispatched. */
+async function backdateSteps(
+  ws: InMemoryWorkflowService,
+  runId: string,
+  ms: number
+): Promise<void> {
+  const past = new Date(Date.now() - ms)
+  for (const step of await ws.getRunHistory(runId)) {
+    ;(step as any).updatedAt = past
+  }
+}
+
+describe('undispatched step relay', () => {
+  test('re-dispatches a step whose arming was lost', async () => {
+    const resumes = trackResumes()
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+    // The row committed; the process died before the timer was armed.
+    await ws.insertStepState(runId, 'Wait 15s', null, { duration: 15000 })
+    await backdateSteps(ws, runId, 60_000)
+
+    const { redispatched } = await ws.relayUndispatchedSteps()
+
+    assert.deepEqual(redispatched, [runId], 'the run is re-dispatched')
+    assert.deepEqual(resumes.runIds, [runId], 'it is put back on the queue')
+  })
+
+  test('leaves a freshly written step alone', async () => {
+    const resumes = trackResumes()
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+    // Written milliseconds ago — its dispatch is almost certainly in flight.
+    await ws.insertStepState(runId, 'Wait 15s', null, { duration: 15000 })
+
+    const { redispatched } = await ws.relayUndispatchedSteps()
+
+    assert.deepEqual(redispatched, [], 'nothing is re-dispatched')
+    assert.deepEqual(resumes.runIds, [], 'nothing is queued')
+  })
+
+  test('backs off rather than re-dispatching the same step every tick', async () => {
+    const resumes = trackResumes()
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+    await ws.insertStepState(runId, 'Charge card', 'charge', {})
+    await backdateSteps(ws, runId, 60_000)
+
+    const first = await ws.relayUndispatchedSteps()
+    // The step is still pending — a real queue backlog looks exactly like this.
+    const second = await ws.relayUndispatchedSteps()
+
+    assert.deepEqual(first.redispatched, [runId], 'the first tick relays it')
+    assert.deepEqual(
+      second.redispatched,
+      [],
+      'the next tick is held off by the backoff'
+    )
+    assert.deepEqual(resumes.runIds, [runId], 'only one queue message')
+  })
+
+  test('ignores steps belonging to a settled run', async () => {
+    const resumes = trackResumes()
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+    await ws.insertStepState(runId, 'Wait 15s', null, { duration: 15000 })
+    await backdateSteps(ws, runId, 60_000)
+    await ws.updateRunStatus(runId, 'completed', {})
+
+    const { redispatched } = await ws.relayUndispatchedSteps()
+
+    assert.deepEqual(redispatched, [], 'a finished run is not re-dispatched')
+    assert.deepEqual(resumes.runIds, [], 'nothing is queued')
+  })
+
+  test('re-dispatches each stuck run once per tick', async () => {
+    const resumes = trackResumes()
+    const ws = new InMemoryWorkflowService()
+    const runIds: string[] = []
+    for (const n of [1, 2]) {
+      const runId = await ws.createRun('flow', {}, false, 'hash', {
+        type: 'test',
+      })
+      // Two orphaned steps in one run must still produce a single resume.
+      await ws.insertStepState(runId, `Wait ${n}a`, null, { duration: 1000 })
+      await ws.insertStepState(runId, `Wait ${n}b`, null, { duration: 1000 })
+      await backdateSteps(ws, runId, 60_000)
+      runIds.push(runId)
+    }
+
+    const { redispatched } = await ws.relayUndispatchedSteps()
+
+    assert.deepEqual(redispatched.sort(), runIds.sort(), 'both runs relayed')
+    assert.equal(resumes.runIds.length, 2, 'one queue message per run')
+  })
+})

--- a/packages/services/kysely-mysql/src/mysql-kysely-workflow-service.ts
+++ b/packages/services/kysely-mysql/src/mysql-kysely-workflow-service.ts
@@ -12,6 +12,17 @@ export class MySQLKyselyWorkflowService extends KyselyWorkflowService {
   }
 
   /**
+   * Safe to opt in: `withStepLock` below takes a real `GET_LOCK`, so the relay's
+   * redundant dispatches lose the claim instead of executing twice.
+   */
+  protected override async findUndispatchedSteps(
+    before: Date,
+    limit: number
+  ): Promise<Array<{ runId: string; stepId: string }>> {
+    return this.queryUndispatchedSteps(before, limit)
+  }
+
+  /**
    * MySQL has `JSON_SET` but no `json()`; a JSON literal is cast instead, so
    * the value lands as a JSON value rather than as a quoted string.
    */

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
@@ -27,6 +27,17 @@ export class PgKyselyWorkflowService extends KyselyWorkflowService {
     return sql<string>`(coalesce(state, '{}')::jsonb || jsonb_build_object(${key}::text, (${json}::text)::jsonb))::text`
   }
 
+  /**
+   * Safe to opt in: `withStepLock` below takes a real advisory lock, so the
+   * relay's redundant dispatches lose the claim instead of executing twice.
+   */
+  protected override async findUndispatchedSteps(
+    before: Date,
+    limit: number
+  ): Promise<Array<{ runId: string; stepId: string }>> {
+    return this.queryUndispatchedSteps(before, limit)
+  }
+
   private hashStringToInt(str: string): number {
     let hash = 0
     for (let i = 0; i < str.length; i++) {

--- a/packages/services/kysely/src/kysely-workflow-service.ts
+++ b/packages/services/kysely/src/kysely-workflow-service.ts
@@ -600,7 +600,17 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       .execute()
   }
 
-  protected async findUndispatchedSteps(
+  /**
+   * The undispatched-step query, shared by the dialects that can safely relay.
+   *
+   * Deliberately NOT an override of `findUndispatchedSteps`: this class's
+   * `withStepLock` is a pass-through, so a subclass inheriting it (kysely-sqlite)
+   * has no atomic claim, and the relay's redundant dispatches would become
+   * double executions. A dialect opts in by overriding `findUndispatchedSteps`
+   * to call this — which `kysely-postgres` and `kysely-mysql` do, having real
+   * locks.
+   */
+  protected async queryUndispatchedSteps(
     before: Date,
     limit: number
   ): Promise<Array<{ runId: string; stepId: string }>> {

--- a/packages/services/kysely/src/kysely-workflow-service.ts
+++ b/packages/services/kysely/src/kysely-workflow-service.ts
@@ -600,6 +600,29 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       .execute()
   }
 
+  protected async findUndispatchedSteps(
+    before: Date,
+    limit: number
+  ): Promise<Array<{ runId: string; stepId: string }>> {
+    const rows = await this.db
+      .selectFrom('workflowStep as s')
+      .innerJoin('workflowRuns as r', 'r.workflowRunId', 's.workflowRunId')
+      .select(['s.workflowStepId', 's.workflowRunId'])
+      .where('s.status', '=', 'pending')
+      .where('s.updatedAt', '<', before)
+      // Leftover `pending` steps on a settled run are not work; only a live run
+      // still has anything to dispatch.
+      .where('r.status', '=', 'running')
+      .orderBy('s.updatedAt', 'asc')
+      .limit(limit)
+      .execute()
+
+    return rows.map((row) => ({
+      runId: row.workflowRunId,
+      stepId: row.workflowStepId,
+    }))
+  }
+
   protected async findStalledRunIds(
     before: Date,
     limit: number


### PR DESCRIPTION
Follow-up to #1145, which added the safety net; this closes the window it was catching.

## The bug

Arming a step is two writes to two systems:

1. `insertStepState` → the step row commits as `pending`
2. `scheduleSleep` / queue publish → the job that will actually run it

Nothing spans both. A crash in between leaves a durable row that nothing will ever pick up, so the run neither finishes nor fails — it just stops. That is what parked a staging run: a deploy restart landed between a `workflow.sleep()` step's insert at `17:33:47.995` and its timer, and the row sat at `pending` (not `scheduled`) indefinitely. Its own 15-minute ceiling never fired either, because that ceiling is the workflow counting its own polls and the workflow had stopped existing.

A transaction cannot fix this — the second write is to NATS/pg-boss, not the database.

## The fix

The step row already *is* an outbox record: written before the publish, `pending` meaning "intent recorded, not yet dispatched". What was missing is the relay. `relayUndispatchedSteps()` re-drives any step still `pending` past a short cutoff (default 30s).

`recoverStalledRuns()` from #1145 stays as the coarse backstop — it needs five minutes of whole-run idleness *and* nothing else in flight, which is the right shape for "this run is dead" but far too slow and too narrow for "this step's dispatch was dropped".

## Why re-dispatching is safe

Age is the only available signal, so a lost dispatch is **indistinguishable** from a job that is merely still queued. The relay does not try to tell them apart — it re-dispatches either way, and correctness rests on the claim rather than on the guess being right:

```ts
// executeWorkflowStepInner
const claimed = await this.withStepLock(runId, stepName, async () => {
  const stepState = await this.getStepState(runId, stepName)
  if (stepState.status === 'succeeded' || stepState.status === 'running') {
    return null                                  // someone else owns it
  }
  ...
  await this.setStepRunning(stepState.stepId)    // take the claim
  return stepState
})
if (!claimed) return                             // exit without invoking
```

A duplicate dispatch therefore costs one queue message: the loser reads `running` and returns without invoking anything. That is what lets the cutoff be 30s instead of 5min.

Two consequences handled:

- **Backlog amplification.** A queue that is genuinely behind looks identical to a lost dispatch, so a naive tick would keep firing at exactly the steps the backlog is already delaying. Re-dispatches back off per step (doubling from 30s, capped at 10m). The backoff is per process and advisory — losing it on restart costs extra dispatches, never correctness.
- **Stores without an atomic lock.** `withStepLock` is a real lock on `kysely-postgres` (`pg_advisory_xact_lock`), `kysely-mysql` (`GET_LOCK`) and `redis`, but a pass-through on `mongodb` and base `kysely` (→ `kysely-sqlite`). Making duplicate dispatch routine would turn that latent gap into double execution, so those stores do not opt in: `findUndispatchedSteps` defaults to `[]`. Mongo's claim wants to become an atomic `findOneAndUpdate` — worth doing, separately.

## Tests

5 new cases in `workflow-dispatch-relay.test.ts` — relays a lost arming, ignores a freshly written step, backs off instead of re-dispatching every tick, ignores steps on a settled run, one resume per run regardless of how many steps are stuck. Full core suite: 1984 pass, 0 fail.

## Known limits

- **Not self-starting**, same as #1145 — needs a scheduled task. The natural companion is invoking it once at startup, since a deploy restart is both the usual cause and a moment when live code runs; not included here.
- **The 30s default is a bet**, not tuned safety: it assumes no healthy queue takes 30s to move a job from `pending` to `running`. It should be set above the observed p99 of that latency; if a deployment's real p99 is higher, healthy steps get re-dispatched routinely — harmless per the claim, but wasteful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery for workflow steps that remain pending after dispatch is interrupted.
  * Supports configurable age and batch limits when identifying pending steps.
  * Automatically retries redispatch with backoff while excluding recently updated or completed workflows.
  * Added support for both in-memory and database-backed workflow services.
* **Bug Fixes**
  * Prevents workflow progress from being lost when dispatch scheduling fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->