### PR TITLE
refactor(core): split pikku-workflow-service into composable modules

### DIFF
--- a/.changeset/child-workflows-inherit-the-parent-user.md
+++ b/.changeset/child-workflows-inherit-the-parent-user.md
@@ -1,0 +1,11 @@
+---
+'@pikku/core': patch
+---
+
+A child workflow now inherits the `pikkuUserId` its parent was running as
+
+`PikkuWorkflowService` filled parts of the wire it builds for a workflow body and for a child run from the RPC service it had been handed — `rpcService.wire?.session`, `rpcService.wire?.rpc`, `rpcService.wire?.pikkuUserId`. `PikkuRPC` has no `wire`, and neither does the object the RPC service actually returns, so every one of those reads was `undefined`; the `rpcService: any` parameter type is what kept it quiet. The visible consequence was that a child workflow started from a step ran as nobody.
+
+Those reads now come from the run record, which is durable and survives the process boundary a queued step crosses. `session` and `rpc` are not copied at all: `runPikkuFunc` attaches `rpc` lazily per invocation and resolves the session from the session store, so both were overwritten moments later regardless. The wires these paths build are typed `PikkuRawWire`, which is what they have always been.
+
+`PikkuRPC` also now declares `rpcWithWire`, which the RPC service has always returned and the workflow service has always called.

--- a/.changeset/tidy-workflow-service-split.md
+++ b/.changeset/tidy-workflow-service-split.md
@@ -1,0 +1,9 @@
+---
+'@pikku/core': patch
+---
+
+Split `pikku-workflow-service.ts` into composable modules and report missing workflow metadata as such
+
+`PikkuWorkflowService`'s module carried its error catalog, run-engine interfaces, queue routing and queue wiring alongside the class. Those now live in `workflow-errors.ts`, `workflow-run-engine.types.ts`, `workflow-constants.ts`, `workflow-meta-resolver.ts`, `workflow-queue-routing.ts` and `workflow-queue-wiring.ts`, with the approval and recovery paths in `workflow-approval.ts` and `workflow-recovery.ts`. The `@pikku/core/workflow` entry point exports the same names as before.
+
+Typing the workflow meta resolver surfaced a crash: a run whose workflow had no generated metadata threw `TypeError: Cannot read properties of undefined` from deep inside the runner, or `WorkflowNotFoundError` — neither of which points at the actual cause. It now throws `PikkuMissingMetaError`, matching how the queue and trigger runners already report the same condition.

--- a/packages/core/knowledge/decisions/internals/a-workflow-wire-is-built-from-the-run-not-from-the-rpc-service.md
+++ b/packages/core/knowledge/decisions/internals/a-workflow-wire-is-built-from-the-run-not-from-the-rpc-service.md
@@ -1,0 +1,45 @@
+---
+type: decision
+title: A workflow's wire is built from the run record, not from the RPC service
+description: The RPC service exposes no wire, so every rpcService.wire read was undefined; the run record is the only thing that carries the caller across a step boundary
+tags: core, workflow
+---
+
+# A workflow's wire is built from the run record, not from the RPC service
+
+`PikkuWorkflowService` builds a fresh wire each time it runs a workflow body or
+starts a child. For a while it filled parts of that wire from the RPC service it
+had been handed:
+
+```ts
+session: rpcService?.wire?.session,
+rpc: rpcService?.wire?.rpc,
+pikkuUserId: rpcService.wire?.pikkuUserId,
+```
+
+`PikkuRPC` has no `wire`. Neither does the object `getContextRPCService`
+actually returns — `ContextAwareRPCService` holds its wire *privately* and
+exposes `invoke`, `remote`, `exposed`, `startWorkflow`, `agent` and
+`rpcWithWire`, and nothing else. Every one of those reads was `undefined`, and
+the `rpcService: any` parameter type is what kept the compiler quiet about it.
+
+The consequence was silent and one-directional: a child workflow started from a
+step never inherited the `pikkuUserId` its parent was running as, so a queued
+child ran as nobody. Nothing failed — the field was simply absent, and the run
+proceeded.
+
+**The run record is the carrier.** `WorkflowRun.wire` is durable, is written
+when the run is created, and survives the process boundary a queued step
+crosses, which is exactly what a live service reference cannot do. Both the
+run-body wire and the child-run wire now read `run.wire?.pikkuUserId`.
+
+`session` and `rpc` are not copied at all. `runPikkuFunc` attaches `rpc` lazily
+for the duration of an invocation and restores the previous descriptor
+afterwards, and it resolves the session from the session store using
+`pikkuUserId` — so both were being overwritten moments later anyway. The wire
+these paths construct is a `PikkuRawWire` for that reason: it genuinely has no
+`rpc` yet, and saying so is what let the dead reads be found.
+
+**What this rules out:** reaching for the RPC service to answer "who is this
+running as". It cannot answer, and the shape of the question hides that.
+Anything a step needs to know about its caller has to be on the run.

--- a/packages/core/knowledge/decisions/internals/index.md
+++ b/packages/core/knowledge/decisions/internals/index.md
@@ -11,6 +11,7 @@ caller is entitled to assume.
 
 <!-- pikku:knowledge-index -->
 - [A secret that fails to decrypt fails the whole read](a-secret-that-fails-to-decrypt-fails-the-whole-read.md) — getSecrets throws naming the key and its key_version rather than omitting the row, because a silent omission surfaces as an unrelated failure much later
+- [A workflow's wire is built from the run record, not from the RPC service](a-workflow-wire-is-built-from-the-run-not-from-the-rpc-service.md) — The RPC service exposes no wire, so every rpcService.wire read was undefined; the run record is the only thing that carries the caller across a step boundary
 - [An actor conversation starts from a seeded kickoff message](actor-flow-conversations-seed-a-hidden-kickoff-message.md) — The actor's first turn needs a non-empty message list because providers reject an empty prompt; the seed is an instruction and stays out of the transcript
 - [The actor-flow conversation engine only sees a transport-agnostic target driver](actor-flow-drives-the-target-through-a-transport-seam.md) — The engine never imports the agent runner; the target is injected as run/approve, so scenarios exercise the real wire path
 - [An actor-flow verdict is the persona's self-evaluation, not an assertion](actor-flow-verdicts-are-llm-self-evaluations.md) — The engine returns what the actor judged plus the transcript; deterministic checks stay with the caller

--- a/packages/core/src/source-files-stay-composable.test.ts
+++ b/packages/core/src/source-files-stay-composable.test.ts
@@ -1,0 +1,41 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname, relative } from 'node:path'
+
+const srcRoot = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * The ceiling a single module may reach before it has to be composed out of
+ * smaller ones.
+ */
+const MAX_LINES = 2000
+
+const collectSourceFiles = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      return entry.name === 'dist' ? [] : collectSourceFiles(entryPath)
+    }
+    return entry.name.endsWith('.ts') ? [entryPath] : []
+  })
+
+describe('source files stay composable', () => {
+  test(`no module in @pikku/core exceeds ${MAX_LINES} lines`, () => {
+    const offenders = collectSourceFiles(srcRoot)
+      .map((file) => ({
+        file: relative(srcRoot, file),
+        lines: readFileSync(file, 'utf-8').split('\n').length,
+      }))
+      .filter(({ lines }) => lines > MAX_LINES)
+      .sort((a, b) => b.lines - a.lines)
+
+    assert.deepEqual(
+      offenders,
+      [],
+      `modules over ${MAX_LINES} lines:\n` +
+        offenders.map(({ file, lines }) => `  ${lines}  ${file}`).join('\n')
+    )
+  })
+})

--- a/packages/core/src/wirings/rpc/rpc-types.ts
+++ b/packages/core/src/wirings/rpc/rpc-types.ts
@@ -1,3 +1,4 @@
+import type { PikkuRawWire } from '../../types/core.types.js'
 import type { AgentInterruptResult } from '../ai-agent/ai-agent-interrupt.js'
 
 export type PikkuRPC<
@@ -12,6 +13,12 @@ export type PikkuRPC<
   invoke: Invoke
   remote: Remote
   exposed: (name: string, data: any) => Promise<any>
+  /** Invoke an RPC with explicit wire fields merged over the caller's. */
+  rpcWithWire: <In = any, Out = any>(
+    rpcName: string,
+    data: In,
+    wire: PikkuRawWire
+  ) => Promise<Out>
   startWorkflow: startWorkflow
   agent: {
     run: AgentRun

--- a/packages/core/src/wirings/workflow/graph/graph-runner.test.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.test.ts
@@ -10,7 +10,7 @@ import {
 import type { WorkflowRuntimeMeta } from '../workflow.types.js'
 import { pikkuState } from '../../../pikku-state.js'
 import { RPCNotFoundError } from '../../rpc/rpc-runner.js'
-import { DEFAULT_STEP_RETRIES } from '../pikku-workflow-service.js'
+import { DEFAULT_STEP_RETRIES } from '../workflow-constants.js'
 
 describe('graph-runner bugs', () => {
   test('continueGraph should NOT mark workflow completed while nodes are still running', async () => {

--- a/packages/core/src/wirings/workflow/graph/graph-runner.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.ts
@@ -1,9 +1,9 @@
+import type { PikkuWorkflowService } from '../pikku-workflow-service.js'
 import {
-  type PikkuWorkflowService,
   WorkflowAsyncException,
   WorkflowSuspendedException,
-  DEFAULT_STEP_RETRIES,
-} from '../pikku-workflow-service.js'
+} from '../workflow-errors.js'
+import { DEFAULT_STEP_RETRIES } from '../workflow-constants.js'
 import type { GraphWireState, PikkuGraphWire } from './workflow-graph.types.js'
 import { pikkuState, getSingletonServices } from '../../../pikku-state.js'
 import type { WorkflowRuntimeMeta, WorkflowRunWire } from '../workflow.types.js'

--- a/packages/core/src/wirings/workflow/index.ts
+++ b/packages/core/src/wirings/workflow/index.ts
@@ -1,18 +1,18 @@
+export { PikkuWorkflowService } from './pikku-workflow-service.js'
 export {
-  PikkuWorkflowService,
   WorkflowCancelledException,
   WorkflowSuspendedException,
   WorkflowDispatchException,
   WorkflowNotFoundError,
   WorkflowRunNotFoundError,
   WorkflowApprovalResolvedError,
-  DEFAULT_STEP_RETRIES,
-} from './pikku-workflow-service.js'
+} from './workflow-errors.js'
+export { DEFAULT_STEP_RETRIES } from './workflow-constants.js'
 export type {
   RunLifecycleContext,
   WorkflowRunEngine,
   WorkflowRunExtension,
-} from './pikku-workflow-service.js'
+} from './workflow-run-engine.types.js'
 export { deriveInvocationId, uuidv5 } from './workflow-invocation-id.js'
 
 export { isRef } from './graph/workflow-graph.types.js'

--- a/packages/core/src/wirings/workflow/pikku-scenario-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-scenario-service.ts
@@ -9,13 +9,13 @@ import { closeWireServices } from '../../utils.js'
 import { PikkuError, addError } from '../../errors/error-handler.js'
 import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
 import { runScheduledTask } from '../scheduler/scheduler-runner.js'
-import {
-  WorkflowStepNameNotString,
-  type RunLifecycleContext,
-  type WorkflowRunEngine,
-  type WorkflowRunExtension,
-} from './pikku-workflow-service.js'
-import type { PikkuWire } from '../../types/core.types.js'
+import { WorkflowStepNameNotString } from './workflow-errors.js'
+import type {
+  RunLifecycleContext,
+  WorkflowRunEngine,
+  WorkflowRunExtension,
+} from './workflow-run-engine.types.js'
+import type { PikkuRawWire } from '../../types/core.types.js'
 import type { ScenarioPersonas } from '../../services/personas-service.js'
 import type { CorePikkuFunctionConfig } from '../../function/functions.types.js'
 import type {
@@ -66,7 +66,7 @@ export const createScenarioRunner = (
 type ScenarioHook = (
   services: any,
   data: any,
-  wire: PikkuWire
+  wire: PikkuRawWire
 ) => Promise<void> | void
 
 /**
@@ -311,7 +311,7 @@ export class PikkuScenarioService implements WorkflowRunExtension {
   }
 
   public decorateRunWire(
-    wire: PikkuWire,
+    wire: PikkuRawWire,
     context: {
       runId: string
       workflowMeta: any
@@ -409,7 +409,7 @@ export class PikkuScenarioService implements WorkflowRunExtension {
     phase: 'before' | 'after',
     scenarioName: string,
     hook: ScenarioHook,
-    wire: PikkuWire,
+    wire: PikkuRawWire,
     data: unknown,
     packageName: string | null
   ): Promise<void> {
@@ -647,12 +647,7 @@ export class PikkuScenarioService implements WorkflowRunExtension {
         )
       },
 
-      // Scenario steps: a named `pikkuScenarioStep` run as one durable step.
-      // `given`/`when` are sugar for each other, differing only in the
-      // prose a reporter renders. `then` is not: the phase is what decides
-      // whether the step's bindings are alternatives or witnesses, so the same
-      // step function called two ways runs differently. See
-      // {@link resolveScenarioSurfaces}.
+      // knowledge: decisions/internals/scenario-given-and-when-are-sugar-but-then-is-not.md
       given: (stepName, stepFunc, data, options) =>
         this.scenarioStep(
           'given',
@@ -695,8 +690,7 @@ export class PikkuScenarioService implements WorkflowRunExtension {
     data?: any,
     options?: ScenarioStepOptions
   ): Promise<any> {
-    const { runId, workflowName, addonNamespace, workflowWire, rpcService } =
-      context
+    const { runId, workflowName, addonNamespace, workflowWire } = context
     // Also the guard for `then` being a wire member: an accidental
     // `await scenario` calls it with a resolve function, which lands here as a
     // loud, named error instead of a silent hang.
@@ -726,11 +720,10 @@ export class PikkuScenarioService implements WorkflowRunExtension {
       stepName,
       async () => {
         const runOnSurface = async (surface: ScenarioSurface) => {
-          const wire: PikkuWire = {
+          // No `rpc` yet — runPikkuFunc attaches it lazily for the invocation.
+          const wire: PikkuRawWire = {
             workflow: workflowWire,
             scenario: workflowWire,
-            rpc: rpcService?.wire?.rpc,
-            session: rpcService?.wire?.session,
             pikkuUserId: workflowWire.pikkuUserId,
             actors: this.runActors.get(runId),
             scenarioStep: {

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
@@ -8,8 +8,8 @@ import { addWorkflow } from './dsl/workflow-runner.js'
 import {
   WorkflowApprovalResolvedError,
   WorkflowSuspendedException,
-  type PikkuWorkflowWire,
-} from './pikku-workflow-service.js'
+} from './workflow-errors.js'
+import type { PikkuWorkflowWire } from './workflow.types.js'
 
 describe('pikku-workflow-service worker registration', () => {
   test('registers sleeper function metadata after wireQueueWorkers', () => {

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -1,53 +1,19 @@
-import { runPikkuFunc, addFunction } from '../../function/function-runner.js'
-import {
-  pikkuWorkflowWorkerFunc,
-  pikkuWorkflowOrchestratorFunc,
-  pikkuWorkflowSleeperFunc,
-} from './workflow-queue-workers.js'
-import { wireQueueWorker } from '../queue/queue-runner.js'
+import { runPikkuFunc } from '../../function/function-runner.js'
 import {
   getSingletonServices,
   getCreateWireServices,
   pikkuState,
 } from '../../pikku-state.js'
 import { getDurationInMilliseconds } from '../../time-utils.js'
-
-const resolveWorkflowMeta = (
-  name: string
-): { meta: any; packageName: string | null; resolvedName: string } | null => {
-  const rootMeta = pikkuState(null, 'workflows', 'meta')
-  if (rootMeta[name]) {
-    return { meta: rootMeta[name], packageName: null, resolvedName: name }
-  }
-
-  const colonIndex = name.indexOf(':')
-  if (colonIndex !== -1) {
-    const namespace = name.substring(0, colonIndex)
-    const localName = name.substring(colonIndex + 1)
-    const addons = pikkuState(null, 'addons', 'packages')
-    const pkgConfig = addons?.get(namespace)
-    if (pkgConfig) {
-      const addonMeta = pikkuState(pkgConfig.package, 'workflows', 'meta')
-      if (addonMeta?.[localName]) {
-        return {
-          meta: addonMeta[localName],
-          packageName: pkgConfig.package,
-          resolvedName: localName,
-        }
-      }
-    }
-  }
-
-  return null
-}
-
-const toKebab = (s: string) =>
-  s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
-import type { PikkuWire, SerializedError } from '../../types/core.types.js'
-import type { QueueService } from '../queue/queue.types.js'
+import type { PikkuRawWire, SerializedError } from '../../types/core.types.js'
+import type {
+  GroupConcurrencyConfig,
+  JobGroup,
+  JobOptions,
+  QueueService,
+} from '../queue/queue.types.js'
 import type {
   ApprovalOutcome,
-  CoreWorkflow,
   PikkuWorkflowWire,
   StepState,
   StepStatus,
@@ -64,6 +30,7 @@ import type {
   WorkflowStepOptions,
 } from './workflow.types.js'
 import {
+  ChildWorkflowStartedException,
   continueGraph,
   executeGraphStep,
   runWorkflowGraph,
@@ -71,13 +38,10 @@ import {
 } from './graph/graph-runner.js'
 import type { WorkflowService } from '../../services/workflow-service.js'
 import type { ScenarioPersonas } from '../../services/personas-service.js'
-import {
-  PikkuError,
-  addError,
-  isExpectedError,
-} from '../../errors/error-handler.js'
+import { isExpectedError } from '../../errors/error-handler.js'
+import { PikkuMissingMetaError } from '../../errors/errors.js'
 import { RPCNotFoundError } from '../rpc/rpc-runner.js'
-import { ChildWorkflowStartedException } from './graph/graph-runner.js'
+import type { PikkuRPC } from '../rpc/rpc-types.js'
 import { deriveInvocationId } from './workflow-invocation-id.js'
 import {
   buildRunTimeline,
@@ -85,237 +49,51 @@ import {
   type RunTimeline,
   type ReconstructedRunState,
 } from './run-timeline.js'
+import {
+  DEFAULT_STEP_RETRIES,
+  WORKFLOW_CHILD_POLL_MAX_MS,
+  WORKFLOW_END_STATES,
+  WORKFLOW_POLL_FACTOR,
+  WORKFLOW_POLL_MIN_MS,
+  WORKFLOW_TERMINAL_STATES,
+} from './workflow-constants.js'
+import {
+  WorkflowAsyncException,
+  WorkflowCancelledException,
+  WorkflowDispatchException,
+  WorkflowNotFoundError,
+  WorkflowRunCancelledError,
+  WorkflowRunFailedError,
+  WorkflowRunNotFoundError,
+  WorkflowStepNameNotString,
+  WorkflowSuspendedException,
+} from './workflow-errors.js'
 import type {
-  GroupConcurrencyConfig,
-  JobGroup,
-  JobOptions,
-  PikkuWorkerConfig,
-} from '../queue/queue.types.js'
-
-export const DEFAULT_STEP_RETRIES = 5
-
-export class WorkflowAsyncException extends Error {
-  constructor(
-    public readonly runId: string,
-    public readonly stepName: string
-  ) {
-    super(`Workflow paused at step: ${stepName}`)
-    this.name = 'WorkflowAsyncException'
-  }
-}
-
-export class WorkflowCancelledException extends Error {
-  constructor(
-    public readonly runId: string,
-    public readonly reason?: string
-  ) {
-    super(reason || 'Workflow cancelled')
-    this.name = 'WorkflowCancelledException'
-  }
-}
-
-export class WorkflowSuspendedException extends Error {
-  constructor(
-    public readonly runId: string,
-    public readonly reason: string
-  ) {
-    super(reason || 'Workflow suspended')
-    this.name = 'WorkflowSuspendedException'
-  }
-}
-
-export class WorkflowDispatchException extends Error {
-  constructor(
-    public readonly runId: string,
-    public readonly stepName: string,
-    options?: { cause?: unknown }
-  ) {
-    super(
-      `Failed to dispatch workflow step '${stepName}' (run ${runId})`,
-      options
-    )
-    this.name = 'WorkflowDispatchException'
-  }
-}
-
-export class WorkflowNotFoundError extends PikkuError {
-  constructor(name: string) {
-    super(`Workflow not found: ${name}`)
-  }
-}
-addError(WorkflowNotFoundError, {
-  status: 404,
-  message: 'Workflow not found.',
-})
-
-export class WorkflowRunNotFoundError extends PikkuError {
-  constructor(runId: string) {
-    super(`Workflow run not found: ${runId}`)
-  }
-}
-addError(WorkflowRunNotFoundError, {
-  status: 404,
-  message: 'Workflow run not found.',
-})
-
-export class WorkflowRunFailedError extends PikkuError {
-  public payload: { message?: string }
-  constructor(message?: string) {
-    super(`Workflow run failed: ${message ?? 'unknown'}`)
-    this.payload = { message }
-  }
-}
-addError(WorkflowRunFailedError, {
-  status: 422,
-  message: 'Workflow run failed.',
-})
-
-export class WorkflowRunCancelledError extends PikkuError {
-  constructor() {
-    super('Workflow was cancelled')
-  }
-}
-addError(WorkflowRunCancelledError, {
-  status: 409,
-  message: 'Workflow was cancelled.',
-})
-
-export class WorkflowApprovalResolvedError extends PikkuError {
-  public payload: {
-    reason: string
-    outcome: ApprovalOutcome<unknown>['status']
-  }
-  constructor(reason: string, outcome: ApprovalOutcome<unknown>['status']) {
-    super(`Approval already ${outcome}: ${reason}`)
-    this.payload = { reason, outcome }
-  }
-}
-addError(WorkflowApprovalResolvedError, {
-  status: 409,
-  message: 'Approval has already been resolved.',
-})
-
-export class WorkflowServiceNotInitialized extends Error {}
-export class WorkflowStepNameNotString extends Error {
-  constructor(stepName: any) {
-    super(`Workflow step name must be a string. Received: ${typeof stepName}`)
-  }
-}
-
-const WORKFLOW_END_STATES: ReadonlySet<string> = new Set([
-  'completed',
-  'failed',
-  'cancelled',
-  'suspended',
-])
-
-export interface RunLifecycleContext {
-  runId: string
-  run: WorkflowRun
-  workflowMeta: any
-  workflow: CoreWorkflow
-  wire: PikkuWire
-  packageName: string | null
-}
-
-export interface WorkflowRunEngine {
-  inlineStep(
-    runId: string,
-    logicalStepName: string,
-    fn: Function,
-    stepOptions?: WorkflowStepOptions,
-    data?: any,
-    funcName?: string
-  ): Promise<any>
-  updateRunStatus(
-    runId: string,
-    status: WorkflowStatus,
-    output?: any,
-    error?: SerializedError
-  ): Promise<void>
-  onChildWorkflowFailed(run: WorkflowRun, error: unknown): Promise<void>
-  verifyStepName(stepName: unknown): void
-}
-
-export interface WorkflowRunExtension {
-  attachRunContext(
-    runId: string,
-    workflowMeta: any,
-    options?: Record<string, any>
-  ): Promise<void>
-  detachRunContext(runId: string): void
-  decorateRunWire(
-    wire: PikkuWire,
-    context: {
-      runId: string
-      workflowMeta: any
-      workflowWire: PikkuWorkflowWire
-    }
-  ): void
-  decorateWorkflowWire(
-    workflowWire: PikkuWorkflowWire,
-    context: {
-      name: string
-      runId: string
-      rpcService: any
-      addonNamespace?: string | null
-    }
-  ): void
-  onBeforeRunFunc(context: RunLifecycleContext): Promise<void>
-  onAfterRunFunc(
-    context: RunLifecycleContext,
-    outcome: 'completed' | 'failed' | 'interrupted',
-    failure: unknown
-  ): Promise<void>
-}
-
-const WORKFLOW_TERMINAL_STATES: ReadonlySet<string> = new Set([
-  'completed',
-  'failed',
-  'cancelled',
-])
-
-/** Idle window before a `running` run with nothing in flight is treated as stalled. */
-const DEFAULT_STALLED_RUN_MS = 5 * 60_000
-
-/** Runs re-driven per `recoverStalledRuns` call, so one sweep is bounded. */
-const DEFAULT_STALLED_RUN_LIMIT = 100
-
-/**
- * How long a step may sit `pending` before the relay assumes its dispatch was
- * lost. This is a bet that no healthy queue takes this long to move a job from
- * `pending` to `running`; set it above the observed p99 of that latency.
- */
-const DEFAULT_UNDISPATCHED_STEP_MS = 30_000
-
-/** Steps re-driven per `relayUndispatchedSteps` call, so one tick is bounded. */
-const DEFAULT_UNDISPATCHED_STEP_LIMIT = 100
-
-/** First wait before a step already re-dispatched once is re-dispatched again. */
-const REDISPATCH_BACKOFF_MS = 30_000
-
-/** Ceiling on the doubling backoff, so a permanently stuck step still gets swept. */
-const REDISPATCH_BACKOFF_MAX_MS = 10 * 60_000
-
-/** Bound on the in-process backoff map, so a long-lived process cannot grow it without bound. */
-const REDISPATCH_BACKOFF_MAX_ENTRIES = 10_000
-
-const WORKFLOW_POLL_MIN_MS = 10
-
-const WORKFLOW_POLL_FACTOR = 1.6
-
-const WORKFLOW_CHILD_POLL_MAX_MS = 500
-
-type RunContext = {
-  activeExecutions: number
-  inline?: boolean
-  ordinals: Map<string, number>
-  lastStep?: string
-  replay?: {
-    steps?: Map<string, StepState>
-    run?: WorkflowRun
-  }
-}
+  RunContext,
+  RunLifecycleContext,
+  WorkflowRunEngine,
+  WorkflowRunExtension,
+} from './workflow-run-engine.types.js'
+import { resolveWorkflowMeta } from './workflow-meta-resolver.js'
+import {
+  jobGroupFor,
+  orchestratorQueueName,
+  resolveWorkflowConfig,
+  stepJobOptions,
+  stepWorkerQueueName,
+} from './workflow-queue-routing.js'
+import { wireWorkflowQueueWorkers } from './workflow-queue-wiring.js'
+import {
+  approvalStepNameFor,
+  evaluateApprovalStep,
+  recordApprovalDecision,
+  type ApprovalStore,
+} from './workflow-approval.js'
+import {
+  RedispatchBackoff,
+  sweepStalledRuns,
+  sweepUndispatchedSteps,
+} from './workflow-recovery.js'
 
 export abstract class PikkuWorkflowService implements WorkflowService {
   private runExtension?: WorkflowRunExtension
@@ -406,112 +184,12 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   }
 
   public wireQueueWorkers(): void {
-    const functions = pikkuState(null, 'function', 'functions')
-    const functionsMeta = pikkuState(null, 'function', 'meta')
-
-    const mkMeta = (funcId: string) => ({
-      pikkuFuncId: funcId,
-      sessionless: true,
-      functionType: 'helper' as const,
-      inputSchemaName: null,
-      outputSchemaName: null,
+    wireWorkflowQueueWorkers({
+      strategy: this.queueStrategy,
+      concurrency: this.queueConcurrency,
+      groupConcurrency: this.queueGroupConcurrency,
+      getLogger: () => this.logger,
     })
-
-    const queueMeta = pikkuState(null, 'queue', 'meta')
-
-    const registerWorkflowFunc = (
-      funcId: string,
-      func: { func: unknown },
-      queueName: string,
-      config?: PikkuWorkerConfig
-    ) => {
-      if (functions.has(funcId)) return
-      addFunction(funcId, func as never)
-      if (!queueMeta[queueName]) {
-        queueMeta[queueName] = { pikkuFuncId: funcId, name: queueName }
-      }
-      wireQueueWorker({ name: queueName, func, config } as never)
-      if (!functionsMeta[funcId]) {
-        functionsMeta[funcId] = mkMeta(funcId)
-      }
-    }
-
-    const sharedGroups = this.queueStrategy === 'shared-groups'
-    const sharedQueueConfig: PikkuWorkerConfig | undefined = sharedGroups
-      ? {
-          batchSize: this.queueConcurrency,
-          groupConcurrency: this.queueGroupConcurrency,
-        }
-      : undefined
-
-    registerWorkflowFunc(
-      'pikkuWorkflowOrchestrator',
-      { func: pikkuWorkflowOrchestratorFunc },
-      'pikku-workflow-orchestrator',
-      sharedQueueConfig
-    )
-    registerWorkflowFunc(
-      'pikkuWorkflowStepWorker',
-      { func: pikkuWorkflowWorkerFunc },
-      'pikku-workflow-step-worker',
-      sharedQueueConfig
-    )
-
-    const registerQueueWorkers = (queueMeta: Record<string, any>) => {
-      for (const [queueName, meta] of Object.entries(queueMeta)) {
-        if (functions.has(meta.pikkuFuncId)) continue
-        if (queueName.startsWith('wf-orchestrator-')) {
-          registerWorkflowFunc(
-            meta.pikkuFuncId,
-            { func: pikkuWorkflowOrchestratorFunc },
-            queueName
-          )
-        } else if (queueName.startsWith('wf-step-')) {
-          registerWorkflowFunc(
-            meta.pikkuFuncId,
-            { func: pikkuWorkflowWorkerFunc },
-            queueName
-          )
-        }
-      }
-    }
-
-    if (!sharedGroups) {
-      registerQueueWorkers(pikkuState(null, 'queue', 'meta'))
-
-      const addons = pikkuState(null, 'addons', 'packages')
-      if (addons) {
-        for (const [, addon] of addons) {
-          const addonQueueMeta = pikkuState(addon.package, 'queue', 'meta')
-          if (addonQueueMeta) {
-            registerQueueWorkers(addonQueueMeta)
-          }
-        }
-      }
-    }
-
-    const workflowCount = Object.keys(
-      pikkuState(null, 'workflows', 'meta') ?? {}
-    ).length
-    const perWorkflowQueues = Object.keys(queueMeta).filter((name) =>
-      name.startsWith('wf-orchestrator-')
-    ).length
-    if (workflowCount > 0 && perWorkflowQueues === 0) {
-      this.logger?.warn?.(
-        `[pikku] ${workflowCount} workflow(s) registered but no per-workflow orchestrator queues were found in queue meta. ` +
-          `All workflows will share a single orchestrator queue, where one slow step blocks every other workflow behind it. ` +
-          `Check that the generated bootstrap imports the queue-workers meta (pikku-queue-workers-wirings-meta.gen.js).`
-      )
-    }
-
-    if (!functions.has('pikkuWorkflowSleeper')) {
-      addFunction('pikkuWorkflowSleeper', {
-        func: pikkuWorkflowSleeperFunc,
-      })
-    }
-    if (!functionsMeta.pikkuWorkflowSleeper) {
-      functionsMeta.pikkuWorkflowSleeper = mkMeta('pikkuWorkflowSleeper')
-    }
   }
 
   protected async isInline(runId: string): Promise<boolean> {
@@ -950,51 +628,6 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   }
 
   /**
-   * Re-drive runs whose next move was lost, and report which were resumed.
-   *
-   * Arming a step is two writes to two systems — the step row, then the queue
-   * or scheduler job — so a process that dies between them leaves a run that is
-   * `running` with nothing in flight. Nothing notices: the run parks on a step
-   * that will never complete and never error, so it neither finishes nor fails.
-   * (Seen on a `workflow.sleep()`: a deploy restart landed between the sleep
-   * step's insert and its timer, parking the run permanently.)
-   *
-   * Replay is the recovery — `resumeWorkflow` re-orchestrates from persisted
-   * step state, and every settled step is memoized, so resuming a run that was
-   * not actually stuck costs an orchestration pass and changes nothing. That
-   * idempotence is what makes an idle-time heuristic safe here; a run that is
-   * legitimately mid-sleep is excluded anyway, since its step is `scheduled`.
-   *
-   * This is not self-starting. Call it from a scheduled task at whatever
-   * interval suits the workload.
-   */
-  public async recoverStalledRuns(options?: {
-    stalledAfterMs?: number
-    limit?: number
-  }): Promise<{ resumed: string[] }> {
-    const before = new Date(
-      Date.now() - (options?.stalledAfterMs ?? DEFAULT_STALLED_RUN_MS)
-    )
-    const runIds = await this.findStalledRunIds(
-      before,
-      options?.limit ?? DEFAULT_STALLED_RUN_LIMIT
-    )
-    const resumed: string[] = []
-    for (const runId of runIds) {
-      try {
-        await this.resumeWorkflow(runId)
-        resumed.push(runId)
-      } catch (err) {
-        // One unresumable run must not stop the sweep from recovering the rest.
-        getSingletonServices()?.logger?.error(
-          `Failed to resume stalled workflow run ${runId}: ${err instanceof Error ? err.message : String(err)}`
-        )
-      }
-    }
-    return { resumed }
-  }
-
-  /**
    * Runs holding a step that has sat `pending` since before `before`, paired
    * with the step that flagged them.
    *
@@ -1014,110 +647,51 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     return []
   }
 
+  private readonly redispatchBackoff = new RedispatchBackoff()
+
+  private get sweepDeps() {
+    return {
+      resume: (runId: string) => this.resumeWorkflow(runId),
+      logger: getSingletonServices()?.logger,
+    }
+  }
+
   /**
-   * Re-drive steps whose dispatch was lost, and report which runs were nudged.
-   *
-   * Arming a step is two writes to two systems: the step row lands `pending`,
-   * then a queue or scheduler job is published. Nothing spans both, so a crash
-   * in between leaves a durable row that nothing will ever pick up — the run
-   * neither finishes nor fails. (Seen on a `workflow.sleep()`: a deploy restart
-   * landed between the sleep step's insert and its timer.)
-   *
-   * The row is the outbox record and this is the relay. Age is the only signal
-   * available — a step `pending` because its dispatch was lost is
-   * indistinguishable from one whose job is merely still queued — so a step
-   * past `undispatchedAfterMs` is re-dispatched regardless, and correctness
-   * rests on the claim rather than on the guess being right. A redundant
-   * dispatch costs one queue message: the loser reads `running` and returns
-   * without invoking anything.
-   *
-   * Re-dispatches back off per step (doubling from 30s, capped at 10m) so a
-   * genuine queue backlog is not amplified by a tick that keeps firing at the
-   * steps the backlog is already delaying. The backoff is per process and
-   * advisory — losing it on restart costs extra dispatches, never correctness.
-   *
-   * This is not self-starting. Call it from a scheduled task; ~30s suits a
-   * queue whose `pending`→`running` latency is well under that.
+   * Re-drive runs whose next move was lost. Not self-starting — call it from a
+   * scheduled task at whatever interval suits the workload.
+   */
+  public async recoverStalledRuns(options?: {
+    stalledAfterMs?: number
+    limit?: number
+  }): Promise<{ resumed: string[] }> {
+    return sweepStalledRuns(
+      (before, limit) => this.findStalledRunIds(before, limit),
+      options,
+      this.sweepDeps
+    )
+  }
+
+  /**
+   * Re-drive steps whose dispatch was lost. Not self-starting — call it from a
+   * scheduled task; ~30s suits a queue whose `pending`→`running` latency is
+   * well under that.
    */
   public async relayUndispatchedSteps(options?: {
     undispatchedAfterMs?: number
     limit?: number
   }): Promise<{ redispatched: string[] }> {
-    const before = new Date(
-      Date.now() -
-        (options?.undispatchedAfterMs ?? DEFAULT_UNDISPATCHED_STEP_MS)
+    return sweepUndispatchedSteps(
+      (before, limit) => this.findUndispatchedSteps(before, limit),
+      this.redispatchBackoff,
+      options,
+      this.sweepDeps
     )
-    const steps = await this.findUndispatchedSteps(
-      before,
-      options?.limit ?? DEFAULT_UNDISPATCHED_STEP_LIMIT
-    )
-
-    // Backoff is keyed by run, not step, because the run is the unit of
-    // re-drive: `resumeWorkflow` replays the whole run and re-dispatches every
-    // step still owed a job. Holding off a single step while resuming its run
-    // would not suppress anything.
-    const now = Date.now()
-    const runIds = new Set<string>()
-    for (const { runId } of steps) {
-      const eligibleAt = this.redispatchBackoff.get(runId)
-      if (eligibleAt !== undefined && eligibleAt > now) {
-        continue
-      }
-      this.noteRedispatch(runId, now)
-      runIds.add(runId)
-    }
-
-    const redispatched: string[] = []
-    for (const runId of runIds) {
-      try {
-        await this.resumeWorkflow(runId)
-        redispatched.push(runId)
-      } catch (err) {
-        // One unresumable run must not stop the tick from relaying the rest.
-        getSingletonServices()?.logger?.error(
-          `Failed to re-dispatch workflow run ${runId}: ${err instanceof Error ? err.message : String(err)}`
-        )
-      }
-    }
-    return { redispatched }
-  }
-
-  /** Advisory, per-process record of when a run may next be re-dispatched. */
-  private readonly redispatchBackoff = new Map<string, number>()
-
-  private readonly redispatchDelays = new Map<string, number>()
-
-  private noteRedispatch(runId: string, now: number): void {
-    const previous = this.redispatchDelays.get(runId)
-    const delay = Math.min(
-      previous === undefined ? REDISPATCH_BACKOFF_MS : previous * 2,
-      REDISPATCH_BACKOFF_MAX_MS
-    )
-    // A run that settles is never returned again, so entries are only evicted by
-    // this bound — oldest first, which is also least recently re-dispatched.
-    if (this.redispatchBackoff.size >= REDISPATCH_BACKOFF_MAX_ENTRIES) {
-      const oldest = this.redispatchBackoff.keys().next()
-      if (!oldest.done) {
-        this.redispatchBackoff.delete(oldest.value)
-        this.redispatchDelays.delete(oldest.value)
-      }
-    }
-    this.redispatchDelays.set(runId, delay)
-    this.redispatchBackoff.set(runId, now + delay)
   }
 
   protected resolveStepJobOptions(
     stepOptions?: WorkflowStepOptions
   ): JobOptions {
-    const retries = stepOptions?.retries ?? DEFAULT_STEP_RETRIES
-    const retryDelay = stepOptions?.retryDelay
-    const backoff =
-      retryDelay !== undefined && retryDelay !== 'exponential'
-        ? { type: 'fixed', delay: getDurationInMilliseconds(retryDelay) }
-        : retries > 0 || retryDelay === 'exponential'
-          ? 'exponential'
-          : undefined
-    return { attempts: retries + 1, ...(backoff ? { backoff } : {}) }
+    return stepJobOptions(stepOptions)
   }
 
   public async queueStepWorker(
@@ -1246,7 +820,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     name: string,
     input: I,
     wire: WorkflowRunWire,
-    rpcService: any,
+    rpcService: PikkuRPC,
     options?: {
       inline?: boolean
       startNode?: string
@@ -1346,7 +920,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   public async runToCompletion<I>(
     name: string,
     input: I,
-    rpcService: any,
+    rpcService: PikkuRPC,
     options?: { pollIntervalMs?: number; wire?: WorkflowRunWire }
   ): Promise<any> {
     const { runId } = await this.startWorkflow(
@@ -1468,7 +1042,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     return stepName
   }
 
-  public async runWorkflowJob(runId: string, rpcService: any): Promise<void> {
+  public async runWorkflowJob(
+    runId: string,
+    rpcService: PikkuRPC
+  ): Promise<void> {
     await this.beginReplay(runId)
     try {
       await this.runWorkflowJobInner(runId, rpcService)
@@ -1479,7 +1056,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
 
   private async runWorkflowJobInner(
     runId: string,
-    rpcService: any
+    rpcService: PikkuRPC
   ): Promise<void> {
     const run = await this.getRunIdentity(runId)
     if (!run) {
@@ -1517,6 +1094,12 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     }
 
     const registrations = pikkuState(pkgName, 'workflows', 'registrations')
+    if (!workflowMeta) {
+      throw new PikkuMissingMetaError(
+        `Missing generated metadata for workflow '${run.workflow}'`
+      )
+    }
+
     const workflow = registrations.get(resolved?.resolvedName ?? run.workflow)
     if (!workflow) {
       throw new WorkflowNotFoundError(run.workflow)
@@ -1533,11 +1116,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         addonNs
       )
       workflowWire.pikkuUserId = run.wire?.pikkuUserId
-      const wire: PikkuWire = {
+      // No `rpc` yet — runPikkuFunc attaches it lazily for the invocation.
+      const wire: PikkuRawWire = {
         workflow: workflowWire,
         pikkuUserId: run.wire?.pikkuUserId,
-        session: rpcService?.wire?.session,
-        rpc: rpcService?.wire?.rpc,
       }
       this.runExtension?.decorateRunWire(wire, {
         runId,
@@ -1649,7 +1231,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   private async runVersionMismatchFallback(
     run: WorkflowRun,
     currentMeta: { source: string },
-    rpcService: any
+    rpcService: PikkuRPC
   ): Promise<void> {
     const source = currentMeta.source
 
@@ -1680,7 +1262,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepName: string,
     rpcName: string,
     data: any,
-    rpcService: any
+    rpcService: PikkuRPC
   ): Promise<void> {
     this.enterExecution(runId)
     try {
@@ -1701,7 +1283,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepName: string,
     rpcName: string,
     data: any,
-    rpcService: any
+    rpcService: PikkuRPC
   ): Promise<void> {
     const claimed = await this.withStepLock(runId, stepName, async () => {
       const stepState = await this.getStepState(runId, stepName)
@@ -1763,7 +1345,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
             id: rpcName,
             parentRunId: runId,
             parentStepId: stepState.stepId,
-            pikkuUserId: rpcService.wire?.pikkuUserId,
+            pikkuUserId: run.wire?.pikkuUserId,
           }
           const shouldInline = !getSingletonServices()?.queueService
           const { runId: childRunId } = await this.startWorkflow(
@@ -1838,7 +1420,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
 
   public async orchestrateWorkflow(
     runId: string,
-    rpcService: any
+    rpcService: PikkuRPC
   ): Promise<void> {
     try {
       await this.runWorkflowJob(runId, rpcService)
@@ -1885,7 +1467,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepState: StepState,
     rpcName: string,
     data: any,
-    rpcService: any,
+    rpcService: PikkuRPC,
     knownRun?: WorkflowRun | null
   ): Promise<any> {
     const run = knownRun ?? (await this.getRunIdentity(runId))
@@ -1943,7 +1525,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     runId: string,
     stepName: string,
     onErrorRpcName: string,
-    rpcService: any,
+    rpcService: PikkuRPC,
     error: Error
   ): Promise<void> {
     await this.rpcStep(
@@ -1961,7 +1543,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     logicalStepName: string,
     rpcName: string,
     data: any,
-    rpcService: any,
+    rpcService: PikkuRPC,
     stepOptions?: WorkflowStepOptions
   ): Promise<any> {
     const fromStepName = this.lastStepName(runId)
@@ -2043,7 +1625,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
             type: 'workflow',
             id: rpcName,
             parentRunId: runId,
-            pikkuUserId: rpcService.wire?.pikkuUserId,
+            pikkuUserId: (await this.getRunIdentity(runId))?.wire?.pikkuUserId,
           }
           const { runId: childRunId } = await this.startWorkflow(
             rpcName,
@@ -2259,16 +1841,33 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     }
   }
 
-  private getApprovalStepName(reason: string): string {
-    return `__workflow_approval:${reason}`
-  }
-
-  private approvalStateKey(stepName: string): string {
-    let hex = ''
-    for (const byte of new TextEncoder().encode(stepName)) {
-      hex += byte.toString(16).padStart(2, '0')
+  private get approvalStore(): ApprovalStore {
+    return {
+      getStepState: (runId, stepName) => this.getStepState(runId, stepName),
+      insertStepState: (
+        runId,
+        stepName,
+        rpcName,
+        input,
+        output,
+        fromStepName
+      ) =>
+        this.insertStepState(
+          runId,
+          stepName,
+          rpcName,
+          input,
+          output,
+          fromStepName
+        ),
+      setStepRunning: (stepId) => this.setStepRunning(stepId),
+      setStepResult: (stepId, result) => this.setStepResult(stepId, result),
+      getRunState: (runId) => this.getRunState(runId),
+      updateRunState: (runId, key, value) =>
+        this.updateRunState(runId, key, value),
+      resumeWorkflow: (runId) => this.resumeWorkflow(runId),
+      scheduleRunWake: (runId, delay) => this.scheduleRunWake(runId, delay),
     }
-    return `__approval_${hex}`
   }
 
   public async approveStep(
@@ -2276,32 +1875,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     reason: string,
     decision: unknown
   ): Promise<void> {
-    const stepName = this.getApprovalStepName(reason)
-    const stateKey = this.approvalStateKey(stepName)
-
-    let resolved: StepState | undefined
-    try {
-      resolved = await this.getStepState(runId, stepName)
-    } catch {
-      // knowledge: decisions/security/workflow-approval-payloads-are-validated-on-replay-inside-the-workflow.md
-    }
-    if (resolved?.stepId && resolved.status === 'succeeded') {
-      const outcome = resolved.result as ApprovalOutcome<unknown> | undefined
-      throw new WorkflowApprovalResolvedError(
-        reason,
-        outcome?.status ?? 'decided'
-      )
-    }
-
-    const state = await this.getRunState(runId)
-    const record = (state[stateKey] ?? {}) as Record<string, unknown>
-    await this.updateRunState(runId, stateKey, {
-      ...record,
-      decision,
-      decidedAt: new Date().toISOString(),
-      error: undefined,
-    })
-    await this.resumeWorkflow(runId)
+    return recordApprovalDecision(this.approvalStore, runId, reason, decision)
   }
 
   private async approvalStep(
@@ -2312,100 +1886,24 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     const fromStepName = this.lastStepName(runId)
     const approvalStepName = this.nextStepKey(
       runId,
-      this.getApprovalStepName(reason)
+      approvalStepNameFor(reason)
     )
-    return await this.withStepLock(runId, approvalStepName, async () => {
-      let stepState: StepState
-      try {
-        stepState = await this.getStepState(runId, approvalStepName)
-      } catch {
-        stepState = await this.insertStepState(
-          runId,
-          approvalStepName,
-          'pikkuWorkflowApproval',
-          { reason, expiry: options.expiry },
-          undefined,
-          fromStepName
-        )
-      }
-      if (!stepState.stepId) {
-        stepState = await this.insertStepState(
-          runId,
-          approvalStepName,
-          'pikkuWorkflowApproval',
-          { reason, expiry: options.expiry },
-          undefined,
-          fromStepName
-        )
-      }
-
-      if (stepState.status === 'succeeded') {
-        return stepState.result as ApprovalOutcome<unknown>
-      }
-
-      const stateKey = this.approvalStateKey(approvalStepName)
-      let record = ((await this.getRunState(runId))[stateKey] ?? {}) as {
-        decision?: unknown
-        decidedAt?: string
-        expiresAt?: string
-        error?: unknown
-      }
-
-      if (stepState.status === 'pending') {
-        await this.setStepRunning(stepState.stepId)
-        if (options.expiry !== undefined && !record.expiresAt) {
-          const expiresAt = new Date(
-            Date.now() + getDurationInMilliseconds(options.expiry)
-          ).toISOString()
-          record = { ...record, expiresAt }
-          await this.updateRunState(runId, stateKey, record)
-          await this.scheduleRunWake(
-            runId,
-            getDurationInMilliseconds(options.expiry)
-          )
-        }
-      }
-
-      if (record.decision !== undefined) {
-        const validation = await options.schema['~standard'].validate(
-          record.decision
-        )
-        if (validation.issues) {
-          await this.updateRunState(runId, stateKey, {
-            ...record,
-            decision: undefined,
-            decidedAt: undefined,
-            error: validation.issues.map((issue) => ({
-              message: issue.message,
-              path: issue.path?.map((segment) =>
-                typeof segment === 'object' ? segment.key : segment
-              ),
-            })),
-          })
-          throw new WorkflowSuspendedException(runId, reason)
-        }
-        const outcome: ApprovalOutcome<unknown> = {
-          status: 'decided',
-          data: validation.value,
-        }
-        await this.setStepResult(stepState.stepId, outcome)
-        return outcome
-      }
-
-      if (record.expiresAt && Date.now() >= Date.parse(record.expiresAt)) {
-        const outcome: ApprovalOutcome<unknown> = { status: 'expired' }
-        await this.setStepResult(stepState.stepId, outcome)
-        return outcome
-      }
-
-      throw new WorkflowSuspendedException(runId, reason)
-    })
+    return await this.withStepLock(runId, approvalStepName, () =>
+      evaluateApprovalStep(
+        this.approvalStore,
+        runId,
+        reason,
+        approvalStepName,
+        fromStepName,
+        options
+      )
+    )
   }
 
   public createWorkflowWire(
     name: string,
     runId: string,
-    rpcService: any,
+    rpcService: PikkuRPC,
     addonNamespace?: string | null
   ): PikkuWorkflowWire {
     const workflowWire: PikkuWorkflowWire = {
@@ -2478,45 +1976,18 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   }
 
   private getConfig(): WorkflowServiceConfig {
-    const singletonServices = getSingletonServices()
-    const workflow = singletonServices.config?.workflow
-    return {
-      retries: workflow?.retries ?? DEFAULT_STEP_RETRIES,
-      retryDelay: workflow?.retryDelay ?? 0,
-      orchestratorQueueName:
-        workflow?.orchestratorQueueName ?? 'pikku-workflow-orchestrator',
-      stepWorkerQueueName:
-        workflow?.stepWorkerQueueName ?? 'pikku-workflow-step-worker',
-      sleeperRPCName: workflow?.sleeperRPCName ?? 'pikkuWorkflowSleeper',
-    }
+    return resolveWorkflowConfig()
   }
 
   protected getOrchestratorQueueName(workflowName?: string): string {
-    if (workflowName && this.queueStrategy !== 'shared-groups') {
-      const perWorkflow = `wf-orchestrator-${toKebab(workflowName)}`
-      const meta = pikkuState(null, 'queue', 'meta')
-      if (meta[perWorkflow]) {
-        return perWorkflow
-      }
-    }
-    return this.getConfig().orchestratorQueueName
+    return orchestratorQueueName(this.queueStrategy, workflowName)
   }
 
   protected getStepWorkerQueueName(rpcName?: string): string {
-    if (rpcName && this.queueStrategy !== 'shared-groups') {
-      const perStep = `wf-step-${toKebab(rpcName)}`
-      const meta = pikkuState(null, 'queue', 'meta')
-      if (meta[perStep]) {
-        return perStep
-      }
-    }
-    return this.getConfig().stepWorkerQueueName
+    return stepWorkerQueueName(this.queueStrategy, rpcName)
   }
 
   protected getJobGroup(id?: string): JobGroup | undefined {
-    if (!id || this.queueStrategy !== 'shared-groups') {
-      return undefined
-    }
-    return { id, tier: id }
+    return jobGroupFor(this.queueStrategy, id)
   }
 }

--- a/packages/core/src/wirings/workflow/workflow-approval.ts
+++ b/packages/core/src/wirings/workflow/workflow-approval.ts
@@ -1,0 +1,185 @@
+import { getDurationInMilliseconds } from '../../time-utils.js'
+import {
+  WorkflowApprovalResolvedError,
+  WorkflowSuspendedException,
+} from './workflow-errors.js'
+import type {
+  ApprovalOutcome,
+  StepState,
+  WorkflowApprovalOptions,
+} from './workflow.types.js'
+
+/** The durable step name an approval point is recorded under. */
+export const approvalStepNameFor = (reason: string): string =>
+  `__workflow_approval:${reason}`
+
+/**
+ * The run-state key holding an approval's decision.
+ *
+ * Hex-encoded because the key is composed from a caller-supplied reason, and
+ * run state is a flat record — an unescaped reason could collide with, or
+ * shadow, another key.
+ */
+export const approvalStateKey = (stepName: string): string => {
+  let hex = ''
+  for (const byte of new TextEncoder().encode(stepName)) {
+    hex += byte.toString(16).padStart(2, '0')
+  }
+  return `__approval_${hex}`
+}
+
+/** What the approval gate needs from the workflow service. */
+export type ApprovalStore = {
+  getStepState: (runId: string, stepName: string) => Promise<StepState>
+  insertStepState: (
+    runId: string,
+    stepName: string,
+    rpcName: string,
+    input: unknown,
+    output: undefined,
+    fromStepName?: string
+  ) => Promise<StepState>
+  setStepRunning: (stepId: string) => Promise<void>
+  setStepResult: (stepId: string, result: unknown) => Promise<void>
+  getRunState: (runId: string) => Promise<Record<string, unknown>>
+  updateRunState: (runId: string, key: string, value: unknown) => Promise<void>
+  resumeWorkflow: (runId: string) => Promise<void>
+  scheduleRunWake: (runId: string, delay: number) => Promise<void>
+}
+
+/**
+ * Record a decision against an approval point and wake the run.
+ *
+ * A decision arriving for an already-settled approval is refused rather than
+ * overwriting it: the run has moved on, and a second answer would be recorded
+ * against a gate nobody is waiting at.
+ */
+export const recordApprovalDecision = async (
+  store: ApprovalStore,
+  runId: string,
+  reason: string,
+  decision: unknown
+): Promise<void> => {
+  const stepName = approvalStepNameFor(reason)
+  const stateKey = approvalStateKey(stepName)
+
+  let resolved: StepState | undefined
+  try {
+    resolved = await store.getStepState(runId, stepName)
+  } catch {
+    // knowledge: decisions/security/workflow-approval-payloads-are-validated-on-replay-inside-the-workflow.md
+  }
+  if (resolved?.stepId && resolved.status === 'succeeded') {
+    const outcome = resolved.result as ApprovalOutcome<unknown> | undefined
+    throw new WorkflowApprovalResolvedError(
+      reason,
+      outcome?.status ?? 'decided'
+    )
+  }
+
+  const state = await store.getRunState(runId)
+  const record = (state[stateKey] ?? {}) as Record<string, unknown>
+  await store.updateRunState(runId, stateKey, {
+    ...record,
+    decision,
+    decidedAt: new Date().toISOString(),
+    error: undefined,
+  })
+  await store.resumeWorkflow(runId)
+}
+
+/**
+ * Evaluate an approval gate on replay.
+ *
+ * The payload is validated here rather than where it was submitted, because the
+ * schema is a value on the workflow and only the workflow has it. A payload
+ * that fails validation is cleared and the run suspends again, so a bad
+ * submission cannot settle the gate.
+ */
+export const evaluateApprovalStep = async (
+  store: ApprovalStore,
+  runId: string,
+  reason: string,
+  approvalStepName: string,
+  fromStepName: string | undefined,
+  options: WorkflowApprovalOptions
+): Promise<ApprovalOutcome<unknown>> => {
+  const insert = () =>
+    store.insertStepState(
+      runId,
+      approvalStepName,
+      'pikkuWorkflowApproval',
+      { reason, expiry: options.expiry },
+      undefined,
+      fromStepName
+    )
+
+  let stepState: StepState
+  try {
+    stepState = await store.getStepState(runId, approvalStepName)
+  } catch {
+    stepState = await insert()
+  }
+  if (!stepState.stepId) {
+    stepState = await insert()
+  }
+
+  if (stepState.status === 'succeeded') {
+    return stepState.result as ApprovalOutcome<unknown>
+  }
+
+  const stateKey = approvalStateKey(approvalStepName)
+  let record = ((await store.getRunState(runId))[stateKey] ?? {}) as {
+    decision?: unknown
+    decidedAt?: string
+    expiresAt?: string
+    error?: unknown
+  }
+
+  if (stepState.status === 'pending') {
+    await store.setStepRunning(stepState.stepId)
+    if (options.expiry !== undefined && !record.expiresAt) {
+      const expiry = getDurationInMilliseconds(options.expiry)
+      record = {
+        ...record,
+        expiresAt: new Date(Date.now() + expiry).toISOString(),
+      }
+      await store.updateRunState(runId, stateKey, record)
+      await store.scheduleRunWake(runId, expiry)
+    }
+  }
+
+  if (record.decision !== undefined) {
+    const validation = await options.schema['~standard'].validate(
+      record.decision
+    )
+    if (validation.issues) {
+      await store.updateRunState(runId, stateKey, {
+        ...record,
+        decision: undefined,
+        decidedAt: undefined,
+        error: validation.issues.map((issue) => ({
+          message: issue.message,
+          path: issue.path?.map((segment) =>
+            typeof segment === 'object' ? segment.key : segment
+          ),
+        })),
+      })
+      throw new WorkflowSuspendedException(runId, reason)
+    }
+    const outcome: ApprovalOutcome<unknown> = {
+      status: 'decided',
+      data: validation.value,
+    }
+    await store.setStepResult(stepState.stepId, outcome)
+    return outcome
+  }
+
+  if (record.expiresAt && Date.now() >= Date.parse(record.expiresAt)) {
+    const outcome: ApprovalOutcome<unknown> = { status: 'expired' }
+    await store.setStepResult(stepState.stepId, outcome)
+    return outcome
+  }
+
+  throw new WorkflowSuspendedException(runId, reason)
+}

--- a/packages/core/src/wirings/workflow/workflow-child-run-session.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-child-run-session.test.ts
@@ -1,0 +1,89 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState, resetPikkuState } from '../../pikku-state.js'
+
+const silentLogger = { error() {}, info() {}, warn() {}, debug() {} }
+
+const registerChildWorkflow = (name: string) => {
+  pikkuState(null, 'workflows', 'meta', {
+    [name]: { name, pikkuFuncId: name, source: 'dsl', graphHash: 'h' },
+  } as any)
+  pikkuState(null, 'workflows', 'registrations').set(name, {
+    name,
+    func: async () => undefined,
+  } as any)
+  pikkuState(null, 'function', 'meta', {
+    [name]: {
+      pikkuFuncId: name,
+      inputSchemaName: null,
+      outputSchemaName: null,
+      sessionless: true,
+    },
+  } as any)
+  pikkuState(null, 'function', 'functions').set(name, {
+    func: async () => undefined,
+  } as any)
+}
+
+/**
+ * A step whose rpcName names a workflow starts that workflow as a child. The
+ * child's wire is built by the parent, so whatever identifies the caller has to
+ * be copied across explicitly — nothing else carries it.
+ */
+describe('a child workflow inherits the parent run wire pikkuUserId', () => {
+  const startParentWithChildStep = async (pikkuUserId?: string) => {
+    resetPikkuState()
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: silentLogger,
+    } as any)
+    registerChildWorkflow('childFlow')
+
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('parentFlow', {}, true, '', {
+      type: 'test',
+      ...(pikkuUserId ? { pikkuUserId } : {}),
+    })
+    ws.registerInlineRun(runId)
+    await ws.insertStepState(runId, 'callChild', 'childFlow', {})
+
+    await (ws as any).rpcStep(runId, 'callChild', 'childFlow', {}, {})
+    return ws
+  }
+
+  const childRunWire = async (ws: InMemoryWorkflowService) => {
+    const runs: any[] = []
+    for (const id of (ws as any).runs?.keys?.() ?? []) {
+      const run = await ws.getRun(id)
+      if (run?.workflow === 'childFlow') runs.push(run)
+    }
+    assert.equal(runs.length, 1, 'exactly one child run should have started')
+    return runs[0]!.wire
+  }
+
+  test('the child run wire carries the parent pikkuUserId', async () => {
+    const ws = await startParentWithChildStep('user-abc')
+
+    assert.equal(
+      (await childRunWire(ws)).pikkuUserId,
+      'user-abc',
+      'a child started from a step must inherit who the parent was running as'
+    )
+  })
+
+  test('no pikkuUserId is invented when the parent has none', async () => {
+    const ws = await startParentWithChildStep()
+
+    assert.equal((await childRunWire(ws)).pikkuUserId, undefined)
+  })
+
+  test('the child records its parent', async () => {
+    const ws = await startParentWithChildStep('user-abc')
+    const wire = await childRunWire(ws)
+
+    assert.equal(wire.type, 'workflow')
+    assert.equal(wire.id, 'childFlow')
+    assert.ok(wire.parentRunId, 'the child must name the run that started it')
+  })
+})

--- a/packages/core/src/wirings/workflow/workflow-constants.ts
+++ b/packages/core/src/wirings/workflow/workflow-constants.ts
@@ -1,0 +1,47 @@
+export const DEFAULT_STEP_RETRIES = 5
+
+/** Statuses from which a run never advances again on its own. */
+export const WORKFLOW_END_STATES: ReadonlySet<string> = new Set([
+  'completed',
+  'failed',
+  'cancelled',
+  'suspended',
+])
+
+/** Statuses a run cannot leave at all. */
+export const WORKFLOW_TERMINAL_STATES: ReadonlySet<string> = new Set([
+  'completed',
+  'failed',
+  'cancelled',
+])
+
+export const WORKFLOW_POLL_MIN_MS = 10
+
+export const WORKFLOW_POLL_FACTOR = 1.6
+
+export const WORKFLOW_CHILD_POLL_MAX_MS = 500
+
+/** Idle window before a `running` run with nothing in flight is treated as stalled. */
+export const DEFAULT_STALLED_RUN_MS = 5 * 60_000
+
+/** Runs re-driven per `recoverStalledRuns` call, so one sweep is bounded. */
+export const DEFAULT_STALLED_RUN_LIMIT = 100
+
+/**
+ * How long a step may sit `pending` before the relay assumes its dispatch was
+ * lost. This is a bet that no healthy queue takes this long to move a job from
+ * `pending` to `running`; set it above the observed p99 of that latency.
+ */
+export const DEFAULT_UNDISPATCHED_STEP_MS = 30_000
+
+/** Steps re-driven per `relayUndispatchedSteps` call, so one tick is bounded. */
+export const DEFAULT_UNDISPATCHED_STEP_LIMIT = 100
+
+/** First wait before a step already re-dispatched once is re-dispatched again. */
+export const REDISPATCH_BACKOFF_MS = 30_000
+
+/** Ceiling on the doubling backoff, so a permanently stuck step still gets swept. */
+export const REDISPATCH_BACKOFF_MAX_MS = 10 * 60_000
+
+/** Bound on the in-process backoff map, so a long-lived process cannot grow it without bound. */
+export const REDISPATCH_BACKOFF_MAX_ENTRIES = 10_000

--- a/packages/core/src/wirings/workflow/workflow-dispatch-durability.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-dispatch-durability.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 
 import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
 import { pikkuState } from '../../pikku-state.js'
-import { WorkflowDispatchException } from './pikku-workflow-service.js'
+import { WorkflowDispatchException } from './workflow-errors.js'
 
 function registerDispatchedFn(rpcName: string): void {
   const funcId = `fn:${rpcName}`

--- a/packages/core/src/wirings/workflow/workflow-errors.ts
+++ b/packages/core/src/wirings/workflow/workflow-errors.ts
@@ -1,0 +1,113 @@
+import { PikkuError, addError } from '../../errors/error-handler.js'
+import type { ApprovalOutcome } from './workflow.types.js'
+
+/**
+ * Thrown to unwind a run that cannot continue on this tick. Not a failure:
+ * the run resumes from its recorded step state.
+ */
+export class WorkflowAsyncException extends Error {
+  constructor(
+    public readonly runId: string,
+    public readonly stepName: string
+  ) {
+    super(`Workflow paused at step: ${stepName}`)
+    this.name = 'WorkflowAsyncException'
+  }
+}
+
+export class WorkflowCancelledException extends Error {
+  constructor(
+    public readonly runId: string,
+    public readonly reason?: string
+  ) {
+    super(reason || 'Workflow cancelled')
+    this.name = 'WorkflowCancelledException'
+  }
+}
+
+export class WorkflowSuspendedException extends Error {
+  constructor(
+    public readonly runId: string,
+    public readonly reason: string
+  ) {
+    super(reason || 'Workflow suspended')
+    this.name = 'WorkflowSuspendedException'
+  }
+}
+
+export class WorkflowDispatchException extends Error {
+  constructor(
+    public readonly runId: string,
+    public readonly stepName: string,
+    options?: { cause?: unknown }
+  ) {
+    super(
+      `Failed to dispatch workflow step '${stepName}' (run ${runId})`,
+      options
+    )
+    this.name = 'WorkflowDispatchException'
+  }
+}
+
+export class WorkflowNotFoundError extends PikkuError {
+  constructor(name: string) {
+    super(`Workflow not found: ${name}`)
+  }
+}
+addError(WorkflowNotFoundError, {
+  status: 404,
+  message: 'Workflow not found.',
+})
+
+export class WorkflowRunNotFoundError extends PikkuError {
+  constructor(runId: string) {
+    super(`Workflow run not found: ${runId}`)
+  }
+}
+addError(WorkflowRunNotFoundError, {
+  status: 404,
+  message: 'Workflow run not found.',
+})
+
+export class WorkflowRunFailedError extends PikkuError {
+  public payload: { message?: string }
+  constructor(message?: string) {
+    super(`Workflow run failed: ${message ?? 'unknown'}`)
+    this.payload = { message }
+  }
+}
+addError(WorkflowRunFailedError, {
+  status: 422,
+  message: 'Workflow run failed.',
+})
+
+export class WorkflowRunCancelledError extends PikkuError {
+  constructor() {
+    super('Workflow was cancelled')
+  }
+}
+addError(WorkflowRunCancelledError, {
+  status: 409,
+  message: 'Workflow was cancelled.',
+})
+
+export class WorkflowApprovalResolvedError extends PikkuError {
+  public payload: {
+    reason: string
+    outcome: ApprovalOutcome<unknown>['status']
+  }
+  constructor(reason: string, outcome: ApprovalOutcome<unknown>['status']) {
+    super(`Approval already ${outcome}: ${reason}`)
+    this.payload = { reason, outcome }
+  }
+}
+addError(WorkflowApprovalResolvedError, {
+  status: 409,
+  message: 'Approval has already been resolved.',
+})
+
+export class WorkflowStepNameNotString extends Error {
+  constructor(stepName: unknown) {
+    super(`Workflow step name must be a string. Received: ${typeof stepName}`)
+  }
+}

--- a/packages/core/src/wirings/workflow/workflow-meta-resolver.ts
+++ b/packages/core/src/wirings/workflow/workflow-meta-resolver.ts
@@ -1,0 +1,45 @@
+import { pikkuState } from '../../pikku-state.js'
+import type { WorkflowRuntimeMeta } from './workflow.types.js'
+
+export type ResolvedWorkflowMeta = {
+  meta: WorkflowRuntimeMeta
+  packageName: string | null
+  resolvedName: string
+}
+
+/**
+ * Resolves a workflow name against the root registry, then — for a
+ * `namespace:name` form — against the addon package that claims the namespace.
+ */
+export const resolveWorkflowMeta = (
+  name: string
+): ResolvedWorkflowMeta | null => {
+  const rootMeta = pikkuState(null, 'workflows', 'meta')
+  if (rootMeta[name]) {
+    return { meta: rootMeta[name], packageName: null, resolvedName: name }
+  }
+
+  const colonIndex = name.indexOf(':')
+  if (colonIndex === -1) {
+    return null
+  }
+
+  const namespace = name.substring(0, colonIndex)
+  const localName = name.substring(colonIndex + 1)
+  const addons = pikkuState(null, 'addons', 'packages')
+  const pkgConfig = addons?.get(namespace)
+  if (!pkgConfig) {
+    return null
+  }
+
+  const addonMeta = pikkuState(pkgConfig.package, 'workflows', 'meta')
+  if (!addonMeta?.[localName]) {
+    return null
+  }
+
+  return {
+    meta: addonMeta[localName],
+    packageName: pkgConfig.package,
+    resolvedName: localName,
+  }
+}

--- a/packages/core/src/wirings/workflow/workflow-missing-meta.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-missing-meta.test.ts
@@ -1,0 +1,92 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState, resetPikkuState } from '../../pikku-state.js'
+import { PikkuMissingMetaError } from '../../errors/errors.js'
+import { WorkflowNotFoundError } from './workflow-errors.js'
+
+const silentLogger = { error() {}, info() {}, warn() {}, debug() {} }
+
+const startRun = async (workflowName: string) => {
+  pikkuState(null, 'package', 'singletonServices', {
+    logger: silentLogger,
+  } as any)
+  const service = new InMemoryWorkflowService()
+  const runId = await service.createRun(workflowName, {}, false, '', {
+    type: 'test',
+  })
+  return { service, runId }
+}
+
+describe('a run whose workflow has no generated meta', () => {
+  test('reports missing metadata rather than crashing on an undefined meta', async () => {
+    resetPikkuState()
+    const { service, runId } = await startRun('flowWithoutMeta')
+
+    // The registration exists, so this is not an unknown workflow — codegen or
+    // the generated bootstrap import is what is missing.
+    pikkuState(null, 'workflows', 'registrations').set('flowWithoutMeta', {
+      name: 'flowWithoutMeta',
+      func: async () => undefined,
+    } as any)
+
+    await assert.rejects(
+      service.runWorkflowJob(runId, {}),
+      (error: unknown) => {
+        assert.ok(
+          error instanceof PikkuMissingMetaError,
+          `expected PikkuMissingMetaError, got ${(error as Error)?.constructor?.name}: ${(error as Error)?.message}`
+        )
+        assert.match(String((error as Error).message), /flowWithoutMeta/)
+        return true
+      }
+    )
+  })
+
+  test('a workflow with neither meta nor a registration is still missing meta', async () => {
+    resetPikkuState()
+    const { service, runId } = await startRun('unknownFlow')
+
+    await assert.rejects(
+      service.runWorkflowJob(runId, {}),
+      (error: unknown) => {
+        assert.ok(
+          error instanceof PikkuMissingMetaError,
+          `expected PikkuMissingMetaError, got ${(error as Error)?.constructor?.name}`
+        )
+        return true
+      }
+    )
+  })
+
+  test('a registered workflow that does have meta gets past both guards', async () => {
+    resetPikkuState()
+    const { service, runId } = await startRun('flowWithMeta')
+
+    pikkuState(null, 'workflows', 'meta', {
+      flowWithMeta: {
+        name: 'flowWithMeta',
+        pikkuFuncId: 'flowWithMeta',
+        source: 'dsl',
+      },
+    } as any)
+
+    // Guards the tests above: without this the assertions would pass for a
+    // service that threw PikkuMissingMetaError unconditionally.
+    await assert.rejects(
+      service.runWorkflowJob(runId, {}),
+      (error: unknown) => {
+        assert.ok(
+          !(error instanceof PikkuMissingMetaError),
+          'meta was present, so the missing-meta guard must not fire'
+        )
+        assert.ok(
+          error instanceof WorkflowNotFoundError,
+          `expected WorkflowNotFoundError, got ${(error as Error)?.constructor?.name}`
+        )
+        return true
+      }
+    )
+  })
+})

--- a/packages/core/src/wirings/workflow/workflow-queue-routing.ts
+++ b/packages/core/src/wirings/workflow/workflow-queue-routing.ts
@@ -1,0 +1,85 @@
+import { getSingletonServices, pikkuState } from '../../pikku-state.js'
+import { getDurationInMilliseconds } from '../../time-utils.js'
+import type { JobGroup, JobOptions } from '../queue/queue.types.js'
+import type {
+  WorkflowServiceConfig,
+  WorkflowStepOptions,
+} from './workflow.types.js'
+import { DEFAULT_STEP_RETRIES } from './workflow-constants.js'
+
+export type WorkflowQueueStrategy = 'per-workflow' | 'shared-groups'
+
+const toKebab = (s: string) =>
+  s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+
+export const resolveWorkflowConfig = (): WorkflowServiceConfig => {
+  const workflow = getSingletonServices().config?.workflow
+  return {
+    retries: workflow?.retries ?? DEFAULT_STEP_RETRIES,
+    retryDelay: workflow?.retryDelay ?? 0,
+    orchestratorQueueName:
+      workflow?.orchestratorQueueName ?? 'pikku-workflow-orchestrator',
+    stepWorkerQueueName:
+      workflow?.stepWorkerQueueName ?? 'pikku-workflow-step-worker',
+    sleeperRPCName: workflow?.sleeperRPCName ?? 'pikkuWorkflowSleeper',
+  }
+}
+
+/**
+ * Falls back to the shared queue whenever the dedicated one was not generated
+ * into queue meta, so a workflow added without a rebuild still runs.
+ */
+const dedicatedQueueName = (
+  prefix: string,
+  name: string | undefined,
+  strategy: WorkflowQueueStrategy,
+  fallback: string
+): string => {
+  if (!name || strategy === 'shared-groups') {
+    return fallback
+  }
+  const dedicated = `${prefix}${toKebab(name)}`
+  return pikkuState(null, 'queue', 'meta')[dedicated] ? dedicated : fallback
+}
+
+export const orchestratorQueueName = (
+  strategy: WorkflowQueueStrategy,
+  workflowName?: string
+): string =>
+  dedicatedQueueName(
+    'wf-orchestrator-',
+    workflowName,
+    strategy,
+    resolveWorkflowConfig().orchestratorQueueName
+  )
+
+export const stepWorkerQueueName = (
+  strategy: WorkflowQueueStrategy,
+  rpcName?: string
+): string =>
+  dedicatedQueueName(
+    'wf-step-',
+    rpcName,
+    strategy,
+    resolveWorkflowConfig().stepWorkerQueueName
+  )
+
+export const jobGroupFor = (
+  strategy: WorkflowQueueStrategy,
+  id?: string
+): JobGroup | undefined =>
+  id && strategy === 'shared-groups' ? { id, tier: id } : undefined
+
+export const stepJobOptions = (
+  stepOptions?: WorkflowStepOptions
+): JobOptions => {
+  const retries = stepOptions?.retries ?? DEFAULT_STEP_RETRIES
+  const retryDelay = stepOptions?.retryDelay
+  const backoff =
+    retryDelay !== undefined && retryDelay !== 'exponential'
+      ? { type: 'fixed', delay: getDurationInMilliseconds(retryDelay) }
+      : retries > 0 || retryDelay === 'exponential'
+        ? 'exponential'
+        : undefined
+  return { attempts: retries + 1, ...(backoff ? { backoff } : {}) }
+}

--- a/packages/core/src/wirings/workflow/workflow-queue-wiring.ts
+++ b/packages/core/src/wirings/workflow/workflow-queue-wiring.ts
@@ -1,0 +1,149 @@
+import { addFunction } from '../../function/function-runner.js'
+import { pikkuState } from '../../pikku-state.js'
+import { wireQueueWorker } from '../queue/queue-runner.js'
+import type {
+  GroupConcurrencyConfig,
+  PikkuWorkerConfig,
+} from '../queue/queue.types.js'
+import type { Logger } from '../../services/logger.js'
+import {
+  pikkuWorkflowOrchestratorFunc,
+  pikkuWorkflowSleeperFunc,
+  pikkuWorkflowWorkerFunc,
+} from './workflow-queue-workers.js'
+import type { WorkflowQueueStrategy } from './workflow-queue-routing.js'
+
+const ORCHESTRATOR_QUEUE_PREFIX = 'wf-orchestrator-'
+const STEP_QUEUE_PREFIX = 'wf-step-'
+
+const helperFunctionMeta = (funcId: string) => ({
+  pikkuFuncId: funcId,
+  sessionless: true,
+  functionType: 'helper' as const,
+  inputSchemaName: null,
+  outputSchemaName: null,
+})
+
+export type WorkflowQueueWiringOptions = {
+  strategy: WorkflowQueueStrategy
+  concurrency: number
+  groupConcurrency: number | GroupConcurrencyConfig
+  /**
+   * Resolved only when there is something to warn about: reading the logger
+   * throws while singleton services are uninitialized, and wiring queues before
+   * that point is legitimate.
+   */
+  getLogger: () => Logger | undefined
+}
+
+/**
+ * Registers the orchestrator, step-worker and sleeper functions and binds them
+ * to their queues. Idempotent: a queue already carrying a registered function
+ * is left alone.
+ */
+export const wireWorkflowQueueWorkers = ({
+  strategy,
+  concurrency,
+  groupConcurrency,
+  getLogger,
+}: WorkflowQueueWiringOptions): void => {
+  const functions = pikkuState(null, 'function', 'functions')
+  const functionsMeta = pikkuState(null, 'function', 'meta')
+  const queueMeta = pikkuState(null, 'queue', 'meta')
+
+  const registerWorkflowFunc = (
+    funcId: string,
+    func: { func: unknown },
+    queueName: string,
+    config?: PikkuWorkerConfig
+  ) => {
+    if (functions.has(funcId)) return
+    addFunction(funcId, func as never)
+    if (!queueMeta[queueName]) {
+      queueMeta[queueName] = { pikkuFuncId: funcId, name: queueName }
+    }
+    wireQueueWorker({ name: queueName, func, config } as never)
+    if (!functionsMeta[funcId]) {
+      functionsMeta[funcId] = helperFunctionMeta(funcId)
+    }
+  }
+
+  const sharedGroups = strategy === 'shared-groups'
+  const sharedQueueConfig: PikkuWorkerConfig | undefined = sharedGroups
+    ? { batchSize: concurrency, groupConcurrency }
+    : undefined
+
+  registerWorkflowFunc(
+    'pikkuWorkflowOrchestrator',
+    { func: pikkuWorkflowOrchestratorFunc },
+    'pikku-workflow-orchestrator',
+    sharedQueueConfig
+  )
+  registerWorkflowFunc(
+    'pikkuWorkflowStepWorker',
+    { func: pikkuWorkflowWorkerFunc },
+    'pikku-workflow-step-worker',
+    sharedQueueConfig
+  )
+
+  const registerDedicatedQueues = (meta: Record<string, any>) => {
+    for (const [queueName, entry] of Object.entries(meta)) {
+      if (functions.has(entry.pikkuFuncId)) continue
+      if (queueName.startsWith(ORCHESTRATOR_QUEUE_PREFIX)) {
+        registerWorkflowFunc(
+          entry.pikkuFuncId,
+          { func: pikkuWorkflowOrchestratorFunc },
+          queueName
+        )
+      } else if (queueName.startsWith(STEP_QUEUE_PREFIX)) {
+        registerWorkflowFunc(
+          entry.pikkuFuncId,
+          { func: pikkuWorkflowWorkerFunc },
+          queueName
+        )
+      }
+    }
+  }
+
+  if (!sharedGroups) {
+    registerDedicatedQueues(pikkuState(null, 'queue', 'meta'))
+
+    const addons = pikkuState(null, 'addons', 'packages')
+    for (const [, addon] of addons ?? []) {
+      const addonQueueMeta = pikkuState(addon.package, 'queue', 'meta')
+      if (addonQueueMeta) {
+        registerDedicatedQueues(addonQueueMeta)
+      }
+    }
+  }
+
+  warnOnMissingDedicatedQueues(queueMeta, getLogger)
+
+  if (!functions.has('pikkuWorkflowSleeper')) {
+    addFunction('pikkuWorkflowSleeper', { func: pikkuWorkflowSleeperFunc })
+  }
+  if (!functionsMeta.pikkuWorkflowSleeper) {
+    functionsMeta.pikkuWorkflowSleeper = helperFunctionMeta(
+      'pikkuWorkflowSleeper'
+    )
+  }
+}
+
+const warnOnMissingDedicatedQueues = (
+  queueMeta: Record<string, unknown>,
+  getLogger: () => Logger | undefined
+) => {
+  const workflowCount = Object.keys(
+    pikkuState(null, 'workflows', 'meta') ?? {}
+  ).length
+  const dedicatedQueues = Object.keys(queueMeta).filter((name) =>
+    name.startsWith(ORCHESTRATOR_QUEUE_PREFIX)
+  ).length
+  if (workflowCount > 0 && dedicatedQueues === 0) {
+    getLogger()?.warn?.(
+      `[pikku] ${workflowCount} workflow(s) registered but no per-workflow orchestrator queues were found in queue meta. ` +
+        `All workflows will share a single orchestrator queue, where one slow step blocks every other workflow behind it. ` +
+        `Check that the generated bootstrap imports the queue-workers meta (pikku-queue-workers-wirings-meta.gen.js).`
+    )
+  }
+}

--- a/packages/core/src/wirings/workflow/workflow-recovery.ts
+++ b/packages/core/src/wirings/workflow/workflow-recovery.ts
@@ -1,0 +1,162 @@
+import type { Logger } from '../../services/logger.js'
+import {
+  DEFAULT_STALLED_RUN_LIMIT,
+  DEFAULT_STALLED_RUN_MS,
+  DEFAULT_UNDISPATCHED_STEP_LIMIT,
+  DEFAULT_UNDISPATCHED_STEP_MS,
+  REDISPATCH_BACKOFF_MAX_ENTRIES,
+  REDISPATCH_BACKOFF_MAX_MS,
+  REDISPATCH_BACKOFF_MS,
+} from './workflow-constants.js'
+
+/**
+ * Per-process, advisory record of when a run may next be re-dispatched.
+ *
+ * Keyed by run rather than by step because the run is the unit of re-drive:
+ * `resumeWorkflow` replays the whole run and re-dispatches every step still
+ * owed a job, so holding off a single step while resuming its run would
+ * suppress nothing.
+ *
+ * Losing this on restart costs extra dispatches, never correctness.
+ */
+export class RedispatchBackoff {
+  private readonly eligibleAt = new Map<string, number>()
+  private readonly delays = new Map<string, number>()
+
+  public isEligible(runId: string, now: number): boolean {
+    const at = this.eligibleAt.get(runId)
+    return at === undefined || at <= now
+  }
+
+  public note(runId: string, now: number): void {
+    const previous = this.delays.get(runId)
+    const delay = Math.min(
+      previous === undefined ? REDISPATCH_BACKOFF_MS : previous * 2,
+      REDISPATCH_BACKOFF_MAX_MS
+    )
+    // A run that settles is never returned again, so entries are only evicted
+    // by this bound — oldest first, which is also least recently re-dispatched.
+    if (this.eligibleAt.size >= REDISPATCH_BACKOFF_MAX_ENTRIES) {
+      const oldest = this.eligibleAt.keys().next()
+      if (!oldest.done) {
+        this.eligibleAt.delete(oldest.value)
+        this.delays.delete(oldest.value)
+      }
+    }
+    this.delays.set(runId, delay)
+    this.eligibleAt.set(runId, now + delay)
+  }
+}
+
+type SweepDeps = {
+  resume: (runId: string) => Promise<void>
+  logger?: Logger
+}
+
+const resumeEach = async (
+  runIds: Iterable<string>,
+  { resume, logger }: SweepDeps,
+  failure: (runId: string, detail: string) => string
+): Promise<string[]> => {
+  const succeeded: string[] = []
+  for (const runId of runIds) {
+    try {
+      await resume(runId)
+      succeeded.push(runId)
+    } catch (err) {
+      // One unresumable run must not stop the sweep from recovering the rest.
+      logger?.error(
+        failure(runId, err instanceof Error ? err.message : String(err))
+      )
+    }
+  }
+  return succeeded
+}
+
+/**
+ * Re-drive runs whose next move was lost, and report which were resumed.
+ *
+ * Arming a step is two writes to two systems — the step row, then the queue or
+ * scheduler job — so a process that dies between them leaves a run that is
+ * `running` with nothing in flight. Nothing notices: the run parks on a step
+ * that will never complete and never error, so it neither finishes nor fails.
+ * (Seen on a `workflow.sleep()`: a deploy restart landed between the sleep
+ * step's insert and its timer, parking the run permanently.)
+ *
+ * Replay is the recovery — `resumeWorkflow` re-orchestrates from persisted step
+ * state, and every settled step is memoized, so resuming a run that was not
+ * actually stuck costs an orchestration pass and changes nothing. That
+ * idempotence is what makes an idle-time heuristic safe here; a run that is
+ * legitimately mid-sleep is excluded anyway, since its step is `scheduled`.
+ */
+export const sweepStalledRuns = async (
+  findStalledRunIds: (before: Date, limit: number) => Promise<string[]>,
+  options: { stalledAfterMs?: number; limit?: number } | undefined,
+  deps: SweepDeps
+): Promise<{ resumed: string[] }> => {
+  const before = new Date(
+    Date.now() - (options?.stalledAfterMs ?? DEFAULT_STALLED_RUN_MS)
+  )
+  const runIds = await findStalledRunIds(
+    before,
+    options?.limit ?? DEFAULT_STALLED_RUN_LIMIT
+  )
+  return {
+    resumed: await resumeEach(
+      runIds,
+      deps,
+      (runId, detail) =>
+        `Failed to resume stalled workflow run ${runId}: ${detail}`
+    ),
+  }
+}
+
+/**
+ * Re-drive steps whose dispatch was lost, and report which runs were nudged.
+ *
+ * The step row is the outbox record and this is the relay. Age is the only
+ * signal available — a step `pending` because its dispatch was lost is
+ * indistinguishable from one whose job is merely still queued — so a step past
+ * `undispatchedAfterMs` is re-dispatched regardless, and correctness rests on
+ * the claim in `executeWorkflowStepInner` rather than on the guess being right.
+ * A redundant dispatch costs one queue message: the loser reads `running` and
+ * returns without invoking anything.
+ *
+ * Re-dispatches back off per run (doubling from 30s, capped at 10m) so a
+ * genuine queue backlog is not amplified by a tick that keeps firing at the
+ * steps the backlog is already delaying.
+ */
+export const sweepUndispatchedSteps = async (
+  findUndispatchedSteps: (
+    before: Date,
+    limit: number
+  ) => Promise<Array<{ runId: string; stepId: string }>>,
+  backoff: RedispatchBackoff,
+  options: { undispatchedAfterMs?: number; limit?: number } | undefined,
+  deps: SweepDeps
+): Promise<{ redispatched: string[] }> => {
+  const before = new Date(
+    Date.now() - (options?.undispatchedAfterMs ?? DEFAULT_UNDISPATCHED_STEP_MS)
+  )
+  const steps = await findUndispatchedSteps(
+    before,
+    options?.limit ?? DEFAULT_UNDISPATCHED_STEP_LIMIT
+  )
+
+  const now = Date.now()
+  const runIds = new Set<string>()
+  for (const { runId } of steps) {
+    if (!backoff.isEligible(runId, now)) continue
+    backoff.note(runId, now)
+    runIds.add(runId)
+  }
+
+  return {
+    redispatched: await resumeEach(
+      runIds,
+      deps,
+      (runId, detail) =>
+        `Failed to re-dispatch workflow run ${runId}: ${detail}`
+    ),
+  }
+}

--- a/packages/core/src/wirings/workflow/workflow-retry-policy.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-retry-policy.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 
 import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
 import { pikkuState } from '../../pikku-state.js'
-import { DEFAULT_STEP_RETRIES } from './pikku-workflow-service.js'
+import { DEFAULT_STEP_RETRIES } from './workflow-constants.js'
 import type { PikkuWorkflowService } from './pikku-workflow-service.js'
 import { deriveInvocationId } from './workflow-invocation-id.js'
 import type { WorkflowStepOptions } from './workflow.types.js'

--- a/packages/core/src/wirings/workflow/workflow-run-engine.types.ts
+++ b/packages/core/src/wirings/workflow/workflow-run-engine.types.ts
@@ -1,0 +1,91 @@
+import type { PikkuRawWire, SerializedError } from '../../types/core.types.js'
+import type {
+  CoreWorkflow,
+  PikkuWorkflowWire,
+  StepState,
+  WorkflowRun,
+  WorkflowStatus,
+  WorkflowStepOptions,
+} from './workflow.types.js'
+
+export interface RunLifecycleContext {
+  runId: string
+  run: WorkflowRun
+  workflowMeta: any
+  workflow: CoreWorkflow
+  wire: PikkuRawWire
+  packageName: string | null
+}
+
+/**
+ * The subset of the workflow service a step executor is allowed to call back
+ * into.
+ */
+export interface WorkflowRunEngine {
+  inlineStep(
+    runId: string,
+    logicalStepName: string,
+    fn: Function,
+    stepOptions?: WorkflowStepOptions,
+    data?: any,
+    funcName?: string
+  ): Promise<any>
+  updateRunStatus(
+    runId: string,
+    status: WorkflowStatus,
+    output?: any,
+    error?: SerializedError
+  ): Promise<void>
+  onChildWorkflowFailed(run: WorkflowRun, error: unknown): Promise<void>
+  verifyStepName(stepName: unknown): void
+}
+
+/**
+ * Hooks a host may install to decorate runs it did not start. Used by the
+ * scenario service to attach its own per-run state.
+ */
+export interface WorkflowRunExtension {
+  attachRunContext(
+    runId: string,
+    workflowMeta: any,
+    options?: Record<string, any>
+  ): Promise<void>
+  detachRunContext(runId: string): void
+  decorateRunWire(
+    wire: PikkuRawWire,
+    context: {
+      runId: string
+      workflowMeta: any
+      workflowWire: PikkuWorkflowWire
+    }
+  ): void
+  decorateWorkflowWire(
+    workflowWire: PikkuWorkflowWire,
+    context: {
+      name: string
+      runId: string
+      rpcService: any
+      addonNamespace?: string | null
+    }
+  ): void
+  onBeforeRunFunc(context: RunLifecycleContext): Promise<void>
+  onAfterRunFunc(
+    context: RunLifecycleContext,
+    outcome: 'completed' | 'failed' | 'interrupted',
+    failure: unknown
+  ): Promise<void>
+}
+
+/**
+ * Per-run bookkeeping held only for the lifetime of an in-process execution.
+ */
+export type RunContext = {
+  activeExecutions: number
+  inline?: boolean
+  ordinals: Map<string, number>
+  lastStep?: string
+  replay?: {
+    steps?: Map<string, StepState>
+    run?: WorkflowRun
+  }
+}


### PR DESCRIPTION
Closes #1182.

**Fifth in the core-surface stack.** Targets #1189 — review that one first; this diff is only the fifth commit.

`pikku-workflow-service.ts` had reached **2325 lines**, with the run lifecycle, error catalog, run-engine interfaces, queue routing, queue wiring, approvals and recovery all in one module. It is now **1993**, and the pieces live where they can be read and tested apart:

| module | what moved |
|---|---|
| `workflow-errors.ts` | the error catalog |
| `workflow-run-engine.types.ts` | run-engine interfaces |
| `workflow-constants.ts` | timing and limit constants |
| `workflow-meta-resolver.ts` | meta lookup |
| `workflow-queue-routing.ts` | queue and group name resolution |
| `workflow-queue-wiring.ts` | worker wiring |
| `workflow-approval.ts` | the approval path |
| `workflow-recovery.ts` | stalled-run and undispatched-step recovery |

`@pikku/core/workflow` exports the same names, and importers point at the real modules rather than re-export shims. `source-files-stay-composable.test.ts` holds a **2000-line ceiling for every module in the package** — the split is only worth doing if it stays done.

## Two defects the split surfaced

Both were held in place by an `any`. Typing the meta resolver and the `rpcService` parameter is what exposed them, which is why they are fixed here rather than separately.

### A run with no generated metadata crashed instead of saying so

It threw `TypeError: Cannot read properties of undefined` from deep inside the runner, or `WorkflowNotFoundError` — neither of which points at the cause. It now throws `PikkuMissingMetaError`, matching how the queue and trigger runners already report the same condition.

### A child workflow ran as nobody

The service filled its wires from `rpcService.wire?.session`, `.rpc` and `.pikkuUserId`. **`PikkuRPC` has no `wire`**, and neither does the object the RPC service actually returns — so every one of those reads was `undefined`, and `rpcService: any` is what kept it quiet. The visible consequence: a child workflow started from a step ran with no user.

Those reads now come from the run record, which is durable and survives the process boundary a queued step crosses. `session` and `rpc` are not copied at all — `runPikkuFunc` attaches `rpc` lazily per invocation and resolves the session from the store, so both were overwritten moments later regardless.

`PikkuRPC` also now declares `rpcWithWire`, which the RPC service has always returned and the workflow service has always called.

[A knowledge note](packages/core/knowledge/decisions/internals/a-workflow-wire-is-built-from-the-run-not-from-the-rpc-service.md) records the reasoning, and is added to the internals index in filename order.

### Verification

| check | result |
|---|---|
| `@pikku/core` full suite | 2024 pass, 0 fail |
| `@pikku/core` `tsc` | clean |
| `source-files-stay-composable` / `workflow-missing-meta` / `workflow-child-run-session` / `no-any-casts` | 9/9 |
| largest module in the package | 1993 lines, under the 2000 ceiling |

`public-surface.json` is untouched — the API pin PR (#1184) owns the generated artifacts and regenerates them once, at the end of the stack.
