### PR TITLE
feat(scenario): capture screenshots and video from a run

### DIFF
--- a/.changeset/capture-index-is-scenario-scoped.md
+++ b/.changeset/capture-index-is-scenario-scoped.md
@@ -1,0 +1,15 @@
+---
+'@pikku/playwright': patch
+---
+
+fix(playwright): count a scenario's captures once, not once per actor
+
+The index leading a capture's filename exists to give a directory listing the
+order the run happened in. It was held on `ActorSession`, and the provider opens
+one session per actor — so a scenario driving two people wrote `01` twice, and
+the listing described an order that never occurred.
+
+The scenario name and the count now live on one capture context the provider
+hands to every session by reference, reset as each scenario begins. Sessions
+opened by the previous scenario follow the new name rather than going on writing
+under the old one.

--- a/.changeset/scenario-captures-reachable-from-the-cli.md
+++ b/.changeset/scenario-captures-reachable-from-the-cli.md
@@ -1,0 +1,18 @@
+---
+'@pikku/core': patch
+'@pikku/cli': patch
+---
+
+fix(cli,core): make scenario captures reachable, filed per scenario, and findable
+
+`--screenshots` and `--video` were read by `scenario run` but never declared as
+options, so both flags were rejected as unknown and silently ignored — capture
+could not be switched on from the command line at all.
+
+A provider's `beginScenario` was never called, so every capture in a run was
+filed under one shared label instead of the scenario that produced it. It is now
+part of `ScenarioBrowserProvider` and called after the per-scenario reset, once
+the previous scenario's context is closed and its video finalised.
+
+The run also never said where it wrote anything. It now reports `Captures → …`
+after the browser closes, which is the point at which a video exists.

--- a/.changeset/scenario-run-captures.md
+++ b/.changeset/scenario-run-captures.md
@@ -1,0 +1,28 @@
+---
+'@pikku/playwright': patch
+'@pikku/cli': patch
+---
+
+Capture screenshots and video from a scenario run.
+
+`pikku scenario run` gains `--screenshots` and `--video`, so a run can produce
+something a person looks at rather than only a pass or a fail.
+
+Screenshots are taken explicitly — `browser.screenshot('description')` — rather
+than automatically after every step. Only the scenario author knows which
+moments are worth a picture, and "after each step" captures the moment a step
+finished instead of the moment that mattered. The description becomes the
+filename, and every capture is stamped with the run and scenario that produced
+it under `.pikku/scenario-runs/<runId>/<scenario>/`. With the flag off, the same
+call returns the bytes and writes nothing, so a scenario that takes pictures
+still runs.
+
+Video records per browser context, which yields one video per scenario because
+contexts are already closed between them. ffmpeg re-encodes the result when it
+is on PATH — this footage is a near-static page, so it compresses hard — and the
+run warns and keeps the raw recordings when it is not.
+
+`ActorSession.screenshot()` previously passed its argument to Playwright as a
+file path, so a name without an extension failed with
+`unsupported mime type "null"`. It now takes a description and the SDK owns the
+filename; callers that own the path use `writeScreenshot(file)`.

--- a/e2e/packages/functions/tests/scenarios/browser.steps.ts
+++ b/e2e/packages/functions/tests/scenarios/browser.steps.ts
@@ -542,3 +542,24 @@ export const navigatesInConsole = pikkuScenarioStep<
     return { href }
   },
 })
+
+/**
+ * Photograph the page, so a run can be reviewed rather than only counted.
+ *
+ * The description is the subject: it becomes the filename, which is how the
+ * artifact is found again. Without `--screenshots` the SDK returns the bytes
+ * and writes nothing, so this step is a no-op rather than a failure — which is
+ * exactly the property `captureScenario` exists to hold onto.
+ */
+export const capturesTheScreen = pikkuScenarioStep<
+  { description: string },
+  { captured: true }
+>({
+  name: 'capturesTheScreen',
+  description: 'photographs the page for review',
+  template: 'photographs the page as {description}',
+  browser: async (_services, { description }, { browser }) => {
+    await browser.screenshot(description)
+    return { captured: true }
+  },
+})

--- a/e2e/packages/functions/tests/scenarios/captures.feature.ts
+++ b/e2e/packages/functions/tests/scenarios/captures.feature.ts
@@ -1,0 +1,68 @@
+/**
+ * Run captures, exercised end to end.
+ *
+ * The unit tests in `@pikku/playwright` cover the naming and the ffmpeg
+ * fallback; what they cannot cover is whether a real `pikku scenario run`
+ * actually threads `--screenshots` through the CLI, the driver and the actor
+ * session and leaves files on disk. That is what this scenario is for, and it
+ * is why the descriptions below are fixed strings: `tests/cli/scenario-run.test.ts`
+ * asserts on the exact filenames they produce.
+ *
+ * It is deliberately a normal scenario, not a capture-only one — with the flag
+ * off `browser.screenshot()` writes nothing and the scenario still passes, so
+ * this also pins the promise that taking pictures never breaks a plain run.
+ */
+import {
+  pikkuFeature,
+  pikkuScenario,
+} from '#pikku/workflow/pikku-workflow-types.gen.js'
+
+export const captureScenario = pikkuScenario<void, { captures: number }>({
+  title: 'A run captures screenshots of the console',
+  description:
+    'An admin opens two console pages and photographs each one, so the run leaves something to look at',
+  tags: ['scenario', 'console'],
+  func: async (_services, _data, { scenario, actors }) => {
+    if (!actors?.admin) {
+      throw new Error(
+        'captureScenario needs the admin actor — run via `pikku scenario run <environment>`'
+      )
+    }
+
+    await scenario.given(
+      'opens the addons page',
+      'opensConsolePage',
+      { path: '/console/addons' },
+      { actor: actors.admin }
+    )
+    await scenario.then(
+      'photographs the addons gallery',
+      'capturesTheScreen',
+      { description: 'Addons gallery' },
+      { actor: actors.admin }
+    )
+
+    await scenario.when(
+      'opens the functions page',
+      'opensConsolePage',
+      { path: '/console/functions' },
+      { actor: actors.admin }
+    )
+    await scenario.then(
+      'photographs the functions list',
+      'capturesTheScreen',
+      { description: 'Functions list' },
+      { actor: actors.admin }
+    )
+
+    return { captures: 2 }
+  },
+})
+
+export const capturesFeature = pikkuFeature({
+  name: 'Run Captures',
+  description:
+    'A scenario run can photograph the pages it visits, and does not depend on being asked to',
+  tags: ['captures', 'console'],
+  scenarios: [captureScenario],
+})

--- a/e2e/tests/cli/scenario-run.test.ts
+++ b/e2e/tests/cli/scenario-run.test.ts
@@ -14,11 +14,15 @@
 import { after, before, describe, test } from 'node:test'
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
-import { resolve, dirname } from 'node:path'
+import { existsSync, readdirSync } from 'node:fs'
+import { resolve, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { startBackend } from '../../bin/backend-harness.js'
 
 const PROJECT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+/** Where `pikku scenario run` files a run's artifacts, one folder per run. */
+const CAPTURE_ROOT = join(PROJECT_DIR, '.pikku', 'scenario-runs')
 
 interface ScenarioRunResult {
   code: number | null
@@ -154,6 +158,72 @@ describe('pikku scenario run', () => {
 
   test('a browser step drives the console as its actor', async () => {
     assertAllPassed(await runScenario('codeEditorConsoleScenario'))
+  })
+
+  /**
+   * Captures, end to end.
+   *
+   * `@pikku/playwright` unit-tests the naming and the ffmpeg fallback, but
+   * nothing there proves `--screenshots` survives the trip from the CLI flag
+   * through the driver to the actor session and onto disk. That is only
+   * answerable by running it.
+   *
+   * The assertion is exact rather than "some png exists": every part of the
+   * filename is derived — the index from call order, the stem from the
+   * description the scenario passes, the suffix from the actor — so a run that
+   * captured the right number of images under the wrong names is a regression,
+   * not a variation. The run directory is a uuid, so it is read back from the
+   * line the CLI prints rather than guessed.
+   */
+  test('--screenshots writes the run’s images under names it chose', async () => {
+    const run = await runScenario('captureScenario', [
+      '--screenshots',
+      '--run',
+      'browser',
+    ])
+    assertAllPassed(run)
+
+    const reported = run.output.match(/Captures → (.+)$/m)
+    assert.ok(
+      reported,
+      `expected the run to report its capture dir:\n${run.output}`
+    )
+
+    // The scenario's folder is its run label — "<feature> › <scenario>" — made
+    // filename-safe, which is what `beginScenario` stamps onto every capture.
+    const scenarioDir = join(
+      reported[1]!.trim(),
+      'run-captures-capturescenario'
+    )
+    assert.ok(
+      existsSync(scenarioDir),
+      `expected captures under ${scenarioDir}:\n${run.output}`
+    )
+    assert.deepEqual(readdirSync(scenarioDir).sort(), [
+      '01-addons-gallery-admin.png',
+      '02-functions-list-admin.png',
+    ])
+  })
+
+  /**
+   * The flag is opt-in, so a scenario that photographs the page has to survive
+   * being run without it — `browser.screenshot()` returns the bytes and writes
+   * nothing. Without this, taking a picture would silently become a dependency
+   * on a flag, and every plain run of the suite would fail.
+   */
+  test('the same scenario passes with capture off, writing nothing', async () => {
+    const before = existsSync(CAPTURE_ROOT)
+      ? readdirSync(CAPTURE_ROOT).length
+      : 0
+    assertAllPassed(await runScenario('captureScenario', ['--run', 'browser']))
+    const after = existsSync(CAPTURE_ROOT)
+      ? readdirSync(CAPTURE_ROOT).length
+      : 0
+    assert.equal(
+      after,
+      before,
+      'a run without --screenshots must write no captures'
+    )
   })
 
   /**

--- a/packages/cli/build.sh
+++ b/packages/cli/build.sh
@@ -72,6 +72,12 @@ echo "Bootstrapping with published @pikku/cli..."
 # Held at the 0.12.79 wave's own version. Moving the wave forward means moving
 # this with it.
 : "${PIKKU_SCHEDULE_VERSION:=0.12.4}"
+# @pikku/ws is the fifth, and it failed the same way one wave later: 0.12.6
+# moved to `@pikku/core/ecosystem` too, so an unpinned ws landing beside the
+# pinned core 0.12.79 reproduces the missing-subpath error verbatim, this time
+# through pikku-ws-server.js. 0.12.5 is the 0.12.79 wave's own version and peers
+# on core ^0.12.73.
+: "${PIKKU_WS_VERSION:=0.12.5}"
 # The other peer that has to be named: @pikku/better-auth peers on the upstream
 # `better-auth` library and imports it at module load, so without it the
 # bootstrap CLI dies on "Cannot find package 'better-auth'".
@@ -102,6 +108,7 @@ cat > "$_bootstrap_dir/package.json" <<JSON
     "@pikku/node-http-server": "${PIKKU_NODE_HTTP_SERVER_VERSION}",
     "@pikku/kysely": "${PIKKU_KYSELY_VERSION}",
     "@pikku/schedule": "${PIKKU_SCHEDULE_VERSION}",
+    "@pikku/ws": "${PIKKU_WS_VERSION}",
     "better-auth": "${BETTER_AUTH_LIB_VERSION}"
   },
   "overrides": {
@@ -111,6 +118,7 @@ cat > "$_bootstrap_dir/package.json" <<JSON
     "@pikku/node-http-server": "${PIKKU_NODE_HTTP_SERVER_VERSION}",
     "@pikku/kysely": "${PIKKU_KYSELY_VERSION}",
     "@pikku/schedule": "${PIKKU_SCHEDULE_VERSION}",
+    "@pikku/ws": "${PIKKU_WS_VERSION}",
     "better-auth": "${BETTER_AUTH_LIB_VERSION}"
   }
 }

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -590,6 +590,16 @@ wireCLI({
                 'Keep every stack frame on a failure. Without it, only the project’s own frames are shown',
               default: false,
             },
+            screenshots: {
+              description:
+                'Write the screenshots scenarios ask for to disk, under .pikku/scenario-runs/<run>/<scenario>. Without it `browser.screenshot()` still returns the bytes and nothing is written',
+              default: false,
+            },
+            video: {
+              description:
+                'Record a video per scenario alongside the screenshots (implies --screenshots)',
+              default: false,
+            },
             apiUrl: {
               description:
                 "Override the environment's apiUrl for this run — for a target that only exists at run time, such as a freshly deployed sandbox",

--- a/packages/cli/src/functions/commands/scenario-browser.ts
+++ b/packages/cli/src/functions/commands/scenario-browser.ts
@@ -21,6 +21,7 @@ export interface ScenarioBrowserDriverOptions {
   actors: Record<string, ResolvedPersona>
   signInPath?: string
   failureDir?: string
+  capture?: ScenarioCaptureOptions
   config: unknown
 }
 
@@ -54,6 +55,22 @@ export interface ScenarioBrowserDriver {
   }) => unknown
 }
 
+/**
+ * Artifacts a run may produce. Mirrors the driver's own CaptureOptions rather
+ * than importing it: the CLI must not depend on a driver package it resolves
+ * dynamically, and this shape is the contract between them.
+ */
+export interface ScenarioCaptureOptions {
+  /** Root directory for the run's artifacts. */
+  dir: string
+  /** The invocation these artifacts belong to. */
+  runId: string
+  /** Record a video per scenario. */
+  video?: boolean
+  /** Re-encode with ffmpeg when available. Defaults on — the footage is nearly static. */
+  compress?: boolean
+}
+
 export interface ResolveScenarioBrowserProviderOptions {
   /** The environment name, for error messages that tell the user what to edit. */
   environment: string
@@ -64,6 +81,12 @@ export interface ResolveScenarioBrowserProviderOptions {
   signInPath?: string
   /** Where failure screenshots are written. */
   failureDir: string
+  /**
+   * Artifacts for this run — named screenshots, and optionally a video per
+   * scenario. Undefined leaves capture off, which is the default: most runs
+   * ask a pass/fail question and writing video to answer it is waste.
+   */
+  capture?: ScenarioCaptureOptions
   /** The scenarios that declared browser steps, named in the missing-driver error. */
   browserScenarios: string[]
   /** Package to drive the browser. Defaults to `@pikku/playwright`. */
@@ -101,6 +124,7 @@ export const resolveScenarioBrowserProvider = async ({
   actors,
   signInPath,
   failureDir,
+  capture,
   browserScenarios,
   driver = DEFAULT_BROWSER_DRIVER,
   importDriver = (specifier) =>
@@ -131,6 +155,7 @@ export const resolveScenarioBrowserProvider = async ({
     actors,
     signInPath,
     failureDir,
+    capture,
     config,
   }
   if (module.createScenarioBrowserProvider) {

--- a/packages/cli/src/functions/commands/scenario-browser.ts
+++ b/packages/cli/src/functions/commands/scenario-browser.ts
@@ -177,6 +177,7 @@ export const resolveScenarioBrowserProvider = async ({
  */
 export interface ScenarioBrowserLifecycle {
   reset(): Promise<void>
+  beginScenario(scenario: string): void
   captureFailure(label: string): Promise<ScenarioBrowserFailure[]>
   close(): Promise<void>
 }
@@ -189,6 +190,9 @@ export const scenarioBrowserLifecycle = (
   // its reset is far easier to diagnose than one failing on stale state.
   reset: async () => {
     await provider?.reset?.()
+  },
+  beginScenario: (scenario) => {
+    provider?.beginScenario?.(scenario)
   },
   captureFailure: async (label) => {
     try {

--- a/packages/cli/src/functions/commands/scenario.ts
+++ b/packages/cli/src/functions/commands/scenario.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { resolve, join } from 'node:path'
 import { mkdirSync, writeFileSync } from 'node:fs'
 
@@ -139,6 +140,8 @@ export const scenarioRun = pikkuSessionlessFunc<
     spawn?: boolean
     keepAlive?: boolean
     trace?: boolean
+    screenshots?: boolean
+    video?: boolean
     apiUrl?: string
     appUrl?: string
   },
@@ -159,6 +162,8 @@ export const scenarioRun = pikkuSessionlessFunc<
       spawn = false,
       keepAlive = false,
       trace = false,
+      screenshots = false,
+      video = false,
       apiUrl,
       appUrl,
     }
@@ -423,6 +428,21 @@ export const scenarioRun = pikkuSessionlessFunc<
       resolve(config.rootDir, config.outDir),
       'scenario-failures'
     )
+    // Artifacts are filed under the run, not the scenario, so one run's output
+    // is one folder to open, keep or delete. `--video` implies capture is on:
+    // recording without somewhere to put it is not a thing anyone wants.
+    const captureDir = join(
+      resolve(config.rootDir, config.outDir),
+      'scenario-runs'
+    )
+    // One id for the whole invocation, distinct from a scenario's own runId:
+    // reviewing artifacts means opening what `pikku scenario run` just produced,
+    // not hunting for one scenario's folder among many.
+    const captureRunId = randomUUID()
+    const capture =
+      screenshots || video
+        ? { dir: captureDir, runId: captureRunId, video, compress: true }
+        : undefined
     const browserLifecycle = scenarioBrowserLifecycle(
       needsBrowser
         ? await (async () => {
@@ -434,6 +454,7 @@ export const scenarioRun = pikkuSessionlessFunc<
               actors: scenarioActors,
               signInPath: env.signInPath,
               failureDir,
+              capture,
               browserScenarios: [...browserStepsByFlow.keys()],
               driver: config.scenarios?.browserDriver,
             })

--- a/packages/cli/src/functions/commands/scenario.ts
+++ b/packages/cli/src/functions/commands/scenario.ts
@@ -562,6 +562,9 @@ export const scenarioRun = pikkuSessionlessFunc<
       // Before the scenario, not after it: the last scenario's window is left
       // open for headed debugging, while this one still starts clean.
       await browserLifecycle.reset()
+      // After the reset, which is what closes the previous scenario's context
+      // and finalises its video.
+      browserLifecycle.beginScenario(label)
       if (coverageActive) {
         const reset = await invokeCoverage('pikkuScenarioResetLiveCoverage')
         if (reset && reset.enabled === false) {
@@ -697,6 +700,13 @@ export const scenarioRun = pikkuSessionlessFunc<
     }
 
     await browserLifecycle.close()
+
+    // Reported after the browser has closed, because video is only finalised
+    // when its context is. A capture nobody can find is a capture nobody
+    // looks at, and looking at them is the entire point of the flags.
+    if (capture) {
+      logger.info(`Captures → ${join(capture.dir, capture.runId)}`)
+    }
 
     if (coverage && Object.keys(scenarioCoverage).length > 0) {
       const coverageDir = join(

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,12 +5,12 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2780 observable things**: 946 exported names, plus
-1834 members on the classes and interfaces among them.
+**2781 observable things**: 946 exported names, plus
+1835 members on the classes and interfaces among them.
 
 | tier | entry points | names | members |
 | --- | ---: | ---: | ---: |
-| stable | 47 | 936 | 1834 |
+| stable | 47 | 936 | 1835 |
 | ecosystem | 2 | 10 | 0 |
 
 An entry point whose exports are mostly *exclusive* is a self-contained
@@ -476,7 +476,7 @@ export type RunTimeline = RunTimelineEvent[]
 export interface RunTimelineEvent { seq: number at: Date type: Extract< StepStatus, 'pending' | 'scheduled' | 'running' | 'succeeded' | 'failed' > stepName: string attemptCount: number fromStepName?: string result?: unknown error?: SerializedError }
 SCENARIO_SURFACES: readonly ScenarioSurface[]
 export interface ScenarioBrowserFailure { actor: string url?: string screenshot?: string consoleErrors: string[] pageErrors: string[] failedRequests: string[] apiErrors: string[] }
-export interface ScenarioBrowserProvider { sessionFor(actorName: string): Promise<PikkuBrowserWire> reset?(): Promise<void> captureFailure?(label: string): Promise<ScenarioBrowserFailure[]> close(): Promise<void> }
+export interface ScenarioBrowserProvider { sessionFor(actorName: string): Promise<PikkuBrowserWire> reset?(): Promise<void> beginScenario?(scenario: string): void captureFailure?(label: string): Promise<ScenarioBrowserFailure[]> close(): Promise<void> }
 export interface ScenarioCookieJar { fetch: typeof fetch clear(): void readonly empty: boolean }
 export interface ScenarioEnvironment { apiUrl: string appUrl?: string }
 export interface ScenarioHttpResponse<T = unknown> { status: number ok: boolean body: T serialized: string }
@@ -595,7 +595,7 @@ export interface PikkuWorkflow { start: <I>(input: I) => Promise<{ runId: string
 export interface PikkuWorkflowWire { name: string runId: string pikkuUserId?: string getRun: () => Promise<WorkflowRun> do: WorkflowWireDoRPC & WorkflowWireDoInline sleep: WorkflowWireSleep suspend: WorkflowWireSuspend approval: WorkflowWireApproval }
 export interface ReturnStepMeta { type: 'return' outputs: Record<string, OutputBinding> spread?: string[] }
 export interface RpcStepMeta { type: 'rpc' stepName: string rpcName: string outputVar?: string inputs?: Record<string, InputSource> | 'passthrough' options?: WorkflowStepOptions actor?: string expectEventually?: boolean }
-export interface ScenarioBrowserProvider { sessionFor(actorName: string): Promise<PikkuBrowserWire> reset?(): Promise<void> captureFailure?(label: string): Promise<ScenarioBrowserFailure[]> close(): Promise<void> }
+export interface ScenarioBrowserProvider { sessionFor(actorName: string): Promise<PikkuBrowserWire> reset?(): Promise<void> beginScenario?(scenario: string): void captureFailure?(label: string): Promise<ScenarioBrowserFailure[]> close(): Promise<void> }
 export type ScenarioStepInvocation = <TOutput = any, TInput = any>( stepName: string, stepFunc: string, data?: TInput, options?: ScenarioStepOptions ) => Promise<TOutput>
 export interface ScenarioStepMeta { type: 'scenarioStep' stepName: string stepFunc: string phase: ScenarioStepPhase outputVar?: string inputs?: Record<string, InputSource> | 'passthrough' options?: WorkflowStepOptions actor?: string surfaces?: ScenarioSurface[] }
 export interface ScenarioStepOptions { actor?: unknown description?: string retries?: number retryDelay?: number | string }

--- a/packages/core/src/wirings/workflow/scenario-step.types.ts
+++ b/packages/core/src/wirings/workflow/scenario-step.types.ts
@@ -230,6 +230,14 @@ export interface ScenarioBrowserProvider {
    */
   reset?(): Promise<void>
   /**
+   * Name the scenario about to run, so anything it captures is filed under it.
+   *
+   * Called before each scenario. A provider that is never told has to fall
+   * back to one shared label, which puts every run's artifacts in a single
+   * folder — findable only by timestamp.
+   */
+  beginScenario?(scenario: string): void
+  /**
    * Snapshot every open window for a failed scenario. `label` identifies the
    * scenario in artifact filenames. Never throws: a failure to capture must
    * not replace the failure being captured.

--- a/packages/playwright/src/actor-session.ts
+++ b/packages/playwright/src/actor-session.ts
@@ -20,6 +20,16 @@ export interface CaptureContext {
   runId: string
   /** The scenario currently executing, set by the provider as each one starts. */
   scenario?: string
+  /**
+   * Captures taken so far in the current scenario, across every actor.
+   *
+   * One object is shared by reference between the actors' sessions rather than
+   * counted per session, because the number leads the filename and is there to
+   * give a directory listing the order the run happened in. Counted per actor
+   * it restarts at 01 for the second window, and describes an order that never
+   * occurred.
+   */
+  taken: number
 }
 
 /** Runtime problems collected for one page navigation. */
@@ -49,8 +59,6 @@ export class ActorSession implements PikkuBrowserWire {
   private inflightApi = 0
   /** Set by the provider when captures are enabled; absent means no captures. */
   capture?: CaptureContext
-  /** Orders captures within a scenario, so the filenames read as a sequence. */
-  private captureIndex = 0
 
   constructor(
     readonly actor: string,
@@ -176,7 +184,7 @@ export class ActorSession implements PikkuBrowserWire {
 
     // The index leads so a directory listing reads in the order the run
     // happened, which is the order somebody reviewing it wants.
-    const index = String(++this.captureIndex).padStart(2, '0')
+    const index = String(++this.capture.taken).padStart(2, '0')
     writeFileSync(
       join(dir, `${index}-${slug(description)}-${slug(this.actor)}.png`),
       bytes

--- a/packages/playwright/src/actor-session.ts
+++ b/packages/playwright/src/actor-session.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import type { Browser, BrowserContext, Locator, Page } from '@playwright/test'
 import { pollUntil } from '@pikku/core/workflow'
 import type { PikkuBrowserWire, TestIdSelector } from '@pikku/core/workflow'
@@ -182,6 +182,22 @@ export class ActorSession implements PikkuBrowserWire {
       bytes
     )
     return bytes
+  }
+
+  /**
+   * Photograph the page to a path the caller chose.
+   *
+   * Separate from `screenshot(description)` because the two have different
+   * owners: a failure capture already knows where the file belongs and what to
+   * call it, whereas a scenario author knows only what the moment *is* and
+   * should not have to construct a path or remember that the extension decides
+   * the encoder.
+   */
+  async writeScreenshot(file: string): Promise<Uint8Array> {
+    mkdirSync(dirname(file), { recursive: true })
+    // Playwright writes it: the caller owns the path, including the extension
+    // that decides the encoder, so there is nothing for this to second-guess.
+    return this.page.screenshot({ path: file })
   }
 
   /**

--- a/packages/playwright/src/actor-session.ts
+++ b/packages/playwright/src/actor-session.ts
@@ -1,8 +1,26 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import type { Browser, BrowserContext, Locator, Page } from '@playwright/test'
 import { pollUntil } from '@pikku/core/workflow'
 import type { PikkuBrowserWire, TestIdSelector } from '@pikku/core/workflow'
 import type { BrowserConfig } from './config.js'
 import { locateTestId, type LocateTestIdOptions } from './testid.js'
+
+/**
+ * Where a capture is filed, and what it is filed under.
+ *
+ * Stamped rather than derived: a screenshot is only useful later if you can say
+ * which run and which scenario produced it, and neither is knowable from inside
+ * a step.
+ */
+export interface CaptureContext {
+  /** Root directory for this run's captures. */
+  dir: string
+  /** The run these captures belong to. */
+  runId: string
+  /** The scenario currently executing, set by the provider as each one starts. */
+  scenario?: string
+}
 
 /** Runtime problems collected for one page navigation. */
 export interface PageIssues {
@@ -29,16 +47,24 @@ export class ActorSession implements PikkuBrowserWire {
   context!: BrowserContext
   private issues: PageIssues = blankIssues()
   private inflightApi = 0
+  /** Set by the provider when captures are enabled; absent means no captures. */
+  capture?: CaptureContext
+  /** Orders captures within a scenario, so the filenames read as a sequence. */
+  private captureIndex = 0
 
   constructor(
     readonly actor: string,
     private readonly config: BrowserConfig
   ) {}
 
-  async open(browser: Browser) {
+  async open(browser: Browser, recordVideoDir?: string) {
     this.context = await browser.newContext({
       ignoreHTTPSErrors: this.config.ignoreHTTPSErrors,
       locale: this.config.locale,
+      // Playwright records per context and only finalises the file on
+      // context.close(), which is why `reset()` between scenarios is what makes
+      // one video per scenario rather than one enormous file per run.
+      ...(recordVideoDir ? { recordVideo: { dir: recordVideoDir } } : {}),
     })
     await this.context.addInitScript((apiUrl) => {
       ;(window as typeof window & { __E2E_API_URL?: string }).__E2E_API_URL =
@@ -120,8 +146,42 @@ export class ActorSession implements PikkuBrowserWire {
     await this.gotoApp(path)
   }
 
-  async screenshot(name?: string): Promise<Uint8Array> {
-    return this.page.screenshot(name ? { path: name } : undefined)
+  /**
+   * Photograph the page, on purpose, at a moment the author chose.
+   *
+   * Taken explicitly rather than automatically after every step: a run
+   * captures dozens of steps and only a handful are worth looking at, and
+   * "after each step" photographs the moment a step *finished* rather than the
+   * moment that mattered. `description` is what you would tell a colleague to
+   * look for — it becomes the filename and the caption.
+   *
+   * Writes into the run's capture directory when one is configured, so every
+   * image is stamped with the run and scenario that produced it. Without a
+   * capture context — a plain `pikku scenario run` with no `--screenshots` —
+   * this still returns the bytes and writes nothing, so a scenario that calls
+   * it is not broken by the flag being off.
+   */
+  async screenshot(description?: string): Promise<Uint8Array> {
+    const bytes = await this.page.screenshot()
+    if (!this.capture || !description) {
+      return bytes
+    }
+
+    const dir = join(
+      this.capture.dir,
+      this.capture.runId,
+      slug(this.capture.scenario ?? 'scenario')
+    )
+    mkdirSync(dir, { recursive: true })
+
+    // The index leads so a directory listing reads in the order the run
+    // happened, which is the order somebody reviewing it wants.
+    const index = String(++this.captureIndex).padStart(2, '0')
+    writeFileSync(
+      join(dir, `${index}-${slug(description)}-${slug(this.actor)}.png`),
+      bytes
+    )
+    return bytes
   }
 
   /**
@@ -253,3 +313,11 @@ function isApiPath(url: string): boolean {
     return false
   }
 }
+
+/** Filename-safe, readable, and stable for the same description. */
+const slug = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 60) || 'capture'

--- a/packages/playwright/src/capture.test.ts
+++ b/packages/playwright/src/capture.test.ts
@@ -1,0 +1,69 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { compressVideosIn, slug } from './capture.js'
+
+describe('slug', () => {
+  test('turns a description into a readable, filename-safe stem', () => {
+    assert.equal(
+      slug('Front desk, after check-in'),
+      'front-desk-after-check-in'
+    )
+  })
+
+  test('is stable for the same description', () => {
+    assert.equal(slug('The Alder — arrivals'), slug('The Alder — arrivals'))
+  })
+
+  test('never yields an empty stem, so a file always has a name', () => {
+    assert.equal(slug('———'), 'capture')
+    assert.equal(slug(''), 'capture')
+  })
+
+  test('bounds the length, because a description may be a sentence', () => {
+    assert.ok(slug('a'.repeat(200)).length <= 60)
+  })
+})
+
+describe('compressVideosIn', () => {
+  test('a missing directory is not an error — capture may be off', async () => {
+    const warnings: string[] = []
+    const count = await compressVideosIn(
+      join(tmpdir(), 'pikku-capture-does-not-exist'),
+      (message) => warnings.push(message)
+    )
+
+    assert.equal(count, 0)
+    // No ffmpeg complaint for a run that recorded nothing.
+    assert.deepEqual(warnings, [])
+  })
+
+  test('warns rather than fails when ffmpeg is unavailable', async (t) => {
+    const dir = mkdtempSync(join(tmpdir(), 'pikku-capture-'))
+    mkdirSync(join(dir, 'video'), { recursive: true })
+    writeFileSync(join(dir, 'video', 'scenario.webm'), 'not really a video')
+
+    const warnings: string[] = []
+    const count = await compressVideosIn(dir, (message) =>
+      warnings.push(message)
+    )
+
+    // ffmpeg may or may not be installed wherever this runs, so assert the
+    // contract rather than the outcome: the recording survives either way, and
+    // the only difference is whether the run said something about it.
+    assert.ok(
+      existsSync(join(dir, 'video', 'scenario.webm')),
+      'the raw recording is kept whether or not it could be compressed'
+    )
+
+    if (warnings.length > 0) {
+      assert.match(warnings[0]!, /ffmpeg/)
+      assert.equal(count, 0, 'nothing is compressed without ffmpeg')
+    } else {
+      t.diagnostic('ffmpeg present — compression path exercised')
+    }
+  })
+})

--- a/packages/playwright/src/capture.ts
+++ b/packages/playwright/src/capture.ts
@@ -1,0 +1,141 @@
+import { spawn } from 'node:child_process'
+import { existsSync, readdirSync, renameSync, rmSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * What a run is allowed to capture, and where it goes.
+ *
+ * Both are off by default. A scenario run is usually a pass/fail question and
+ * writing a video per scenario to answer it is waste; the flags exist for the
+ * runs where somebody is going to *look*.
+ */
+export interface CaptureOptions {
+  /** Root directory for this run's artifacts. */
+  dir: string
+  /** The run these artifacts belong to — the folder everything is filed under. */
+  runId: string
+  /** Record a video per scenario. */
+  video?: boolean
+  /**
+   * Re-encode finished videos with ffmpeg when it is on PATH.
+   *
+   * Worth doing by default: a scenario video is a mostly-static page with a
+   * cursor moving over it, so consecutive frames are nearly identical and an
+   * inter-frame codec collapses it to a fraction of the size. Without ffmpeg
+   * the raw webm is kept as-is rather than failing the run — an uncompressed
+   * artifact is still an artifact.
+   */
+  compress?: boolean
+}
+
+/** Filename-safe and stable for the same input. */
+export const slug = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 60) || 'capture'
+
+/** Is ffmpeg callable? Answered once; the answer cannot change mid-run. */
+let ffmpegAvailable: Promise<boolean> | undefined
+export const hasFfmpeg = (): Promise<boolean> => {
+  ffmpegAvailable ??= new Promise<boolean>((resolve) => {
+    const probe = spawn('ffmpeg', ['-version'], { stdio: 'ignore' })
+    probe.on('error', () => resolve(false))
+    probe.on('exit', (code) => resolve(code === 0))
+  })
+  return ffmpegAvailable
+}
+
+/**
+ * Re-encode one video in place, keeping the original only if the encode fails.
+ *
+ * `-crf 32` with `libvpx-vp9` is deliberately aggressive. This footage is read
+ * by a person checking whether a page looked right, not by anything measuring
+ * quality, and the alternative to a heavily compressed video is usually no
+ * video at all because nobody wants the disk cost.
+ */
+export const compressVideo = async (file: string): Promise<string> => {
+  if (!(await hasFfmpeg())) {
+    return file
+  }
+  const out = file.replace(/\.webm$/, '.compressed.webm')
+
+  const ok = await new Promise<boolean>((resolve) => {
+    const proc = spawn(
+      'ffmpeg',
+      [
+        '-y',
+        '-i',
+        file,
+        '-c:v',
+        'libvpx-vp9',
+        '-crf',
+        '32',
+        '-b:v',
+        '0',
+        // One keyframe every 10s: seeking matters less than size here, and
+        // long GOPs are most of the win on near-static footage.
+        '-g',
+        '300',
+        '-an',
+        out,
+      ],
+      { stdio: 'ignore' }
+    )
+    proc.on('error', () => resolve(false))
+    proc.on('exit', (code) => resolve(code === 0))
+  })
+
+  if (!ok || !existsSync(out)) {
+    return file
+  }
+
+  // Only replace the original if the encode actually saved something —
+  // occasionally it does not, and a larger "compressed" file helps nobody.
+  const before = statSync(file).size
+  const after = statSync(out).size
+  if (after >= before) {
+    rmSync(out, { force: true })
+    return file
+  }
+
+  rmSync(file, { force: true })
+  renameSync(out, file)
+  return file
+}
+
+/**
+ * Compress every `.webm` under a directory, in place.
+ *
+ * ffmpeg is optional. Without it the raw recordings are kept exactly as
+ * Playwright wrote them and the run still succeeds — but it says so, because a
+ * silently-uncompressed artifact directory is how somebody discovers a
+ * gigabyte of video a week later and has no idea why.
+ */
+export const compressVideosIn = async (
+  dir: string,
+  onWarn: (message: string) => void = console.warn
+): Promise<number> => {
+  if (!existsSync(dir)) {
+    return 0
+  }
+  if (!(await hasFfmpeg())) {
+    onWarn(
+      '[pikku] ffmpeg is not on PATH — scenario videos were kept uncompressed. ' +
+        'Install ffmpeg to shrink them; the footage is nearly static, so it compresses hard.'
+    )
+    return 0
+  }
+  let count = 0
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      count += await compressVideosIn(full, onWarn)
+    } else if (entry.name.endsWith('.webm')) {
+      await compressVideo(full)
+      count++
+    }
+  }
+  return count
+}

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -39,7 +39,18 @@ export {
   type ElementKind,
   type ElementMap,
 } from './elements.js'
-export { ActorSession, type PageIssues } from './actor-session.js'
+export {
+  ActorSession,
+  type PageIssues,
+  type CaptureContext,
+} from './actor-session.js'
+export {
+  compressVideo,
+  compressVideosIn,
+  hasFfmpeg,
+  slug,
+  type CaptureOptions,
+} from './capture.js'
 export {
   connectOrLaunch,
   resolveCdpWsUrl,

--- a/packages/playwright/src/provider.test.ts
+++ b/packages/playwright/src/provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtemp, rm } from 'node:fs/promises'
+import { readdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -369,5 +370,75 @@ describe('PlaywrightScenarioBrowserProvider', () => {
     })
 
     assert.deepEqual(await provider.captureFailure('someScenario'), [])
+  })
+
+  /**
+   * The number leading a capture's filename is there so a directory listing
+   * reads in the order the run happened. A scenario with two actors is where
+   * that claim is testable: counted per session both windows start at 01, and
+   * the listing describes an order that never occurred.
+   */
+  test('actors in one scenario share a single capture sequence', async () => {
+    const { browser } = fakeBrowser()
+    const dir = await mkdtemp(join(tmpdir(), 'pikku-captures-'))
+    const provider = new PlaywrightScenarioBrowserProvider({
+      config: config(),
+      secret: 's',
+      actors: {
+        admin: { email: 'admin@test' },
+        shopper: { email: 'shopper@test' },
+      },
+      connectBrowser: async () => ({ browser }),
+      signIn: async () => {},
+      capture: { dir, runId: 'run-1' },
+    })
+
+    provider.beginScenario('Checkout › two people')
+    await (await provider.sessionFor('admin')).screenshot('opens the order')
+    await (await provider.sessionFor('shopper')).screenshot('sees it arrive')
+    await (await provider.sessionFor('admin')).screenshot('marks it shipped')
+
+    assert.deepEqual(
+      readdirSync(join(dir, 'run-1', 'checkout-two-people')).sort(),
+      [
+        '01-opens-the-order-admin.png',
+        '02-sees-it-arrive-shopper.png',
+        '03-marks-it-shipped-admin.png',
+      ]
+    )
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  /**
+   * The counter is per scenario, not per run: each scenario's folder is read on
+   * its own, so a second scenario starting at 03 would be describing captures
+   * that are not in it.
+   */
+  test('the next scenario files under its own name, counting from one', async () => {
+    const { browser } = fakeBrowser()
+    const dir = await mkdtemp(join(tmpdir(), 'pikku-captures-'))
+    const provider = new PlaywrightScenarioBrowserProvider({
+      config: config(),
+      secret: 's',
+      actors: { admin: { email: 'admin@test' } },
+      connectBrowser: async () => ({ browser }),
+      signIn: async () => {},
+      capture: { dir, runId: 'run-1' },
+    })
+
+    provider.beginScenario('First')
+    await (await provider.sessionFor('admin')).screenshot('one')
+    // Without a reset in between, so the session opened by the first scenario
+    // is the one that has to follow the new name.
+    provider.beginScenario('Second')
+    await (await provider.sessionFor('admin')).screenshot('two')
+
+    assert.deepEqual(readdirSync(join(dir, 'run-1', 'first')), [
+      '01-one-admin.png',
+    ])
+    assert.deepEqual(readdirSync(join(dir, 'run-1', 'second')), [
+      '01-two-admin.png',
+    ])
+    await rm(dir, { recursive: true, force: true })
   })
 })

--- a/packages/playwright/src/provider.ts
+++ b/packages/playwright/src/provider.ts
@@ -7,6 +7,7 @@ import type {
   ScenarioBrowserProvider,
 } from '@pikku/core/workflow'
 import { ActorSession } from './actor-session.js'
+import { compressVideosIn, type CaptureOptions } from './capture.js'
 import { connectOrLaunch, type BrowserConnection } from './browser-launch.js'
 import { browserConfigFromEnv, type BrowserConfig } from './config.js'
 
@@ -44,6 +45,12 @@ export interface PlaywrightScenarioBrowserProviderOptions {
   signInPath?: string
   /** Where `captureFailure` writes screenshots. Without it, none are taken. */
   failureDir?: string
+  /**
+   * Artifacts for this run — screenshots taken by name, and optionally a video
+   * per scenario. Absent means a step's `screenshot()` still returns bytes and
+   * writes nothing, so scenarios do not have to know whether the flag is on.
+   */
+  capture?: CaptureOptions
   connectBrowser?: () => Promise<BrowserConnection>
   signIn?: ActorSignIn
 }
@@ -60,11 +67,31 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
   private readonly config: BrowserConfig
   private sessions = new Map<string, Promise<ActorSession>>()
   private connection?: Promise<BrowserConnection>
+  /** The scenario currently running, stamped onto every capture it takes. */
+  private scenario?: string
 
   constructor(
     private readonly options: PlaywrightScenarioBrowserProviderOptions
   ) {
     this.config = options.config ?? browserConfigFromEnv()
+  }
+
+  /**
+   * Name the scenario about to run.
+   *
+   * Called by the runner as each scenario starts so captures are filed under
+   * it. A provider that is never told simply files under 'scenario', which is
+   * worse to read and never wrong.
+   */
+  beginScenario(scenario: string): void {
+    this.scenario = scenario
+    for (const pending of this.sessions.values()) {
+      pending
+        .then((s) => {
+          if (s.capture) s.capture.scenario = scenario
+        })
+        .catch(() => {})
+    }
   }
 
   async sessionFor(actorName: string): Promise<ActorSession> {
@@ -136,6 +163,14 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
 
   async close(): Promise<void> {
     await this.reset()
+    // Only after reset(): Playwright finalises a video when its context closes,
+    // so compressing before this point would re-encode files still being written.
+    const capture = this.options.capture
+    if (capture?.video && capture.compress !== false) {
+      await compressVideosIn(join(capture.dir, capture.runId, 'video')).catch(
+        () => 0
+      )
+    }
     const connection = this.connection
     this.connection = undefined
     if (connection) {
@@ -150,7 +185,18 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
   ): Promise<ActorSession> {
     const { browser } = await this.browser()
     const session = new ActorSession(actorName, this.config)
-    await session.open(browser)
+    const capture = this.options.capture
+    await session.open(
+      browser,
+      capture?.video ? join(capture.dir, capture.runId, 'video') : undefined
+    )
+    if (capture) {
+      session.capture = {
+        dir: capture.dir,
+        runId: capture.runId,
+        scenario: this.scenario,
+      }
+    }
     const signIn = this.options.signIn ?? defaultActorSignIn
     await signIn(
       session.context,

--- a/packages/playwright/src/provider.ts
+++ b/packages/playwright/src/provider.ts
@@ -6,7 +6,7 @@ import type {
   ScenarioBrowserFailure,
   ScenarioBrowserProvider,
 } from '@pikku/core/workflow'
-import { ActorSession } from './actor-session.js'
+import { ActorSession, type CaptureContext } from './actor-session.js'
 import { compressVideosIn, type CaptureOptions } from './capture.js'
 import { connectOrLaunch, type BrowserConnection } from './browser-launch.js'
 import { browserConfigFromEnv, type BrowserConfig } from './config.js'
@@ -67,8 +67,12 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
   private readonly config: BrowserConfig
   private sessions = new Map<string, Promise<ActorSession>>()
   private connection?: Promise<BrowserConnection>
-  /** The scenario currently running, stamped onto every capture it takes. */
-  private scenario?: string
+  /**
+   * The capture state for the scenario currently running, handed to every
+   * session by reference so the scenario name and the capture count are shared
+   * rather than copied per actor.
+   */
+  private captureContext?: CaptureContext
 
   constructor(
     private readonly options: PlaywrightScenarioBrowserProviderOptions
@@ -84,14 +88,16 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
    * worse to read and never wrong.
    */
   beginScenario(scenario: string): void {
-    this.scenario = scenario
-    for (const pending of this.sessions.values()) {
-      pending
-        .then((s) => {
-          if (s.capture) s.capture.scenario = scenario
-        })
-        .catch(() => {})
+    const capture = this.options.capture
+    if (!capture) {
+      return
     }
+    // Mutated in place rather than replaced, so sessions opened by the previous
+    // scenario — which hold this object by reference — follow the new name and
+    // count instead of going on writing under the old one.
+    this.captureContext ??= { dir: capture.dir, runId: capture.runId, taken: 0 }
+    this.captureContext.scenario = scenario
+    this.captureContext.taken = 0
   }
 
   async sessionFor(actorName: string): Promise<ActorSession> {
@@ -191,11 +197,12 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
       capture?.video ? join(capture.dir, capture.runId, 'video') : undefined
     )
     if (capture) {
-      session.capture = {
+      this.captureContext ??= {
         dir: capture.dir,
         runId: capture.runId,
-        scenario: this.scenario,
+        taken: 0,
       }
+      session.capture = this.captureContext
     }
     const signIn = this.options.signIn ?? defaultActorSignIn
     await signIn(

--- a/packages/playwright/src/provider.ts
+++ b/packages/playwright/src/provider.ts
@@ -152,7 +152,7 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
             `${slugify(label)}-${slugify(actorName)}.png`
           )
           await mkdir(this.options.failureDir, { recursive: true })
-          await session.screenshot(file)
+          await session.writeScreenshot(file)
           failure.screenshot = file
         } catch {}
       }


### PR DESCRIPTION
Closes #1207.

Adds `--screenshots` and `--video` to `pikku scenario run`, so a run can produce something a person looks at rather than only a pass or a fail.

## Why explicit screenshots

Screenshots are taken explicitly — `browser.screenshot('description')` — rather than automatically after every step. Knowing *when* a picture is worth taking is the hard part and only the scenario author knows it: a run has dozens of steps, a handful of moments matter, and "after each step" photographs the moment a step finished instead of the moment that mattered. The description becomes the filename and the caption.

Every capture is stamped with the run and scenario that produced it, filed under `.pikku/scenario-runs/<runId>/<scenario>/` and ordered by an index so a directory listing reads in the order the run happened. Without `--screenshots` the same call returns the bytes and writes nothing, so a scenario that takes pictures is not broken by the flag being off.

## Video and ffmpeg

Video records per browser context, which is why one video comes out per scenario: Playwright finalises the file when the context closes, and `reset()` already closes contexts between scenarios.

ffmpeg is optional and re-encodes the result when present. This footage is a mostly-static page with a cursor moving over it, so consecutive frames are nearly identical and an inter-frame codec collapses it — the difference between keeping the videos and deleting them. Without ffmpeg the raw recordings are kept and the run warns, because a silently uncompressed artifact directory is how somebody finds a gigabyte of video a week later with no idea where it came from.

## The screenshot()/writeScreenshot() split

`ActorSession.screenshot` passed its argument straight to Playwright as a file path, so a name without an extension failed with `unsupported mime type "null"`. The argument is now a *description* and the SDK owns the filename.

That took away what `captureFailure` relied on — it owns its own path. The two callers want different things, so they now have different methods: `screenshot(description)` for a scenario author who knows only what the moment is, and `writeScreenshot(file)` for a caller that already knows where the file belongs, which lets Playwright infer the encoder from the extension as before.

## Testing

`packages/playwright` 32/32 pass, including the new `capture.test.ts` and the existing `captureFailure` coverage that caught the `screenshot()` regression above. The ffmpeg test asserts the contract rather than the outcome, since whether ffmpeg is installed varies by machine: the raw recording survives either way, and the only difference is whether the run said something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REr934jy4usrMbUhxAv5kz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional screenshot and video capture for scenario runs.
  * Screenshots are saved with descriptive, organized filenames and support custom output paths.
  * Videos are recorded per browser context and can be compressed automatically.
  * Captured artifacts are organized by run and scenario for easier review.

* **Bug Fixes**
  * Preserved raw video recordings and displayed a warning when compression is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->