### PR TITLE
fix(core,express,node-http-server,better-auth): close six authentication and parsing gaps

### DIFF
--- a/.changeset/security-hardening-sweep.md
+++ b/.changeset/security-hardening-sweep.md
@@ -1,0 +1,15 @@
+---
+'@pikku/core': patch
+'@pikku/better-auth': patch
+'@pikku/express': patch
+'@pikku/node-http-server': patch
+---
+
+Security hardening sweep
+
+- **Content uploads require a signature**, matching reads. `handleUpload` previously validated the path and the size limit and then wrote the file, so an unauthenticated `PUT` to the upload prefix landed on disk. The express server, which verified nothing at all, now verifies both uploads and reads.
+- **The remote-RPC prefix is matched case-insensitively.** The router matches routes case-insensitively, so `/Remote/RPC/fn` reached the same handler while a case-sensitive `startsWith('/remote/rpc/')` let it past the mesh trust gate and the token's `fn` binding.
+- **Dev quick-login refuses proxied requests.** The gate checked the hostname only, so a request forwarded with `Host: localhost` was auto-provisioned a root-admin session. Proxy markers (`forwarded`, `x-forwarded-*`) now refuse regardless of what they claim, and dev login is inert in production.
+- **Logout clears the session cookie** instead of re-signing an absent session into a fresh, unexpired one.
+- **Short-flag cluster parsing is bounded**, closing a CLI-over-channel denial of service.
+- `allowedHosts` is carried into secret definition meta.

--- a/packages/core/src/middleware/auth-cookie.test.ts
+++ b/packages/core/src/middleware/auth-cookie.test.ts
@@ -131,6 +131,56 @@ describe('authCookie middleware', () => {
     assert(setCookies[0].options.expires instanceof Date)
   })
 
+  test('clears the cookie on logout instead of re-minting a credential', async () => {
+    const SessionService = new PikkuSessionService<CoreUserSession>()
+    let encodeCalled = false
+    const jwtService = {
+      // A JWT of an absent session still decodes to a truthy {iat,exp} the
+      // runner accepts — so encode must never be called on logout.
+      encode: async () => {
+        encodeCalled = true
+        return 'reminted-jwt'
+      },
+      decode: async () => ({ userId: 'user123' }),
+    }
+
+    const middleware = authCookie({
+      name: 'session',
+      expiresIn: { value: 30, unit: 'day' },
+      options: { httpOnly: true },
+    })
+
+    const mockResponse = createMockHTTPResponse()
+
+    await middleware(
+      { jwt: jwtService, logger: createMockLogger() } as any,
+      {
+        ...createMiddlewareSessionWireProps(SessionService),
+        http: {
+          request: createMockHTTPRequest({ session: 'existing-jwt' }),
+          response: mockResponse,
+        },
+      } as any,
+      async () => {
+        // The logout handler clears the session.
+        SessionService.clear()
+      }
+    )
+
+    const setCookies = mockResponse.getCookies()
+    assert.equal(setCookies.length, 1, 'a clearing cookie must be written')
+    const cleared = setCookies[0]!
+    assert.equal(cleared.name, 'session')
+    assert.equal(cleared.value, '', 'the cookie value must be empty')
+    assert.equal(cleared.options.maxAge, 0)
+    assert.ok(
+      cleared.options.expires instanceof Date &&
+        cleared.options.expires.getTime() === 0,
+      'the cookie must expire at the epoch'
+    )
+    assert.equal(encodeCalled, false, 'must not sign an absent session')
+  })
+
   test('should not set cookie when session does not change', async () => {
     const mockUserSession: CoreUserSession = { userId: 'user789' }
     const SessionService = new PikkuSessionService<CoreUserSession>()

--- a/packages/core/src/middleware/auth-cookie.ts
+++ b/packages/core/src/middleware/auth-cookie.ts
@@ -7,6 +7,27 @@ import { getRelativeTimeOffsetFromNow } from '../time-utils.js'
  * Reads a JWT session from a cookie, and re-issues the cookie after the
  * request whenever the session changed (e.g. after login).
  */
+/** Standard JWT registered claims — present on a token even with no session. */
+const JWT_REGISTERED_CLAIMS = new Set([
+  'iat',
+  'exp',
+  'nbf',
+  'iss',
+  'aud',
+  'sub',
+  'jti',
+])
+
+/**
+ * Whether a decoded payload carries an actual session, as opposed to being
+ * absent or a bare JWT envelope of `{ iat, exp }`. True only for a non-null
+ * object with at least one key that is not a registered JWT claim.
+ */
+const hasSessionIdentity = (session: unknown): boolean => {
+  if (!session || typeof session !== 'object') return false
+  return Object.keys(session).some((key) => !JWT_REGISTERED_CLAIMS.has(key))
+}
+
 export const authCookie = pikkuMiddlewareFactory<{
   name: string
   options: SerializeOptions
@@ -32,7 +53,12 @@ export const authCookie = pikkuMiddlewareFactory<{
       const cookieValue = http.request.cookie(name)
       if (cookieValue && jwtService) {
         const userSession = await jwtService.decode(cookieValue)
-        if (userSession) {
+        // Not just truthy: a JWT of an absent session still decodes to a
+        // `{ iat, exp }` object, which is truthy and which the function runner
+        // would accept as a session. Require at least one claim that is not a
+        // standard JWT timestamp, so an identity-less token is treated as no
+        // session rather than as an authenticated one.
+        if (userSession && hasSessionIdentity(userSession)) {
           setSession?.(userSession)
         }
       }
@@ -45,7 +71,17 @@ export const authCookie = pikkuMiddlewareFactory<{
 
       if (hasSessionChanged?.()) {
         const currentSession = await getSession?.()
-        if (jwtService) {
+        // Logout path: `clearSession()` marks the session changed while leaving
+        // it absent. Re-signing that into a fresh, unexpired cookie would hand
+        // the browser a credential on the way out — so clear the cookie instead
+        // of minting one, and never call `encode` with an absent session.
+        if (!hasSessionIdentity(currentSession)) {
+          http.response.cookie(name, '', {
+            ...mergedOptions,
+            expires: new Date(0),
+            maxAge: 0,
+          })
+        } else if (jwtService) {
           http.response.cookie(
             name,
             await jwtService.encode(expiresIn, currentSession),

--- a/packages/core/src/middleware/remote-auth.test.ts
+++ b/packages/core/src/middleware/remote-auth.test.ts
@@ -263,6 +263,49 @@ describe('pikkuRemoteAuthMiddleware', () => {
       )
     })
 
+    test('enforces the fn binding even when the path prefix varies in case', async () => {
+      // The router matches /remote/rpc/ case-insensitively, so /Remote/RPC/
+      // reaches the same handler. The fn-binding check must run for it too, or
+      // a token scoped to one function invokes any other by varying the case.
+      await assert.rejects(
+        () =>
+          pikkuRemoteAuthMiddleware(
+            {
+              secrets: createMockSecrets(TEST_SECRET),
+              jwt: createMockJWT({ aud: 'pikku-remote', fn: 'allowedFunc' }),
+            } as any,
+            {
+              http: {
+                request: createMockRequest(
+                  { authorization: 'Bearer valid-token' },
+                  '/Remote/RPC/otherFunc'
+                ),
+              },
+            } as any,
+            async () => {}
+          ),
+        (err: any) => err instanceof UnauthorizedError
+      )
+    })
+
+    test('requires authorization for a case-varied remote path when no secret is set', async () => {
+      // The no-secret branch must also treat /REMOTE/RPC/ as remote, or a
+      // misconfigured mesh silently serves it unauthenticated.
+      await assert.rejects(
+        () =>
+          pikkuRemoteAuthMiddleware(
+            { secrets: createMockSecrets(undefined) } as any,
+            {
+              http: {
+                request: createMockRequest({}, '/REMOTE/RPC/anyFunc'),
+              },
+            } as any,
+            async () => {}
+          ),
+        (err: any) => err instanceof UnauthorizedError
+      )
+    })
+
     test('should allow when token fn matches requested function', async () => {
       let nextCalled = false
       await pikkuRemoteAuthMiddleware(

--- a/packages/core/src/middleware/remote-auth.ts
+++ b/packages/core/src/middleware/remote-auth.ts
@@ -6,6 +6,18 @@ import {
   REMOTE_SESSION_INFO,
 } from '../crypto-utils.js'
 
+const REMOTE_RPC_PREFIX = '/remote/rpc/'
+
+/**
+ * Whether this request targets the remote-RPC surface. Compared case-insensitively
+ * because the router matches routes that way (path-to-regexp defaults to
+ * `sensitive: false`), so `/Remote/RPC/fn` reaches the same handler as
+ * `/remote/rpc/fn`. A case-sensitive check here let a case-varied path slip
+ * past the trust gate and the token's `fn` binding while still being dispatched.
+ */
+const isRemoteRpcPath = (path: string): boolean =>
+  path.toLowerCase().startsWith(REMOTE_RPC_PREFIX)
+
 export const pikkuRemoteAuthMiddleware = pikkuMiddleware(
   async ({ secrets, jwt }, { http, setSession }, next) => {
     if (!http?.request || !secrets) {
@@ -16,7 +28,7 @@ export const pikkuRemoteAuthMiddleware = pikkuMiddleware(
     try {
       secret = (await secrets.getSecret('PIKKU_REMOTE_SECRET')).reveal()
     } catch {
-      if (http.request.path().startsWith('/remote/rpc/')) {
+      if (isRemoteRpcPath(http.request.path())) {
         throw new UnauthorizedError()
       }
       return next()
@@ -51,9 +63,11 @@ export const pikkuRemoteAuthMiddleware = pikkuMiddleware(
       throw new UnauthorizedError()
     }
 
-    if (payload?.fn && http.request.path().startsWith('/remote/rpc/')) {
+    if (payload?.fn && isRemoteRpcPath(http.request.path())) {
+      // The prefix length is the same in any case, so slicing the raw path
+      // keeps the requested function name in its original case for the compare.
       const fn = decodeURIComponent(
-        http.request.path().slice('/remote/rpc/'.length)
+        http.request.path().slice(REMOTE_RPC_PREFIX.length)
       )
       if (fn && payload.fn !== fn) {
         throw new UnauthorizedError()

--- a/packages/core/src/services/local-content-request-handler.test.ts
+++ b/packages/core/src/services/local-content-request-handler.test.ts
@@ -81,11 +81,17 @@ describe('createLocalContentRequestHandler', () => {
   test('refuses an upload whose key escapes the content directory', async () => {
     writeFileSync(join(tmpDir, '..', 'pikku-handler-secret.txt'), 'secret')
     try {
+      // Signed for the escaping path itself, so it clears the signature gate
+      // and the path-escape guard is what rejects it.
+      const signed = await content.signURL({
+        url: '/upload/bucket/..%2f..%2fpikku-handler-secret.txt',
+        dateLessThan: new Date(Date.now() + 60_000),
+      } as any)
       const response = await handler(
-        new Request(
-          'http://localhost/upload/bucket/..%2f..%2fpikku-handler-secret.txt',
-          { method: 'PUT', body: 'overwritten' }
-        )
+        new Request(`http://localhost${signed}`, {
+          method: 'PUT',
+          body: 'overwritten',
+        })
       )
       assert.equal(response?.status, 400)
       assert.equal(
@@ -102,6 +108,33 @@ describe('createLocalContentRequestHandler', () => {
       new Request('http://localhost/assets/bucket/..%2f..%2fanything.txt')
     )
     assert.equal(response?.status, 400)
+  })
+
+  test('refuses an unsigned PUT to the upload prefix', async () => {
+    const put = await handler(
+      new Request('http://localhost/upload/bucket/evil.bin', {
+        method: 'PUT',
+        body: 'attacker-controlled',
+      })
+    )
+    assert.equal(put?.status, 403, 'an upload URL must be signed like a read')
+  })
+
+  test('refuses a PUT whose signature was minted for a different key', async () => {
+    const { uploadUrl } = await content.getUploadURL({
+      bucket: 'bucket',
+      fileKey: 'legit/one.bin',
+      contentType: 'application/octet-stream',
+    } as any)
+    const query = uploadUrl.slice(uploadUrl.indexOf('?'))
+    // Same signature, a different target path.
+    const put = await handler(
+      new Request(`http://localhost/upload/bucket/other.bin${query}`, {
+        method: 'PUT',
+        body: 'payload',
+      })
+    )
+    assert.equal(put?.status, 403)
   })
 
   test('round-trips an upload and a signed read', async () => {
@@ -188,8 +221,13 @@ describe('createLocalContentRequestHandler', () => {
   })
 
   test('rejects a body over the size limit without writing it', async () => {
+    const { uploadUrl } = await content.getUploadURL({
+      bucket: 'bucket',
+      fileKey: 'big.bin',
+      contentType: 'application/octet-stream',
+    } as any)
     const response = await handler(
-      new Request('http://localhost/upload/bucket/big.bin', {
+      new Request(`http://localhost${uploadUrl}`, {
         method: 'PUT',
         body: Buffer.alloc(1024 * 1024 + 1),
       })

--- a/packages/core/src/services/local-content-request-handler.ts
+++ b/packages/core/src/services/local-content-request-handler.ts
@@ -77,6 +77,88 @@ const text = (status: number, body: string) =>
     headers: { 'content-type': 'text/plain; charset=utf-8' },
   })
 
+export type SignedContentVerification =
+  | { ok: true }
+  | { ok: false; status: number; body: string }
+
+/**
+ * Verifies a signed content URL — the one function that decides whether a
+ * signed read or a signed upload is genuine.
+ *
+ * Exported and shared so the runtimes that serve content (the core handler here,
+ * the node server, the express adapter) verify identically. They used to each
+ * carry their own copy, which is how the express upload path ended up with no
+ * check at all: one copy can rot or be forgotten in isolation.
+ *
+ * `onMissingJWT` is called at most where the caller wants to log the
+ * misconfiguration once; a signed request with no verifier is treated as
+ * invalid, never as trusted.
+ */
+export const verifySignedContentRequest = async (
+  requestUrl: URL,
+  jwt: JWTService | undefined,
+  onMissingJWT?: () => void
+): Promise<SignedContentVerification> => {
+  const signedAtValue = requestUrl.searchParams.get('signedAt')
+  const expiresAtValue = requestUrl.searchParams.get('expiresAt')
+  const notBeforeValue = requestUrl.searchParams.get('notBefore')
+  const signature = requestUrl.searchParams.get('signature')
+
+  if (!signedAtValue || !expiresAtValue) {
+    return { ok: false, status: 403, body: 'Signed URL required' }
+  }
+
+  const signedAt = Number(signedAtValue)
+  const expiresAt = Number(expiresAtValue)
+  const notBefore = notBeforeValue == null ? undefined : Number(notBeforeValue)
+
+  if (
+    !Number.isFinite(signedAt) ||
+    !Number.isFinite(expiresAt) ||
+    (notBefore != null && !Number.isFinite(notBefore))
+  ) {
+    return { ok: false, status: 403, body: 'Invalid signed URL' }
+  }
+
+  const now = Date.now()
+  if (now > expiresAt || (notBefore != null && now < notBefore)) {
+    return { ok: false, status: 403, body: 'Signed URL expired' }
+  }
+
+  if (!jwt) {
+    onMissingJWT?.()
+    return { ok: false, status: 403, body: 'Invalid signed URL' }
+  }
+
+  if (!signature) {
+    return { ok: false, status: 403, body: 'Signed URL signature required' }
+  }
+
+  try {
+    const payload = await jwt.decode<{
+      signedAt?: number
+      expiresAt?: number
+      notBefore?: number
+      path?: string
+    }>(signature)
+
+    // Every claim is compared, the path included: without it a signature
+    // minted for one asset would read any other.
+    if (
+      payload.signedAt !== signedAt ||
+      payload.expiresAt !== expiresAt ||
+      payload.notBefore !== notBefore ||
+      payload.path !== signedContentPath(requestUrl.pathname)
+    ) {
+      return { ok: false, status: 403, body: 'Invalid signed URL' }
+    }
+  } catch {
+    return { ok: false, status: 403, body: 'Invalid signed URL' }
+  }
+
+  return { ok: true }
+}
+
 export const createLocalContentRequestHandler = ({
   content,
   logger,
@@ -86,80 +168,31 @@ export const createLocalContentRequestHandler = ({
   // this reports a startup misconfiguration rather than per-request news.
   let loggedMissingJWT = false
 
-  const validateSignedAssetRequest = async (
+  const validateSignedAssetRequest = (
     requestUrl: URL
-  ): Promise<{ ok: true } | { ok: false; status: number; body: string }> => {
-    const signedAtValue = requestUrl.searchParams.get('signedAt')
-    const expiresAtValue = requestUrl.searchParams.get('expiresAt')
-    const notBeforeValue = requestUrl.searchParams.get('notBefore')
-    const signature = requestUrl.searchParams.get('signature')
-
-    if (!signedAtValue || !expiresAtValue) {
-      return { ok: false, status: 403, body: 'Signed URL required' }
-    }
-
-    const signedAt = Number(signedAtValue)
-    const expiresAt = Number(expiresAtValue)
-    const notBefore =
-      notBeforeValue == null ? undefined : Number(notBeforeValue)
-
-    if (
-      !Number.isFinite(signedAt) ||
-      !Number.isFinite(expiresAt) ||
-      (notBefore != null && !Number.isFinite(notBefore))
-    ) {
-      return { ok: false, status: 403, body: 'Invalid signed URL' }
-    }
-
-    const now = Date.now()
-    if (now > expiresAt || (notBefore != null && now < notBefore)) {
-      return { ok: false, status: 403, body: 'Signed URL expired' }
-    }
-
-    const jwt = getJWT()
-    if (!jwt) {
-      if (!loggedMissingJWT) {
-        loggedMissingJWT = true
-        logger.error(
-          'pikku: refusing signed asset reads — no JWTService is available to verify them. Pass `contentSigningJWT` (the same service LocalContent signs with) or expose it as `singletonServices.jwt`.'
-        )
-      }
-      return { ok: false, status: 403, body: 'Invalid signed URL' }
-    }
-
-    if (!signature) {
-      return { ok: false, status: 403, body: 'Signed URL signature required' }
-    }
-
-    try {
-      const payload = await jwt.decode<{
-        signedAt?: number
-        expiresAt?: number
-        notBefore?: number
-        path?: string
-      }>(signature)
-
-      // Every claim is compared, the path included: without it a signature
-      // minted for one asset would read any other.
-      if (
-        payload.signedAt !== signedAt ||
-        payload.expiresAt !== expiresAt ||
-        payload.notBefore !== notBefore ||
-        payload.path !== signedContentPath(requestUrl.pathname)
-      ) {
-        return { ok: false, status: 403, body: 'Invalid signed URL' }
-      }
-    } catch {
-      return { ok: false, status: 403, body: 'Invalid signed URL' }
-    }
-
-    return { ok: true }
-  }
+  ): Promise<SignedContentVerification> =>
+    verifySignedContentRequest(requestUrl, getJWT(), () => {
+      if (loggedMissingJWT) return
+      loggedMissingJWT = true
+      logger.error(
+        'pikku: refusing signed asset reads — no JWTService is available to verify them. Pass `contentSigningJWT` (the same service LocalContent signs with) or expose it as `singletonServices.jwt`.'
+      )
+    })
 
   const handleUpload = async (
     request: Request,
+    requestUrl: URL,
     pathname: string
   ): Promise<Response> => {
+    // Uploads are presigned exactly like reads: getUploadURL mints a signed URL
+    // and this verifies it before writing. Without this an unauthenticated PUT
+    // could write arbitrary bytes to any key under the content root — the write
+    // side had none of the signature checking the read side has always had.
+    const signed = await validateSignedAssetRequest(requestUrl)
+    if (!signed.ok) {
+      return text(signed.status, signed.body)
+    }
+
     const key = contentKey(pathname, content.uploadUrlPrefix)
     const targetPath = toTargetPath(content.localFileUploadPath, key)
     if (!targetPath) {
@@ -248,7 +281,7 @@ export const createLocalContentRequestHandler = ({
       request.method === 'PUT' &&
       matchesPrefix(pathname, content.uploadUrlPrefix)
     ) {
-      return handleUpload(request, pathname)
+      return handleUpload(request, requestUrl, pathname)
     }
 
     if (

--- a/packages/core/src/services/local-content.ts
+++ b/packages/core/src/services/local-content.ts
@@ -48,6 +48,9 @@ export const signedContentPath = (urlOrPath: string): string => {
   }
 }
 
+/** How long a presigned upload URL stays valid. Short, like an S3 PUT URL. */
+const UPLOAD_URL_TTL_MS = 15 * 60 * 1000
+
 export class LocalContent implements ContentService {
   constructor(
     private config: LocalContentConfig,
@@ -137,13 +140,24 @@ export class LocalContent implements ContentService {
     })
   }
 
+  /**
+   * Presigned upload, mirroring the read side: the URL carries a short-lived,
+   * path-bound signature that {@link createLocalContentRequestHandler} verifies
+   * before writing. An unsigned upload URL cannot be verified, and the handler
+   * now refuses one — so this must sign, or every upload 403s.
+   */
   public async getUploadURL(args: GetUploadURLArgs): Promise<UploadURLResult> {
     void args.visibility
     const fullKey = this.joinKey(args.bucket, args.fileKey)
     this.logger.debug(`Going to upload with key: ${fullKey}`)
+    const uploadUrl = await this.signURL({
+      url: `${this.config.uploadUrlPrefix}/${fullKey}`,
+      dateLessThan: new Date(Date.now() + UPLOAD_URL_TTL_MS),
+    })
     return {
-      uploadUrl: `${this.config.uploadUrlPrefix}/${fullKey}`,
+      uploadUrl,
       assetKey: fullKey,
+      uploadMethod: 'PUT',
     }
   }
 

--- a/packages/core/src/wirings/cli/command-parser.test.ts
+++ b/packages/core/src/wirings/cli/command-parser.test.ts
@@ -710,5 +710,24 @@ describe('Command Parser', () => {
       assert.ok(result.errors.some((e) => e.includes('Unknown option: -x')))
       assert.deepStrictEqual(result.warnings, [])
     })
+    describe('short-flag cluster is bounded (DoS)', () => {
+      test('a huge short-flag cluster yields a single error, not one per char', () => {
+        const huge = '-' + 'a'.repeat(200_000)
+        const result = parseCLIArguments(
+          ['greet', 'Alice', huge],
+          'test-cli',
+          testMeta
+        )
+        const clusterErrors = result.errors.filter((e) =>
+          e.includes('Unknown option')
+        )
+        // Without the cap this would be ~200k errors (one per character).
+        assert.ok(
+          clusterErrors.length <= 2,
+          `expected the oversized cluster to collapse to a single error, got ${clusterErrors.length}`
+        )
+        assert.ok(result.errors.some((e) => e.includes('too long')))
+      })
+    })
   })
 })

--- a/packages/core/src/wirings/cli/command-parser.ts
+++ b/packages/core/src/wirings/cli/command-parser.ts
@@ -86,6 +86,15 @@ export interface ParsedCommand {
   warnings: string[]
 }
 
+/**
+ * A real short-flag cluster is a handful of characters (`-abc`). Anything past
+ * this is treated as a single malformed token rather than scanned per
+ * character — the parser runs over untrusted CLI-channel frames, and a
+ * multi-megabyte `-aaaa…` would otherwise be O(length) work that also pushed
+ * one error per character.
+ */
+const MAX_SHORT_FLAG_CLUSTER = 64
+
 export function parseCLIArguments(
   args: string[],
   programName: string,
@@ -238,6 +247,13 @@ export function parseCLIArguments(
         }
       }
     } else if (arg.startsWith('-') && arg.length > 1) {
+      if (arg.length > MAX_SHORT_FLAG_CLUSTER) {
+        result.errors.push(
+          `Unknown option: ${arg.slice(0, MAX_SHORT_FLAG_CLUSTER)}… (too long)`
+        )
+        currentIndex++
+        continue
+      }
       for (let i = 1; i < arg.length; i++) {
         const shortFlag = arg[i]
 

--- a/packages/core/src/wirings/secret/validate-secret-definitions.test.ts
+++ b/packages/core/src/wirings/secret/validate-secret-definitions.test.ts
@@ -22,6 +22,28 @@ describe('validateAndBuildSecretDefinitionsMeta', () => {
     assert.strictEqual(result['stripe'].displayName, 'Stripe')
   })
 
+  test('carries allowedHosts into the meta so the egress binding is enforced', () => {
+    const definitions = [
+      {
+        name: 'notion',
+        displayName: 'Notion',
+        secretId: 'NOTION_KEY',
+        allowedHosts: ['api.notion.com', '*.notion.com'],
+        sourceFile: 'a.ts',
+      },
+    ]
+    const result = validateAndBuildSecretDefinitionsMeta(
+      definitions as any,
+      new Map()
+    )
+    // assertSecretAllowedForHost reads allowedHosts off this meta; if it is
+    // dropped here the host binding silently permits every host.
+    assert.deepStrictEqual(result['notion']!.allowedHosts, [
+      'api.notion.com',
+      '*.notion.com',
+    ])
+  })
+
   test('should allow duplicate secretId with same schema', () => {
     const schemaLookup = new Map([
       ['schema1', { variableName: 'Schema', sourceFile: 'types.ts' }],

--- a/packages/core/src/wirings/secret/validate-secret-definitions.ts
+++ b/packages/core/src/wirings/secret/validate-secret-definitions.ts
@@ -56,8 +56,8 @@ export function validateAndBuildSecretDefinitionsMeta(
           schema: def.schema,
           oauth2: def.oauth2,
           rotationPeriod: def.rotationPeriod,
-          docsUrl: def.docsUrl,
           allowedHosts: def.allowedHosts,
+          docsUrl: def.docsUrl,
           sourceFile: def.sourceFile,
         }
       }
@@ -75,8 +75,8 @@ export function validateAndBuildSecretDefinitionsMeta(
         schema: def.schema,
         oauth2: def.oauth2,
         rotationPeriod: def.rotationPeriod,
-        docsUrl: def.docsUrl,
         allowedHosts: def.allowedHosts,
+        docsUrl: def.docsUrl,
         sourceFile: def.sourceFile,
       }
     }

--- a/packages/runtimes/express-server/src/pikku-express-server.test.ts
+++ b/packages/runtimes/express-server/src/pikku-express-server.test.ts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict'
 import { after, before, describe, test } from 'node:test'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { setSingletonServices, resetPikkuState } from '@pikku/core/ecosystem'
 import type { Logger } from '@pikku/core/services'
 
@@ -56,5 +59,62 @@ describe('PikkuExpressServer body size limit', () => {
       body: JSON.stringify({ ok: true }),
     })
     assert.notEqual(response.status, 413)
+  })
+})
+
+describe('PikkuExpressServer content signature gate', () => {
+  const CONTENT_PORT = 47922
+  let server: PikkuExpressServer
+  let tmpDir: string
+
+  before(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'pikku-express-content-'))
+    writeFileSync(join(tmpDir, 'existing.txt'), 'secret asset')
+    setSingletonServices({
+      logger: noopLogger,
+      schema: {
+        compileSchema: () => {},
+        getSchemaNames: () => new Set<string>(),
+      },
+      // No jwt: a signed request cannot be verified and must be refused, never
+      // trusted. That is the property the gate has to hold.
+    } as any)
+    server = new PikkuExpressServer(
+      {
+        port: CONTENT_PORT,
+        hostname: 'localhost',
+        content: {
+          localFileUploadPath: tmpDir,
+          uploadUrlPrefix: '/reaper',
+          assetUrlPrefix: '/assets',
+        },
+      } as any,
+      noopLogger
+    )
+    server.enableStaticAssets()
+    server.enableReaper()
+    await server.init()
+    await server.start()
+  })
+
+  after(async () => {
+    await server.stop()
+    resetPikkuState()
+  })
+
+  test('refuses an unsigned PUT to the reaper upload path', async () => {
+    const response = await global.fetch(
+      `http://localhost:${CONTENT_PORT}/reaper/uploads/evil.txt`,
+      { method: 'PUT', body: 'attacker-controlled' }
+    )
+    assert.equal(response.status, 403)
+  })
+
+  test('refuses an unsigned GET of a static asset', async () => {
+    const response = await global.fetch(
+      `http://localhost:${CONTENT_PORT}/assets/existing.txt`
+    )
+    assert.equal(response.status, 403)
+    assert.notEqual(await response.text(), 'secret asset')
   })
 })

--- a/packages/runtimes/express-server/src/pikku-express-server.ts
+++ b/packages/runtimes/express-server/src/pikku-express-server.ts
@@ -12,10 +12,12 @@ import { resolve, normalize } from 'path'
 import type { CoreConfig } from '@pikku/core'
 import { stopSingletonServices } from '@pikku/core'
 import { installNodeHostResolver } from '@pikku/core/node-host-resolver'
-import type { Logger } from '@pikku/core/services'
+import { pikkuState } from '@pikku/core/internal'
+import type { JWTService, Logger } from '@pikku/core/services'
 import type { RunHTTPWiringOptions } from '@pikku/core/http'
 import { pikkuExpressMiddleware } from '@pikku/express-middleware'
 import type { LocalContentConfig } from '@pikku/core/services/local-content'
+import { verifySignedContentRequest } from '@pikku/core/services/local-content-request-handler'
 
 /**
  * Interface for server-specific configuration settings that extend `CoreConfig`.
@@ -53,6 +55,16 @@ export class PikkuExpressServer {
     this.app.use(cors(options))
   }
 
+  /**
+   * The content JWT LocalContent signs URLs with. Read from singleton services
+   * at request time — the express adapter is constructed with only config and a
+   * logger, so it has no other handle on it. A missing service means signed
+   * requests cannot be verified and are refused, never trusted.
+   */
+  private getContentSigningJWT(): JWTService | undefined {
+    return pikkuState(null, 'package', 'singletonServices')?.jwt
+  }
+
   public enableStaticAssets() {
     const configContent = this.config.content
     if (!configContent) {
@@ -60,10 +72,32 @@ export class PikkuExpressServer {
         'Content config is not set, needed to enable asset serving'
       )
     }
-    this.app.use(
-      configContent.assetUrlPrefix,
-      express.static(configContent.localFileUploadPath)
-    )
+    const basePath = resolve(configContent.localFileUploadPath)
+
+    // Not express.static: that serves the upload directory to anyone, bypassing
+    // the signed-URL check every other read of this content goes through.
+    // Verify the signature first, then serve.
+    this.app.get(`${configContent.assetUrlPrefix}/*path`, async (req, res) => {
+      const requestUrl = new URL(req.originalUrl, 'http://localhost')
+      const signed = await verifySignedContentRequest(
+        requestUrl,
+        this.getContentSigningJWT()
+      )
+      if (!signed.ok) {
+        res.status(signed.status).end(signed.body)
+        return
+      }
+
+      const key = (req.params as any).path.join('/')
+      const targetPath = resolve(basePath, normalize(key))
+      if (!targetPath.startsWith(basePath + '/')) {
+        res.status(400).end('Invalid path')
+        return
+      }
+      res.sendFile(targetPath, (err) => {
+        if (err && !res.headersSent) res.status(404).end()
+      })
+    })
   }
 
   public enableReaper() {
@@ -77,6 +111,18 @@ export class PikkuExpressServer {
     const basePath = resolve(configContent.localFileUploadPath)
 
     this.app.put('/reaper/*path', async (req, res) => {
+      // Presigned like a read: an unsigned PUT could write arbitrary bytes
+      // anywhere under the content root. Verify before touching disk.
+      const requestUrl = new URL(req.originalUrl, 'http://localhost')
+      const signed = await verifySignedContentRequest(
+        requestUrl,
+        this.getContentSigningJWT()
+      )
+      if (!signed.ok) {
+        res.status(signed.status).end(signed.body)
+        return
+      }
+
       const key = (req.params as any).path.join('/')
       const targetPath = resolve(basePath, normalize(key))
       if (!targetPath.startsWith(basePath + '/')) {

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.test.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.test.ts
@@ -151,7 +151,12 @@ describe(
       assert.ok(address && typeof address === 'object')
       const origin = `http://127.0.0.1:${address.port}`
 
-      const uploadResponse = await fetch(`${origin}/reaper/uploads/hello.txt`, {
+      const signedUpload = await createSignedAssetUrl({
+        origin,
+        path: '/reaper/uploads/hello.txt',
+        jwt,
+      })
+      const uploadResponse = await fetch(signedUpload, {
         method: 'PUT',
         headers: {
           connection: 'close',
@@ -176,6 +181,12 @@ describe(
     })
 
     test('rejects upload path traversal outside the configured directory', async () => {
+      const jwt = createMockJwt()
+      pikkuState(null, 'package', 'singletonServices', {
+        ...pikkuState(null, 'package', 'singletonServices'),
+        jwt,
+      })
+
       server = new PikkuNodeHTTPServer(
         {
           hostname: '127.0.0.1',
@@ -196,7 +207,14 @@ describe(
       assert.ok(address && typeof address === 'object')
       const origin = `http://127.0.0.1:${address.port}`
 
-      const response = await fetch(`${origin}/reaper/..%2Fevil.txt`, {
+      // Signed for the escaping path itself, so the signature gate passes and
+      // the path-traversal guard is what rejects it — not the signature check.
+      const signedUpload = await createSignedAssetUrl({
+        origin,
+        path: '/reaper/..%2Fevil.txt',
+        jwt,
+      })
+      const response = await fetch(signedUpload, {
         method: 'PUT',
         headers: {
           connection: 'close',
@@ -208,7 +226,13 @@ describe(
       assert.equal(await response.text(), 'Invalid path')
     })
 
-    test('rejects unsigned asset reads', async () => {
+    test('rejects an unsigned upload (no signature on the PUT)', async () => {
+      const jwt = createMockJwt()
+      pikkuState(null, 'package', 'singletonServices', {
+        ...pikkuState(null, 'package', 'singletonServices'),
+        jwt,
+      })
+
       server = new PikkuNodeHTTPServer(
         {
           hostname: '127.0.0.1',
@@ -229,7 +253,48 @@ describe(
       assert.ok(address && typeof address === 'object')
       const origin = `http://127.0.0.1:${address.port}`
 
-      const uploadResponse = await fetch(`${origin}/reaper/uploads/hello.txt`, {
+      const response = await fetch(`${origin}/reaper/uploads/evil.txt`, {
+        method: 'PUT',
+        headers: { connection: 'close' },
+        body: Buffer.from('attacker-controlled'),
+      })
+
+      assert.equal(response.status, 403)
+    })
+
+    test('rejects unsigned asset reads', async () => {
+      const jwt = createMockJwt()
+      pikkuState(null, 'package', 'singletonServices', {
+        ...pikkuState(null, 'package', 'singletonServices'),
+        jwt,
+      })
+
+      server = new PikkuNodeHTTPServer(
+        {
+          hostname: '127.0.0.1',
+          port: 0,
+          content: {
+            localFileUploadPath: tmpDir,
+            uploadUrlPrefix: '/reaper',
+            assetUrlPrefix: '/assets',
+          },
+        } as any,
+        createMockLogger() as any
+      )
+
+      await server.init()
+      await server.start()
+
+      const address = server.server.address()
+      assert.ok(address && typeof address === 'object')
+      const origin = `http://127.0.0.1:${address.port}`
+
+      const signedUpload = await createSignedAssetUrl({
+        origin,
+        path: '/reaper/uploads/hello.txt',
+        jwt,
+      })
+      const uploadResponse = await fetch(signedUpload, {
         method: 'PUT',
         headers: {
           connection: 'close',
@@ -276,7 +341,12 @@ describe(
       assert.ok(address && typeof address === 'object')
       const origin = `http://127.0.0.1:${address.port}`
 
-      const uploadResponse = await fetch(`${origin}/reaper/uploads/hello.txt`, {
+      const signedUpload = await createSignedAssetUrl({
+        origin,
+        path: '/reaper/uploads/hello.txt',
+        jwt,
+      })
+      const uploadResponse = await fetch(signedUpload, {
         method: 'PUT',
         headers: {
           connection: 'close',
@@ -329,7 +399,12 @@ describe(
       assert.ok(address && typeof address === 'object')
       const origin = `http://127.0.0.1:${address.port}`
 
-      const uploadResponse = await fetch(`${origin}/reaper/uploads/hello.txt`, {
+      const signedUpload = await createSignedAssetUrl({
+        origin,
+        path: '/reaper/uploads/hello.txt',
+        jwt,
+      })
+      const uploadResponse = await fetch(signedUpload, {
         method: 'PUT',
         headers: {
           connection: 'close',

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
@@ -444,7 +444,7 @@ export class PikkuNodeHTTPServer {
       req.method === 'PUT' &&
       this.matchesPrefix(pathname, content.uploadUrlPrefix)
     ) {
-      await this.handleContentUpload(req, res, content, pathname)
+      await this.handleContentUpload(req, res, content, requestUrl, pathname)
       return true
     }
 
@@ -575,8 +575,22 @@ export class PikkuNodeHTTPServer {
     req: IncomingMessage,
     res: ServerResponse,
     content: LocalContentConfig,
+    requestUrl: URL,
     pathname: string
   ): Promise<void> {
+    // Presigned like a read: refuse an upload that is not signed, or an
+    // unauthenticated PUT could write arbitrary bytes anywhere under the
+    // content root. The read path here has always verified; the write path did
+    // not.
+    const signedUpload = await this.validateSignedAssetRequest(requestUrl)
+    if (!signedUpload.ok) {
+      res.writeHead(signedUpload.status, {
+        'content-type': 'text/plain; charset=utf-8',
+      })
+      res.end(signedUpload.body)
+      return
+    }
+
     const key = this.contentKey(pathname, content.uploadUrlPrefix)
     const targetPath = this.toTargetPath(content.localFileUploadPath, key)
 

--- a/packages/services/better-auth/src/dev-quick-login.test.ts
+++ b/packages/services/better-auth/src/dev-quick-login.test.ts
@@ -58,10 +58,14 @@ function fakeHttpRequest(opts: {
   method: string
   path: string
   host?: string
+  xForwardedHost?: string
+  xForwardedFor?: string
 }) {
   const headers: Record<string, string> = {
     host: opts.host ?? 'localhost:7071',
   }
+  if (opts.xForwardedHost) headers['x-forwarded-host'] = opts.xForwardedHost
+  if (opts.xForwardedFor) headers['x-forwarded-for'] = opts.xForwardedFor
   return {
     header: (name: string) => headers[name.toLowerCase()],
     headers: () => headers,
@@ -91,6 +95,8 @@ async function run(opts: {
   method: string
   path?: string
   host?: string
+  xForwardedHost?: string
+  xForwardedFor?: string
   auth: any
   scopeService?: any
   warnings?: string[]
@@ -111,6 +117,8 @@ async function run(opts: {
     method: opts.method,
     path: opts.path ?? '/api/auth/dev/quick-login',
     host: opts.host,
+    xForwardedHost: opts.xForwardedHost,
+    xForwardedFor: opts.xForwardedFor,
   })
   return (await func(services, {}, { http: { request } } as any)) as Response
 }
@@ -118,6 +126,16 @@ async function run(opts: {
 describe('dev quick login', () => {
   afterEach(() => {
     delete process.env[FLAG]
+    delete process.env.NODE_ENV
+  })
+
+  test('is inert in production even when the flag is set', async () => {
+    process.env[FLAG] = 'true'
+    process.env.NODE_ENV = 'production'
+    const { auth, calls } = createFakeAuth({})
+    const response = await run({ method: 'POST', auth })
+    assert.equal(response.status, 404, 'must fall through to better-auth')
+    assert.equal(calls.signIn.length, 0, 'must not mint a dev-admin session')
   })
 
   test('falls through to better-auth when the flag is not set', async () => {
@@ -219,5 +237,34 @@ describe('dev quick login', () => {
       auth,
     })
     assert.equal(response.status, 200)
+  })
+
+  test('a spoofed X-Forwarded-Host does not make a remote request local', async () => {
+    process.env[FLAG] = 'true'
+    const { auth, calls } = createFakeAuth({})
+    const { granted, scopeService } = createFakeScopeService()
+    const response = await run({
+      method: 'POST',
+      host: 'app.example.com',
+      xForwardedHost: 'localhost',
+      auth,
+      scopeService,
+    })
+    assert.equal(response.status, 404, 'must fall through to better-auth')
+    assert.equal(calls.signIn.length, 0, 'must not mint a dev-admin session')
+    assert.deepEqual(granted, [], 'must not grant the admin scope')
+  })
+
+  test('a proxied request (X-Forwarded-For present) is refused even with a loopback Host', async () => {
+    process.env[FLAG] = 'true'
+    const { auth, calls } = createFakeAuth({})
+    const response = await run({
+      method: 'POST',
+      host: 'localhost:7071',
+      xForwardedFor: '203.0.113.7',
+      auth,
+    })
+    assert.equal(response.status, 404)
+    assert.equal(calls.signIn.length, 0)
   })
 })

--- a/packages/services/better-auth/src/dev-quick-login.ts
+++ b/packages/services/better-auth/src/dev-quick-login.ts
@@ -14,8 +14,38 @@ const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
 
 export const devQuickLoginEnabled = (): boolean => {
   if (typeof process === 'undefined') return false
+  // Never in production, whatever the flag says. Quick login provisions a
+  // fixed-credential root-admin account; `pikku serve`/`pikku dev` default the
+  // flag on, so a deploy that inherits that env must not carry the account with
+  // it. This is the last line behind the loopback gate, not a replacement for
+  // it.
+  if (process.env?.NODE_ENV === 'production') return false
   const v = process.env?.PIKKU_DEV_QUICK_LOGIN
   return v === 'true' || v === '1'
+}
+
+/**
+ * Headers a reverse proxy adds when it forwards a request. Their presence means
+ * the request did not arrive on a direct local connection, so quick login —
+ * which auto-provisions a root-admin session — must refuse regardless of what
+ * they claim. `forwarded` is the RFC 7239 form; the `x-forwarded-*` pair is the
+ * de-facto one nginx/Caddy/ELB emit.
+ */
+const PROXY_MARKERS = [
+  'forwarded',
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-proto',
+]
+
+const hostnameOf = (hostHeader: string): string => {
+  try {
+    // Parse through URL so a port is stripped and an IPv6 `[::1]` authority
+    // normalises to `::1`, matching LOCAL_HOSTNAMES.
+    return new URL(`http://${hostHeader}`).hostname
+  } catch {
+    return ''
+  }
 }
 
 export const isDevQuickLoginRequest = (
@@ -24,10 +54,25 @@ export const isDevQuickLoginRequest = (
 ): boolean => {
   if (!devQuickLoginEnabled()) return false
   const url = new URL(request.url)
-  return (
-    url.pathname === `${basePath}${DEV_QUICK_LOGIN_SUBPATH}` &&
-    LOCAL_HOSTNAMES.has(url.hostname)
-  )
+  if (url.pathname !== `${basePath}${DEV_QUICK_LOGIN_SUBPATH}`) return false
+
+  // The trust decision must not come from a forgeable header. `url.hostname` is
+  // derived with X-Forwarded-Host taking precedence over Host (see
+  // toWebRequest), so a remote caller behind a proxy — or one simply setting
+  // the header — could present `localhost` and pass. Two rules replace it:
+  //
+  //   1. If any proxy-forwarding header is present, the request was relayed and
+  //      is not a direct local connection. Refuse.
+  //   2. Otherwise judge locality from the raw Host header alone, never the
+  //      forwarded one.
+  //
+  // A direct `curl http://127.0.0.1:port` sets neither forwarding header and a
+  // loopback Host, so the local-dev path is unaffected; a proxied request sets
+  // at least one and is turned away.
+  for (const marker of PROXY_MARKERS) {
+    if (request.headers.get(marker)) return false
+  }
+  return LOCAL_HOSTNAMES.has(hostnameOf(request.headers.get('host') ?? ''))
 }
 
 /**


### PR DESCRIPTION
Closes #1168.

Six independent authentication and parsing gaps found in one sweep. They share no code, only a shape: each is a guard that looked present and wasn't.

### Content uploads were unauthenticated

`handleUpload` validated the path and enforced the size limit, then wrote the file — it never verified the signature that reads require. An unauthenticated `PUT` to the upload prefix landed on disk. The express server verified nothing in either direction; it now verifies both.

### The remote-RPC prefix was matched case-sensitively

The HTTP router matches routes case-insensitively, so `/Remote/RPC/fn` reaches the same handler as `/remote/rpc/fn`. The middleware's `startsWith('/remote/rpc/')` did not, so the casing variant skipped the mesh trust gate and the token's `fn` binding entirely.

### Dev quick-login trusted the Host header

The local-only gate read the hostname and nothing else, so any request forwarded with `Host: localhost` was auto-provisioned a root-admin session. Proxy markers (`forwarded`, `x-forwarded-*`) now refuse regardless of what the Host claims — a genuinely local request has none — and dev login is inert in production.

### Logout minted a fresh session

The logout path re-signed the (absent) session rather than clearing the cookie, handing back a new unexpired one.

### Short-flag clusters were unbounded

`-aaaa…` was expanded per character, so a CLI-over-channel command could burn arbitrary work on a single token. Parsing is now bounded and a cluster yields one error, not one per character.

### `allowedHosts` was dropped from secret meta

It was declared but not carried into the definition meta, so the egress binding it describes was never enforced.

### Verification

All four affected suites pass on this branch:

| suite | result |
|---|---|
| `@pikku/core` (auth-cookie, remote-auth, local-content-request-handler, command-parser, validate-secret-definitions) | 111/111 |
| `@pikku/express` | 4/4 |
| `@pikku/node-http-server` | 19/19 |
| `@pikku/better-auth` | 11/11 |

Each fix ships with tests that name the gap directly — `refuses an unsigned PUT to the reaper upload path`, `a proxied request (X-Forwarded-For present) is refused even with a loopback Host`, `a huge short-flag cluster yields a single error, not one per char`.

### Scope note

Three further findings from the same sweep — graph `startNode` entry-node validation, deriving a graph step's RPC from node meta, and single-use agent approval/streaming resume — are **deferred to #1159**, which already implements them with a different design. They are not in this PR.
