### PR TITLE
fix(repo): build addons before generating the apps that reference them

### DIFF
--- a/.changeset/addon-build-order.md
+++ b/.changeset/addon-build-order.md
@@ -1,0 +1,6 @@
+---
+---
+
+Root build script only: `build:addons` now runs ahead of `yarn pikku`, so an
+HTTP route whose handler is an addon ref has something to resolve against when
+the apps are generated. No published package changes.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build:console": "cd packages/console && yarn generate && yarn build && rm -rf ../cli/console-app && cp -r dist ../cli/console-app",
     "build:templates": "yarn workspaces foreach -p -A --include 'templates/**' run build",
     "build:verifiers": "yarn workspaces foreach -p -A --include 'verifiers/**' run build",
-    "build": "yarn build:packages && yarn pikku && yarn build:addons && yarn build:templates",
+    "build": "yarn build:packages && yarn build:addons && yarn pikku && yarn build:templates",
     "check:licenses": "node scripts/check-licenses.mjs",
     "check:workspace-protocol": "node scripts/check-no-workspace-protocol.mjs",
     "check:no-publish-rebuild": "node scripts/check-no-publish-time-cli-rebuild.mjs",


### PR DESCRIPTION
Closes #1163.

The build ran `yarn pikku` before `build:addons`, so an HTTP route whose handler is an addon ref — `func: ref('console:streamWorkflowRun')` — had nothing to resolve against and produced no HTTP meta. At runtime `wireHTTP` found no metadata and skipped the route, so the console's live workflow-run SSE endpoint did not exist in the Next.js template. The only announcement was a `console.warn` on a build that exited 0.

It was the sole scaffolded route affected, because it is the only one whose handler is an addon ref rather than a local symbol.

`build:addons` now runs ahead of `yarn pikku`.

No changeset: this changes a root build script only, and bumps no published package.
