### PR TITLE
fix(core): enforce CLI command auth/permissions; mask CLI channel errors in prod

### DIFF
--- a/.changeset/cli-command-auth-and-error-masking.md
+++ b/.changeset/cli-command-auth-and-error-masking.md
@@ -1,0 +1,20 @@
+---
+'@pikku/core': patch
+---
+
+Enforce a CLI command's declared `auth`/`permissions`, and mask CLI channel
+errors in production.
+
+A command's declared `auth`/`permissions` were accepted by the types but dropped
+in `registerCLICommands`: when the command wrapped a function-config object,
+`unwrapFunc` kept only the inner func's fields, so a command-level access-control
+declaration was a silent no-op. They are now merged into the config passed to
+`addFunction` — command-level winning, falling back to the handler's — so the
+function runner enforces them.
+
+The CLI raw channel runner returned the raw exception message to the remote
+client. It can carry internals (a stack, a DB error, a path), so it is now logged
+server-side and replaced with a generic `Command failed` in production; dev keeps
+the message inline.
+
+CWE-862 / CWE-209.

--- a/packages/cli/build.sh
+++ b/packages/cli/build.sh
@@ -72,6 +72,12 @@ echo "Bootstrapping with published @pikku/cli..."
 # Held at the 0.12.79 wave's own version. Moving the wave forward means moving
 # this with it.
 : "${PIKKU_SCHEDULE_VERSION:=0.12.4}"
+# @pikku/ws is the fifth, and it failed the same way one wave later: 0.12.6
+# moved to `@pikku/core/ecosystem` too, so an unpinned ws landing beside the
+# pinned core 0.12.79 reproduces the missing-subpath error verbatim, this time
+# through pikku-ws-server.js. 0.12.5 is the 0.12.79 wave's own version and peers
+# on core ^0.12.73.
+: "${PIKKU_WS_VERSION:=0.12.5}"
 # The other peer that has to be named: @pikku/better-auth peers on the upstream
 # `better-auth` library and imports it at module load, so without it the
 # bootstrap CLI dies on "Cannot find package 'better-auth'".
@@ -102,6 +108,7 @@ cat > "$_bootstrap_dir/package.json" <<JSON
     "@pikku/node-http-server": "${PIKKU_NODE_HTTP_SERVER_VERSION}",
     "@pikku/kysely": "${PIKKU_KYSELY_VERSION}",
     "@pikku/schedule": "${PIKKU_SCHEDULE_VERSION}",
+    "@pikku/ws": "${PIKKU_WS_VERSION}",
     "better-auth": "${BETTER_AUTH_LIB_VERSION}"
   },
   "overrides": {
@@ -111,6 +118,7 @@ cat > "$_bootstrap_dir/package.json" <<JSON
     "@pikku/node-http-server": "${PIKKU_NODE_HTTP_SERVER_VERSION}",
     "@pikku/kysely": "${PIKKU_KYSELY_VERSION}",
     "@pikku/schedule": "${PIKKU_SCHEDULE_VERSION}",
+    "@pikku/ws": "${PIKKU_WS_VERSION}",
     "better-auth": "${BETTER_AUTH_LIB_VERSION}"
   }
 }

--- a/packages/core/src/wirings/cli/channel/cli-raw-channel-runner.test.ts
+++ b/packages/core/src/wirings/cli/channel/cli-raw-channel-runner.test.ts
@@ -103,6 +103,29 @@ describe('handleRawCLI', () => {
     assert.match(result.error!, /deploy plan is red/)
   })
 
+  test('masks the raw error message to the client in production', async () => {
+    const prior = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      wireTestCLI(() => {
+        throw new Error('connection to internal-db:5432 failed: bad password')
+      })
+
+      const result = await handleRawCLI({
+        programName: 'fabric',
+        args: ['deploy'],
+        singletonServices,
+      })
+
+      assert.equal(result.exitCode, 1)
+      assert.equal(result.error, 'Command failed')
+      assert.doesNotMatch(result.error!, /internal-db|password/)
+    } finally {
+      if (prior === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = prior
+    }
+  })
+
   test('exits 0 on help and 1 on an unknown command', async () => {
     wireTestCLI(() => ({}))
 

--- a/packages/core/src/wirings/cli/channel/cli-raw-channel-runner.ts
+++ b/packages/core/src/wirings/cli/channel/cli-raw-channel-runner.ts
@@ -1,4 +1,5 @@
 import { pikkuState } from '../../../pikku-state.js'
+import { isProduction } from '../../../env.js'
 import type { CLIMeta } from '../cli.types.js'
 import { parseCLIArguments, generateCommandHelp } from '../command-parser.js'
 import { runCLICommand } from '../cli-runner.js'
@@ -132,6 +133,16 @@ export async function handleRawCLI({
     // A command can throw anything; `.message` off a string is undefined, and
     // the run would then exit 1 saying nothing at all.
     const message = e instanceof Error ? e.message : String(e)
-    return { error: message || 'Command failed', exitCode: 1, commandId }
+    // The raw message can carry internals (a stack, a DB error, a path). This
+    // runs over a channel that may be remote, so return a generic error in
+    // production and keep the detail server-side. Dev keeps the message inline.
+    singletonServices.logger.error?.(
+      `CLI channel command failed: ${message}`,
+      e
+    )
+    const clientError = isProduction()
+      ? 'Command failed'
+      : message || 'Command failed'
+    return { error: clientError, exitCode: 1, commandId }
   }
 }

--- a/packages/core/src/wirings/cli/cli-runner.test.ts
+++ b/packages/core/src/wirings/cli/cli-runner.test.ts
@@ -396,6 +396,74 @@ describe('CLI Runner', () => {
       const programs = pikkuState(null, 'cli', 'programs')
       assert.strictEqual(programs['nonexistent'], undefined)
     })
+
+    test('enforces command-level permissions declared on a CLI command', async () => {
+      let functionRan = false
+
+      pikkuState(null, 'cli', 'meta', {
+        programs: {
+          'sec-cli': {
+            program: 'sec-cli',
+            commands: {
+              secret: {
+                command: 'secret',
+                pikkuFuncId: 'secretFunc',
+                positionals: [],
+                options: {},
+              },
+            },
+            options: {},
+          },
+        },
+        renderers: {},
+      })
+      pikkuState(null, 'function', 'meta', {
+        secretFunc: {
+          pikkuFuncId: 'secretFunc',
+          inputSchemaName: null,
+          outputSchemaName: null,
+          sessionless: true,
+        },
+      })
+
+      wireCLI({
+        program: 'sec-cli',
+        commands: {
+          // command.func is a function-config object, so unwrapFunc reads the
+          // inner func's auth/permissions and previously dropped the
+          // command-level ones — the branch this fix restores.
+          secret: {
+            func: {
+              func: async () => {
+                functionRan = true
+                return {}
+              },
+            },
+            // A permission that always denies.
+            permissions: { deny: async () => false },
+          } as any,
+        },
+      })
+
+      const result = await runCLICommand({
+        program: 'sec-cli',
+        commandPath: ['secret'],
+        data: {},
+        singletonServices,
+        createWireServices,
+      }).catch((error) => ({ success: false, error }))
+
+      assert.equal(
+        functionRan,
+        false,
+        'the function must not run when a declared permission denies'
+      )
+      assert.notEqual(
+        (result as any).success,
+        true,
+        'the command must not report success when permission is denied'
+      )
+    })
   })
 
   describe('pikkuCLIRender', () => {

--- a/packages/core/src/wirings/cli/cli-runner.ts
+++ b/packages/core/src/wirings/cli/cli-runner.ts
@@ -169,7 +169,24 @@ function registerCLICommands(
       }
     }
 
-    addFunction(funcName, unwrapFunc(command), currentMeta?.packageName)
+    // Merge the command-level auth/permissions into the registered config so
+    // they are actually enforced by the function runner. They were accepted by
+    // the types but dropped here, making a command's declared access control a
+    // silent no-op. Command-level wins over the handler's own, then falls back
+    // to it.
+    const unwrapped = unwrapFunc(command)
+    const commandAuth = typeof command === 'object' ? command.auth : undefined
+    const commandPermissions =
+      typeof command === 'object' ? command.permissions : undefined
+    addFunction(
+      funcName,
+      {
+        ...unwrapped,
+        auth: commandAuth ?? unwrapped.auth,
+        permissions: commandPermissions ?? unwrapped.permissions,
+      },
+      currentMeta?.packageName
+    )
 
     if (typeof command === 'object' && command.render) {
       if (programs[program]) {


### PR DESCRIPTION
Closes #1213.

Two CLI-over-channel hardenings.

A command's declared `auth`/`permissions` were accepted by the types but dropped in `registerCLICommands` — when the command wrapped a function-config object, `unwrapFunc` kept only the inner func's fields, so a command-level access-control declaration was a silent no-op. They are now merged into the config passed to `addFunction` (command-level winning, falling back to the handler's), so the function runner enforces them.

The CLI raw channel runner returned the raw exception message to the remote client. It can carry internals (a stack, a DB error, a path), so it is now logged server-side and replaced with a generic `Command failed` in production; dev keeps the message inline.

CWE-862 / CWE-209.

## Provenance

Recovered from an offline branch that never reached origin. Both gaps verified present in `main` before raising — `unwrapFunc` still returns only `command.func.*`, and `cli-raw-channel-runner.ts:134` still returns the raw message.

## Testing

`cli-runner.test.ts` + `cli-raw-channel-runner.test.ts`: 22 pass, 0 fail, including the new `enforces command-level permissions declared on a CLI command`. The 1 skipped test (`should provide CLI context to middleware`, `cli-runner.test.ts:211`) is pre-existing on `main` at the same line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REr934jy4usrMbUhxAv5kz