### PR TITLE
docs(core,cli): say the scenario-context rationale once

### DIFF
--- a/packages/cli/src/functions/commands/scenario.ts
+++ b/packages/cli/src/functions/commands/scenario.ts
@@ -535,10 +535,9 @@ export const scenarioRun = pikkuSessionlessFunc<
      * scenario body gets, the CLI's own singletons included, and its result is
      * discarded.
      *
-     * The context is *feature*-scoped: `before` and `after` of one feature share
-     * it, so setup can hand teardown the ids it created. It is deliberately not
-     * the context the scenarios in the group see — sharing one bag across a
-     * group is the invisible coupling a Cucumber world had.
+     * Its context is *feature*-scoped — shared by that feature's `before` and
+     * `after`, and deliberately not the context the group's scenarios see:
+     * one bag across a group is the invisible coupling a Cucumber world had.
      */
     const singletonServices = pikkuState(null, 'package', 'singletonServices')
     const runFeatureHook = async (

--- a/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
@@ -317,15 +317,10 @@ export const pikkuApprovalDescription = <In = unknown, RequiredServices extends 
  * @template In - The input type
  * @template Out - The output type that the function returns
  * @template RequiredServices - Services required by this function
- * @template ScenarioOut - Types \`scenario.context\`. Only scenarios set it:
- *   \`PikkuFunctionScenario\` passes the scenario's own output, and a *hook*
- *   passes the output of the scenario it belongs to (it returns void itself).
- *
- *   It deliberately does NOT default to \`Out\`. That would make every ordinary
- *   function's wire type vary with its return type, and a \`func\` written
- *   against the \`PikkuFunction | PikkuFunctionSessionless\` union then loses
- *   contextual typing — its parameters fall back to \`any\` and the assignment
- *   fails with no hint as to why.
+ * @template ScenarioOut - Types \`scenario.context\`; only scenarios set it.
+ *   Not defaulted to \`Out\`, which would make every ordinary function's wire
+ *   type vary with its return type and cost a \`func\` written against the
+ *   \`PikkuFunction | PikkuFunctionSessionless\` union its contextual typing.
  */
 export type PikkuFunctionSessionless<
   In = unknown,
@@ -379,10 +374,8 @@ export type PikkuFunctionConfig<
   In = unknown,
   Out = unknown,
   RequiredWires extends keyof PikkuWire = never,
-  // \`any\` in the ScenarioOut slot, not \`unknown\`: a scenario body types its
-  // context as its own output, and a constraint pinned to one context type
-  // would refuse it. \`ScenarioContext<any>\` collapses to \`any\`, so the
-  // constraint stays open on that axis alone.
+  // \`any\` in the ScenarioOut slot: a constraint pinned to one context type
+  // would refuse a scenario body, which types its context as its own output.
   PikkuFunc extends PikkuFunction<In, Out, RequiredWires, any> | PikkuFunctionSessionless<In, Out, RequiredWires, any, any> = PikkuFunction<In, Out, RequiredWires> | PikkuFunctionSessionless<In, Out, RequiredWires>,
   InputSchema extends StandardSchemaV1 | undefined = undefined,
   OutputSchema extends StandardSchemaV1 | undefined = undefined

--- a/packages/cli/src/functions/wirings/workflow/scenario-hook.compile.test.ts
+++ b/packages/cli/src/functions/wirings/workflow/scenario-hook.compile.test.ts
@@ -137,8 +137,7 @@ describe('pikkuScenarioHook', () => {
   })
 
   test('a hook reads the context as a partial of the scenario output', () => {
-    // The point of the context: teardown learns the ids the body minted, and
-    // `Partial` is what makes it honest — a run that failed before creating the
+    // `Partial` is what makes it honest: a run that failed before creating the
     // project has no projectId, so the hook is forced to handle its absence.
     assert.deepEqual(
       typeErrors(`

--- a/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.ts
+++ b/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.ts
@@ -79,10 +79,7 @@ export interface TypedScenarioSteps {
   ): Promise<FlattenedScenarioStepMap[K]['output']>
 }
 
-/**
- * \`Out\` types \`scenario.context\` — the scratch the body shares with its
- * \`before\`/\`after\` hooks — as a partial of what a completed run produces.
- */
+/** \`Out\` types \`scenario.context\`. */
 export type TypedScenario<Out = unknown> = TypedWorkflow &
   Omit<PikkuScenarioWire<Out>, keyof PikkuWorkflowWire | keyof TypedScenarioSteps> &
   TypedScenarioSteps
@@ -99,9 +96,9 @@ export type PikkuFunctionWorkflow<
 > = PikkuFunctionSessionless<In, Out, 'workflow'>
 
 /**
- * \`Ctx\` types \`scenario.context\` and defaults to the function's own output,
- * which is what a scenario body wants. A hook returns void but shares the
- * scenario's context, so it passes the scenario's output here instead.
+ * \`Ctx\` types \`scenario.context\`, defaulting to the body's own output. A hook
+ * returns void but shares the scenario's context, so it passes that scenario's
+ * output here instead.
  */
 export type PikkuFunctionScenario<
   In = unknown,
@@ -193,10 +190,8 @@ export type PikkuScenarioConfigWithSchema<
    * Always runs after the scenario body, in a \`finally\`, whether it passed or
    * failed. Throwing fails a run that would otherwise have passed; on an
    * already-failed run it attaches as the \`cause\` and never replaces the
-   * original error.
-   *
-   * Reads \`scenario.context\` for whatever the body managed to record before it
-   * stopped — that is how teardown learns the ids a failed run created.
+   * original error. Reads \`scenario.context\` for whatever the body managed to
+   * record before it stopped.
    */
   after?: PikkuScenarioHook<InputSchema, OutputSchema>
   /**
@@ -210,11 +205,8 @@ export type PikkuScenarioConfigWithSchema<
 
 /**
  * A scenario lifecycle hook: the scenario's own \`(services, data, wire)\`
- * signature with its result discarded.
- *
- * The hook returns void but shares the scenario's \`context\`, so the output
- * schema types \`scenario.context\` while the return type stays \`void\` — a hook
- * is setup and teardown, never a step, and nothing it returns is recorded.
+ * signature with its result discarded. \`OutputSchema\` types
+ * \`scenario.context\` while the return type stays \`void\`.
  */
 export type PikkuScenarioHook<
   InputSchema extends StandardSchemaV1 | undefined = undefined,

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -383,10 +383,9 @@ export type PikkuWire<
   MCPTools extends string | never = never,
   TypedWorkflow extends PikkuWorkflowWire | never = PikkuWorkflowWire,
   TriggerOutput = unknown,
-  // Defaulted to `any` rather than to `Out`: the emitted `TypedScenario<Out>`
-  // supplies the real context, while `PikkuWire`'s own defaults are what other
-  // generics constrain against — and a constraint that pinned the context to
-  // `Out` would reject every wire whose scenario output is anything else.
+  // `any`, not `Out`: the emitted `TypedScenario<Out>` supplies the real
+  // context, and this default is what other generics constrain against. See
+  // `ScenarioContext`.
   TypedScenario extends PikkuScenarioWire<any> | never = PikkuScenarioWire<any>,
   TypedActors extends ScenarioPersonas = ScenarioPersonas,
 > = {

--- a/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
+++ b/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
@@ -545,15 +545,14 @@ export interface PikkuWorkflowWire {
 /**
  * What a scenario has accumulated so far, shared by its body and its hooks.
  *
- * Typed as a partial of the scenario's own output because a scenario can fail
- * at any step: the shape describes what a *completed* run produces, and the
- * context holds however much of it this run reached. A scenario declaring no
- * object output gets an open record rather than `Partial<never>`.
+ * `Partial` because a scenario can fail at any step: `Out` describes what a
+ * *completed* run produces, and the context holds however much of it this run
+ * reached.
  *
- * `any` collapses to `any`, not to the union of both branches. `PikkuWire`'s
- * default depends on that: the wire type is also used as a generic *constraint*,
- * and a constraint carrying a concrete context would reject every wire whose
- * scenario output differs from it.
+ * The `0 extends 1 & Out` branch keeps `any` collapsing to `any` rather than to
+ * the union of the other two. `PikkuWire` and `PikkuFunctionConfig` both use
+ * this type as a generic *constraint*, and a constraint carrying a concrete
+ * context would reject every wire whose scenario output differs from it.
  */
 export type ScenarioContext<Out = unknown> = 0 extends 1 & Out
   ? any
@@ -563,12 +562,9 @@ export type ScenarioContext<Out = unknown> = 0 extends 1 & Out
 
 export interface PikkuScenarioWire<Out = unknown> extends PikkuWorkflowWire {
   /**
-   * Scratch the body writes and the `before`/`after` hooks read.
-   *
-   * A hook is a separate function, so it cannot see the body's locals — which
-   * is why teardown had nowhere to learn the ids the body minted. Assigning
-   * them here (`scenario.context.projectId = project.projectId`) hands them to
-   * `after`, which runs in a `finally` and so cleans up on a failed run too.
+   * Scratch the body writes and the `before`/`after` hooks read. A hook is a
+   * separate function and cannot see the body's locals, so this is how teardown
+   * learns the ids the body minted.
    *
    * Deliberately *not* a world: it is scoped to one run, and scenario steps
    * cannot reach it. Steps stay pure functions of their declared inputs, so the

--- a/packages/core/src/wirings/workflow/pikku-scenario-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-scenario-service.ts
@@ -246,9 +246,9 @@ export class PikkuScenarioService implements WorkflowRunExtension {
   // Scenario actors per run: live authenticated clients (cookie jars) are
   // process-local by nature, so they ride this map, never the persisted wire.
   private runActors = new Map<string, ScenarioPersonas>()
-  // What each run has accumulated so far. Process-local like the actors above:
-  // a scenario is a single in-process run, so the body and its hooks share one
-  // object rather than reading it back off the persisted wire.
+  // What each run has accumulated so far — process-local like the actors above,
+  // so the body and its hooks share one object rather than reading it back off
+  // the persisted wire.
   private runContexts = new Map<string, Record<string, unknown>>()
   private scenarioBrowserProvider?: ScenarioBrowserProvider
   private scenarioEnvironment?: ScenarioEnvironment
@@ -319,20 +319,14 @@ export class PikkuScenarioService implements WorkflowRunExtension {
     this.runContexts.delete(runId)
   }
 
-  /**
-   * What the run has accumulated, for a reporter that wants to say what a
-   * failed scenario left behind. Undefined for a plain workflow.
-   */
+  /** What the run has accumulated. Undefined for a plain workflow. */
   public getRunContext(runId: string): Record<string, unknown> | undefined {
     return this.runContexts.get(runId)
   }
 
   /**
-   * The run's context, created on demand.
-   *
-   * `attachRunContext` seeds it for an ordinary scenario run, but the wire is
-   * also built on paths that skip attach; without this the body would be
-   * writing to an `undefined` and teardown would read nothing.
+   * The run's context, created on demand because the wire is also built on
+   * paths that skip `attachRunContext`.
    */
   private contextForRun(runId: string): Record<string, unknown> {
     let runContext = this.runContexts.get(runId)
@@ -540,9 +534,6 @@ export class PikkuScenarioService implements WorkflowRunExtension {
       rpcService,
     })
     Object.assign(workflowWire, {
-      // One object per run, resolved through the map rather than created here,
-      // so the body and its before/after hooks share the same scratch even
-      // though the hooks are separate functions that cannot see its locals.
       context: this.contextForRun(runId),
 
       // Durable polling step: invoke an RPC (as an actor when options.as is

--- a/packages/core/src/wirings/workflow/pikku-scenario-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-scenario-service.ts
@@ -319,7 +319,13 @@ export class PikkuScenarioService implements WorkflowRunExtension {
     this.runContexts.delete(runId)
   }
 
-  /** What the run has accumulated. Undefined for a plain workflow. */
+  /**
+   * What the run has accumulated.
+   *
+   * Undefined only for a run whose wire was never decorated — decoration calls
+   * `contextForRun` unconditionally, so a plain workflow that has reached a
+   * step holds an empty context rather than none.
+   */
   public getRunContext(runId: string): Record<string, unknown> | undefined {
     return this.runContexts.get(runId)
   }

--- a/packages/core/src/wirings/workflow/scenario-hooks.test.ts
+++ b/packages/core/src/wirings/workflow/scenario-hooks.test.ts
@@ -185,8 +185,9 @@ describe('scenario before/after hooks', () => {
   })
 
   test('after reads what the body wrote to the scenario context', async () => {
-    // The reason the context exists: a hook only ever receives the run's
-    // *input*, never what the body produced.
+    // The reason the context exists: a hook's `data` is only ever the run's
+    // *input*, never what the body produced. The context is the channel the
+    // body writes that through, and it reaches the hook on the shared wire.
     let seen: any
     await runScenario('contextHandover', {
       after: async (_services, _data, wire) => {

--- a/packages/core/src/wirings/workflow/scenario-hooks.test.ts
+++ b/packages/core/src/wirings/workflow/scenario-hooks.test.ts
@@ -185,8 +185,8 @@ describe('scenario before/after hooks', () => {
   })
 
   test('after reads what the body wrote to the scenario context', async () => {
-    // The reason the context exists: teardown needs the ids the body minted,
-    // and a hook only ever receives the run's *input*.
+    // The reason the context exists: a hook only ever receives the run's
+    // *input*, never what the body produced.
     let seen: any
     await runScenario('contextHandover', {
       after: async (_services, _data, wire) => {


### PR DESCRIPTION
#1197 repeated the same two explanations across six files: why `ScenarioContext` is a `Partial`, and why `any` has to collapse to `any` for the type to survive being used as a generic constraint. Both now live on `ScenarioContext` itself, where the conditional type they describe is, and the echoes elsewhere are pointers rather than restatements.

The two serializer templates are trimmed hardest — comments inside them are emitted into every user's generated code, so an essay there is one they cannot delete.

No behaviour change; comments only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified scenario context behavior across workflow bodies and hooks.
  * Documented how context is shared between `before` and `after` hooks and remains scoped to each feature run.
  * Clarified partial output handling during teardown and the distinction between scenario and scenario-group context.
  * Updated type and workflow documentation to better explain context defaults and data flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->