### PR TITLE
refactor(core): delete exports nothing references

### DIFF
--- a/.changeset/delete-unreferenced-exports.md
+++ b/.changeset/delete-unreferenced-exports.md
@@ -1,0 +1,14 @@
+---
+'@pikku/core': patch
+'@pikku/inspector': patch
+---
+
+Delete exports nothing references
+
+A sweep of the `@pikku/core` surface for exports with no consumer anywhere in the repo — no package, template, verifier or e2e project imports them: `ExtractFunctionOutput`, `CLICommandDefinition`, `RequestHeaders`, `HTTPFunctionsMeta`, `HTTPWiringMiddleware`, `JsonRpcError`, `TriggerSourceInfo`, `getMCPResources`, `getMCPPrompts`, `onGraphNodeComplete` and `InputRef`.
+
+Every one was a compatibility promise with nothing on the other end of it. Removing them narrows what 0.13 has to keep stable.
+
+`isRef` looked like the twelfth, and isn't. It is the type guard that reads what `createRef` writes — the `__isRef` brand marking a graph node input as "substitute another node's output here". Nothing imported it because neither it nor `RefValue` was reachable from any entry point, so the one consumer that needed it, the inspector's graph serializer, had reimplemented the same four conditions privately as `isRefValue` along with its own structural copy of `RefValue`. Deleting `isRef` would have made that duplicate permanent, with the brand's shape asserted in two places free to drift apart.
+
+So `isRef` and `RefValue` are exported from `@pikku/core/workflow` instead, and the inspector imports them rather than keeping its own copy.

--- a/packages/core/src/column-form.ts
+++ b/packages/core/src/column-form.ts
@@ -23,10 +23,7 @@ export const hashToken = async (raw: string): Promise<HashedValue> => {
   if (!subtle) {
     throw new Error('WebCrypto not available')
   }
-  const digest = await subtle.digest(
-    'SHA-256',
-    new TextEncoder().encode(raw)
-  )
+  const digest = await subtle.digest('SHA-256', new TextEncoder().encode(raw))
   let hex = ''
   for (const byte of new Uint8Array(digest)) {
     hex += byte.toString(16).padStart(2, '0')

--- a/packages/core/src/errors/error.test.ts
+++ b/packages/core/src/errors/error.test.ts
@@ -199,7 +199,10 @@ describe('getErrorResponse resolution order', () => {
   test('a subclass of a registered error inherits its registered status', () => {
     class TenantNotFoundError extends NotFoundError {}
     const expected = getErrorResponse(new NotFoundError())
-    assert.deepStrictEqual(getErrorResponse(new TenantNotFoundError()), expected)
+    assert.deepStrictEqual(
+      getErrorResponse(new TenantNotFoundError()),
+      expected
+    )
   })
 
   test('an unregistered, non-colliding error class resolves to undefined', () => {

--- a/packages/core/src/permissions.test.ts
+++ b/packages/core/src/permissions.test.ts
@@ -72,7 +72,9 @@ describe('runPermissions — function permissions (OR gate)', () => {
       run({ funcPermissions: { grp: [async () => true, async () => false] } }),
       { message: 'Permission denied' }
     )
-    await run({ funcPermissions: { grp: [async () => true, async () => true] } })
+    await run({
+      funcPermissions: { grp: [async () => true, async () => true] },
+    })
   })
 
   test('accepts a bare permission array as a single AND branch', async () => {

--- a/packages/core/src/services/local-email-service.ts
+++ b/packages/core/src/services/local-email-service.ts
@@ -1,4 +1,8 @@
-import type { EmailService, SendEmailInput, SendEmailResult } from './email-service.js'
+import type {
+  EmailService,
+  SendEmailInput,
+  SendEmailResult,
+} from './email-service.js'
 
 export class LocalEmailService implements EmailService {
   async send(input: SendEmailInput): Promise<SendEmailResult> {

--- a/packages/core/src/services/system-role-guard.test.ts
+++ b/packages/core/src/services/system-role-guard.test.ts
@@ -11,7 +11,10 @@ import {
   SystemRoleShadowedError,
 } from '../errors/errors.js'
 
-const system = (...names: string[]) => (name: string) => names.includes(name)
+const system =
+  (...names: string[]) =>
+  (name: string) =>
+    names.includes(name)
 
 describe('mutating a role', () => {
   test('a declared role refuses to be deleted or re-scoped', async () => {

--- a/packages/core/src/wirings/cli/channel/cli-raw-client-runner.ts
+++ b/packages/core/src/wirings/cli/channel/cli-raw-client-runner.ts
@@ -32,7 +32,10 @@ export type CorePikkuCLIClientRender<Data> = (
 ) => void | Promise<void>
 
 /** The normal case once the server owns the command tree. */
-const defaultJSONRenderer: CorePikkuCLIClientRender<any> = (_services, data) => {
+const defaultJSONRenderer: CorePikkuCLIClientRender<any> = (
+  _services,
+  data
+) => {
   console.log(JSON.stringify(data))
 }
 

--- a/packages/core/src/wirings/cli/cli.types.ts
+++ b/packages/core/src/wirings/cli/cli.types.ts
@@ -198,18 +198,6 @@ export type ValidateParameters<Params extends string, Input> =
     : never
 
 /**
- * Extract output type from a Pikku function config type
- */
-export type ExtractFunctionOutput<Func> =
-  Func extends CorePikkuFunctionConfig<infer FuncType, any, any>
-    ? FuncType extends
-        | CorePikkuFunction<any, infer Output, any, any, any>
-        | CorePikkuFunctionSessionless<any, infer Output, any, any, any>
-      ? Output
-      : never
-    : never
-
-/**
  * CLI command configuration that infers options from function input type.
  * This is a helper type for creating type-safe CLI commands.
  */
@@ -289,33 +277,6 @@ export type CLICommandShorthand<
     | CorePikkuFunctionSessionless<In, Out, any, any, any>
   >,
 > = PikkuFunctionConfig
-
-/**
- * Command definition (either full or shorthand)
- */
-export type CLICommandDefinition<
-  In,
-  Out,
-  PikkuFunctionConfig extends CorePikkuFunctionConfig<
-    | CorePikkuFunction<In, Out, any, any, any>
-    | CorePikkuFunctionSessionless<In, Out, any, any, any>
-  >,
-  PikkuPermission extends CorePikkuPermission<any, any, any>,
-  PikkuMiddleware extends CorePikkuMiddleware,
-  Options = any,
-  Subcommands extends Record<string, CoreCLICommandConfig<any, any, any>> =
-    Record<string, CoreCLICommandConfig<any, any, any>>,
-> =
-  | CoreCLICommand<
-      In,
-      Out,
-      PikkuFunctionConfig,
-      PikkuPermission,
-      PikkuMiddleware,
-      Options,
-      Subcommands
-    >
-  | CLICommandShorthand<In, Out, PikkuFunctionConfig>
 
 /**
  * CLI wiring configuration

--- a/packages/core/src/wirings/http/http.types.ts
+++ b/packages/core/src/wirings/http/http.types.ts
@@ -73,10 +73,6 @@ export interface PikkuHTTP<In = unknown> {
   response?: PikkuHTTPResponse
 }
 
-export type RequestHeaders =
-  | Record<string, string | string[] | undefined>
-  | ((headerName: string) => string | string[] | undefined)
-
 export type PikkuQuery<T = Record<string, string | undefined>> = Record<
   string,
   string | T | null | Array<T | null>
@@ -206,17 +202,6 @@ export type HTTPWiringMeta = CommonWireMeta & {
   groupBasePath?: string
 }
 export type HTTPWiringsMeta = Record<HTTPMethod, Record<string, HTTPWiringMeta>>
-
-export type HTTPFunctionsMeta = Array<{
-  name: string
-  inputs: string[] | null
-  outputs: string[] | null
-}>
-
-export type HTTPWiringMiddleware = {
-  route: string
-  middleware: CorePikkuMiddleware[]
-}
 
 export interface PikkuHTTPRequest<In = unknown> {
   method(): HTTPMethod

--- a/packages/core/src/wirings/mcp/mcp-runner.ts
+++ b/packages/core/src/wirings/mcp/mcp-runner.ts
@@ -39,12 +39,6 @@ export type RunMCPEndpointParams<Tools extends string = any> = {
   exposeErrors?: boolean
 }
 
-export type JsonRpcError = {
-  code: number
-  message: string
-  data?: any
-}
-
 export const wireMCPResource = <
   PikkuFunctionConfig extends CorePikkuFunctionConfig<
     CorePikkuFunctionSessionless<any, any>
@@ -293,20 +287,12 @@ async function runMCPPikkuFunc(
   }
 }
 
-export const getMCPResources = () => {
-  return pikkuState(null, 'mcp', 'resources')
-}
-
 export const getMCPResourcesMeta = () => {
   return pikkuState(null, 'mcp', 'resourcesMeta')
 }
 
 export const getMCPToolsMeta = () => {
   return pikkuState(null, 'mcp', 'toolsMeta')
-}
-
-export const getMCPPrompts = () => {
-  return pikkuState(null, 'mcp', 'prompts')
 }
 
 export const getMCPPromptsMeta = () => {

--- a/packages/core/src/wirings/persona/persona-environments.test.ts
+++ b/packages/core/src/wirings/persona/persona-environments.test.ts
@@ -44,7 +44,11 @@ describe('resolvePersonaEnvironments', () => {
 describe('personaEnvironmentErrors', () => {
   test('a persona that declares nothing cannot be wrong', () => {
     assert.deepEqual(
-      personaEnvironmentErrors('shopper', { disposition: 'careless' }, ENVIRONMENTS),
+      personaEnvironmentErrors(
+        'shopper',
+        { disposition: 'careless' },
+        ENVIRONMENTS
+      ),
       []
     )
   })
@@ -106,8 +110,15 @@ describe('personaEnvironmentErrors', () => {
   })
 
   test('with nothing configured it says where environments go', () => {
-    const [error] = personaEnvironmentErrors('shopper', { environments: ['x'] }, {})
-    assert.match(error!, /Declare it under 'environments' in pikku\.config\.json/)
+    const [error] = personaEnvironmentErrors(
+      'shopper',
+      { environments: ['x'] },
+      {}
+    )
+    assert.match(
+      error!,
+      /Declare it under 'environments' in pikku\.config\.json/
+    )
   })
 })
 

--- a/packages/core/src/wirings/persona/persona.test.ts
+++ b/packages/core/src/wirings/persona/persona.test.ts
@@ -23,7 +23,10 @@ describe('computed addresses', () => {
   })
 
   test('without a run id the address is the stable, seedable form', () => {
-    assert.equal(personaEmail('susan', 'mail.example.com'), 'susan@mail.example.com')
+    assert.equal(
+      personaEmail('susan', 'mail.example.com'),
+      'susan@mail.example.com'
+    )
   })
 
   test('an id that is not address-shaped is reduced to one', () => {
@@ -34,7 +37,10 @@ describe('computed addresses', () => {
   })
 
   test('an id with nothing usable in it is refused rather than guessed at', () => {
-    assert.throws(() => personaEmail('...', 'example.com'), /no usable email label/)
+    assert.throws(
+      () => personaEmail('...', 'example.com'),
+      /no usable email label/
+    )
   })
 
   // A synthetic domain was rejected precisely because it makes every
@@ -97,7 +103,11 @@ describe('verifying roles at sign-in', () => {
   })
 
   test('order and duplication are not drift', () => {
-    const v = verifyPersonaRoles('yasser', ['admin', 'buyer'], ['buyer', 'admin', 'buyer'])
+    const v = verifyPersonaRoles(
+      'yasser',
+      ['admin', 'buyer'],
+      ['buyer', 'admin', 'buyer']
+    )
     assert.equal(v.ok, true)
   })
 

--- a/packages/core/src/wirings/persona/validate-personas.ts
+++ b/packages/core/src/wirings/persona/validate-personas.ts
@@ -1,4 +1,8 @@
-import type { PersonaDefinitions, PersonaMeta, PersonasMeta } from './persona.types.js'
+import type {
+  PersonaDefinitions,
+  PersonaMeta,
+  PersonasMeta,
+} from './persona.types.js'
 
 /**
  * Whether a persona can actually be driven by a virtual user.

--- a/packages/core/src/wirings/trigger/pikku-trigger-service.ts
+++ b/packages/core/src/wirings/trigger/pikku-trigger-service.ts
@@ -14,11 +14,6 @@ export type TriggerTarget = {
   startNode?: string
 }
 
-export type TriggerSourceInfo = {
-  name: string
-  input: unknown
-}
-
 export abstract class PikkuTriggerService implements TriggerService {
   protected activeTriggers = new Map<string, TriggerInstance>()
 

--- a/packages/core/src/wirings/virtual-user/run-virtual-user.test.ts
+++ b/packages/core/src/wirings/virtual-user/run-virtual-user.test.ts
@@ -41,7 +41,11 @@ const CATALOGUE: ApiCatalogueEntry[] = [
 ]
 
 const INTENTS: IntentSource[] = [
-  { id: 'onboard', title: 'set up your first project', steps: ['sign in', 'make a project'] },
+  {
+    id: 'onboard',
+    title: 'set up your first project',
+    steps: ['sign in', 'make a project'],
+  },
 ]
 
 const PERSONA = {
@@ -84,10 +88,7 @@ const scripted = (
   return { llm, turns: () => turn }
 }
 
-const respond = <T>(
-  status: number,
-  body: T
-): ScenarioHttpResponse<T> => ({
+const respond = <T>(status: number, body: T): ScenarioHttpResponse<T> => ({
   status,
   ok: status >= 200 && status < 300,
   body,
@@ -126,7 +127,12 @@ describe('running a virtual user', () => {
       { kind: 'complete', summary: 'done' },
     ])
 
-    const result = await runVirtualUser({ ...base, target, llm, budget: { steps: 3 } })
+    const result = await runVirtualUser({
+      ...base,
+      target,
+      llm,
+      budget: { steps: 3 },
+    })
 
     // The first attempt cost a step and bought the schema; only the second
     // reached the server.
@@ -355,7 +361,9 @@ describe('what a virtual user reports', () => {
   })
 
   test('an app-specific oracle can add what the engine cannot know', async () => {
-    const target = recordingTarget(() => respond(200, { orgId: 'someone-else' }))
+    const target = recordingTarget(() =>
+      respond(200, { orgId: 'someone-else' })
+    )
     const { llm } = scripted(walkTo('listProjects'))
 
     const result = await runVirtualUser({
@@ -595,8 +603,9 @@ describe('goals and persona', () => {
   test('goals in the user’s own words become intents alongside the derived ones', async () => {
     const seen: string[] = []
     const target = recordingTarget(() => respond(200, {}))
-    const { llm } = scripted([{ kind: 'complete' }, { kind: 'complete' }], (_i, m) =>
-      seen.push(...m)
+    const { llm } = scripted(
+      [{ kind: 'complete' }, { kind: 'complete' }],
+      (_i, m) => seen.push(...m)
     )
 
     const result = await runVirtualUser({

--- a/packages/core/src/wirings/virtual-user/virtual-user-agents.test.ts
+++ b/packages/core/src/wirings/virtual-user/virtual-user-agents.test.ts
@@ -45,7 +45,10 @@ describe('reachableAgents', () => {
 
   test('carries the description through, which is what the model chooses on', () => {
     const [router] = reachableAgents(AGENTS, ['content:write'])
-    assert.equal(router!.description, 'Routes requests to the right domain agent')
+    assert.equal(
+      router!.description,
+      'Routes requests to the right domain agent'
+    )
   })
 
   test('omits description rather than passing undefined', () => {

--- a/packages/core/src/wirings/virtual-user/virtual-user-dispositions.test.ts
+++ b/packages/core/src/wirings/virtual-user/virtual-user-dispositions.test.ts
@@ -1,6 +1,9 @@
 import { strict as assert } from 'assert'
 import { describe, test } from 'node:test'
-import { DISPOSITIONS, dispositionProfile } from './virtual-user-dispositions.js'
+import {
+  DISPOSITIONS,
+  dispositionProfile,
+} from './virtual-user-dispositions.js'
 
 describe('resolving a disposition profile', () => {
   test('an unknown disposition falls back to realistic rather than throwing', () => {
@@ -46,7 +49,9 @@ describe('resolving a disposition profile', () => {
     const profile = dispositionProfile('careless', {
       instructions: 'Paste ids from other tabs.',
     })
-    assert.ok(profile.instructions.startsWith(DISPOSITIONS.careless.instructions))
+    assert.ok(
+      profile.instructions.startsWith(DISPOSITIONS.careless.instructions)
+    )
     assert.ok(profile.instructions.endsWith('Paste ids from other tabs.'))
   })
 

--- a/packages/core/src/wirings/virtual-user/virtual-user-intents.test.ts
+++ b/packages/core/src/wirings/virtual-user/virtual-user-intents.test.ts
@@ -3,7 +3,10 @@ import assert from 'node:assert/strict'
 
 import { IntentStack, intentsForPersona } from './virtual-user-intents.js'
 import { createRng } from './virtual-user-rng.js'
-import { DISPOSITIONS, type DispositionProfile } from './virtual-user-dispositions.js'
+import {
+  DISPOSITIONS,
+  type DispositionProfile,
+} from './virtual-user-dispositions.js'
 import type { IntentSource } from './virtual-user.types.js'
 
 const profileWith = (
@@ -182,7 +185,11 @@ describe('intents for an actor', () => {
   const catalogue: IntentSource[] = [
     { id: 'a', title: 'invite a teammate', personas: ['orgAdmin'] },
     { id: 'b', title: 'read the dashboard' },
-    { id: 'c', title: 'deploy a stage', personas: ['platformAdmin', 'orgAdmin'] },
+    {
+      id: 'c',
+      title: 'deploy a stage',
+      personas: ['platformAdmin', 'orgAdmin'],
+    },
   ]
 
   test('an actor gets what names it, plus anything that names nobody', () => {
@@ -201,7 +208,10 @@ describe('intents for an actor', () => {
 
   test('an empty actor list means everyone', () => {
     assert.deepEqual(
-      intentsForPersona([{ id: 'x', title: 'anything', personas: [] }], 'nobody'),
+      intentsForPersona(
+        [{ id: 'x', title: 'anything', personas: [] }],
+        'nobody'
+      ),
       [{ id: 'x', title: 'anything', personas: [] }]
     )
   })

--- a/packages/core/src/wirings/workflow/graph/graph-runner.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.ts
@@ -695,14 +695,6 @@ export async function executeGraphStep(
   }
 }
 
-export async function onGraphNodeComplete(
-  workflowService: PikkuWorkflowService,
-  runId: string,
-  graphName: string
-): Promise<void> {
-  await continueGraph(workflowService, runId, graphName)
-}
-
 export async function runFromMeta(
   workflowService: PikkuWorkflowService,
   runId: string,

--- a/packages/core/src/wirings/workflow/graph/workflow-graph.types.ts
+++ b/packages/core/src/wirings/workflow/graph/workflow-graph.types.ts
@@ -16,11 +16,6 @@ export const isRef = (value: unknown): value is RefValue =>
   '__isRef' in value &&
   (value as RefValue).__isRef === true
 
-export interface InputRef {
-  nodeId: string
-  path?: string
-}
-
 export type RefFn<NodeIds extends string = string> = (
   nodeId: NodeIds,
   path?: string

--- a/packages/core/src/wirings/workflow/index.ts
+++ b/packages/core/src/wirings/workflow/index.ts
@@ -15,6 +15,9 @@ export type {
 } from './pikku-workflow-service.js'
 export { deriveInvocationId, uuidv5 } from './workflow-invocation-id.js'
 
+export { isRef } from './graph/workflow-graph.types.js'
+export type { RefValue } from './graph/workflow-graph.types.js'
+
 export {
   buildRunTimeline,
   reconstructStateAt,

--- a/packages/inspector/src/utils/workflow/graph/serialize-workflow-graph.ts
+++ b/packages/inspector/src/utils/workflow/graph/serialize-workflow-graph.ts
@@ -1,3 +1,4 @@
+import { isRef } from '@pikku/core/workflow'
 import type {
   SerializedWorkflowGraph,
   SerializedGraphNode,
@@ -17,20 +18,6 @@ function convertRef(ref: { nodeId: string; path?: string }): DataRef {
 }
 
 /**
- * Check if a value is a runtime RefValue
- */
-function isRefValue(
-  value: unknown
-): value is { __isRef: true; nodeId: string; path?: string } {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    '__isRef' in value &&
-    (value as any).__isRef === true
-  )
-}
-
-/**
  * Convert input mapping from runtime format to serialized format
  */
 function serializeInputMapping(
@@ -39,7 +26,7 @@ function serializeInputMapping(
   const result: Record<string, unknown | DataRef> = {}
 
   for (const [key, value] of Object.entries(input)) {
-    if (isRefValue(value)) {
+    if (isRef(value)) {
       result[key] = convertRef(value)
     } else {
       result[key] = value


### PR DESCRIPTION
Closes #1179.

**Second in the core-surface stack.** Targets #1186 — review that one first; this diff is only the second commit.

`@pikku/core` exported a set of types and helpers that nothing imports — not a package, template, verifier, addon or the e2e project. Each was a compatibility promise with nothing on the other end of it:

| export | where it lived |
|---|---|
| `ExtractFunctionOutput` | `column-form.ts` |
| `CLICommandDefinition` | `wirings/cli/cli.types.ts` |
| `RequestHeaders`, `HTTPFunctionsMeta`, `HTTPWiringMiddleware` | `wirings/http/http.types.ts` |
| `JsonRpcError`, `getMCPResources`, `getMCPPrompts` | `wirings/mcp/mcp-runner.ts` |
| `TriggerSourceInfo` | `wirings/trigger/pikku-trigger-service.ts` |
| `onGraphNodeComplete`, `InputRef` | `wirings/workflow/graph/` |

The `*Meta` MCP accessors (`getMCPResourcesMeta`, `getMCPPromptsMeta`) are the ones `@pikku/modelcontextprotocol` actually uses; those stay.

### `isRef` looked like the twelfth, and isn't

`isRef` is the type guard that reads what `createRef` writes — the `__isRef` brand marking a graph node input as "substitute another node's output here". Nothing imported it because neither it nor `RefValue` was reachable from any entry point, so the one consumer that needed it — the inspector's graph serializer — had reimplemented the same four conditions privately as `isRefValue`, alongside its own structural copy of `RefValue`. Deleting `isRef` would have made that duplicate permanent, with the brand's shape asserted in two places free to drift apart.

So `isRef` and `RefValue` are exported from `@pikku/core/workflow` instead, and `packages/inspector/src/utils/workflow/graph/serialize-workflow-graph.ts` imports them rather than keeping its own copy.

### Verification

| check | result |
|---|---|
| `@pikku/core` full suite | 2000 pass, 0 fail, 10 skipped |
| `@pikku/inspector` full suite | 660 pass, 0 fail |
| `@pikku/core` + `@pikku/inspector` `tsc` | clean |
| tree-wide grep for each deleted name | no references outside the deletions themselves |

The non-deletion diff in this commit is Prettier reformatting that the tree already wanted — no test behaviour changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared workflow reference utilities for consistent workflow inspection and serialization.
  * Added stronger permission typing for authentication-based permissions.

* **Breaking Changes**
  * Removed several deprecated and unused public exports, including legacy permission helpers and types.
  * Permission wiring now uses the streamlined permission APIs.

* **Bug Fixes**
  * Pinned the HTTP server version during CLI setup to prevent compatibility issues.

* **Chores**
  * Applied formatting and type-safety improvements without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->