### PR TITLE
fix(cli): gate the generated console secret/variable brokers behind admin scope

### DIFF
--- a/.changeset/console-brokers-admin-scope.md
+++ b/.changeset/console-brokers-admin-scope.md
@@ -1,0 +1,17 @@
+---
+'@pikku/cli': patch
+---
+
+Gate the generated console secret and variable brokers behind admin scope.
+
+The console scaffold emits `pikkuConsoleGetSecret`, `pikkuConsoleSetSecret`,
+`pikkuConsoleHasSecret` and the two variable brokers as exposed `pikkuFunc`s with
+no scope. `wireAddon({ scopes: ['admin'] })` only governs functions whose
+`packageName` is the addon, and these are emitted into the app's own scaffold —
+so the addon gate never reached them, and any authenticated user could read and
+overwrite every application secret through `POST /rpc/:rpcName`.
+
+Each broker now declares `scopes: ['admin']` itself, enforced per-call in the
+function runner.
+
+CWE-862.

--- a/packages/cli/src/functions/wirings/console/serialize-console-functions.test.ts
+++ b/packages/cli/src/functions/wirings/console/serialize-console-functions.test.ts
@@ -20,6 +20,31 @@ test('serializeConsoleFunctions gates the console addon behind the admin scope',
   )
 })
 
+test('every secret/variable broker function carries its own admin scope gate', () => {
+  const { functions } = serializeConsoleFunctions('#pikku', '#agents', '/api')
+
+  // wireAddon({ scopes: ['admin'] }) only governs functions whose packageName
+  // is the addon. These are emitted into the app's own scaffold, so the addon
+  // gate does not reach them — each must declare the scope itself, or any
+  // authenticated user can read and overwrite every secret via POST /rpc.
+  for (const fn of [
+    'pikkuConsoleGetSecret',
+    'pikkuConsoleSetSecret',
+    'pikkuConsoleHasSecret',
+    'pikkuConsoleGetVariable',
+    'pikkuConsoleSetVariable',
+  ]) {
+    const start = functions.indexOf(`export const ${fn} = pikkuFunc({`)
+    assert.notEqual(start, -1, `${fn} should be emitted`)
+    const body = functions.slice(start, functions.indexOf('})', start))
+    assert.match(
+      body,
+      /scopes: \['admin'\]/,
+      `${fn} must declare scopes: ['admin']`
+    )
+  }
+})
+
 test('serializeConsoleFunctions describes every payload with a zod schema', () => {
   const { schemas, functions } = serializeConsoleFunctions(
     '#pikku',

--- a/packages/cli/src/functions/wirings/console/serialize-console-functions.ts
+++ b/packages/cli/src/functions/wirings/console/serialize-console-functions.ts
@@ -51,6 +51,7 @@ import {
 
 export const pikkuConsoleSetSecret = pikkuFunc({
   secretBroker: true,
+  scopes: ['admin'],
   tags: ['pikku'],
   description: 'Set the value of a secret',
   expose: true,
@@ -64,6 +65,7 @@ export const pikkuConsoleSetSecret = pikkuFunc({
 
 export const pikkuConsoleGetVariable = pikkuFunc({
   tags: ['pikku'],
+  scopes: ['admin'],
   description: 'Get the current value of a variable',
   expose: true,
   input: VariableRef,
@@ -85,6 +87,7 @@ export const pikkuConsoleGetVariable = pikkuFunc({
 
 export const pikkuConsoleSetVariable = pikkuFunc({
   tags: ['pikku'],
+  scopes: ['admin'],
   description: 'Set the value of a variable',
   expose: true,
   input: SetVariable,
@@ -101,6 +104,7 @@ export const pikkuConsoleSetVariable = pikkuFunc({
 
 export const pikkuConsoleHasSecret = pikkuFunc({
   secretBroker: true,
+  scopes: ['admin'],
   tags: ['pikku'],
   description: 'Check if a secret exists without reading its value',
   expose: true,
@@ -114,6 +118,7 @@ export const pikkuConsoleHasSecret = pikkuFunc({
 
 export const pikkuConsoleGetSecret = pikkuFunc({
   secretBroker: true,
+  scopes: ['admin'],
   tags: ['pikku'],
   description: 'Get the current value of a secret',
   expose: true,


### PR DESCRIPTION
Closes #1211.

The console scaffold emits `pikkuConsoleGetSecret`/`SetSecret`/`HasSecret` and the two variable brokers as exposed `pikkuFunc`s with no scope. `wireAddon({ scopes: ['admin'] })` only governs functions whose `packageName` is the addon, and these are emitted into the app's own scaffold — so the addon gate never reached them, and any authenticated user could read and overwrite every application secret through `POST /rpc/:rpcName`.

Each broker now declares `scopes: ['admin']` itself, enforced per-call in the function runner.

CWE-862. The companion PKU574 hardening — flagging a session-only `secretBroker` function as ungated — is left as follow-up.

## Provenance

Recovered from an offline branch that never reached origin. Verified against `main` before raising: `wireAddon(… scopes: ['admin'])` is present at `serialize-console-functions.ts:145`, but none of the five broker functions carries a `scopes` field, and `pikkuConsoleGetSecret` returns `value.reveal()`.

## Testing

`serialize-console-functions.test.ts`: 5/5 pass, including the new `every secret/variable broker function carries its own admin scope gate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REr934jy4usrMbUhxAv5kz