### PR TITLE
fix(schedule): invoke the RPC a delayed schedule names, with its data

### DIFF
--- a/.changeset/schedule-delayed-rpc-runs.md
+++ b/.changeset/schedule-delayed-rpc-runs.md
@@ -1,0 +1,13 @@
+---
+'@pikku/schedule': patch
+---
+
+**A delayed RPC now actually runs.** `InMemorySchedulerService.scheduleRPC`
+dispatched through `runScheduledTask`, which resolves names against the wired
+*cron task* registry — a registry no internally scheduled RPC is ever in. Every
+such call died as `ScheduledTaskNotFoundError` and was swallowed into a log
+line, and the payload captured alongside it was never forwarded. The one that
+mattered was `pikkuWorkflowSleeper`: it is what wakes a run from
+`workflow.sleep`, so an async workflow containing a sleep stopped at the first
+one and stayed `running` forever. It now invokes the RPC with its data, matching
+what the BullMQ and pg-boss schedulers already do.

--- a/packages/schedule/src/in-memory-scheduler-service.test.ts
+++ b/packages/schedule/src/in-memory-scheduler-service.test.ts
@@ -1,8 +1,18 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
 import { pikkuState } from '@pikku/core/ecosystem'
+import { addFunction } from '@pikku/core/function'
 
 import { InMemorySchedulerService } from './in-memory-scheduler-service.js'
+
+const waitFor = async (predicate: () => boolean, withinMs = 2000) => {
+  const deadline = Date.now() + withinMs
+  while (Date.now() < deadline) {
+    if (predicate()) return true
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  return false
+}
 
 describe('InMemorySchedulerService scheduleRPC', () => {
   test('schedules and executes delayed RPC', async () => {
@@ -27,6 +37,56 @@ describe('InMemorySchedulerService scheduleRPC', () => {
       const task = await scheduler.getTask(taskId)
       assert.ok(task)
       assert.equal(task.rpcName, 'testRpc')
+    } finally {
+      await scheduler.close()
+    }
+  })
+
+  /**
+   * The delay actually has to invoke the RPC, with its data.
+   *
+   * The test above only proved the task was registered, which is why the
+   * scheduler could dispatch through `runScheduledTask` — a lookup against the
+   * *cron task* registry that no scheduled RPC is ever in — and still pass.
+   * Every internally scheduled RPC failed with ScheduledTaskNotFoundError,
+   * `pikkuWorkflowSleeper` among them, so an async workflow never woke from
+   * `workflow.sleep`.
+   */
+  test('invokes the named RPC with its data once the delay elapses', async () => {
+    const errors: string[] = []
+    const logger = {
+      info: () => {},
+      warn: () => {},
+      debug: () => {},
+      error: (message: string) => errors.push(message),
+    }
+    pikkuState(null, 'package', 'singletonServices', { logger } as any)
+
+    const calls: unknown[] = []
+    addFunction(
+      'delayedTestRpc',
+      {
+        func: async (_services: any, data: unknown) => calls.push(data),
+      } as any,
+      null
+    )
+    pikkuState(null, 'function', 'meta')['delayedTestRpc'] = {
+      name: 'delayedTestRpc',
+      sessionless: true,
+      permissions: [],
+    } as any
+
+    const scheduler = new InMemorySchedulerService()
+    try {
+      await scheduler.scheduleRPC(20, 'delayedTestRpc', {
+        runId: 'run-1',
+        stepId: 'step-1',
+      })
+      assert.ok(
+        await waitFor(() => calls.length > 0),
+        `RPC was never invoked; scheduler errors: ${JSON.stringify(errors)}`
+      )
+      assert.deepEqual(calls[0], { runId: 'run-1', stepId: 'step-1' })
     } finally {
       await scheduler.close()
     }

--- a/packages/schedule/src/in-memory-scheduler-service.ts
+++ b/packages/schedule/src/in-memory-scheduler-service.ts
@@ -5,8 +5,9 @@ import type {
   ScheduledTaskSummary,
 } from '@pikku/core'
 import { SchedulerService, parseDurationString } from '@pikku/core'
-import { pikkuState } from '@pikku/core/ecosystem'
+import { pikkuState, getSingletonServices } from '@pikku/core/ecosystem'
 import { runScheduledTask, getScheduledTasks } from '@pikku/core/scheduler'
+import { rpcService } from '@pikku/core/rpc'
 
 interface DelayedTask {
   taskId: string
@@ -49,7 +50,27 @@ export class InMemorySchedulerService extends SchedulerService {
     const timer = setTimeout(async () => {
       this.delayedTasks.delete(taskId)
       try {
-        await runScheduledTask({ name: rpcName, session })
+        // An RPC, not a cron task. `runScheduledTask` looks the name up in the
+        // scheduler's task registry, which only ever holds wired cron tasks —
+        // so every internally-scheduled RPC died here as
+        // ScheduledTaskNotFoundError. The one that matters most is
+        // `pikkuWorkflowSleeper`: it is registered by the workflow service as a
+        // function, and it is what wakes a run from `workflow.sleep`. With the
+        // wake-up lost to a swallowed log line, an async workflow run stopped
+        // at its first sleep and stayed `running` forever.
+        //
+        // `data` has to be forwarded for the same reason. The sleeper is called
+        // with `{ runId, stepId }` and cannot identify the sleeping step
+        // without it — it was captured in `delayedTasks` but never passed on.
+        // This matches what the BullMQ and pg-boss schedulers already do:
+        // enqueue `{ rpcName, data, session }` and invoke the RPC with it.
+        const services = getSingletonServices()
+        const rpc = rpcService.getContextRPCService(
+          services as any,
+          {},
+          false
+        ) as { invoke: (name: string, data: unknown) => Promise<unknown> }
+        await rpc.invoke(rpcName, data)
       } catch (err: unknown) {
         getLogger().error(`Failed to execute delayed RPC '${rpcName}': ${err}`)
       }


### PR DESCRIPTION
Closes #1160.

`scheduleRPC` dispatched through `runScheduledTask`, which resolves names against the wired cron task registry — a registry no internally scheduled RPC is ever in. Every such call failed as `ScheduledTaskNotFoundError` and was swallowed into a log line, and the payload captured alongside it was never forwarded.

The one that mattered was `pikkuWorkflowSleeper`, which is what wakes a run from `workflow.sleep`: an async workflow containing a sleep stopped at the first one and stayed `running` forever. It now invokes the RPC with its data, matching what the BullMQ and pg-boss schedulers already do.

The existing test asserted only that scheduling returned an id, never that the RPC ran, which is how this survived. The new one fails against the old dispatch.
