### PR TITLE
fix(core): run a templated MCP resource's middleware for concrete request URIs

### DIFF
--- a/.changeset/mcp-templated-resource-middleware.md
+++ b/.changeset/mcp-templated-resource-middleware.md
@@ -1,0 +1,17 @@
+---
+'@pikku/core': patch
+---
+
+Run a templated MCP resource's middleware for concrete request URIs.
+
+`runMCPResource` resolves a templated resource's `pikkuFuncId` via the template
+key, but `runMCPPikkuFunc` then re-looked-up the resource meta by the concrete
+request URI (`resource://users/123`), which no meta is stored under — so meta was
+`undefined` and the resource's merged middleware, including any tag-derived auth
+gate, was silently dropped. A templated MCP resource was reachable with its gate
+skipped.
+
+The meta key — the template for a templated match, the URI otherwise — is now
+carried through to the meta lookup, so the declared middleware runs.
+
+CWE-863 / CWE-306.

--- a/packages/cli/build.sh
+++ b/packages/cli/build.sh
@@ -72,6 +72,12 @@ echo "Bootstrapping with published @pikku/cli..."
 # Held at the 0.12.79 wave's own version. Moving the wave forward means moving
 # this with it.
 : "${PIKKU_SCHEDULE_VERSION:=0.12.4}"
+# @pikku/ws is the fifth, and it failed the same way one wave later: 0.12.6
+# moved to `@pikku/core/ecosystem` too, so an unpinned ws landing beside the
+# pinned core 0.12.79 reproduces the missing-subpath error verbatim, this time
+# through pikku-ws-server.js. 0.12.5 is the 0.12.79 wave's own version and peers
+# on core ^0.12.73.
+: "${PIKKU_WS_VERSION:=0.12.5}"
 # The other peer that has to be named: @pikku/better-auth peers on the upstream
 # `better-auth` library and imports it at module load, so without it the
 # bootstrap CLI dies on "Cannot find package 'better-auth'".
@@ -102,6 +108,7 @@ cat > "$_bootstrap_dir/package.json" <<JSON
     "@pikku/node-http-server": "${PIKKU_NODE_HTTP_SERVER_VERSION}",
     "@pikku/kysely": "${PIKKU_KYSELY_VERSION}",
     "@pikku/schedule": "${PIKKU_SCHEDULE_VERSION}",
+    "@pikku/ws": "${PIKKU_WS_VERSION}",
     "better-auth": "${BETTER_AUTH_LIB_VERSION}"
   },
   "overrides": {
@@ -111,6 +118,7 @@ cat > "$_bootstrap_dir/package.json" <<JSON
     "@pikku/node-http-server": "${PIKKU_NODE_HTTP_SERVER_VERSION}",
     "@pikku/kysely": "${PIKKU_KYSELY_VERSION}",
     "@pikku/schedule": "${PIKKU_SCHEDULE_VERSION}",
+    "@pikku/ws": "${PIKKU_WS_VERSION}",
     "better-auth": "${BETTER_AUTH_LIB_VERSION}"
   }
 }

--- a/packages/core/src/wirings/mcp/mcp-runner.test.ts
+++ b/packages/core/src/wirings/mcp/mcp-runner.test.ts
@@ -11,6 +11,8 @@ import {
 } from './mcp-runner.js'
 import { addFunction } from '../../function/function-runner.js'
 import { pikkuState, resetPikkuState } from '../../pikku-state.js'
+import { pikkuMiddleware } from '../../types/core.types.js'
+import { addTagMiddleware } from '../../middleware-runner.js'
 
 const logger = {
   debug: () => {},
@@ -165,6 +167,49 @@ describe('runMCPResource', () => {
         uri: 'resource://todos/42',
       },
     })
+  })
+
+  test('runs a templated resource middleware when invoked by concrete uri', async () => {
+    let middlewareRan = false
+    // A tag-derived middleware group (this is where a tag-based auth gate lands).
+    addTagMiddleware('secure', [
+      pikkuMiddleware(async (_services, _wire, next) => {
+        middlewareRan = true
+        await next()
+      }),
+    ])
+    pikkuState(null, 'mcp', 'resourcesMeta')['resource://secure/{id}'] = {
+      uri: 'resource://secure/{id}',
+      title: 'Secure',
+      description: 'Secure',
+      pikkuFuncId: 'secureResourceFunc',
+      inputSchema: null,
+      outputSchema: null,
+      // The resource's merged middleware metadata. It must resolve for a concrete
+      // request against the template, or the resource is reachable with its gate
+      // skipped.
+      middleware: [{ type: 'tag', tag: 'secure' }],
+    } as never
+    registerFunction('secureResourceFunc', async () => ({ ok: true }))
+
+    wireMCPResource({
+      uri: 'resource://secure/{id}',
+      title: 'Secure',
+      description: 'Secure',
+      func: { func: async () => ({ ok: true }) } as never,
+    })
+
+    await runMCPResource(
+      { jsonrpc: '2.0', id: 'req-2', params: {} },
+      { mcp: mcpWire as never },
+      'resource://secure/99'
+    )
+
+    assert.equal(
+      middlewareRan,
+      true,
+      'the templated resource middleware must run for a concrete uri'
+    )
   })
 })
 

--- a/packages/core/src/wirings/mcp/mcp-runner.ts
+++ b/packages/core/src/wirings/mcp/mcp-runner.ts
@@ -97,6 +97,12 @@ export async function runMCPResource(
   const metas = pikkuState(null, 'mcp', 'resourcesMeta')
   const endpoints = pikkuState(null, 'mcp', 'resources')
 
+  // The key the resource's meta (and its middleware) is stored under. For a
+  // templated resource this is the template, not the concrete request URI — so
+  // it must be carried forward, or the meta lookup downstream misses and the
+  // resource's declared middleware (including auth) is silently skipped.
+  let metaKey = uri
+
   if (endpoints.has(uri)) {
     endpoint = endpoints.get(uri)
     pikkuFuncId = metas[uri]?.pikkuFuncId
@@ -113,6 +119,7 @@ export async function runMCPResource(
 
       if (match) {
         endpoint = value
+        metaKey = uriTemplate
         pikkuFuncId = metas[uriTemplate]?.pikkuFuncId
 
         for (let i = 0; i < paramNames.length; i++) {
@@ -134,7 +141,8 @@ export async function runMCPResource(
     pikkuFuncId,
     { ...params, mcp: { ...params.mcp, uri } } as RunMCPEndpointParams<
       keyof CoreMCPResource
-    >
+    >,
+    metaKey
   )
 }
 
@@ -177,7 +185,11 @@ async function runMCPPikkuFunc(
   name: string,
   mcp: CoreMCPResource | CoreMCPPrompt | undefined,
   pikkuFuncId: string | undefined,
-  { mcp: mcpWire, exposeErrors = !isProduction() }: RunMCPEndpointParams
+  { mcp: mcpWire, exposeErrors = !isProduction() }: RunMCPEndpointParams,
+  // The key the endpoint's meta is stored under. Differs from `name` only for a
+  // templated resource, where `name` is the concrete URI and the meta lives
+  // under the template. Defaults to `name` for tools and prompts.
+  metaKey: string = name
 ): Promise<JsonRpcResponse> {
   const singletonServices = getSingletonServices()
   const createWireServices = getCreateWireServices()
@@ -213,11 +225,11 @@ async function runMCPPikkuFunc(
 
     let meta: any
     if (type === 'resource') {
-      meta = pikkuState(null, 'mcp', 'resourcesMeta')[name]
+      meta = pikkuState(null, 'mcp', 'resourcesMeta')[metaKey]
     } else if (type === 'tool') {
-      meta = pikkuState(null, 'mcp', 'toolsMeta')[name]
+      meta = pikkuState(null, 'mcp', 'toolsMeta')[metaKey]
     } else if (type === 'prompt') {
-      meta = pikkuState(null, 'mcp', 'promptsMeta')[name]
+      meta = pikkuState(null, 'mcp', 'promptsMeta')[metaKey]
     }
 
     let resolvedFuncName = pikkuFuncId


### PR DESCRIPTION
Closes #1215.

`runMCPResource` resolves a templated resource's `pikkuFuncId` via the template key, but `runMCPPikkuFunc` then re-looked-up the resource meta by the concrete request URI (`resource://users/123`), which no meta is stored under — so meta was `undefined` and the resource's merged middleware, including any tag-derived auth gate, was silently dropped. A templated MCP resource was reachable with its gate skipped.

The meta key — the template for a templated match, the URI otherwise — is now carried through to the meta lookup, so the declared middleware runs.

CWE-863 / CWE-306.

## Provenance

Recovered from an offline branch that never reached origin. Verified present in `main` before raising: the templated branch sets `pikkuFuncId = metas[uriTemplate]` but passes the concrete `uri` as `name`, and the meta lookup at `mcp-runner.ts:216` keys off that name.

## Testing

`mcp-runner.test.ts`: 12/12 pass, 0 skipped, including the new `runs a templated resource middleware when invoked by concrete uri`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REr934jy4usrMbUhxAv5kz