### PR TITLE
fix(templates): declare the todo CLI channel unauthenticated

### DIFF
--- a/templates/functions/src/wirings/cli.wiring.ts
+++ b/templates/functions/src/wirings/cli.wiring.ts
@@ -15,6 +15,7 @@ import {
 
 wireCLI({
   program: 'todo-cli',
+  auth: false,
   commands: {
     list: pikkuCLICommand({
       func: listTodos,


### PR DESCRIPTION
main is red on three jobs — `Templates (24, cli, yarn)`, `Template Functions Runtimes (24, dev)` and `(24, standalone)` — all with the same failure:

```
Matched channel: todo-cli-cli | route: /cli/todo-cli | auth: true
Channel todo-cli-cli … requires a session for route 'command:__raw'.
Error: Authentication required
```

#1174 made the generated CLI channel session-required by default, so it matches core's `auth !== false` rather than the old inverted `auth === true`. That change is right. What it exposed is that the functions template's `todo-cli` program declares no `auth` at all, so it silently inherited the new default — and `client/cli-raw.ts` opens a bare websocket with no credentials.

The template's todo surface is deliberately open: `todos.http.ts` and `sse.wiring.ts` both set `auth: false`. The CLI serving the same functions now says so explicitly instead of leaning on a default.

Regenerating `templates/functions` with this in place emits `auth: false` on the channel and drops the `cliRequireSession` onConnect guard, which is what the raw client needs. The generated wiring is gitignored, so the one-line source change is the whole diff.

Verified locally: `yarn build` clean, `yarn test` clean apart from the unrelated `crypto-utils` wall-clock budget flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
