### PR TITLE
feat(inspector): report a schema a contract names but codegen never generated

### DIFF
--- a/.changeset/inspector-reports-ungenerated-schema.md
+++ b/.changeset/inspector-reports-ungenerated-schema.md
@@ -1,0 +1,12 @@
+---
+'@pikku/inspector': patch
+---
+
+**Codegen reports a schema it named but never generated (PKU463).** A named
+contract type that is declared but not exported is imported by the virtual
+source file the schema generator compiles, resolves to nothing, and yields no
+schema — while the function meta still carries the name. `pikku all` exited 0
+and the first call to that function failed in a deployment with
+`MissingSchemaError`. The reference is now checked once addon schemas are
+merged, since an addon supplies its own and checking earlier would report every
+one of them as unresolved.

--- a/packages/inspector/src/error-codes.ts
+++ b/packages/inspector/src/error-codes.ts
@@ -45,6 +45,7 @@ export enum ErrorCode {
 
   // Configuration errors
   SCHEMA_GENERATION_ERROR = 'PKU456',
+  SCHEMA_REFERENCE_UNRESOLVED = 'PKU463',
   INLINE_SCHEMA = 'PKU489',
 
   // Function errors

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -32,6 +32,7 @@ import {
   validateNoSecretAliasServices,
   validateSecretUsage,
   computeDiagnostics,
+  validateSchemaReferences,
   validateSchemaWiringSeparation,
   validateScenarioServices,
   validateScenarioSteps,
@@ -443,6 +444,12 @@ export const inspect = async (
 
     // Re-load addon schemas (generateAllSchemas replaces state.schemas)
     await loadAddonSchemas(logger, state)
+
+    // After the addon merge, not before: an addon supplies its own schemas here,
+    // and checking earlier would report every one of them as unresolved.
+    if (options.schemaConfig) {
+      validateSchemaReferences(logger, state)
+    }
 
     state.manifest.initial = options.manifest ?? null
     const contracts = extractContractsFromMeta(state.functions.meta)

--- a/packages/inspector/src/utils/post-process.ts
+++ b/packages/inspector/src/utils/post-process.ts
@@ -689,6 +689,63 @@ export function computeRequiredSchemas(
   ])
 }
 
+/**
+ * Every schema a function's contract names has to exist once codegen is done.
+ *
+ * The way it stops existing is quiet. `generateCustomTypes` hands the schema
+ * generator a virtual source file that *imports* each named contract type, so a
+ * type that is declared but never exported resolves to nothing and yields no
+ * schema — while the function's meta still carries the name. Nothing downstream
+ * reads that name until the first call, which fails with a runtime
+ * `MissingSchemaError` in a deployment rather than in the build that caused it.
+ *
+ * Reported rather than critical: the reference is only *guaranteed* to break
+ * the functions that are actually invoked, so this blocks CI through
+ * `--fail-on-error` without failing a dev server over a function nobody calls.
+ */
+export function validateSchemaReferences(
+  logger: InspectorLogger,
+  state: InspectorState
+): void {
+  const { functions, schemas } = state
+  const available = new Set(Object.keys(schemas ?? {}))
+  const unresolved: string[] = []
+
+  const resolve = (typeName: string): string => {
+    try {
+      return functions.typesMap.getUniqueName(typeName)
+    } catch {
+      return typeName
+    }
+  }
+
+  for (const [funcName, meta] of Object.entries(functions.meta)) {
+    for (const [role, declared] of [
+      ['input', meta.inputs?.[0]],
+      ['output', meta.outputs?.[0]],
+    ] as const) {
+      if (!declared || PRIMITIVE_TYPES.has(declared)) continue
+      const resolved = resolve(declared)
+      if (PRIMITIVE_TYPES.has(resolved) || available.has(resolved)) continue
+      unresolved.push(`${funcName}.${role} → '${resolved}'`)
+    }
+  }
+
+  if (unresolved.length === 0) return
+
+  logger.diagnostic({
+    severity: 'error',
+    code: ErrorCode.SCHEMA_REFERENCE_UNRESOLVED,
+    message:
+      `${unresolved.length} function contract${unresolved.length === 1 ? '' : 's'} ` +
+      `name${unresolved.length === 1 ? 's' : ''} a schema that was never generated, so ` +
+      `calling ${unresolved.length === 1 ? 'it' : 'them'} fails at runtime with ` +
+      `MissingSchemaError: ${unresolved.join(', ')}. ` +
+      `The usual cause is a named type used as the function's input/output that ` +
+      `is declared but not exported — export it, or inline the type at the call site.`,
+  })
+}
+
 export function validateAgentModels(
   logger: InspectorLogger,
   state: InspectorState | Omit<InspectorState, 'typesLookup'>


### PR DESCRIPTION
Closes #1162.

PKU463. A named contract type that is declared but not exported is imported by the virtual source file the schema generator compiles, resolves to nothing, and yields no schema — while the function meta still carries the name. `pikku all` exited 0 and the first call to that function failed in a deployment with `MissingSchemaError`.

Checked after addon schemas are merged, since an addon supplies its own and checking earlier would report every one of them as unresolved.

Severity `error` rather than `critical`: the reference only certainly breaks the functions that are actually invoked, so it gates CI through `--fail-on-error` without stopping a dev server over a function nobody calls.
