### PR TITLE
chore: release @pikku/ws so the /ecosystem move reaches npm

### DIFF
--- a/.changeset/ws-release-ecosystem-import.md
+++ b/.changeset/ws-release-ecosystem-import.md
@@ -1,0 +1,18 @@
+---
+'@pikku/ws': patch
+---
+
+Release the `/ecosystem` import fix so the server loads against core 0.12.80
+
+`pikku-ws-server.ts` was moved onto `@pikku/core/ecosystem` alongside every other adapter in #1191, but that changeset listed only `@pikku/core`. `@pikku/ws` declares core as a peer dependency rather than a dependency, so changesets had no edge to follow and never bumped it — the source fix landed on `main` while npm kept serving the pre-move build.
+
+The result is a version pair that resolves cleanly and then dies at import: `@pikku/ws@0.12.5` reaches for `getSingletonServices` on the package root, `@pikku/core@0.12.80` has moved it, and the CLI aborts before it does any work.
+
+```
+Failed to run Pikku CLI: The requested module '@pikku/core' does not
+provide an export named 'getSingletonServices'
+```
+
+Nothing else needs republishing. Of the twenty packages touched by #1191, the rest either got bumped in that release or changed in ways the old root still satisfies; `@pikku/ws` was the only one holding a moved symbol.
+
+No source change here — this exists to give the fix already on `main` a version number.


### PR DESCRIPTION
## What

Adds a patch changeset for `@pikku/ws`. No source change — the fix is already on `main`.

## Why

#1191 moved the adapter surface onto `@pikku/core/ecosystem` and updated `packages/runtimes/ws/src/pikku-ws-server.ts` along with every other adapter. Its changeset listed only `@pikku/core`.

`@pikku/ws` takes core as a **peer** dependency rather than a dependency, so changesets had no edge to follow and never bumped it. #1198 published `@pikku/core@0.12.80` and left `@pikku/ws` at `0.12.5` — the corrected source sits on `main` while npm keeps serving the build that imports `getSingletonServices` from the package root.

Every published `@pikku/*` package that a consumer can install today resolves to `core@^0.12.80`, so there is no version combination that avoids this. Any project on the current line fails at CLI load, before doing any work:

```
Failed to run Pikku CLI: The requested module '@pikku/core' does not
provide an export named 'getSingletonServices'
```

## Scope

Only `@pikku/ws`. I checked all twenty packages whose `src/` changed in #1191 against the thirteen symbols the root dropped in 0.12.80 (`getSingletonServices`, `setSingletonServices`, `getCreateWireServices`, `runPikkuFunc`, `runQueueJob`, `runScheduledTask`, `runCLICommand`, `runMCP*`, `addFunction`, `addMiddleware`, `addGlobalMiddleware`) — at both the runtime and `.d.ts` level. The rest were either bumped in #1198 or changed in ways the old root still satisfies. `@pikku/ws` was the only one left holding a moved symbol.

## Verification

`changeset status` resolves to exactly one patch bump, `@pikku/ws`.

Found while trying to move fabric to the latest pikku line; that bump is blocked until this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an import compatibility issue affecting the `/ecosystem` integration.
  * Resolved a CLI failure that could occur when importing ecosystem-related functionality.

* **Release**
  * Published a patch update for `@pikku/ws` containing these compatibility fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->