### PR TITLE
test(e2e): add chaos workflows and a durable side-effect ledger

### DIFF
--- a/.changeset/e2e-chaos-workflows.md
+++ b/.changeset/e2e-chaos-workflows.md
@@ -1,0 +1,7 @@
+---
+---
+
+e2e project only: four DSL chaos workflows, a durable side-effect ledger, and
+an opt-in `SQLITE_PATH` that points the SQLite backend at a file so workflow
+durability is observable across a restart. The default stays `:memory:`, so the
+standard suite is unaffected. No published package changes.

--- a/e2e/knowledge/decisions/durability-is-only-observable-against-a-file.md
+++ b/e2e/knowledge/decisions/durability-is-only-observable-against-a-file.md
@@ -1,0 +1,31 @@
+---
+type: decision
+title: Durability is only observable against a file
+description: The harness stores workflow runs in memory by default, so SQLITE_PATH is what makes crash recovery testable at all
+tags: workflows, chaos
+resource: env:SQLITE_PATH, env:DB_BACKEND, service:workflowService
+---
+
+# Durability is only observable against a file
+
+`src/services.ts` builds the SQLite backend over `new Database(':memory:')`. That
+is the right default for the standard suite — every run starts from an empty
+store, and nothing leaks between scenarios.
+
+It also means the harness cannot answer the one question a chaos test exists to
+ask. Kill the server mid-run against an in-memory store and the run does not
+survive to be recovered: `GET /workflow/:name/status/:runId` answers
+`Run not found`. A framework that resumes correctly and one that drops the run
+on the floor produce the identical observation, so the test proves nothing.
+
+`SQLITE_PATH` points the same backend at a file. Set it, and an interrupted run
+is still there after the restart — which is what turns "did it recover?" into a
+question with two distinguishable answers.
+
+**What this rules out:** treating a green chaos run against the default
+configuration as evidence of durability. If `SQLITE_PATH` is unset, a
+crash-recovery scenario is measuring the store, not the framework.
+
+The same reasoning applies to side effects. A ledger held in a module-level map
+is cleared by the very crash under test, so it reports "ran once" whether the
+step ran once or twice. `chaos-ledger.ts` appends to a file for that reason.

--- a/e2e/knowledge/decisions/index.md
+++ b/e2e/knowledge/decisions/index.md
@@ -9,4 +9,5 @@ A rule that was chosen, and what it rules out.
 
 <!-- pikku:knowledge-index -->
 - [security](security/index.md) — a rule about who may do what
+- [Durability is only observable against a file](durability-is-only-observable-against-a-file.md) — SQLITE_PATH is what makes crash recovery testable
 <!-- /pikku:knowledge-index -->

--- a/e2e/packages/functions/src/functions/chaos-ledger.ts
+++ b/e2e/packages/functions/src/functions/chaos-ledger.ts
@@ -1,0 +1,55 @@
+import { appendFileSync, mkdirSync, readFileSync, existsSync } from 'fs'
+import { dirname, join } from 'path'
+
+/**
+ * A file-backed record of every side effect the chaos steps perform.
+ *
+ * It is on disk rather than in a module-level map because the questions it
+ * exists to answer span a process restart: after the server is killed mid-run
+ * and brought back, did a step that had already succeeded run its body a second
+ * time? An in-memory ledger is cleared by the very event under test and would
+ * report "ran once" for both the correct and the incorrect outcome.
+ *
+ * Appends are single `O_APPEND` writes so that concurrent steps in a parallel
+ * branch interleave whole lines instead of corrupting each other.
+ */
+export type ChaosLedgerEntry = {
+  key: string
+  runId: string
+  /**
+   * The step's stable dedupe key. Recorded because it is what distinguishes a
+   * legitimate retry of one logical call (same invocationId, higher attempt)
+   * from the same call being dispatched twice (two invocationIds) — the two
+   * look identical if you only count effects.
+   */
+  invocationId?: string
+  attempt: number
+  at: number
+  detail?: unknown
+}
+
+const ledgerPath = (dir: string) => join(dir, 'chaos-ledger.jsonl')
+
+export const recordEffect = (dir: string, entry: ChaosLedgerEntry): void => {
+  const path = ledgerPath(dir)
+  mkdirSync(dirname(path), { recursive: true })
+  appendFileSync(path, `${JSON.stringify(entry)}\n`)
+}
+
+export const readEffects = (dir: string): ChaosLedgerEntry[] => {
+  const path = ledgerPath(dir)
+  if (!existsSync(path)) return []
+  return readFileSync(path, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as ChaosLedgerEntry)
+}
+
+/**
+ * An externally flippable failure switch, so a dependency can be "healed"
+ * partway through a run and a retry observed to succeed for a reason other
+ * than attempt count. `attemptCount` alone can only express flakiness that
+ * resolves itself on a schedule the workflow already knows.
+ */
+export const isDependencyDown = (dir: string, name: string): boolean =>
+  existsSync(join(dir, `down-${name}`))

--- a/e2e/packages/functions/src/functions/chaos.functions.ts
+++ b/e2e/packages/functions/src/functions/chaos.functions.ts
@@ -1,0 +1,165 @@
+import { pikkuSessionlessFunc } from '#pikku/pikku-types.gen.js'
+import {
+  isDependencyDown,
+  readEffects,
+  recordEffect,
+  type ChaosLedgerEntry,
+} from './chaos-ledger.js'
+
+const DEFAULT_LEDGER_DIR = '/tmp/pikku-chaos'
+
+const ledgerDir = async (variables: {
+  get: (name: string) => Promise<string | undefined> | string | undefined
+}): Promise<string> =>
+  (await variables.get('CHAOS_LEDGER_DIR')) ?? DEFAULT_LEDGER_DIR
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * The shared shape every chaos step accepts.
+ *
+ * Failure is expressed two ways because they answer different questions.
+ * `failAttemptsBelow` is deterministic — it reads the durable `attemptCount`,
+ * so a replay reaches the same verdict and the step is a clean model of
+ * self-healing flakiness. `dependency` reads an external file switch, so a
+ * dependency can be held down across many attempts and healed by hand mid-run,
+ * which is the only way to observe a retry succeed for a reason the workflow
+ * did not already know at planning time.
+ */
+export type ChaosInput = {
+  /** Ledger key — the identity of the side effect being performed. */
+  key: string
+  /** Block for this long before returning, to open a window for a kill. */
+  delayMs?: number
+  /** Fail while the durable attempt count is below this. */
+  failAttemptsBelow?: number
+  /** Fail on every attempt, forever. */
+  failAlways?: boolean
+  /** Fail while the file switch `down-<dependency>` exists. */
+  dependency?: string
+  /** Echoed back in the output, so a workflow can thread a value through. */
+  echo?: string
+}
+
+export type ChaosOutput = {
+  key: string
+  attempt: number
+  echo?: string
+  /** How many times this key's body has run, across every restart. */
+  totalEffects: number
+}
+
+/**
+ * Records a side effect, then optionally stalls and/or fails.
+ *
+ * The ledger write happens BEFORE the failure check on purpose: a step that
+ * fails after touching the world is exactly the case compensation exists for,
+ * and recording only successes would hide the double-effect bugs this is
+ * meant to catch.
+ */
+const performEffect = async (
+  dir: string,
+  data: ChaosInput,
+  runId: string,
+  invocationId: string | undefined,
+  attempt: number
+): Promise<ChaosOutput> => {
+  recordEffect(dir, {
+    key: data.key,
+    runId,
+    invocationId,
+    attempt,
+    at: Date.now(),
+    detail: data.echo,
+  } satisfies ChaosLedgerEntry)
+
+  if (data.delayMs) {
+    await wait(data.delayMs)
+  }
+
+  if (data.failAlways) {
+    throw new Error(`chaos:${data.key} is configured to always fail`)
+  }
+  if (data.dependency && isDependencyDown(dir, data.dependency)) {
+    throw new Error(
+      `chaos:${data.key} dependency '${data.dependency}' is down (attempt ${attempt})`
+    )
+  }
+  if (data.failAttemptsBelow && attempt < data.failAttemptsBelow) {
+    throw new Error(
+      `chaos:${data.key} transient failure on attempt ${attempt} of ${data.failAttemptsBelow}`
+    )
+  }
+
+  const totalEffects = readEffects(dir).filter((e) => e.key === data.key).length
+  return { key: data.key, attempt, echo: data.echo, totalEffects }
+}
+
+/**
+ * The single configurable work step every chaos workflow is built from.
+ *
+ * One function rather than a family of near-identical ones: the interesting
+ * variable in a reliability test is the *shape of the workflow around* the
+ * step, not the step itself, and a single well-known RPC name keeps the graphs
+ * comparable.
+ */
+export const chaosStep = pikkuSessionlessFunc<ChaosInput, ChaosOutput>({
+  description:
+    'Perform a recorded side effect with injectable delay and failure',
+  expose: true,
+  func: async ({ variables }, data, { workflowStep }) =>
+    performEffect(
+      await ledgerDir(variables),
+      data,
+      workflowStep?.runId ?? 'no-run',
+      workflowStep?.invocationId,
+      workflowStep?.attemptCount ?? 0
+    ),
+})
+
+/**
+ * The compensating half of a saga pair. Distinct from `chaosStep` only so that
+ * `onError` targets read as compensation at the call site and in the graph.
+ *
+ * `key` is optional because it has to be. A step's `onError` handler is invoked
+ * with `{ error: { message } }` and nothing else — not the failed step's input —
+ * so when this runs as compensation it cannot be told which entity to undo, and
+ * a required `key` makes the handler itself fail schema validation. Called
+ * directly through `workflow.do` the caller supplies one, and the run id is the
+ * fallback identity for the compensation-fired assertion.
+ */
+export const chaosCompensate = pikkuSessionlessFunc<
+  { key?: string; error?: { message?: string } },
+  { compensated: string }
+>({
+  description: 'Record a compensating action for a failed step',
+  expose: true,
+  func: async ({ variables }, data, { workflowStep }) => {
+    const runId = workflowStep?.runId ?? 'no-run'
+    const compensated = data.key ?? `run:${runId}`
+    recordEffect(await ledgerDir(variables), {
+      key: `compensate:${compensated}`,
+      runId,
+      invocationId: workflowStep?.invocationId,
+      attempt: 0,
+      at: Date.now(),
+      detail: data.error?.message,
+    })
+    return { compensated }
+  },
+})
+
+/** Reads the ledger back, so a test can assert on effects without file access. */
+export const chaosReadLedger = pikkuSessionlessFunc<
+  { key?: string; runId?: string },
+  { entries: ChaosLedgerEntry[]; count: number }
+>({
+  description: 'Read recorded chaos side effects',
+  expose: true,
+  func: async ({ variables }, { key, runId }) => {
+    const entries = readEffects(await ledgerDir(variables)).filter(
+      (e) => (!key || e.key === key) && (!runId || e.runId === runId)
+    )
+    return { entries, count: entries.length }
+  },
+})

--- a/e2e/packages/functions/src/workflows/chaos-fanout.workflow.ts
+++ b/e2e/packages/functions/src/workflows/chaos-fanout.workflow.ts
@@ -1,0 +1,51 @@
+import { pikkuWorkflowFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
+
+/**
+ * A batch of independent shards run concurrently, where one shard is rigged to
+ * fail.
+ *
+ * The question is what a `Promise.all` over `workflow.do` does to the siblings
+ * of a failing branch: whether the healthy shards that were already in flight
+ * are recorded as succeeded, and whether they are re-executed when the run is
+ * retried. Concurrency is where step bookkeeping is most likely to race, so
+ * the ledger — not the return value — is the thing worth asserting on.
+ */
+export const chaosFanoutWorkflow = pikkuWorkflowFunc<
+  {
+    batchId: string
+    shards: number
+    /** Zero-based index of the shard rigged to fail; -1 for none. */
+    poisonShard?: number
+    shardDelayMs?: number
+    /** Retries granted to each shard, so a poisoned one burns attempts. */
+    shardRetries?: number
+  },
+  { batchId: string; completed: number; attempts: number[] }
+>({
+  func: async ({}, data, { workflow }) => {
+    const indexes = Array.from({ length: data.shards }, (_, i) => i)
+
+    const results = await Promise.all(
+      indexes.map((index) =>
+        workflow.do(
+          `Process shard ${index}`,
+          'chaosStep',
+          {
+            key: `shard:${data.batchId}:${index}`,
+            delayMs: data.shardDelayMs,
+            failAlways: index === data.poisonShard,
+            echo: `${data.batchId}/${index}`,
+          },
+          { retries: data.shardRetries, retryDelay: '1s' }
+        )
+      )
+    )
+
+    return {
+      batchId: data.batchId,
+      completed: results.length,
+      attempts: results.map((r) => r.attempt),
+    }
+  },
+  tags: ['chaos', 'parallel'],
+})

--- a/e2e/packages/functions/src/workflows/chaos-onboarding.workflow.ts
+++ b/e2e/packages/functions/src/workflows/chaos-onboarding.workflow.ts
@@ -1,0 +1,95 @@
+import { pikkuWorkflowFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
+import { z } from 'zod'
+
+const managerDecision = z.object({
+  approved: z.boolean(),
+  reviewer: z.string(),
+})
+
+/**
+ * Employee onboarding: the flow that spends most of its life not running.
+ *
+ * It combines the three ways a DSL workflow gives up its process — a timer
+ * (`sleep`), a human gate (`approval`), and an explicit hold (`suspend`) — so
+ * that a single run can be interrupted at three structurally different kinds
+ * of wait. Each is durable for a different reason, and a restart during each
+ * exercises a different recovery path.
+ */
+export const chaosOnboardingWorkflow = pikkuWorkflowFunc<
+  {
+    employeeId: string
+    /** How long the provisioning timer holds the run. */
+    settleFor?: string
+    /** Hold the run open for an external resume before the manager gate. */
+    holdForResume?: boolean
+    /** Give up on the manager if nobody answers within this long. */
+    approvalExpiry?: string
+    provisionDelayMs?: number
+  },
+  {
+    employeeId: string
+    provisioned: boolean
+    outcome: 'active' | 'expired' | 'rejected'
+    reviewer?: string
+  }
+>({
+  func: async ({}, data, { workflow }) => {
+    await workflow.do('Create account', 'chaosStep', {
+      key: `account:${data.employeeId}`,
+      echo: data.employeeId,
+    })
+
+    const provisioned = await workflow.do('Provision laptop', 'chaosStep', {
+      key: `laptop:${data.employeeId}`,
+      delayMs: data.provisionDelayMs,
+      echo: data.employeeId,
+    })
+
+    await workflow.sleep('Settle provisioning', data.settleFor ?? '2s')
+
+    if (data.holdForResume) {
+      await workflow.suspend(`Hold onboarding for ${data.employeeId}`)
+    }
+
+    const decision = await workflow.approval(
+      `Manager sign-off for ${data.employeeId}`,
+      { schema: managerDecision, expiry: data.approvalExpiry }
+    )
+
+    if (decision.status === 'expired') {
+      await workflow.do('Revoke on expiry', 'chaosCompensate', {
+        key: `account:${data.employeeId}`,
+      })
+      return {
+        employeeId: data.employeeId,
+        provisioned: provisioned.totalEffects > 0,
+        outcome: 'expired',
+      }
+    }
+
+    if (!decision.data.approved) {
+      await workflow.do('Revoke on rejection', 'chaosCompensate', {
+        key: `account:${data.employeeId}`,
+      })
+      return {
+        employeeId: data.employeeId,
+        provisioned: provisioned.totalEffects > 0,
+        outcome: 'rejected',
+        reviewer: decision.data.reviewer,
+      }
+    }
+
+    await workflow.do('Grant access', 'chaosStep', {
+      key: `access:${data.employeeId}`,
+      echo: data.employeeId,
+    })
+
+    return {
+      employeeId: data.employeeId,
+      provisioned: provisioned.totalEffects > 0,
+      outcome: 'active',
+      reviewer: decision.data.reviewer,
+    }
+  },
+  tags: ['chaos', 'approval'],
+})

--- a/e2e/packages/functions/src/workflows/chaos-order-saga.workflow.ts
+++ b/e2e/packages/functions/src/workflows/chaos-order-saga.workflow.ts
@@ -1,0 +1,67 @@
+import { pikkuWorkflowFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
+
+/**
+ * Order fulfilment as a saga: every step that touches the world names the
+ * compensation that undoes it, so a failure late in the flow unwinds the
+ * earlier effects rather than leaving a half-shipped order.
+ *
+ * `onError` is compensation, not recovery — the original error still
+ * propagates and the run fails. The assertion this workflow supports is
+ * therefore about the *ledger*: when payment fails for good, the inventory
+ * reservation must have a matching `compensate:` entry.
+ */
+export const chaosOrderSagaWorkflow = pikkuWorkflowFunc<
+  {
+    orderId: string
+    /** Attempts below this fail for the payment step, modelling a flaky PSP. */
+    paymentFlakyUntil?: number
+    /** Hold payment down until the external switch is cleared. */
+    paymentDependency?: string
+    /** Payment never succeeds — drives the compensation path. */
+    paymentFatal?: boolean
+    /** Widen the courier step so a kill lands inside it. */
+    courierDelayMs?: number
+  },
+  { orderId: string; reserved: number; charged: number; shipped: boolean }
+>({
+  func: async ({}, data, { workflow }) => {
+    const reserved = await workflow.do(
+      'Reserve inventory',
+      'chaosStep',
+      { key: `reserve:${data.orderId}`, echo: data.orderId },
+      { onError: 'chaosCompensate' }
+    )
+
+    const charged = await workflow.do(
+      'Charge payment',
+      'chaosStep',
+      {
+        key: `charge:${data.orderId}`,
+        failAttemptsBelow: data.paymentFlakyUntil,
+        dependency: data.paymentDependency,
+        failAlways: data.paymentFatal,
+        echo: data.orderId,
+      },
+      { retries: 3, retryDelay: '1s', onError: 'chaosCompensate' }
+    )
+
+    await workflow.do('Allocate courier', 'chaosStep', {
+      key: `courier:${data.orderId}`,
+      delayMs: data.courierDelayMs,
+      echo: data.orderId,
+    })
+
+    const shipped = await workflow.do('Ship order', 'chaosStep', {
+      key: `ship:${data.orderId}`,
+      echo: data.orderId,
+    })
+
+    return {
+      orderId: data.orderId,
+      reserved: reserved.totalEffects,
+      charged: charged.attempt,
+      shipped: shipped.totalEffects > 0,
+    }
+  },
+  tags: ['chaos', 'saga'],
+})

--- a/e2e/packages/functions/src/workflows/chaos-restart.workflow.ts
+++ b/e2e/packages/functions/src/workflows/chaos-restart.workflow.ts
@@ -1,0 +1,49 @@
+import { pikkuWorkflowFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
+
+/**
+ * A run shaped to be killed.
+ *
+ * Three phases separated by timers, each recording a distinct ledger key, so
+ * that after a kill and restart the ledger says exactly which phases had run
+ * and the run status says which the orchestrator believes had run. Recovery is
+ * correct only when those two agree — a phase present in the ledger but marked
+ * pending is a lost effect, and a phase re-recorded after restart is a
+ * duplicated one.
+ */
+export const chaosRestartWorkflow = pikkuWorkflowFunc<
+  {
+    tag: string
+    sleepFor?: string
+    /** Widen phase two so a kill reliably lands while it is executing. */
+    phaseTwoDelayMs?: number
+  },
+  { tag: string; phases: number[] }
+>({
+  func: async ({}, data, { workflow }) => {
+    const one = await workflow.do('Phase one', 'chaosStep', {
+      key: `phase1:${data.tag}`,
+      echo: data.tag,
+    })
+
+    await workflow.sleep('Wait between one and two', data.sleepFor ?? '3s')
+
+    const two = await workflow.do('Phase two', 'chaosStep', {
+      key: `phase2:${data.tag}`,
+      delayMs: data.phaseTwoDelayMs,
+      echo: data.tag,
+    })
+
+    await workflow.sleep('Wait between two and three', data.sleepFor ?? '3s')
+
+    const three = await workflow.do('Phase three', 'chaosStep', {
+      key: `phase3:${data.tag}`,
+      echo: data.tag,
+    })
+
+    return {
+      tag: data.tag,
+      phases: [one.totalEffects, two.totalEffects, three.totalEffects],
+    }
+  },
+  tags: ['chaos', 'restart'],
+})

--- a/e2e/src/services.ts
+++ b/e2e/src/services.ts
@@ -86,8 +86,15 @@ export const createSingletonServices = pikkuServices(
         SQLiteKyselyWorkflowRunService,
       } = await import('@pikku/kysely-sqlite')
       const { SerializePlugin } = await import('@pikku/kysely')
+      // `:memory:` by default so the standard suite stays isolated and fast.
+      // SQLITE_PATH points the same backend at a file, which is what makes
+      // durability observable at all: an in-memory store loses every run when
+      // the process dies, so a crash-recovery test against it can only ever
+      // report "Run not found" and never distinguishes a framework that
+      // resumes correctly from one that does not.
+      const sqlitePath = process.env.SQLITE_PATH ?? ':memory:'
       const db = new Kysely<KyselyPikkuDB>({
-        dialect: new SqliteDialect({ database: new Database(':memory:') }),
+        dialect: new SqliteDialect({ database: new Database(sqlitePath) }),
         plugins: [new CamelCasePlugin(), new SerializePlugin()],
       })
       aiStorage = new SQLiteKyselyAIStorageService(db)


### PR DESCRIPTION
Closes #1167.

Four DSL-only workflows — an order saga, onboarding, a parallel fan-out and a restart target — over stub steps whose delay and failure mode come from the workflow input.

Failure is injectable two ways on purpose: `failAttemptsBelow` reads the durable `attemptCount`, so a replay reaches the same verdict, while `dependency` reads an external file switch, so a dependency can be held down across attempts and healed by hand mid-run.

`SQLITE_PATH` points the SQLite backend at a file; the default stays `:memory:` so the standard suite is unaffected. It is what makes durability observable at all — against an in-memory store a killed server loses the run entirely, so a framework that resumes correctly and one that drops the run produce the identical observation.

The ledger is on disk for the same reason: one held in a module-level map is cleared by the very crash under test.

### Verification

**Not verified locally — deferred to CI.** Typechecking the e2e project requires generated `.pikku` types, which requires building `@pikku/cli`, and that build fails on `main` today for an unrelated reason: the bootstrap installs published packages, and the published `@pikku/core` does not export `./node-host-resolver` while the published `@pikku/node-http-server` imports it. Confirmed pre-existing by reproducing it on a pristine `main` checkout.

Without codegen every file in the e2e project reports `Cannot find module '#pikku/...gen.js'`; the five new chaos files report that same error and nothing else.

Empty changeset: e2e is not a published workspace.
