### PR TITLE
fix(cli): default the generated CLI channel to session-required

### DIFF
--- a/.changeset/cli-channel-session-required-default.md
+++ b/.changeset/cli-channel-session-required-default.md
@@ -1,0 +1,11 @@
+---
+'@pikku/cli': patch
+---
+
+**The generated CLI channel defaults to session-required.** It was emitted with
+`auth: ${auth === true}`, so it was public unless the program explicitly opted
+in — inverting `wireChannel`'s own `auth !== false` default. A CLI program that
+declared no auth got an unauthenticated channel exposing every command. It now
+emits `auth: ${auth !== false}` and the connect-time session guard under the
+same condition, so a channel is public only when the program explicitly sets
+`auth: false`. CWE-306.

--- a/packages/cli/src/functions/wirings/cli/serialize-channel-cli.test.ts
+++ b/packages/cli/src/functions/wirings/cli/serialize-channel-cli.test.ts
@@ -1,0 +1,49 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import { serializeChannelCLI } from './serialize-channel-cli.js'
+import type { CLIProgramMeta } from '@pikku/core/cli'
+
+const programMeta = (auth?: boolean): CLIProgramMeta =>
+  ({
+    name: 'fabric',
+    description: 'fabric',
+    commands: {},
+    options: {},
+    ...(auth === undefined ? {} : { auth }),
+  }) as unknown as CLIProgramMeta
+
+const serialize = (auth?: boolean): string =>
+  serializeChannelCLI(
+    'fabric',
+    programMeta(auth),
+    '#channel',
+    new Map(),
+    {},
+    '#channelTypes',
+    '#functionTypes'
+  )
+
+describe('serializeChannelCLI auth default', () => {
+  test('defaults the generated channel to session-required when auth is unset', () => {
+    const out = serialize(undefined)
+    assert.match(
+      out,
+      /auth: true/,
+      'an unset program auth must emit a session-required channel'
+    )
+    assert.match(out, /onConnect: cliRequireSession/)
+  })
+
+  test('emits session-required when auth is explicitly true', () => {
+    assert.match(serialize(true), /auth: true/)
+  })
+
+  test('emits a public channel only when auth is explicitly false', () => {
+    const out = serialize(false)
+    assert.match(out, /auth: false/)
+    assert.ok(
+      !out.includes('onConnect: cliRequireSession'),
+      'an explicitly public channel must not require a session'
+    )
+  })
+})

--- a/packages/cli/src/functions/wirings/cli/serialize-channel-cli.ts
+++ b/packages/cli/src/functions/wirings/cli/serialize-channel-cli.ts
@@ -193,7 +193,7 @@ export const cliRaw = pikkuSessionlessFunc<{ args: string[] }, RawCLIFrame>({
 })
 
 ${
-  programMeta.auth === true
+  programMeta.auth !== false
     ? `/**
  * Refuses a connection that arrives without a session.
  *
@@ -219,8 +219,8 @@ export const cliRequireSession = pikkuSessionlessFunc<void, RawCLIFrame | void>(
 wireChannel({
   name: '${finalChannelName}',
   route: '${finalChannelRoute}',
-  auth: ${programMeta.auth === true},
-${programMeta.auth === true ? '  onConnect: cliRequireSession,\n' : ''}  onMessageWiring: {
+  auth: ${programMeta.auth !== false},
+${programMeta.auth !== false ? '  onConnect: cliRequireSession,\n' : ''}  onMessageWiring: {
     command: {
       '__help': {
         func: cliHelp,


### PR DESCRIPTION
Closes #1165.

The generated CLI websocket channel was emitted with `auth: ${auth === true}`, so it was public unless the program explicitly opted in — inverting `wireChannel`'s own `auth !== false` (session-required) default. A CLI program that declared no auth got an unauthenticated channel exposing every command.

It now emits `auth: ${auth !== false}` and the connect-time session guard under the same condition, so a channel is public only when the program explicitly sets `auth: false`.

CWE-306.

**Verified (TDD):** `serialize-channel-cli.test.ts` covers all three cases — unset, explicit `true`, explicit `false`. Against the old serializer the unset case fails (2/3 pass); with the fix all 3 pass.
