### PR TITLE
fix(cli): pin @pikku/node-http-server with the rest of the bootstrap set

### DIFF
--- a/.changeset/pin-node-http-server-in-cli-bootstrap.md
+++ b/.changeset/pin-node-http-server-in-cli-bootstrap.md
@@ -1,0 +1,13 @@
+---
+'@pikku/cli': patch
+---
+
+Pin `@pikku/node-http-server` in the CLI bootstrap
+
+The bootstrap installs published `@pikku/*` packages into a temp directory to run
+codegen, and pinned only `@pikku/core`. `@pikku/node-http-server` arrived
+transitively through the CLI's `^0.12.7`, so it floated to the newest release
+while the pin held core still. When a release wave published node-http-server
+0.12.8 — which imports `@pikku/core/node-host-resolver` — one second before core
+0.12.79, the first core to export that subpath, every bootstrap died on a missing
+export in a package the pin never named.

--- a/packages/cli/build.sh
+++ b/packages/cli/build.sh
@@ -34,7 +34,17 @@ echo "Bootstrapping with published @pikku/cli..."
 : "${PIKKU_BETTER_AUTH_VERSION:=0.12.20}"
 # core is a *peer* of both the CLI and the inspector, which is why it has to be
 # named here to exist at all once peer resolution is off.
-: "${PIKKU_CORE_VERSION:=0.12.77}"
+: "${PIKKU_CORE_VERSION:=0.12.79}"
+# @pikku/node-http-server is the third member of this family to need naming, and
+# it arrives the same way @pikku/kysely did: transitively, through the CLI's
+# `^0.12.7`, so it floats to the newest release while `overrides` holds core
+# still. The 2026-08-06 09:08 wave published node-http-server 0.12.8 — which
+# imports `@pikku/core/node-host-resolver` — one second before core 0.12.79, the
+# first core to export that subpath. The pin held core at 0.12.77, so the new
+# server landed on the old core and every bootstrap died on a missing export, in
+# a package the pin never mentioned. main went red without a commit to blame:
+# its last green run had started twenty-one minutes before the wave.
+: "${PIKKU_NODE_HTTP_SERVER_VERSION:=0.12.8}"
 # @pikku/kysely is an ordinary *dependency* of the CLI, so unlike the peers above
 # it installs whether or not it is named — and left unnamed it floats on the
 # CLI's `^0.13.7`, which means the newest release wave, not the wave this pin
@@ -74,6 +84,7 @@ cat > "$_bootstrap_dir/package.json" <<JSON
     "@pikku/inspector": "${PIKKU_INSPECTOR_VERSION}",
     "@pikku/better-auth": "${PIKKU_BETTER_AUTH_VERSION}",
     "@pikku/core": "${PIKKU_CORE_VERSION}",
+    "@pikku/node-http-server": "${PIKKU_NODE_HTTP_SERVER_VERSION}",
     "@pikku/kysely": "${PIKKU_KYSELY_VERSION}",
     "better-auth": "${BETTER_AUTH_LIB_VERSION}"
   },
@@ -81,6 +92,7 @@ cat > "$_bootstrap_dir/package.json" <<JSON
     "@pikku/better-auth": "${PIKKU_BETTER_AUTH_VERSION}",
     "@pikku/inspector": "${PIKKU_INSPECTOR_VERSION}",
     "@pikku/core": "${PIKKU_CORE_VERSION}",
+    "@pikku/node-http-server": "${PIKKU_NODE_HTTP_SERVER_VERSION}",
     "@pikku/kysely": "${PIKKU_KYSELY_VERSION}",
     "better-auth": "${BETTER_AUTH_LIB_VERSION}"
   }


### PR DESCRIPTION
Closes #1194.

**This unblocks `main` and every open PR.** All of them fail the Build job identically, and none of them caused it.

### What broke

`packages/cli/build.sh` pins the CLI, inspector, better-auth, core and kysely, but not `@pikku/node-http-server`. It arrives transitively through the CLI's `^0.12.7`, so it floats to the newest release while `overrides` holds core still.

On 2026-08-06 the 09:08 release wave published, in this order:

| time | package | |
|---|---|---|
| 09:08:19 | `@pikku/node-http-server@0.12.8` | depends on core `^0.12.79`, imports `@pikku/core/node-host-resolver` |
| 09:08:20 | `@pikku/core@0.12.79` | first core to export `./node-host-resolver` |

The pin held core at 0.12.77. The floating server landed on the pinned older core and every bootstrap has died since:

```
Failed to run Pikku CLI: Package subpath './node-host-resolver' is not defined by
"exports" in .../node_modules/@pikku/core/package.json imported from
.../node_modules/@pikku/node-http-server/dist/pikku-node-http-server.js
```

`main`'s last green run started at 08:47 — twenty-one minutes before the wave — so it went red with no commit to blame, and #1159's green tick is from the same morning. Nothing since has passed Build.

### The fix

This is the failure mode `build.sh`'s own comments already record for `@pikku/kysely`: an unpinned member of a release wave lands next to a pinned older core. It gets the same remedy — name it, and move core up with it. Every pinned peer range accepts 0.12.79:

| package | peer on core | 0.12.79 |
|---|---|---|
| `@pikku/cli@0.12.96` | `^0.12.74` | ✅ |
| `@pikku/inspector@0.12.52` | `^0.12.74` | ✅ |
| `@pikku/kysely@0.13.10` | `^0.12.77` | ✅ |
| `@pikku/better-auth@0.12.20` | `^0.12.73` | ✅ |

### Verification

- Reproduced the bootstrap install with the new pins: resolves core 0.12.79 / node-http-server 0.12.8, and importing `@pikku/node-http-server` — the exact import CI died on — succeeds.
- `yarn build:packages` (the step CI runs) exits 0.

No changeset: this changes how the CLI is built, not anything it publishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bootstrap build to use the latest compatible core package version.
  * Added configurable versioning for the Node HTTP server package, with a default version provided.
  * Ensured the temporary bootstrap configuration consistently applies the selected package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->