### PR TITLE
fix(core): strip undefined-valued properties before schema validation

### DIFF
--- a/.changeset/schema-strips-undefined-properties.md
+++ b/.changeset/schema-strips-undefined-properties.md
@@ -1,0 +1,13 @@
+---
+'@pikku/core': patch
+---
+
+**An explicitly-`undefined` property no longer kills a step.** JSON Schema
+cannot describe such a property, so the validator rejected the whole instance
+rather than the field — `{ a: undefined }` threw
+`Instances of "undefined" type are not supported`. Whether a payload could
+contain one depended on how the call travelled: `JSON.stringify` drops those
+keys over HTTP, while an in-process dispatch hands the object over intact, so
+`workflow.do('step', 'rpc', { retries: data.maybeRetries })` failed only when
+the step ran inline. `validateSchema` now strips them first, and an
+explicitly-undefined *required* field reports as the missing property it is.

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -265,6 +265,84 @@ describe('Schema', () => {
       await validateSchema(logger, schemaService, null, {})
     })
 
+    test('strips undefined-valued properties before validating', async () => {
+      addSchema('undefinedProps', {
+        properties: { name: { type: 'string' }, count: { type: 'number' } },
+      })
+      const logger = {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      } as any
+      let seen: any
+      const schemaService = {
+        compileSchema: async () => {},
+        validateSchema: async (_name: string, data: any) => {
+          seen = data
+        },
+        getSchemaNames: () => new Set<string>(),
+      }
+      await validateSchema(logger, schemaService, 'undefinedProps', {
+        name: 'ada',
+        count: undefined,
+      })
+      assert.deepStrictEqual(seen, { name: 'ada' })
+      assert.ok(!('count' in seen))
+    })
+
+    test('strips undefined nested in objects and arrays', async () => {
+      addSchema('nestedUndefined', { properties: {} })
+      const logger = {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      } as any
+      let seen: any
+      const schemaService = {
+        compileSchema: async () => {},
+        validateSchema: async (_name: string, data: any) => {
+          seen = data
+        },
+        getSchemaNames: () => new Set<string>(),
+      }
+      await validateSchema(logger, schemaService, 'nestedUndefined', {
+        nested: { keep: 1, drop: undefined },
+        list: [{ keep: 2, drop: undefined }],
+      })
+      assert.deepStrictEqual(seen, {
+        nested: { keep: 1 },
+        list: [{ keep: 2 }],
+      })
+    })
+
+    test('leaves Date instances intact while stripping', async () => {
+      addSchema('withDate', { properties: {} })
+      const logger = {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      } as any
+      const when = new Date('2020-01-01T00:00:00.000Z')
+      let seen: any
+      const schemaService = {
+        compileSchema: async () => {},
+        validateSchema: async (_name: string, data: any) => {
+          seen = data
+        },
+        getSchemaNames: () => new Set<string>(),
+      }
+      await validateSchema(logger, schemaService, 'withDate', {
+        when,
+        drop: undefined,
+      })
+      assert.ok(seen.when instanceof Date)
+      assert.equal(seen.when.getTime(), when.getTime())
+      assert.ok(!('drop' in seen))
+    })
+
     test('should throw MissingSchemaError when schema not found', async () => {
       const logger = {
         info: () => {},

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -135,6 +135,41 @@ export const coerceTopLevelDataFromSchema = (
   }
 }
 
+/**
+ * Drops object properties whose value is literally `undefined`.
+ *
+ * JSON Schema has no way to describe such a property, and the validator refuses
+ * the whole instance rather than reporting it — `{ a: undefined }` throws
+ * "Instances of \"undefined\" type are not supported" instead of validating.
+ *
+ * That matters because whether a payload can contain one depends on how the
+ * call travelled. Over HTTP `JSON.stringify` drops these keys before the
+ * request is built, so they never arrive. Dispatched in-process — an inline
+ * workflow step calling an RPC — the object is handed over as-is, and
+ * `{ retries: data.maybeRetries }` with the field omitted by the caller is
+ * enough to kill the step. Normalising here makes the two paths agree, and an
+ * explicitly-undefined *required* field now reports as the missing property it
+ * is rather than as an internal error.
+ *
+ * Deliberately not a JSON round-trip: `coerceTopLevelDataFromSchema` puts real
+ * `Date` instances on the data first, and stringifying would flatten them back
+ * to strings the validator has never been given.
+ */
+const stripUndefinedValues = <T>(value: T): T => {
+  if (Array.isArray(value)) return value.map(stripUndefinedValues) as T
+  if (value === null || typeof value !== 'object') return value
+  // Only plain objects: a Date, Map or class instance is data, not a bag of
+  // properties to be rewritten.
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) return value
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([, entry]) => entry !== undefined)
+      .map(([key, entry]) => [key, stripUndefinedValues(entry)])
+  ) as T
+}
+
 export const validateSchema = async (
   logger: Logger,
   schemaService: SchemaService | undefined,
@@ -164,6 +199,6 @@ export const validateSchema = async (
       )
     }
     await schemaService.compileSchema(key, schema)
-    await schemaService.validateSchema(key, data ?? {})
+    await schemaService.validateSchema(key, stripUndefinedValues(data ?? {}))
   }
 }


### PR DESCRIPTION
Closes #1161.

JSON Schema cannot describe a property whose value is `undefined`, so the validator rejected the whole instance rather than the field: `{ a: undefined }` threw `Instances of "undefined" type are not supported`.

Whether a payload could contain one depended on how the call travelled. `JSON.stringify` drops those keys over HTTP, so they never arrive; an in-process dispatch hands the object over intact. An inline workflow step calling `workflow.do('step', 'rpc', { retries: data.maybeRetries })` therefore failed only when the step ran inline — the same workflow, a different outcome depending on where the step executed.

Not a JSON round-trip: `coerceTopLevelDataFromSchema` puts real `Date` instances on the data first, and stringifying would flatten them. Nothing is copied unless an `undefined` is actually found. An explicitly-undefined *required* field now reports as the missing property it is.
