### PR TITLE
refactor(core): assert to named types, never to any

### DIFF
--- a/.changeset/fix-channel-handler-wrapper-registration.md
+++ b/.changeset/fix-channel-handler-wrapper-registration.md
@@ -1,0 +1,9 @@
+---
+'@pikku/core': patch
+---
+
+Fix `onConnect`/`onDisconnect` wrapper handlers, and correct `wireChannel`'s generic arguments
+
+`CoreChannel` accepts three shapes for a handler: a function config, a simple wrapper (`{ func, middleware }`), and a wrapper around a function config (`{ func: { func }, middleware }`). `wireChannel` unwrapped the third shape for `onMessage` and `onMessageWiring`, but registered `onConnect` and `onDisconnect` as-is — so the registered config's `func` was an object, and the function runner threw when it tried to call it. All three shapes now register a callable config on every handler.
+
+`wireChannel`'s type arguments were also misaligned with `CoreChannel`'s parameter list: `PikkuPermission` was being passed into the `ChannelConnect` slot and `PikkuMiddleware` into `ChannelDisconnect`, which made `wireChannel({ onConnect: { func } })` fail to typecheck with "not assignable to `CorePikkuPermission`". End users did not see this — the CLI's generated `wireChannel` wrapper casts before calling core — but anyone importing `wireChannel` from `@pikku/core/channel` directly did. The signature is now `wireChannel<In, Channel>(channel: CoreChannel<In, Channel>)`; the three surplus type parameters were never used for anything correct and are gone.

--- a/.changeset/tighten-types-that-any-was-masking.md
+++ b/.changeset/tighten-types-that-any-was-masking.md
@@ -1,0 +1,11 @@
+---
+'@pikku/core': patch
+---
+
+Tighten several public types that `as any` was masking
+
+- `AIStreamEvent`'s `approval-request` variant now declares `runId: string` rather than `runId?: string`. Every emitter already set it, and `AIAgentResult['pendingApprovals']` has always required it — the optional let `undefined` reach a field consumers rely on to resume a suspended run.
+- `PikkuWire` gains an optional `logger`. The no-op audit service already read `wire.logger` before falling back to the singleton, but nothing declared it, so a host had no typed way to attach an invocation-scoped logger.
+- `pikkuAuth`'s marker is now the exported `AuthBranded` type instead of an untyped property, so the brand that agent tool filtering depends on is visible to the type system at both the site that sets it and the sites that read it.
+
+Internally this takes core's non-test modules from 108 `as any` casts to none. Each is replaced by an assertion to the type actually wanted, or by a change to the surrounding types that makes the assertion unnecessary. A test holds the count at zero.

--- a/.changeset/type-the-session-readonly-flag-and-gateway-channel-meta.md
+++ b/.changeset/type-the-session-readonly-flag-and-gateway-channel-meta.md
@@ -1,0 +1,9 @@
+---
+'@pikku/core': patch
+---
+
+Declare `CoreUserSession.readonly` and `ChannelMeta.gateway`, which the runtime already used
+
+The function runner throws `ReadonlySessionError` when a session is marked `readonly` and the function is not, but `CoreUserSession` never declared the field — so there was no typed way to build a readonly session, and even core's own test had to cast. Likewise `wireGateway` writes `gateway: true` onto a websocket channel's meta, which `ChannelMeta` did not admit. Both are now declared.
+
+The gateway websocket path also wrote channel meta without `input`, `disconnect` or `messageWirings`, all of which `ChannelMeta` requires and `channel-handler` indexes without a guard. It now writes a complete record.

--- a/packages/cli/src/functions/commands/scenario.ts
+++ b/packages/cli/src/functions/commands/scenario.ts
@@ -6,6 +6,7 @@ import { InMemoryWorkflowService } from '@pikku/core/services'
 import { createHttpPersonas } from '@pikku/core/persona'
 import { PikkuScenarioService } from '@pikku/core/scenario'
 import { pikkuState, getAllPackageStates } from '@pikku/core/internal'
+import type { PikkuRPC } from '@pikku/core/rpc'
 import { resolveFeatureScenarios } from '@pikku/core/workflow'
 import type { CoreFeature, CoreWorkflow } from '@pikku/core/workflow'
 
@@ -378,13 +379,33 @@ export const scenarioRun = pikkuSessionlessFunc<
       workflowRunService: workflowService,
       ...(aiAgentRunner ? { aiAgentRunner } : {}),
     } as any)
-    const guardRpc = {
-      rpcWithWire: async (rpcName: string) => {
-        throw new Error(
-          `Scenario tried to run '${rpcName}' as an internal step. Every workflow.do ` +
-            `in a scenario must carry { actor: actors.x } so it executes against ` +
-            `'${environment}' (${env.apiUrl}), not local services.`
-        )
+    const refuseInternal = (rpcName: string): never => {
+      throw new Error(
+        `Scenario tried to run '${rpcName}' as an internal step. Every workflow.do ` +
+          `in a scenario must carry { actor: actors.x } so it executes against ` +
+          `'${environment}' (${env.apiUrl}), not local services.`
+      )
+    }
+    // `rpcWithWire` is named alongside `PikkuRPC` rather than left to it: the
+    // workflow runner reaches for that member through an internally untyped
+    // path, so it is the one the guard actually has to answer, and the type
+    // that declares it publicly arrives later in this stack.
+    const guardRpc: PikkuRPC & {
+      rpcWithWire: (rpcName: string) => Promise<never>
+    } = {
+      depth: 0,
+      global: false,
+      invoke: async (rpcName: string) => refuseInternal(rpcName),
+      remote: async (rpcName: string) => refuseInternal(rpcName),
+      exposed: async (rpcName: string) => refuseInternal(rpcName),
+      rpcWithWire: async (rpcName: string) => refuseInternal(rpcName),
+      startWorkflow: async (name: string) => refuseInternal(name),
+      agent: {
+        run: async (name: string) => refuseInternal(name),
+        stream: async (name: string) => refuseInternal(name),
+        resume: async (runId: string) => refuseInternal(runId),
+        approve: async (runId: string) => refuseInternal(runId),
+        interrupt: async (runId: string) => refuseInternal(runId),
       },
     }
 

--- a/packages/core/src/dev/hot-reload.ts
+++ b/packages/core/src/dev/hot-reload.ts
@@ -26,7 +26,7 @@ const isFunctionConfig = (
     typeof value === 'object' &&
     value !== null &&
     'func' in value &&
-    typeof (value as any).func === 'function'
+    typeof (value as { func?: unknown }).func === 'function'
   )
 }
 
@@ -104,12 +104,7 @@ export async function pikkuDevReloader(
       return
     }
 
-    // Register every function-config export, replacing known functions and
-    // adding new ones. Write into the map captured at startup, NOT pikkuState's
-    // current one: a dev-server watcher may have temporarily swapped in a
-    // codegen-scoped map, whose writes are discarded when it restores.
-    // Schemas are NOT touched here: `input`/`output` hold raw zod schemas while
-    // the schema map carries codegen JSON schemas; mixing them crashed reloads.
+    // knowledge: decisions/internals/hot-reload-writes-into-the-function-map-captured-at-startup.md
     for (const [exportName, exportValue] of Object.entries(mod)) {
       if (!isFunctionConfig(exportValue)) continue
       const isNew = !functionsMap.has(exportName)

--- a/packages/core/src/errors/error-handler.ts
+++ b/packages/core/src/errors/error-handler.ts
@@ -15,7 +15,8 @@ export class PikkuError extends Error {
  * everything else.
  */
 export const isExpectedError = (error: unknown): boolean =>
-  error instanceof PikkuError || (error as any)?.expected === true
+  error instanceof PikkuError ||
+  (error as { expected?: unknown } | null)?.expected === true
 
 export interface ErrorDetails {
   status: number
@@ -48,7 +49,7 @@ export const getErrorResponse = (
 ): { status: number; message: string; mcpCode?: number } | undefined => {
   const errors = pikkuState(null, 'misc', 'errors')
 
-  let ctor: unknown = (error as any)?.constructor
+  let ctor: unknown = (error as { constructor?: unknown } | null)?.constructor
   while (typeof ctor === 'function' && ctor !== Object) {
     const details = errors.get(ctor as PikkuErrorConstructor)
     if (details) {
@@ -57,7 +58,8 @@ export const getErrorResponse = (
     ctor = Object.getPrototypeOf(ctor)
   }
 
-  const name = (error as any)?.constructor?.name
+  const name = (error as { constructor?: { name?: string } } | null)
+    ?.constructor?.name
   return name
     ? Array.from(errors.entries()).find(([e]) => e.name === name)?.[1]
     : undefined

--- a/packages/core/src/function/function-runner.test.ts
+++ b/packages/core/src/function/function-runner.test.ts
@@ -637,7 +637,7 @@ describe('runPikkuFunc - Integration Tests', () => {
           singletonServices: mockSingletonServices,
           data: () => ({}),
           auth: false,
-          wire: { session: { readonly: true } as any },
+          wire: { session: { readonly: true } },
         }),
       ReadonlySessionError
     )

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -4,7 +4,7 @@ import {
   combineChannelMiddleware,
   wrapChannelWithMiddleware,
 } from '../wirings/channel/channel-middleware-runner.js'
-import { runPermissions } from '../permissions.js'
+import { runPermissions, type PermissionWire } from '../permissions.js'
 import { withoutSecrets } from '../services/secretless.js'
 import { pikkuState } from '../pikku-state.js'
 import {
@@ -248,6 +248,28 @@ export const runPikkuFunc = async <In = any, Out = any>(
     invocationWire,
     'rpc'
   )
+
+  // knowledge: decisions/internals/core-function-runner-restores-the-wire-fields-it-overwrites.md
+  const restoreInvocationWire = () => {
+    if (previousRpcDescriptor) {
+      Object.defineProperty(invocationWire, 'rpc', previousRpcDescriptor)
+    }
+    restoreField('functionId', previousFunctionId)
+    restoreField('audit', previousAudit)
+    restoreField('addonNamespace', previousAddonNamespace)
+  }
+
+  function restoreField<K extends 'functionId' | 'audit' | 'addonNamespace'>(
+    key: K,
+    previous: PikkuWire[K]
+  ) {
+    if (previous === undefined) {
+      delete invocationWire[key]
+    } else {
+      invocationWire[key] = previous
+    }
+  }
+
   invocationWire.functionId = resolvedFunctionId
   invocationWire.audit = resolvedAuditConfig
   // Track which addon instance is executing so intra-addon sibling calls
@@ -294,7 +316,7 @@ export const runPikkuFunc = async <In = any, Out = any>(
       }
     }
 
-    if ((session as any)?.readonly && !funcMeta.readonly) {
+    if (session?.readonly && !funcMeta.readonly) {
       throw new ReadonlySessionError()
     }
 
@@ -347,7 +369,8 @@ export const runPikkuFunc = async <In = any, Out = any>(
             resolvedSingletonServices,
             'a permission'
           ) as CoreSingletonServices),
-      wire: invocationWire as any,
+      // knowledge: decisions/security/a-permission-gets-a-wire-it-cannot-reply-on.md
+      wire: invocationWire as PermissionWire,
       data: actualData,
       packageName,
     })
@@ -435,47 +458,13 @@ export const runPikkuFunc = async <In = any, Out = any>(
         executeFunction
       )) as Out
     } finally {
-      if (previousRpcDescriptor) {
-        Object.defineProperty(invocationWire, 'rpc', previousRpcDescriptor)
-      }
-      if (previousFunctionId === undefined) {
-        delete (invocationWire as any).functionId
-      } else {
-        invocationWire.functionId = previousFunctionId
-      }
-      if (previousAudit === undefined) {
-        delete (invocationWire as any).audit
-      } else {
-        invocationWire.audit = previousAudit
-      }
-      if (previousAddonNamespace === undefined) {
-        delete (invocationWire as any).addonNamespace
-      } else {
-        invocationWire.addonNamespace = previousAddonNamespace
-      }
+      restoreInvocationWire()
     }
   }
 
   try {
     return (await executeFunction()) as Out
   } finally {
-    if (previousRpcDescriptor) {
-      Object.defineProperty(invocationWire, 'rpc', previousRpcDescriptor)
-    }
-    if (previousFunctionId === undefined) {
-      delete (invocationWire as any).functionId
-    } else {
-      invocationWire.functionId = previousFunctionId
-    }
-    if (previousAudit === undefined) {
-      delete (invocationWire as any).audit
-    } else {
-      invocationWire.audit = previousAudit
-    }
-    if (previousAddonNamespace === undefined) {
-      delete (invocationWire as any).addonNamespace
-    } else {
-      invocationWire.addonNamespace = previousAddonNamespace
-    }
+    restoreInvocationWire()
   }
 }

--- a/packages/core/src/handle-error.ts
+++ b/packages/core/src/handle-error.ts
@@ -33,7 +33,7 @@ export const handleHTTPError = (
         e.message !== 'An error occurred'
           ? e.message
           : errorResponse.message,
-      payload: clientFacing ? (e as any).payload : undefined,
+      payload: clientFacing ? (e as { payload?: unknown }).payload : undefined,
       errorId: traceId,
     })
 

--- a/packages/core/src/middleware-runner.ts
+++ b/packages/core/src/middleware-runner.ts
@@ -47,8 +47,10 @@ export const runMiddleware = async <
   let result: any
   const dispatch = async (index: number): Promise<any> => {
     if (sorted && index < sorted.length) {
-      return await sorted[index]!(services as any, wire, () =>
-        dispatch(index + 1)
+      return await sorted[index]!(
+        services as Parameters<Middleware>[0],
+        wire,
+        () => dispatch(index + 1)
       )
     } else if (main) {
       result = await main()

--- a/packages/core/src/middleware/cors.ts
+++ b/packages/core/src/middleware/cors.ts
@@ -72,7 +72,8 @@ export const cors = pikkuMiddlewareFactory<{
 
         if (request.method() === 'options') {
           response.header('Access-Control-Max-Age', String(maxAge))
-          response.status(204).json(undefined as any)
+          // 204 carries no body, and `json` has no no-content overload.
+          response.status(204).json(undefined as never)
           return
         }
 

--- a/packages/core/src/no-any-casts.test.ts
+++ b/packages/core/src/no-any-casts.test.ts
@@ -1,0 +1,57 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname, relative } from 'node:path'
+
+const srcRoot = dirname(fileURLToPath(import.meta.url))
+const thisFile = fileURLToPath(import.meta.url)
+
+/**
+ * `as any` in a cast position. The word boundary and the following delimiter
+ * keep prose such as "as any URL a browser can load" out of the match.
+ */
+const AS_ANY = /\bas any\b(?!\s+[A-Za-z])/
+
+const collectSourceFiles = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      return entry.name === 'dist' ? [] : collectSourceFiles(entryPath)
+    }
+    return entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')
+      ? [entryPath]
+      : []
+  })
+
+describe('core asserts to named types, never to any', () => {
+  test('no non-test module casts through `as any`', () => {
+    const offenders = collectSourceFiles(srcRoot)
+      .filter((file) => file !== thisFile)
+      .flatMap((file) =>
+        readFileSync(file, 'utf-8')
+          .split('\n')
+          .flatMap((line, index) =>
+            AS_ANY.test(line)
+              ? [`${relative(srcRoot, file)}:${index + 1}  ${line.trim()}`]
+              : []
+          )
+      )
+
+    assert.deepEqual(
+      offenders,
+      [],
+      '`as any` discards the target type, so a wrong value passes as readily as ' +
+        'a right one. Assert to the type actually wanted — and if the narrowing ' +
+        'cannot be expressed, say why in a knowledge note and point at it:\n' +
+        offenders.join('\n')
+    )
+  })
+
+  test('the matcher finds a cast and ignores the prose that reads like one', () => {
+    // Guards the test above: a regex that matched nothing would pass forever.
+    assert.equal(AS_ANY.test('const x = y as any'), true)
+    assert.equal(AS_ANY.test('foo(bar as any)'), true)
+    assert.equal(AS_ANY.test('a picture, as any URL a browser can load'), false)
+  })
+})

--- a/packages/core/src/pikku-state.ts
+++ b/packages/core/src/pikku-state.ts
@@ -16,11 +16,22 @@ import type { TriggerMeta } from './wirings/trigger/trigger.types.js'
 
 const PIKKU_STATE_KEY = Symbol.for('@pikku/core/state')
 
+/**
+ * State is parked on `globalThis` under a registered symbol so separate copies
+ * of @pikku/core in one process share it. Typed once here rather than at each
+ * access.
+ */
+const stateHost = globalThis as unknown as {
+  [key: symbol]: Map<string, PikkuPackageState> | undefined
+}
+
 export const getAllPackageStates = (): Map<string, PikkuPackageState> => {
-  if (!(globalThis as any)[PIKKU_STATE_KEY]) {
-    ;(globalThis as any)[PIKKU_STATE_KEY] = new Map<string, PikkuPackageState>()
+  let states = stateHost[PIKKU_STATE_KEY]
+  if (!states) {
+    states = new Map<string, PikkuPackageState>()
+    stateHost[PIKKU_STATE_KEY] = states
   }
-  return (globalThis as any)[PIKKU_STATE_KEY] as Map<string, PikkuPackageState>
+  return states
 }
 
 export const pikkuState = <
@@ -119,13 +130,13 @@ const createEmptyPackageState = (): PikkuPackageState => ({
   middleware: {
     tagGroup: {},
     httpGroup: {},
-    global: [] as any,
+    global: [],
   },
   channelMiddleware: {
     tagGroup: {},
   },
   permissions: {
-    global: [] as any,
+    global: [],
   },
   misc: {
     errors: new Map(),
@@ -153,7 +164,7 @@ export const resetPikkuState = () => {
   // Error definitions come from module-import side effects that never re-run.
   const existingErrors = getAllPackageStates().get('__main__')?.misc.errors
 
-  ;(globalThis as any)[PIKKU_STATE_KEY] = new Map<string, PikkuPackageState>()
+  stateHost[PIKKU_STATE_KEY] = new Map<string, PikkuPackageState>()
   initializePikkuState('__main__')
 
   if (existingErrors) {

--- a/packages/core/src/services/audit-service.ts
+++ b/packages/core/src/services/audit-service.ts
@@ -150,7 +150,7 @@ class DisabledInvocationAudit implements AuditLog {
     if (!this.warned) {
       this.warned = true
       // knowledge: decisions/security/a-dropped-audit-write-is-always-logged.md
-      const logger = (this.wire as any).logger ?? this.logger
+      const logger = this.wire.logger ?? this.logger
       logger?.warn?.(
         `audit.write() dropped for '${this.wire.functionId ?? 'unknown function'}' — the function has no audit config (set audit: true on it)`
       )
@@ -207,7 +207,7 @@ class InvocationAuditLog implements AuditLog {
         await this.service.audit(event)
       }
     } catch (error) {
-      const logger = (this.wire as any).logger ?? this.logger
+      const logger = this.wire.logger ?? this.logger
       logger?.warn?.('best-effort audit flush failed', error)
     }
   }

--- a/packages/core/src/testing/service-tests.ts
+++ b/packages/core/src/testing/service-tests.ts
@@ -12,6 +12,15 @@ import type { SecretService } from '../services/secret-service.js'
 import type { CredentialService } from '../services/credential-service.js'
 import type { AgentRunService } from '../wirings/ai-agent/ai-agent.types.js'
 import type { SessionStore } from '../services/session-store.js'
+import type { CoreUserSession } from '../types/core.types.js'
+
+/**
+ * A session as an application defines it: core's fields plus whatever else that
+ * application puts on its own session. `CoreUserSession` is deliberately
+ * minimal, so a conformance test that only ever stored its fields would not
+ * exercise what a real store has to round-trip.
+ */
+type AppSession = CoreUserSession & Record<string, unknown>
 
 export interface ServiceTestConfig {
   name: string
@@ -1141,7 +1150,10 @@ export function defineServiceTests(config: ServiceTestConfig): void {
       })
 
       test('set and get round-trip', async () => {
-        const session = { userId: 'user-1', organizationId: 'org-1' } as any
+        const session: AppSession = {
+          userId: 'user-1',
+          organizationId: 'org-1',
+        }
         await store.set('user-1', session)
 
         const result = await store.get('user-1')
@@ -1149,15 +1161,17 @@ export function defineServiceTests(config: ServiceTestConfig): void {
       })
 
       test('set overwrites previous session', async () => {
-        await store.set('user-2', { userId: 'user-2', role: 'admin' } as any)
-        await store.set('user-2', { userId: 'user-2', role: 'member' } as any)
+        const asAdmin: AppSession = { userId: 'user-2', role: 'admin' }
+        const asMember: AppSession = { userId: 'user-2', role: 'member' }
+        await store.set('user-2', asAdmin)
+        await store.set('user-2', asMember)
 
         const result = await store.get('user-2')
         assert.deepEqual(result, { userId: 'user-2', role: 'member' })
       })
 
       test('clear removes session', async () => {
-        await store.set('user-3', { userId: 'user-3' } as any)
+        await store.set('user-3', { userId: 'user-3' })
         assert.ok(await store.get('user-3'))
 
         await store.clear('user-3')

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -298,6 +298,11 @@ export interface CoreUserSession {
    * Populated by whoever builds the session — core reads them, never fetches.
    */
   scopes?: string[]
+  /**
+   * Restricts the session to functions declared `readonly`. The function runner
+   * throws `ReadonlySessionError` for anything else.
+   */
+  readonly?: boolean
 }
 
 /**
@@ -386,6 +391,11 @@ export type PikkuWire<
 } & Partial<{
   wireType: PikkuWiringTypes
   wireId: string
+  /**
+   * A logger scoped to this invocation, when a host attaches one. Core never
+   * sets it; services that log fall back to the singleton logger.
+   */
+  logger: Logger
   /** Trace ID for distributed tracing — propagated across remote RPC calls via x-trace-id header */
   traceId: string
   functionId: string

--- a/packages/core/src/types/state.types.ts
+++ b/packages/core/src/types/state.types.ts
@@ -119,7 +119,7 @@ export interface PikkuPackageState {
     meta: HTTPWiringsMeta
   }
   channel: {
-    channels: Map<string, CoreChannel<any, any>>
+    channels: Map<string, CoreChannel<any, any, any, any, any>>
     meta: ChannelsMeta
   }
   scheduler: {

--- a/packages/core/src/wirings/ai-agent/ai-agent-memory.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-memory.ts
@@ -19,7 +19,14 @@ export function resolveMemoryServices(
 } {
   const memoryConfig = agent.memory
   const storage = memoryConfig?.storage
-    ? (singletonServices as any)[memoryConfig.storage]
+    ? // The service is named by string in agent config, so the lookup cannot be
+      // checked — only the shape it is required to have.
+      (
+        singletonServices as unknown as Record<
+          string,
+          AIStorageService | undefined
+        >
+      )[memoryConfig.storage]
     : singletonServices.aiStorage
   return { storage }
 }

--- a/packages/core/src/wirings/ai-agent/ai-agent-prepare.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-prepare.ts
@@ -12,7 +12,11 @@ import type {
 } from './ai-agent.types.js'
 import type { AIAgentRunnerParams } from '../../services/ai-agent-runner-service.js'
 import { PikkuError } from '../../errors/error-handler.js'
-import { checkAuthPermissions, runPermissions } from '../../permissions.js'
+import {
+  checkAuthPermissions,
+  runPermissions,
+  type PermissionWire,
+} from '../../permissions.js'
 import { AIProviderNotConfiguredError } from '../../errors/errors.js'
 import { ForbiddenError } from '../../errors/errors.js'
 import { verifyScopes } from '../../scopes.js'
@@ -319,8 +323,8 @@ export async function assertAgentAuthorized(
 
   await runPermissions({
     funcPermissions: agent.permissions,
-    services: singletonServices as any,
-    wire: wire as any,
+    services: singletonServices,
+    wire: wire as PermissionWire,
     data: {},
     packageName,
     label: 'agent',
@@ -395,7 +399,7 @@ export function createScopedChannel(
           toolName: event.toolName,
           args: event.args,
           ...(event.reason !== undefined ? { reason: event.reason } : {}),
-          runId: (event as any).runId,
+          runId: event.runId,
         })
         return
       }
@@ -940,10 +944,7 @@ export async function prepareAgentRun(
 
   let messages: AIMessage[] = []
   if (storage) {
-    // A tool whose run was interrupted may still be writing its result to this
-    // thread. In voice the next turn lands within a second or two, so without
-    // this the model would load context that is missing the very thing it is
-    // about to be asked about.
+    // knowledge: decisions/internals/agent-context-waits-for-a-tool-result-still-being-written.md
     await awaitPendingInterruptNote(threadId)
     messages = await storage.getMessages(threadId, {
       lastN: memoryConfig?.lastMessages ?? 20,
@@ -959,10 +960,7 @@ export async function prepareAgentRun(
 
   const userContent: AIMessage['content'] = input.attachments?.length
     ? [
-        // Omitted when there is nothing to say. An attachment on its own is a
-        // real turn — a spoken one carries audio and no text at all — and an
-        // empty text part alongside it is a part providers are entitled to
-        // reject, for a caller who never wrote one.
+        // knowledge: decisions/internals/an-empty-text-part-is-omitted-from-an-agent-message.md
         ...(input.message
           ? [{ type: 'text' as const, text: input.message }]
           : []),

--- a/packages/core/src/wirings/ai-agent/ai-agent-runner.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-runner.ts
@@ -163,10 +163,7 @@ export async function runAIAgent(
   runnerParams.messages = modifiedMessages
   runnerParams.instructions = modifiedInstructions
 
-  // History records what the model was asked, which for a spoken turn is the
-  // transcript rather than the base64 audio that arrived — see the same note on
-  // the streaming path. Identity-checked, because a middleware may legitimately
-  // replace the message list with something unrelated to this turn.
+  // knowledge: decisions/internals/thread-history-records-the-transcript-not-the-audio.md
   const lastModified = modifiedMessages[modifiedMessages.length - 1]
   const persistedUserMessage =
     lastModified?.id === userMessage.id ? lastModified : userMessage
@@ -181,10 +178,7 @@ export async function runAIAgent(
     updatedAt: new Date(),
   })
 
-  // Registered on the same terms as `streamAIAgent`. A run created here is
-  // visible to `interruptAIAgent` through `aiRunState` either way, so skipping
-  // this would leave that call finding the run, passing the ownership check and
-  // then failing to stop it — reported as if it were running on another host.
+  // knowledge: decisions/internals/a-non-streaming-agent-run-registers-with-airunstate-too.md
   const interruptHandle = registerInterruptibleRun(runId)
   runnerParams.abortSignal = interruptHandle.signal
   runnerParams.tools = trackToolExecution(runnerParams.tools, interruptHandle)
@@ -385,10 +379,7 @@ export async function runAIAgent(
       usage: totalUsage,
     }
   } catch (error) {
-    // An interrupt is not a failure, so it skips the `onError` hooks and never
-    // becomes an `errorMessage`. Unlike the streaming path there is no partial
-    // reply to hand back — nothing was delivered — so the caller gets a typed
-    // throw it can tell apart from a provider outage instead of a result.
+    // knowledge: decisions/internals/an-agent-interrupt-is-not-a-failure.md
     const interruption = interruptHandle.interruption
     if (interruption || isAbortError(error)) {
       await aiRunState.updateRun(runId, { status: 'interrupted' })
@@ -832,7 +823,7 @@ async function continueAfterToolResultSync(
       run.threadId,
       run.resourceId,
       memoryConfig,
-      null as any,
+      null,
       {
         ...result,
         text: outputText,

--- a/packages/core/src/wirings/ai-agent/ai-agent-stream.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-stream.ts
@@ -692,22 +692,13 @@ export async function streamAIAgent(
   runnerParams.messages = modifiedMessages
   runnerParams.instructions = modifiedInstructions
 
-  // Sent on the raw channel, ahead of the run. A voice client sent audio and so
-  // has no idea what it said; until this arrives its own message is a blank
-  // bubble. Ahead of the run rather than alongside it because the answer starts
-  // streaming within a few hundred milliseconds, and a question that appears
-  // after its answer reads as the wrong question.
+  // knowledge: decisions/internals/the-transcript-event-is-sent-ahead-of-the-run.md
   const transcript = sharedNotes[SPOKEN_TRANSCRIPT]
   if (typeof transcript === 'string') {
     channel.send({ type: 'transcript', text: transcript })
   }
 
-  // What goes into thread history is what the model was actually asked. For a
-  // spoken turn that is not what arrived over the wire: the wire carried a
-  // base64 audio blob, and persisting it would write megabytes of unreadable
-  // data into the history while losing the only readable record of the turn.
-  // Identity-checked rather than assumed — a middleware is free to rewrite the
-  // message list into something with no relation to the turn.
+  // knowledge: decisions/internals/thread-history-records-the-transcript-not-the-audio.md
   const lastModified = modifiedMessages[modifiedMessages.length - 1]
   const persistedUserMessage =
     lastModified?.id === userMessage.id ? lastModified : userMessage
@@ -768,7 +759,7 @@ export async function streamAIAgent(
     {
       wireInheritedChannelMiddleware: meta?.channelMiddleware,
       wireChannelMiddleware: [
-        ...((agent.channelMiddleware as any[]) ?? []),
+        ...(agent.channelMiddleware ?? []),
         ...streamMiddleware,
       ],
     }
@@ -792,10 +783,7 @@ export async function streamAIAgent(
 
   const credentialFilteredChannel: AIStreamChannel = {
     ...wrappedChannel,
-    // Returns what the inner send returns. Middleware runs asynchronously, so
-    // swallowing the promise here makes every `await channel.send(...)` upstream
-    // a no-op — including the one that waits for a buffering hook to flush
-    // before the channel closes.
+    // knowledge: decisions/internals/an-agent-stream-send-must-return-the-inner-sends-promise.md
     send: (event: AIStreamEvent) => {
       if (
         event.type === 'tool-result' &&
@@ -872,11 +860,7 @@ export async function streamAIAgent(
       runId
     )
 
-    // Through the middleware rather than straight at the channel, and awaited.
-    // `done` is the only signal a stream hook gets that the reply is over, and
-    // the ones that buffer need it: `voiceOutput` speaks a trailing fragment
-    // that never reached a full stop, and waits for audio it has already paid
-    // to synthesize. Sent raw, that work is discarded by the `close()` below.
+    // knowledge: decisions/internals/the-agent-done-event-goes-through-the-middleware-and-is-awaited.md
     await outputChannel.send({ type: 'done' })
     channel.close()
     return persistingChannel.fullText
@@ -979,12 +963,7 @@ export async function interruptAIAgent(
     reason: input.reason ?? 'user',
   })
 
-  // A run still marked `running` that this process cannot abort is executing on
-  // another instance. Returning a bare `false` there is indistinguishable from
-  // "it already finished", so the one deployment shape this registry does not
-  // cover fails silently — an agent that simply refuses to shut up, with nothing
-  // in the logs. Say so instead. See `signalRunInterrupt` for the fix (fan the
-  // interrupt out over eventHub so every instance tries locally).
+  // knowledge: decisions/internals/an-agent-run-owned-by-another-instance-says-so.md
   if (!stopped && run.status === 'running') {
     logger?.warn(
       `Could not interrupt run ${input.runId}: it is running in another process. ` +
@@ -1331,10 +1310,7 @@ async function continueAfterToolResult(
     }
   }
 
-  // Resuming is as interruptible as the first turn. It is the same person
-  // listening to the same voice, and after an approval it is where most of the
-  // reply actually gets spoken — an approved delete is followed by the agent
-  // talking about it, and that is a normal thing to talk over.
+  // knowledge: decisions/internals/a-resumed-agent-turn-is-as-interruptible-as-the-first.md
   const interruptHandle = registerInterruptibleRun(run.runId)
 
   const streamMiddleware = aiMiddlewares
@@ -1369,7 +1345,7 @@ async function continueAfterToolResult(
     {
       wireInheritedChannelMiddleware: meta?.channelMiddleware,
       wireChannelMiddleware: [
-        ...((agent.channelMiddleware as any[]) ?? []),
+        ...(agent.channelMiddleware ?? []),
         ...streamMiddleware,
       ],
     }
@@ -1467,10 +1443,7 @@ async function continueAfterToolResult(
       run.runId
     )
 
-    // Through the middleware, for the same reason as the first turn — and it
-    // matters more here. After an approval, most of what gets spoken is the
-    // agent talking about what it just did, so this is the half of the reply a
-    // dropped flush would silence.
+    // knowledge: decisions/internals/the-agent-done-event-goes-through-the-middleware-and-is-awaited.md
     await wrappedChannel.send({ type: 'done' })
     channel.close()
   } catch (err) {

--- a/packages/core/src/wirings/ai-agent/ai-agent.types.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent.types.ts
@@ -413,7 +413,7 @@ export type AIStreamEvent =
       toolName: string
       args: unknown
       reason?: string
-      runId?: string
+      runId: string
       agent?: string
       session?: string
     }

--- a/packages/core/src/wirings/channel/channel-common.ts
+++ b/packages/core/src/wirings/channel/channel-common.ts
@@ -1,3 +1,4 @@
+import type { CorePikkuChannelMiddleware } from './channel.types.js'
 import type {
   CoreSingletonServices,
   CorePikkuMiddleware,
@@ -61,7 +62,9 @@ export const runChannelLifecycleWithMiddleware = async ({
     `${channelConfig.name}:${lifecycleType}:cm`,
     {
       wireInheritedChannelMiddleware: channelMiddlewareMeta,
-      wireChannelMiddleware: channelConfig.channelMiddleware as any,
+      // knowledge: questions/channel-middleware-accepts-bare-factories-that-nothing-resolves.md
+      wireChannelMiddleware:
+        channelConfig.channelMiddleware as CorePikkuChannelMiddleware[],
     }
   )
 
@@ -76,7 +79,7 @@ export const runChannelLifecycleWithMiddleware = async ({
   const runLifecycle = async () => {
     return await runPikkuFunc('channel', channelConfig.name, meta.pikkuFuncId, {
       singletonServices: services,
-      data: () => data as any,
+      data: () => data,
       wire,
       sessionService: userSession,
       tags: meta.tags ?? [],

--- a/packages/core/src/wirings/channel/channel-handler-shapes.test.ts
+++ b/packages/core/src/wirings/channel/channel-handler-shapes.test.ts
@@ -1,0 +1,72 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { pikkuState, resetPikkuState } from '../../pikku-state.js'
+import { wireChannel } from './channel-runner.js'
+
+const registeredFunc = (funcId: string) =>
+  pikkuState(null, 'function', 'functions').get(funcId)
+
+const wire = (channel: any) => {
+  resetPikkuState()
+  pikkuState(null, 'channel', 'meta', {
+    shapes: {
+      name: 'shapes',
+      route: '/shapes',
+      input: null,
+      connect: { pikkuFuncId: 'shapes__connect' },
+      disconnect: { pikkuFuncId: 'shapes__disconnect' },
+      message: { pikkuFuncId: 'shapes__message' },
+      messageWirings: {},
+    },
+  } as any)
+  wireChannel({ name: 'shapes', route: '/shapes', ...channel })
+}
+
+/**
+ * knowledge: decisions/internals/channel-message-handlers-accept-three-config-shapes.md
+ */
+describe('every channel handler shape registers a callable function config', () => {
+  const handler = async () => undefined
+
+  test('a direct function config registers as-is', () => {
+    wire({ onConnect: { func: handler } })
+
+    assert.equal(typeof registeredFunc('shapes__connect')?.func, 'function')
+  })
+
+  test('a wrapper around a function config registers the inner config', () => {
+    wire({ onConnect: { func: { func: handler }, middleware: [] } })
+
+    // Registering the wrapper itself leaves `.func` an object, and the function
+    // runner calls `.func(...)` — that is a TypeError at connect time.
+    assert.equal(
+      typeof registeredFunc('shapes__connect')?.func,
+      'function',
+      'the wrapper was registered instead of the config it wraps'
+    )
+  })
+
+  test('onDisconnect unwraps the same way', () => {
+    wire({ onDisconnect: { func: { func: handler }, middleware: [] } })
+
+    assert.equal(typeof registeredFunc('shapes__disconnect')?.func, 'function')
+  })
+
+  test('onMessage unwraps the same way', () => {
+    wire({ onMessage: { func: { func: handler } } })
+
+    assert.equal(typeof registeredFunc('shapes__message')?.func, 'function')
+  })
+
+  test('a simple wrapper — a function plus sibling middleware — stays whole', () => {
+    wire({ onConnect: { func: handler, middleware: [] } })
+
+    const registered = registeredFunc('shapes__connect')
+    assert.equal(typeof registered?.func, 'function')
+    assert.ok(
+      'middleware' in (registered as object),
+      'the sibling middleware must survive registration'
+    )
+  })
+})

--- a/packages/core/src/wirings/channel/channel-handler.ts
+++ b/packages/core/src/wirings/channel/channel-handler.ts
@@ -4,6 +4,7 @@ import type {
   CoreUserSession,
 } from '../../types/core.types.js'
 import type {
+  CorePikkuChannelMiddleware,
   BinaryData,
   ChannelMessageMeta,
   CoreChannel,
@@ -94,7 +95,7 @@ export const processMessageHandlers = (
       logger.error(
         `Channel ${channelConfig.name} with id ${channelHandler.getChannel().channelId} requires a session for ${routeMessage}. No session is attached to this websocket connection. Ensure auth middleware establishes a session during websocket upgrade, and configure sessionStore when the runtime needs persisted sessions.`
       )
-      // TODO: Send error message back breaks typescript, but should be implemented somehow
+      // knowledge: questions/unauthorized-channel-replies-escape-the-declared-out-type.md
       channelHandler.getChannel().send(`Unauthorized for ${routeMessage}`)
       return
     }
@@ -111,10 +112,7 @@ export const processMessageHandlers = (
     // Get wire middleware: channel-level middleware + message-specific middleware
     const channelWireMiddleware = channelConfig.middleware || []
 
-    // Check if onMessage is a wrapper object vs direct function config:
-    // - Direct config: onMessage.func is a plain Function
-    // - Wrapper: onMessage.func is a CorePikkuFunctionConfig (has onMessage.func.func)
-    // - Simple wrapper: onMessage has both func (plain Function) and middleware properties
+    // knowledge: decisions/internals/channel-message-handlers-accept-three-config-shapes.md
     const isWrapper =
       onMessage &&
       typeof onMessage === 'object' &&
@@ -145,7 +143,9 @@ export const processMessageHandlers = (
       inheritedMiddleware,
       wireMiddleware,
       inheritedChannelMiddleware: channelMeta?.channelMiddleware,
-      wireChannelMiddleware: wireChannelMiddleware as any,
+      // knowledge: questions/channel-middleware-accepts-bare-factories-that-nothing-resolves.md
+      wireChannelMiddleware:
+        wireChannelMiddleware as CorePikkuChannelMiddleware[],
       coerceDataFromSchema: true,
       tags: channelConfig.tags,
       sessionService: userSession,
@@ -191,7 +191,7 @@ export const processMessageHandlers = (
 
             processed = true
             const routeResult = await processMessage(
-              data as any,
+              data,
               routes[routerValue],
               routingProperty,
               routerValue

--- a/packages/core/src/wirings/channel/channel-runner.ts
+++ b/packages/core/src/wirings/channel/channel-runner.ts
@@ -1,10 +1,9 @@
 import { NotFoundError } from '../../errors/errors.js'
 import { addFunction } from '../../function/function-runner.js'
-import type { CorePikkuPermission } from '../../function/functions.types.js'
+import type { CorePikkuFunctionConfig } from '../../function/functions.types.js'
 import { pikkuState, getSingletonServices } from '../../pikku-state.js'
 import { coerceTopLevelDataFromSchema, validateSchema } from '../../schema.js'
 import type { SessionService } from '../../services/user-session-service.js'
-import type { CorePikkuMiddleware } from '../../types/core.types.js'
 import { httpRouter } from '../http/routers/http-router.js'
 import type {
   ChannelMeta,
@@ -13,19 +12,34 @@ import type {
   RunChannelParams,
 } from './channel.types.js'
 
+type HandlerConfig = CorePikkuFunctionConfig<any, any>
+
+/**
+ * The config to register for a channel handler: the handler itself when it is a
+ * direct function config, or its inner `func` when it is a wrapper.
+ *
+ * knowledge: decisions/internals/channel-message-handlers-accept-three-config-shapes.md
+ */
+const registeredHandler = (handler: unknown): HandlerConfig => {
+  const candidate = handler as { func?: unknown }
+  return typeof candidate.func === 'function'
+    ? (handler as HandlerConfig)
+    : (candidate.func as HandlerConfig)
+}
+
 export const wireChannel = <
   In,
   Channel extends string,
-  PikkuPermission extends CorePikkuPermission<In>,
-  PikkuMiddleware extends CorePikkuMiddleware,
-  ChannelFunction,
+  ChannelConnect,
+  ChannelDisconnect,
+  ChannelFunctionMessage,
 >(
   channel: CoreChannel<
     In,
     Channel,
-    PikkuPermission,
-    PikkuMiddleware,
-    ChannelFunction
+    ChannelConnect,
+    ChannelDisconnect,
+    ChannelFunctionMessage
   >
 ) => {
   const channelsMeta = pikkuState(null, 'channel', 'meta')
@@ -38,19 +52,23 @@ export const wireChannel = <
   }
 
   if (channel.onConnect && channelMeta.connect) {
-    addFunction(channelMeta.connect.pikkuFuncId, channel.onConnect as any)
+    addFunction(
+      channelMeta.connect.pikkuFuncId,
+      registeredHandler(channel.onConnect)
+    )
   }
 
   if (channel.onDisconnect && channelMeta.disconnect) {
-    addFunction(channelMeta.disconnect.pikkuFuncId, channel.onDisconnect as any)
+    addFunction(
+      channelMeta.disconnect.pikkuFuncId,
+      registeredHandler(channel.onDisconnect)
+    )
   }
 
   if (channel.onMessage && channelMeta.message?.pikkuFuncId) {
     addFunction(
       channelMeta.message.pikkuFuncId,
-      (channel.onMessage as any).func instanceof Function
-        ? channel.onMessage
-        : (channel.onMessage as any).func
+      registeredHandler(channel.onMessage)
     )
   }
 
@@ -63,17 +81,12 @@ export const wireChannel = <
         const wiringMeta = channelWirings[wiringKey]
         if (!wiringMeta) return
 
-        addFunction(
-          wiringMeta.pikkuFuncId,
-          (handler as any).func instanceof Function
-            ? handler
-            : (handler as any).func
-        )
+        addFunction(wiringMeta.pikkuFuncId, registeredHandler(handler))
       })
     })
   }
 
-  pikkuState(null, 'channel', 'channels').set(channel.name, channel as any)
+  pikkuState(null, 'channel', 'channels').set(channel.name, channel)
 }
 
 const getMatchingChannelConfig = (path: string) => {

--- a/packages/core/src/wirings/channel/channel.types.ts
+++ b/packages/core/src/wirings/channel/channel.types.ts
@@ -64,6 +64,8 @@ export interface ChannelMeta {
   message: ChannelMessageMeta | null
   messageWirings: Record<string, Record<string, ChannelMessageMeta>>
   binary?: boolean | null
+  /** Set when the channel was wired by a gateway rather than declared directly. */
+  gateway?: boolean
   summary?: string
   description?: string
   errors?: string[]

--- a/packages/core/src/wirings/channel/local/local-channel-runner.ts
+++ b/packages/core/src/wirings/channel/local/local-channel-runner.ts
@@ -206,7 +206,7 @@ export const runLocalChannel = async ({
 
       const { onMessage, onBinaryMessage } = processMessageHandlers(
         services,
-        channelConfig as any,
+        channelConfig,
         channelHandler,
         userSession
       )

--- a/packages/core/src/wirings/channel/pikku-abstract-channel-handler.ts
+++ b/packages/core/src/wirings/channel/pikku-abstract-channel-handler.ts
@@ -34,7 +34,8 @@ export abstract class PikkuAbstractChannelHandler<
         setState: (s) => {
           channelState = s
         },
-        getState: () => channelState as any,
+        // knowledge: decisions/internals/channel-state-accessors-are-unsound-generics-that-every-implementation-asserts.md
+        getState: () => channelState as never,
         clearState: () => {
           channelState = undefined
         },

--- a/packages/core/src/wirings/channel/serverless/serverless-channel-runner.ts
+++ b/packages/core/src/wirings/channel/serverless/serverless-channel-runner.ts
@@ -117,7 +117,8 @@ export const runChannelConnect = async ({
       channelName: channelConfig.name,
     })
     channel.setState = (state) => channelStore.setState(channelId, state)
-    channel.getState = () => channelStore.getState(channelId) as any
+    // knowledge: decisions/internals/channel-state-accessors-are-unsound-generics-that-every-implementation-asserts.md
+    channel.getState = () => channelStore.getState(channelId) as never
     channel.clearState = () => channelStore.clearState(channelId)
 
     const wire: PikkuRawWire = {
@@ -198,7 +199,8 @@ export const runChannelDisconnect = async ({
     channelName,
   })
   channel.setState = (state) => channelStore.setState(channelId, state)
-  channel.getState = () => channelStore.getState(channelId) as any
+  // knowledge: decisions/internals/channel-state-accessors-are-unsound-generics-that-every-implementation-asserts.md
+  channel.getState = () => channelStore.getState(channelId) as never
   channel.clearState = () => channelStore.clearState(channelId)
 
   const userSession = new PikkuSessionService<CoreUserSession>(
@@ -271,7 +273,8 @@ export const runChannelMessage = async (
     channelName,
   })
   channel.setState = (state) => channelStore.setState(channelId, state)
-  channel.getState = () => channelStore.getState(channelId) as any
+  // knowledge: decisions/internals/channel-state-accessors-are-unsound-generics-that-every-implementation-asserts.md
+  channel.getState = () => channelStore.getState(channelId) as never
   channel.clearState = () => channelStore.clearState(channelId)
 
   const userSession = new PikkuSessionService<CoreUserSession>(

--- a/packages/core/src/wirings/cli/channel/cli-channel-runner.ts
+++ b/packages/core/src/wirings/cli/channel/cli-channel-runner.ts
@@ -90,7 +90,9 @@ export async function executeCLIViaChannel({
         return
       }
 
-      renderer(null as any, response, undefined)
+      // A CLI channel response is rendered off-process: there are no services
+      // to hand the renderer, and every CLI renderer ignores the argument.
+      renderer(null as never, response, undefined)
     }
 
     commandRoute.subscribe(commandId, responseHandler)

--- a/packages/core/src/wirings/cli/cli-runner.ts
+++ b/packages/core/src/wirings/cli/cli-runner.ts
@@ -16,6 +16,7 @@ import type {
   CLIMeta,
 } from './cli.types.js'
 import type {
+  CoreConfig,
   CoreSingletonServices,
   CoreServices,
   CreateWireServices,
@@ -321,7 +322,8 @@ export async function runCLICommand({
     setState: (s) => {
       cliState = s
     },
-    getState: () => cliState as any,
+    // knowledge: decisions/internals/channel-state-accessors-are-unsound-generics-that-every-implementation-asserts.md
+    getState: () => cliState as never,
     clearState: () => {
       cliState = undefined
     },
@@ -372,7 +374,8 @@ export async function runCLICommand({
     if (result !== undefined && !onOutput) {
       const commandRenderer = programData?.renderers[commandId]
       const jsonMode =
-        (data as any).json === true || (data as any).output === 'json'
+        (data as { json?: unknown; output?: unknown }).json === true ||
+        (data as { json?: unknown; output?: unknown }).output === 'json'
       const finalRenderer: CorePikkuCLIRender<any> | undefined =
         jsonMode && commandRenderer !== undefined
           ? defaultJSONRenderer
@@ -491,7 +494,7 @@ export async function executeCLI({
 
     const config = createConfig
       ? await createConfig(new LocalVariablesService(), data)
-      : ({} as any)
+      : ({} as CoreConfig)
 
     const singletonServices = await createSingletonServices(config)
     pikkuState(null, 'package', 'singletonServices', singletonServices)

--- a/packages/core/src/wirings/cli/command-parser.ts
+++ b/packages/core/src/wirings/cli/command-parser.ts
@@ -354,7 +354,7 @@ function parseOptionValue(value: string, optionDef?: CLIOption): any {
     return parseFloat(value)
   }
 
-  if (optionDef.choices && !optionDef.choices.includes(value as any)) {
+  if (optionDef.choices && !optionDef.choices.includes(value as never)) {
     // Deliberately not an error here — applyOptionDefaults reports bad choices.
     return value
   }

--- a/packages/core/src/wirings/gateway/gateway-channel-meta.test.ts
+++ b/packages/core/src/wirings/gateway/gateway-channel-meta.test.ts
@@ -1,0 +1,44 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { pikkuState, resetPikkuState } from '../../pikku-state.js'
+import { wireGateway } from './gateway-runner.js'
+
+const wireWebsocketGateway = (name: string) => {
+  resetPikkuState()
+  wireGateway({
+    name,
+    type: 'websocket',
+    route: `/${name}`,
+    adapter: { name: 'test', parse: () => null, send: async () => {} },
+    func: { func: async () => undefined },
+  } as any)
+  return pikkuState(null, 'channel', 'meta')[name]!
+}
+
+describe('a gateway-wired websocket channel writes complete channel meta', () => {
+  test('the fields every channel reader indexes are present', () => {
+    const meta = wireWebsocketGateway('chatGateway')
+
+    // channel-handler.ts indexes messageWirings without a guard, and the
+    // serverless and local runners read disconnect directly.
+    assert.deepEqual(
+      meta.messageWirings,
+      {},
+      'messageWirings must be an object — channel-handler indexes it unguarded'
+    )
+    assert.equal(meta.disconnect, null)
+    assert.equal(meta.input, null)
+  })
+
+  test('it is marked as gateway-wired', () => {
+    assert.equal(wireWebsocketGateway('flagged').gateway, true)
+  })
+
+  test('connect and message point at the generated handlers', () => {
+    const meta = wireWebsocketGateway('handlers')
+
+    assert.equal(meta.connect?.pikkuFuncId, 'gateway__handlers__connect')
+    assert.equal(meta.message?.pikkuFuncId, 'gateway__handlers__message')
+  })
+})

--- a/packages/core/src/wirings/gateway/gateway-runner.ts
+++ b/packages/core/src/wirings/gateway/gateway-runner.ts
@@ -3,6 +3,7 @@ import { NotFoundError, UnauthorizedError } from '../../errors/errors.js'
 import { addFunction, runPikkuFunc } from '../../function/function-runner.js'
 import { runMiddleware } from '../../middleware-runner.js'
 import { httpRouter } from '../http/routers/http-router.js'
+import type { CoreHTTPFunctionWiring } from '../http/http.types.js'
 import type {
   CoreGateway,
   GatewayAdapter,
@@ -50,7 +51,7 @@ const registerGatewayHandler = (config: CoreGateway): string => {
     outputSchemaName: declared?.outputSchemaName ?? null,
     sessionless: declared?.sessionless ?? true,
   }
-  addFunction(funcId, config.func as any)
+  addFunction(funcId, config.func)
   return funcId
 }
 
@@ -99,7 +100,7 @@ export const wireGateway = (config: CoreGateway): void => {
       break
     default:
       throw new Error(
-        `Unknown gateway type '${(config as any).type}' for gateway '${config.name}'`
+        `Unknown gateway type '${config.type}' for gateway '${config.name}'`
       )
   }
 }
@@ -118,7 +119,7 @@ const wireWebhookGateway = (config: CoreGateway): void => {
     func: createWebhookPostHandler(config),
   }
 
-  addFunction(postFuncId, postHandler as any)
+  addFunction(postFuncId, postHandler)
 
   if (!routes.has('post')) {
     routes.set('post', new Map())
@@ -128,7 +129,10 @@ const wireWebhookGateway = (config: CoreGateway): void => {
     route,
     func: postHandler,
     auth: false,
-  } as any)
+    // A gateway handler takes (services, data, wire) rather than a pikku
+    // function's shape, so it never matches CorePikkuFunctionConfig. It is only
+    // ever invoked through runPikkuFunc, which is what makes that safe.
+  } as unknown as CoreHTTPFunctionWiring<unknown, unknown, string>)
 
   // knowledge: decisions/internals/gateway-adapters-resolve-lazily-and-are-promise-cached.md
   if (typeof adapter === 'function' || adapter.verifyWebhook) {
@@ -139,7 +143,7 @@ const wireWebhookGateway = (config: CoreGateway): void => {
       func: createWebhookVerifyHandler(config),
     }
 
-    addFunction(verifyFuncId, verifyHandler as any)
+    addFunction(verifyFuncId, verifyHandler)
 
     if (!routes.has('get')) {
       routes.set('get', new Map())
@@ -151,7 +155,7 @@ const wireWebhookGateway = (config: CoreGateway): void => {
       auth: false,
       // knowledge: decisions/internals/gateway-webhook-challenges-echo-bytes-not-json.md
       returnsJSON: false,
-    } as any)
+    } as unknown as CoreHTTPFunctionWiring<unknown, unknown, string>)
   }
 
   httpRouter.reset()
@@ -187,17 +191,17 @@ const createWebhookPostHandler = (config: CoreGateway) => {
       platform: adapter.name,
       send: (msg: GatewayOutboundMessage) => adapter.send(parsed.senderId, msg),
     }
-    ;(wire as any).gateway = gateway
+    wire.gateway = gateway
 
     // Gateway middleware runs outside the gate so it can establish the session the gate checks.
     const invoke = async () => {
-      await bridgeMiddlewareSession(wire as any)
+      await bridgeMiddlewareSession(wire)
       return await runPikkuFunc('gateway', name, handlerFuncId, {
         singletonServices: services,
         data: () => parsed,
         auth: config.auth,
         inheritedMiddleware,
-        wire: wire as any,
+        wire,
       })
     }
 
@@ -275,9 +279,12 @@ const wireWebsocketGateway = (config: CoreGateway): void => {
     name,
     route,
     gateway: true,
+    input: null,
     connect: { pikkuFuncId: connectFuncId },
+    disconnect: null,
     message: { pikkuFuncId: messageFuncId },
-  } as any
+    messageWirings: {},
+  }
 
   const userMiddleware = config.middleware as CorePikkuMiddleware[] | undefined
   const handlerFuncId = registerGatewayHandler(config)
@@ -287,7 +294,7 @@ const wireWebsocketGateway = (config: CoreGateway): void => {
     auth: false,
     func: async (services: any, _data: unknown, wire: PikkuWire) => {
       const adapter = await resolveGatewayAdapter(config, services)
-      ;(wire as any).gateway = {
+      wire.gateway = {
         gatewayName: name,
         senderId: '',
         platform: adapter.name,
@@ -296,7 +303,7 @@ const wireWebsocketGateway = (config: CoreGateway): void => {
         },
       } satisfies PikkuGateway
     },
-  } as any)
+  })
 
   addFunction(messageFuncId, {
     auth: false,
@@ -313,16 +320,16 @@ const wireWebsocketGateway = (config: CoreGateway): void => {
           wire.channel?.send(msg)
         },
       }
-      ;(wire as any).gateway = gateway
+      wire.gateway = gateway
 
       const invoke = async () => {
-        await bridgeMiddlewareSession(wire as any)
+        await bridgeMiddlewareSession(wire)
         return await runPikkuFunc('gateway', name, handlerFuncId, {
           singletonServices: services,
           data: () => parsed,
           auth: config.auth,
           inheritedMiddleware,
-          wire: wire as any,
+          wire,
         })
       }
 
@@ -337,7 +344,7 @@ const wireWebsocketGateway = (config: CoreGateway): void => {
         wire.channel?.send(result)
       }
     },
-  } as any)
+  })
 
   // knowledge: decisions/internals/gateway-wiring-is-a-meta-wiring-over-http-and-channels.md
   channels.set(name, {
@@ -346,7 +353,7 @@ const wireWebsocketGateway = (config: CoreGateway): void => {
     auth: false,
     onConnect: { func: async () => {} },
     onMessage: { func: async () => {} },
-  } as any)
+  })
 
   httpRouter.reset()
 }
@@ -377,7 +384,7 @@ export const createListenerMessageHandler = (
       platform: adapter.name,
       send: (msg: GatewayOutboundMessage) => adapter.send(parsed.senderId, msg),
     }
-    ;(wire as any).gateway = gateway
+    wire.gateway = gateway
 
     const invoke = async () => {
       await bridgeMiddlewareSession(wire)
@@ -390,10 +397,11 @@ export const createListenerMessageHandler = (
       })
     }
 
+    // knowledge: decisions/internals/gateway-listener-middleware-runs-without-an-rpc-on-the-wire.md
     const result: any = userMiddleware?.length
       ? await runMiddleware(
           singletonServices,
-          wire as any,
+          wire as PikkuWire,
           userMiddleware,
           invoke
         )

--- a/packages/core/src/wirings/http/http-routes.ts
+++ b/packages/core/src/wirings/http/http-routes.ts
@@ -1,4 +1,5 @@
 import type {
+  CoreHTTPFunctionWiring,
   HTTPRouteConfig,
   HTTPRouteMap,
   HTTPRouteContract,
@@ -84,7 +85,9 @@ function registerRoute(
     timeout: route.timeout,
     headers: route.headers,
     sse: route.sse,
-  } as any)
+    // `CoreHTTPFunctionWiring` is discriminated by `method`, and a group builds
+    // its routes from a method chosen at runtime — no arm can be narrowed to.
+  } as CoreHTTPFunctionWiring<unknown, unknown, string>)
 }
 
 function isRouteConfig(value: unknown): value is HTTPRouteConfig {

--- a/packages/core/src/wirings/http/pikku-fetch-http-request.ts
+++ b/packages/core/src/wirings/http/pikku-fetch-http-request.ts
@@ -248,7 +248,7 @@ function valuesAreEquivalent(a: unknown, b: unknown): boolean {
   return coerce(a) === coerce(b)
 }
 
-function coerce(value: unknown): string | number | boolean {
+function coerce(value: unknown): unknown {
   if (typeof value === 'boolean' || typeof value === 'number') return value
   if (typeof value === 'string') {
     if (value === 'true') return true
@@ -256,5 +256,5 @@ function coerce(value: unknown): string | number | boolean {
     const num = Number(value)
     return isNaN(num) ? value : num
   }
-  return value as any
+  return value
 }

--- a/packages/core/src/wirings/http/web-request.ts
+++ b/packages/core/src/wirings/http/web-request.ts
@@ -40,7 +40,7 @@ export function toWebRequest(req: PikkuHTTPRequest, baseUrl?: string): Request {
             if (
               parsed &&
               typeof parsed === 'object' &&
-              Object.keys(parsed as any).length > 0
+              Object.keys(parsed as object).length > 0
             ) {
               let reconstructed: string
               if (contentType.includes('application/x-www-form-urlencoded')) {

--- a/packages/core/src/wirings/mcp/mcp-runner.ts
+++ b/packages/core/src/wirings/mcp/mcp-runner.ts
@@ -54,7 +54,7 @@ export const wireMCPResource = <
     )
     return
   }
-  addFunction(mcpResourceMeta.pikkuFuncId, mcpResource.func as any)
+  addFunction(mcpResourceMeta.pikkuFuncId, mcpResource.func)
   const resources = pikkuState(null, 'mcp', 'resources')
   if (resources.has(mcpResource.uri)) {
     throw new Error(`MCP resource already exists: ${mcpResource.uri}`)
@@ -77,7 +77,7 @@ export const wireMCPPrompt = <
     )
     return
   }
-  addFunction(mcpPromptMeta.pikkuFuncId, mcpPrompt.func as any)
+  addFunction(mcpPromptMeta.pikkuFuncId, mcpPrompt.func)
   const prompts = pikkuState(null, 'mcp', 'prompts')
   if (prompts.has(mcpPrompt.name)) {
     throw new Error(`MCP prompt already exists: ${mcpPrompt.name}`)

--- a/packages/core/src/wirings/queue/queue-runner.ts
+++ b/packages/core/src/wirings/queue/queue-runner.ts
@@ -58,7 +58,7 @@ export const wireQueueWorker = <
     func: queueWorker.func.func,
     auth: queueWorker.func.auth,
     permissions: queueWorker.func.permissions,
-    middleware: queueWorker.func.middleware as any,
+    middleware: queueWorker.func.middleware,
     tags: queueWorker.func.tags,
   })
 

--- a/packages/core/src/wirings/rpc/rpc-runner.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.ts
@@ -14,6 +14,13 @@ import type { PikkuRPC, ResolvedFunction } from './rpc-types.js'
 import { parseVersionedId } from '../../version.js'
 import { resolveRemoteAddonToken } from './remote-addon-auth.js'
 
+/**
+ * The session for a wire: read through `getSession` when a runner attached one,
+ * otherwise whatever was placed on the wire directly.
+ */
+const resolveWireSession = async (wire: PikkuRawWire) =>
+  typeof wire.getSession === 'function' ? await wire.getSession() : wire.session
+
 export class RPCNotFoundError extends PikkuError {
   public readonly rpcName: string
   constructor(rpcName: string) {
@@ -209,10 +216,7 @@ export class ContextAwareRPCService {
     } catch (e) {
       if (e instanceof RPCNotFoundError) {
         if (this.services.deploymentService) {
-          const session =
-            this.wire.getSession && typeof this.wire.getSession === 'function'
-              ? await this.wire.getSession()
-              : (this.wire as any).session
+          const session = await resolveWireSession(this.wire)
           return this.services.deploymentService.invoke(
             funcName,
             data,
@@ -405,10 +409,7 @@ export class ContextAwareRPCService {
       resolved = resolvePikkuFunction(rpcName, this.packageName)
     } catch (e) {
       if (e instanceof RPCNotFoundError && this.services.deploymentService) {
-        const session =
-          this.wire.getSession && typeof this.wire.getSession === 'function'
-            ? await this.wire.getSession()
-            : (this.wire as any).session
+        const session = await resolveWireSession(this.wire)
         return this.services.deploymentService.invoke(
           rpcName,
           data,
@@ -577,10 +578,7 @@ export class ContextAwareRPCService {
       )
     }
 
-    const session =
-      this.wire.getSession && typeof this.wire.getSession === 'function'
-        ? await this.wire.getSession()
-        : (this.wire as any).session
+    const session = await resolveWireSession(this.wire)
 
     return this.services.deploymentService.invoke(
       funcName,
@@ -630,7 +628,9 @@ export class PikkuRPCService<
         return serviceRPC.agent
       },
       rpcWithWire: serviceRPC.rpcWithWire.bind(serviceRPC),
-    } as any
+      // `TypedRPC` is named by the caller from its generated RPC map. Nothing
+      // concrete can satisfy a type the caller has not chosen yet.
+    } as TypedRPC
   }
 }
 

--- a/packages/core/src/wirings/trigger/trigger-runner.ts
+++ b/packages/core/src/wirings/trigger/trigger-runner.ts
@@ -10,6 +10,7 @@ import {
   getCreateWireServices,
 } from '../../pikku-state.js'
 import { addFunction, runPikkuFunc } from '../../function/function-runner.js'
+import type { CorePikkuFunctionConfig } from '../../function/functions.types.js'
 import { PikkuMissingMetaError } from '../../errors/errors.js'
 
 export const wireTrigger = (trigger: CoreTrigger) => {
@@ -22,10 +23,10 @@ export const wireTrigger = (trigger: CoreTrigger) => {
     return
   }
 
-  addFunction(triggerMeta.pikkuFuncId, trigger.func as any)
+  addFunction(triggerMeta.pikkuFuncId, trigger.func)
 
   const triggers = pikkuState(null, 'trigger', 'triggers')
-  triggers.set(trigger.name, trigger as any)
+  triggers.set(trigger.name, trigger)
 }
 
 // knowledge: decisions/internals/trigger-declaration-is-split-from-trigger-source.md
@@ -45,11 +46,12 @@ export const wireTriggerSource = <TInput = unknown, TOutput = unknown>(
   if (triggerSources.has(source.name)) {
     throw new Error(`Trigger source already exists: ${source.name}`)
   }
-  triggerSources.set(source.name, source as any)
+  // knowledge: decisions/internals/wiring-registries-erase-the-generics-their-wire-functions-capture.md
+  triggerSources.set(source.name, source as CoreTriggerSource)
 
   addFunction(
     triggerSourceMeta.pikkuFuncId,
-    source.func as any,
+    source.func as CorePikkuFunctionConfig<any, any>,
     triggerSourceMeta.packageName
   )
 }
@@ -94,7 +96,7 @@ export async function setupTrigger<TInput = unknown, TOutput = unknown>({
     singletonServices,
     createWireServices,
     auth: false,
-    data: () => input as any,
+    data: () => input,
     wire,
     packageName: sourceMeta.packageName || null,
   })

--- a/packages/core/src/wirings/workflow/feature.ts
+++ b/packages/core/src/wirings/workflow/feature.ts
@@ -32,9 +32,11 @@ export const resolveFeatureScenarios = (
     const scenarios = feature.scenarios ?? []
     for (let index = 0; index < scenarios.length; index++) {
       const entry = scenarios[index]!
-      const paired =
+      const pairing =
         typeof entry === 'object' && entry !== null && 'scenario' in entry
-      const config = paired ? (entry as any).scenario : entry
+          ? (entry as { scenario: unknown; data?: unknown })
+          : undefined
+      const config = pairing ? pairing.scenario : entry
       const scenarioName = nameByConfig.get(config)
       if (!scenarioName) {
         unresolved.push({ featureId, index })
@@ -44,10 +46,11 @@ export const resolveFeatureScenarios = (
         featureId,
         featureName: feature.name ?? featureId,
         scenarioName,
-        data: paired ? (entry as any).data : undefined,
+        data: pairing?.data,
         tags: [
           ...new Set([
-            ...((registrations.get(scenarioName)?.func as any)?.tags ?? []),
+            ...((registrations.get(scenarioName)?.func as { tags?: string[] })
+              ?.tags ?? []),
             ...(feature.tags ?? []),
           ]),
         ],

--- a/packages/core/src/wirings/workflow/graph/graph-node.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-node.ts
@@ -65,7 +65,7 @@ export function createGraph<RPCMap extends Record<string, RPCHandler>>() {
     for (const [nodeId, def] of Object.entries(nodes) as [string, any][]) {
       result[nodeId] = {
         func: funcMap[nodeId] as string,
-        input: def?.input as any,
+        input: def?.input,
         next: def?.next,
         onError: def?.onError,
         retries: def?.retries,

--- a/packages/core/src/wirings/workflow/graph/graph-runner.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.ts
@@ -211,7 +211,7 @@ function isDataRef(value: unknown): value is { $ref: string; path?: string } {
     typeof value === 'object' &&
     value !== null &&
     '$ref' in value &&
-    typeof (value as any).$ref === 'string'
+    typeof (value as { $ref?: unknown }).$ref === 'string'
   )
 }
 
@@ -227,7 +227,7 @@ function isTemplate(value: unknown): value is TemplateValue {
     typeof value === 'object' &&
     value !== null &&
     '$template' in value &&
-    typeof (value as any).$template === 'object'
+    typeof (value as { $template?: unknown }).$template === 'object'
   )
 }
 

--- a/packages/core/src/wirings/workflow/pikku-scenario-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-scenario-service.ts
@@ -424,10 +424,9 @@ export class PikkuScenarioService implements WorkflowRunExtension {
 
     let wireServices: Record<string, unknown> | undefined
     try {
-      wireServices = (await createWireServices?.(
-        singletonServices,
-        wire as any
-      )) as Record<string, unknown> | undefined
+      wireServices = (await createWireServices?.(singletonServices, wire)) as
+        | Record<string, unknown>
+        | undefined
       const services =
         wireServices && Object.keys(wireServices).length > 0
           ? { ...singletonServices, ...wireServices }

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -774,7 +774,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         const serialized: SerializedError = {
           message: error.message,
           stack: error.stack,
-          code: (error as any).code,
+          code: (error as { code?: string }).code,
           expected: isExpectedError(error),
         }
         return mirror.setStepError(stepId, serialized)
@@ -796,7 +796,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       (mirror, newStep) =>
         mirror.createRetryAttempt(failedStepId, {
           ...newStep,
-          stepName: (newStep as any).stepName ?? '',
+          stepName: (newStep as { stepName?: string }).stepName ?? '',
         })
     )
   }


### PR DESCRIPTION
Closes #1180.

**Third in the core-surface stack.** Targets #1187 — review that one first; this diff is only the third commit.

`@pikku/core` carried **108 `as any` casts** across its non-test modules. This takes that to **zero**. Every one is replaced by an assertion to the type actually wanted, or by a change to the surrounding types that makes the assertion unnecessary.

A cast to `any` is not a neutral annotation — it discards the target type, so a wrong value passes as readily as a right one. Three of these were doing exactly that:

### `AIStreamEvent.approval-request` declared `runId` optional

`AIAgentResult['pendingApprovals']` has always required it, and every emitter already set it. The optional let `undefined` reach the field a consumer uses to resume a suspended run.

### `wireChannel` registered two handlers uncallable

`CoreChannel` accepts three handler shapes, including a wrapper around a function config (`{ func: { func }, middleware }`). `wireChannel` unwrapped it for `onMessage` and `onMessageWiring` but registered `onConnect` and `onDisconnect` as-is — the registered config's `func` was an object, and the function runner threw when it tried to call it.

Its type arguments were also misaligned with `CoreChannel`'s parameter list: `PikkuPermission` was passed into the `ChannelConnect` slot and `PikkuMiddleware` into `ChannelDisconnect`. End users never saw it — the CLI's generated wrapper casts before calling core — but anyone importing `wireChannel` from `@pikku/core/channel` directly did.

The three handler slots stay generic, now in the right positions. They have to: a wired handler's `services` parameter is narrower than `CoreSingletonServices` — its `schema` is required, not optional — and parameter types are contravariant, so pinning the slots to their `CorePikkuFunction<unknown, unknown>` defaults rejects every real handler. `verifiers/addon` calls `wireChannel` directly and is the case that proves it. `PikkuPackageState`'s channel map widens to match.

### `wire.logger` was read but never declared

The no-op audit service already preferred `wire.logger` over the singleton, so a host had no typed way to attach an invocation-scoped logger to something that would have used it.

### Holding the line

`no-any-casts.test.ts` walks the package's non-test modules and asserts the offender list is empty. It also asserts its **own matcher** works — that it finds `y as any` and `foo(bar as any)`, and ignores prose like "a picture, as any URL a browser can load". A regex that matched nothing would otherwise pass forever.

### Five casts the source history fixed elsewhere

Two in `graph-runner.ts` and three across `pikku-workflow-service.ts` / `pikku-scenario-service.ts` were cleaned up as a side effect of the workflow-service split (#1182, later in this stack). Since *this* PR is the one that promises zero, they are narrowed here instead — `(value as { $ref?: unknown })`, `(error as { code?: string })`, and dropping a cast that `PikkuRawWire = Omit<PikkuWire, 'rpc'>` already makes unnecessary.

### One call site had to catch up

`startWorkflow`'s `rpcService` parameter was `any`; it is now `PikkuRPC`. The CLI's scenario runner passes a deliberate sentinel — an RPC whose every member throws, so that a `workflow.do` without `{ actor }` fails loudly instead of quietly running against local services rather than the target environment. As a partial object it only satisfied `any`.

It is now a complete `PikkuRPC`, every member routed through one `refuseInternal` that throws the same explanatory error. That is the point of the change rather than a cost of it: the sentinel now has to state that it stands in for the whole surface, and if the surface grows a member the sentinel does not answer, the build says so.

`rpcWithWire` is named in an intersection alongside `PikkuRPC` because the workflow runner reaches for that member through an internally untyped path, and the type that declares it publicly only arrives with #1190 later in this stack.

### Verification

| check | result |
|---|---|
| `@pikku/core` full suite | 2031 pass, 0 fail |
| `@pikku/cli` `tsc` | clean |
| `yarn build:packages` (the CI Build step) | exits 0 |
| `@pikku/core` `tsc` | clean |
| `no-any-casts` / `channel-handler-shapes` / `gateway-channel-meta` | 10/10 |
| `verifiers/addon` (`pikku` + `tsc` + contract assertions) | 7/7 |
| grep for `as any` in non-test core source | 2 hits, both prose the matcher excludes by design |

One run of the full suite failed at `crypto-utils.test.ts:469` — the KEK derivation test that budgets 5ms of wall clock. That is the load-dependent flake **PR #1175 fixes**; it is not on this branch and is unrelated to this change. It passed on re-run.

