### PR TITLE
fix(benchmarks): repair the two unrunnable hot-path profilers

### DIFF
--- a/.changeset/benchmark-profilers-run.md
+++ b/.changeset/benchmark-profilers-run.md
@@ -1,0 +1,7 @@
+---
+---
+
+Benchmarks only: `bench-profile-granular.ts` and `bench-profile-hotpath.ts`
+reach core and uws-handler through relative paths rather than `./src/*`
+subpaths their packages do not map, so both profilers run again. No published
+package changes.

--- a/benchmarks/bench-profile-granular.ts
+++ b/benchmarks/bench-profile-granular.ts
@@ -1,16 +1,18 @@
 import { setupBenchmarkRoutes } from './bench-shared.js'
 import { fetchData } from '@pikku/core/http'
 import { pikkuState, httpRouter } from '@pikku/core/ecosystem'
-import { UWSPikkuHTTPRequest } from '@pikku/uws-handler/src/uws-pikku-http-request.js'
-import { UWSPikkuHTTPResponse } from '@pikku/uws-handler/src/uws-pikku-http-response.js'
+import { UWSPikkuHTTPRequest } from '../packages/runtimes/uws-handler/src/uws-pikku-http-request.js'
+import { UWSPikkuHTTPResponse } from '../packages/runtimes/uws-handler/src/uws-pikku-http-response.js'
 
-// Direct imports from source for profiling (not normally exported)
-import { createWeakUID, closeWireServices } from '@pikku/core/src/utils.js'
-import { combineChannelMiddleware } from '@pikku/core/src/wirings/channel/channel-middleware-runner.js'
-import { combineMiddleware } from '@pikku/core/src/middleware-runner.js'
-import { runPermissions } from '@pikku/core/src/permissions.js'
-import { rpcService } from '@pikku/core/src/wirings/rpc/rpc-runner.js'
-import { PikkuSessionService } from '@pikku/core/src/services/user-session-service.js'
+// Profiling reaches past the package entry points on purpose: these are the hot
+// paths, and none of them is public API. Relative paths rather than
+// `@pikku/core/src/...`, which the package's `exports` map correctly refuses.
+import { createWeakUID, closeWireServices } from '../packages/core/src/utils.js'
+import { combineChannelMiddleware } from '../packages/core/src/wirings/channel/channel-middleware-runner.js'
+import { combineMiddleware } from '../packages/core/src/middleware-runner.js'
+import { runPermissions } from '../packages/core/src/permissions.js'
+import { rpcService } from '../packages/core/src/wirings/rpc/rpc-runner.js'
+import { PikkuSessionService } from '../packages/core/src/services/user-session-service.js'
 
 const ITERATIONS = 100_000
 

--- a/benchmarks/bench-profile-hotpath.ts
+++ b/benchmarks/bench-profile-hotpath.ts
@@ -5,8 +5,8 @@ import {
 } from './bench-shared.js'
 import { fetchData } from '@pikku/core/http'
 import { pikkuState, httpRouter } from '@pikku/core/ecosystem'
-import { UWSPikkuHTTPRequest } from '@pikku/uws-handler/src/uws-pikku-http-request.js'
-import { UWSPikkuHTTPResponse } from '@pikku/uws-handler/src/uws-pikku-http-response.js'
+import { UWSPikkuHTTPRequest } from '../packages/runtimes/uws-handler/src/uws-pikku-http-request.js'
+import { UWSPikkuHTTPResponse } from '../packages/runtimes/uws-handler/src/uws-pikku-http-response.js'
 import { PikkuFetchHTTPRequest, PikkuFetchHTTPResponse } from '@pikku/core/http'
 
 const ITERATIONS = 100_000


### PR DESCRIPTION
Closes #1164.

`bench-profile-granular.ts` and `bench-profile-hotpath.ts` imported through `@pikku/core/src/...` and `@pikku/uws-handler/src/...`, which Node refuses with `ERR_PACKAGE_PATH_NOT_EXPORTED` — neither package maps a `./src/*` subpath, correctly. Both files have therefore been dead for some time; `benchmarks/` is not a workspace, so nothing typechecks or runs them and no script references either one.

Fixed with relative paths rather than by widening core's exports map: profiling reaches past the entry points on purpose, and none of these symbols is public API.

**Verified:** both profilers were run to completion on this branch — `bench-profile-hotpath.ts` produces its full A–O breakdown, and `bench-profile-granular.ts` its per-step µs table.

Empty changeset: `benchmarks/` is not a published workspace.
