### PR TITLE
feat(workflow): let an approval gate declare who may answer it

### DIFF
--- a/.changeset/workflow-approval-approvers-policy.md
+++ b/.changeset/workflow-approval-approvers-policy.md
@@ -18,6 +18,15 @@ the gate. A decision that fails the policy is discarded and the gate stays
 closed. Where the run has already published its policy, the check also runs at
 submission time so the caller gets a 403 rather than silence.
 
+An answer is now recorded where it can be answered for later. The settled
+decision carries `decidedBy` and `decidedAt` in its `ApprovalOutcome`, so who
+signed reaches `workflowStep.result` and `workflowStepHistory` rather than
+living only in mutable run state. Every answer — accepted, refused at the door,
+or cleared on replay — is also written to the audit sink as
+`workflow.approval.decided`, which outlives the run: `deleteRun` cascades to
+steps and history, and a refused attempt never reaches a step at all. Projects
+with no audit service wired are unaffected.
+
 **This loosens the default.** `approveStep` previously refused anyone but the
 run's initiator, unconditionally. A gate that declares no `approvers` now
 accepts a decision from anyone the approve entrypoint admits — restore the old

--- a/.changeset/workflow-approval-approvers-policy.md
+++ b/.changeset/workflow-approval-approvers-policy.md
@@ -1,0 +1,25 @@
+---
+'@pikku/core': patch
+'@pikku/inspector': patch
+'@pikku/cli': patch
+'@pikku/skills': patch
+---
+
+feat(workflow): let an approval gate declare who may answer it
+
+`workflow.approval()` gains `approvers` (`'any' | 'owner' | 'not-initiator'`)
+and `approverScope`, so a gate can require four-eyes sign-off, restrict itself
+to the run's initiator, or require the decider to hold a named scope.
+
+Both are enforced when the workflow replays the gate — the same place, and for
+the same reason, the decision payload is validated: the policy is a value on
+the workflow, and a decision can be recorded before the run has ever reached
+the gate. A decision that fails the policy is discarded and the gate stays
+closed. Where the run has already published its policy, the check also runs at
+submission time so the caller gets a 403 rather than silence.
+
+**This loosens the default.** `approveStep` previously refused anyone but the
+run's initiator, unconditionally. A gate that declares no `approvers` now
+accepts a decision from anyone the approve entrypoint admits — restore the old
+behaviour per-gate with `approvers: 'owner'`, or gate the approve route with
+`auth`/`permissions`. Ownership still governs *reads* of a run unchanged.

--- a/packages/cli/src/functions/wirings/workflow/serialize-workflow-routes.ts
+++ b/packages/cli/src/functions/wirings/workflow/serialize-workflow-routes.ts
@@ -284,10 +284,12 @@ export const workflowStatusStreamFull = pikkuSessionlessFunc({
  * The decision is validated on replay inside the workflow body — the only place
  * the approval's schema value is in scope — so this route deliberately accepts
  * an unknown payload. An invalid one re-closes the gate rather than failing the
- * A run started through a session may only be approved by that session's user
- * (\`assertWorkflowRunOwner\`). A run with no recorded owner has nobody to compare
- * a caller against — gate this route with your own auth/permissions to control
- * WHO may approve those.
+ * request.
+ *
+ * WHO may approve is likewise the gate's own business, declared with
+ * \`approvers\`/\`approverScope\` on \`workflow.approval()\` and enforced on replay.
+ * A gate that declares neither accepts a decision from anyone this route lets
+ * through — gate the route with your own auth/permissions to narrow that.
  */
 export const workflowApprover = pikkuSessionlessFunc({
   tags: ['pikku'],

--- a/packages/cli/src/functions/wirings/workflow/serialize-workflow-routes.ts
+++ b/packages/cli/src/functions/wirings/workflow/serialize-workflow-routes.ts
@@ -287,7 +287,13 @@ export const workflowStatusStreamFull = pikkuSessionlessFunc({
  * request.
  *
  * WHO may approve is likewise the gate's own business, declared with
- * \`approvers\`/\`approverScope\` on \`workflow.approval()\` and enforced on replay.
+ * \`approvers\`/\`approverScope\` on \`workflow.approval()\`, and enforced in two
+ * places. Once the run has reached the gate it has published its policy, so this
+ * route judges the caller against it and refuses with a 403. A decision arriving
+ * before the gate has no policy to judge against yet, so it is accepted here and
+ * judged on replay instead, where failing discards the decision and leaves the
+ * gate closed. A caller sees either outcome depending on that timing.
+ *
  * A gate that declares neither accepts a decision from anyone this route lets
  * through — gate the route with your own auth/permissions to narrow that.
  */

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,12 +5,12 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2830 observable things**: 975 exported names, plus
-1855 members on the classes and interfaces among them.
+**2842 observable things**: 979 exported names, plus
+1863 members on the classes and interfaces among them.
 
 | tier | entry points | names | members |
 | --- | ---: | ---: | ---: |
-| stable | 48 | 965 | 1855 |
+| stable | 48 | 969 | 1863 |
 | ecosystem | 2 | 10 | 0 |
 
 An entry point whose exports are mostly *exclusive* is a self-contained
@@ -20,8 +20,8 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | --- | ---: | ---: | ---: |
 | `./services` | 168 | 74 | 277 |
 | `.` | 241 | 98 | 128 |
+| `./workflow` | 128 | 51 | 153 |
 | `./virtual-user` | 51 | 51 | 152 |
-| `./workflow` | 124 | 50 | 151 |
 | `./ai-agent` | 63 | 62 | 90 |
 | `./channel` | 50 | 49 | 82 |
 | `./queue` | 32 | 31 | 68 |
@@ -40,7 +40,7 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | `./rpc` | 15 | 10 | 8 |
 | `./services/local-content` | 3 | 3 | 15 |
 | `./cli/channel` | 12 | 12 | 5 |
-| `./workflow/types` | 69 | 4 | 8 |
+| `./workflow/types` | 72 | 4 | 8 |
 | `./scheduler` | 7 | 7 | 4 |
 | `./services/temporary-file-service` | 2 | 2 | 9 |
 | `./scope` | 10 | 10 | 0 |
@@ -1737,14 +1737,25 @@ wrapChannelWithMiddleware: <Out>(wire: PikkuRawWire, services: CoreSingletonServ
 ```ts
 addFeature: (featureId: string, feature: CoreFeature, packageName?: string | null) => void
 addWorkflow: (workflowName: string, workflowFunc: any, packageName?: string | null) => void
+export interface ApprovalDecider {
+  userId?: string
+  scopes?: string[]
+}
 export type ApprovalOutcome<T> =
-  | { status: 'decided'; data: T }
+  | {
+      status: 'decided'
+      data: T
+      decidedBy?: ApprovalDecider
+      decidedAt?: string
+    }
   | { status: 'expired' }
 export interface ApprovalStepMeta {
   type: 'approval'
   reason: string
   outputVar?: string
   expiry?: string | number
+  approvers?: WorkflowApprovalApprovers
+  approverScope?: string
 }
 export interface ArrayPredicateStepMeta {
   type: 'arrayPredicate'
@@ -2227,9 +2238,18 @@ export interface TestIdSelector {
 }
 uuidv5: (name: string, namespace?: string) => string
 witnessesAgree: (a: unknown, b: unknown) => boolean
-export interface WorkflowApprovalOptions< TSchema extends StandardSchemaV1 = StandardSchemaV1, > {
+export type WorkflowApprovalApprovers = 'any' | 'owner' | 'not-initiator'
+export class WorkflowApprovalForbiddenError extends ForbiddenError {
+  public payload: { reason: string; detail: string }
+  constructor(reason: string, detail: string)
+}
+export interface WorkflowApprovalOptions< TSchema extends StandardSchemaV1 = StandardSchemaV1, > extends WorkflowApprovalPolicy {
   schema: TSchema
   expiry?: string | number
+}
+export interface WorkflowApprovalPolicy {
+  approvers?: WorkflowApprovalApprovers
+  approverScope?: string
 }
 export class WorkflowApprovalResolvedError extends PikkuError {
   public payload: { reason: string; outcome: ApprovalOutcome<unknown>['status'] }
@@ -2549,14 +2569,25 @@ export interface RunTimelineEvent {
 ## ./workflow/types
 
 ```ts
+export interface ApprovalDecider {
+  userId?: string
+  scopes?: string[]
+}
 export type ApprovalOutcome<T> =
-  | { status: 'decided'; data: T }
+  | {
+      status: 'decided'
+      data: T
+      decidedBy?: ApprovalDecider
+      decidedAt?: string
+    }
   | { status: 'expired' }
 export interface ApprovalStepMeta {
   type: 'approval'
   reason: string
   outputVar?: string
   expiry?: string | number
+  approvers?: WorkflowApprovalApprovers
+  approverScope?: string
 }
 export interface ArrayPredicateStepMeta {
   type: 'arrayPredicate'
@@ -2810,9 +2841,14 @@ export interface SwitchStepMeta {
   cases: SwitchCaseMeta[]
   defaultSteps?: WorkflowStepMeta[]
 }
-export interface WorkflowApprovalOptions< TSchema extends StandardSchemaV1 = StandardSchemaV1, > {
+export type WorkflowApprovalApprovers = 'any' | 'owner' | 'not-initiator'
+export interface WorkflowApprovalOptions< TSchema extends StandardSchemaV1 = StandardSchemaV1, > extends WorkflowApprovalPolicy {
   schema: TSchema
   expiry?: string | number
+}
+export interface WorkflowApprovalPolicy {
+  approvers?: WorkflowApprovalApprovers
+  approverScope?: string
 }
 export type WorkflowContext = Record<string, ContextVariable>
 export interface WorkflowExpectErrorOptions extends WorkflowStepOptions {

--- a/packages/core/knowledge/decisions/security/a-workflow-run-is-read-and-approved-by-its-owner.md
+++ b/packages/core/knowledge/decisions/security/a-workflow-run-is-read-and-approved-by-its-owner.md
@@ -33,9 +33,14 @@ initiator may answer" the one available rule. That is right for "confirm your ow
 action" and exactly wrong for four-eyes sign-off, where the initiator is the one
 person who must not sign. Which applies is a property of the decision, so it is
 declared on the gate — `approvers` (`'any' | 'owner' | 'not-initiator'`) and
-`approverScope` on `WorkflowApprovalOptions` — and enforced on replay alongside
-payload validation, because the policy is a value on the workflow and a decision
-can legitimately be recorded before the run has reached the gate.
+`approverScope` on `WorkflowApprovalOptions`.
+
+It is enforced wherever the policy is known. Reaching the gate publishes the
+policy into the run state, so a decision submitted after that is judged by the
+approve entrypoint and refused with a 403. A decision can legitimately be
+recorded before the run has reached the gate, and that one has no policy to be
+judged against yet — it is judged on replay instead, alongside payload
+validation, and discarded if it fails.
 
 The default is therefore `any`: a gate is a pause for a decision, not an
 authorization boundary, and a route that needs one has `auth`/`permissions`.

--- a/packages/core/knowledge/decisions/security/a-workflow-run-is-read-and-approved-by-its-owner.md
+++ b/packages/core/knowledge/decisions/security/a-workflow-run-is-read-and-approved-by-its-owner.md
@@ -1,11 +1,11 @@
 ---
 type: decision
-title: A workflow run is read and approved by its owner
-description: A run started through a session records that user and only that user may read it or answer its approval gates; a run with no recorded owner has no ownership to enforce
+title: A workflow run is read by its owner, and answered by whoever its gate declares
+description: A run started through a session records that user and only that user may read it; who may answer an approval gate is the gate's own declaration, and a run with no recorded owner has no ownership to enforce
 tags: workflow
 ---
 
-# A workflow run is read and approved by its owner
+# A workflow run is read by its owner, and answered by whoever its gate declares
 
 `WorkflowRunWire.pikkuUserId` has always been recorded on every run started
 through a session — `RPCService.startWorkflow` copies it off the wire — and
@@ -14,9 +14,9 @@ routes (which stream `output` and `error`) and `approveStep`, which took no
 session at all and rejected only an already-resolved gate.
 
 `assertWorkflowRunOwner`
-(`packages/core/src/wirings/workflow/workflow-run-ownership.ts`) is the one check
-both paths share. `approveStep` takes the caller's session and asserts it, and
-the generated status routes assert it against the run they were already reading.
+(`packages/core/src/wirings/workflow/workflow-run-ownership.ts`) is the check the
+**read** paths share: the generated status routes assert it against the run they
+were already reading.
 
 **A run with no recorded owner is not gated.** Triggers, schedulers and routes
 wired without auth start runs with no `pikkuUserId`; there is nobody to compare a
@@ -24,11 +24,22 @@ caller against, and inventing one would reject the framework's own callers rathe
 than secure anything. Gate those at the entrypoint with `auth` or `permissions`.
 
 This is ownership, not an approver model. It answers "is this your run", not "are
-you entitled to approve this particular gate" — `WorkflowApprovalOptions` still
-carries no approver, role or permission, and a second approver on someone else's
-run is still a matter for the route's own `permissions`.
+you entitled to approve this particular gate".
 
-**What this rules out:** treating a run id as a capability, and adding a new run
-read path that does not take a session. It does not rule out a richer approver
-model on `WorkflowApprovalOptions` later; that would narrow this gate, never
-replace it.
+## Approving is a separate question, and the gate answers it
+
+`approveStep` originally shared `assertWorkflowRunOwner`, which made "only the
+initiator may answer" the one available rule. That is right for "confirm your own
+action" and exactly wrong for four-eyes sign-off, where the initiator is the one
+person who must not sign. Which applies is a property of the decision, so it is
+declared on the gate — `approvers` (`'any' | 'owner' | 'not-initiator'`) and
+`approverScope` on `WorkflowApprovalOptions` — and enforced on replay alongside
+payload validation, because the policy is a value on the workflow and a decision
+can legitimately be recorded before the run has reached the gate.
+
+The default is therefore `any`: a gate is a pause for a decision, not an
+authorization boundary, and a route that needs one has `auth`/`permissions`.
+
+**What this rules out:** treating a run id as a capability, adding a new run read
+path that does not take a session, and re-deriving who may approve from who
+started the run.

--- a/packages/core/knowledge/decisions/security/an-approval-answer-outlives-the-run-it-answered.md
+++ b/packages/core/knowledge/decisions/security/an-approval-answer-outlives-the-run-it-answered.md
@@ -1,0 +1,59 @@
+---
+type: decision
+title: An approval answer outlives the run it answered
+description: Run state holds a decision only while the gate is open, so the settled answer carries decidedBy/decidedAt into the step result and every attempt is written to the audit sink, which has no foreign key to the run
+tags: workflow, audit
+---
+
+# An approval answer outlives the run it answered
+
+An approval gate is asked for so it can be answered for afterwards. "Who
+released the funds" is the entire point of four-eyes sign-off, and until this
+change none of it was kept.
+
+Run state is where a decision *waits*, not where it is kept. The record under
+`workflowRuns.state.__approval_<hex>` is overwritten by the next write to that
+key, and cleared outright — `decidedBy: undefined` included — whenever a
+decision is refused on replay. A trail that erases exactly the events worth
+keeping is not a trail.
+
+So the answer is recorded twice, in two places with different lifetimes.
+
+## The settled decision keeps its provenance
+
+`ApprovalOutcome<T>` carries `decidedBy` and `decidedAt` alongside `data`, so
+the answer reaches `workflowStep.result` and, through it,
+`workflowStepHistory` — append-only, and already the per-step event log. Both
+are spread in only when present, so a gate answered without a session keeps the
+shape it had before there was anything to record.
+
+## The audit sink is what survives deletion
+
+`deleteRun` cascades: `workflowStep` is `onDelete('cascade')` from
+`workflowRuns`, and `workflowStepHistory` from `workflowStep`. Deleting a run
+therefore deletes the sign-off with it — and a *refused* attempt never reaches a
+step at all, so it was never in that trail to begin with.
+
+Every answer — accepted, refused at submission, or cleared on replay — is
+written to the `AuditService` as `workflow.approval.decided`, with
+`outcome: 'success' | 'denied'`, the decider under `userIdentity.pikkuUserId`,
+and the run, reason, scopes and refusal in `metadata`. The `audit` table holds
+no foreign key to any workflow table, which is precisely why it is the right
+home.
+
+`auditApprovalDecision`
+(`packages/core/src/wirings/workflow/workflow-approval-audit.ts`) is a module of
+its own rather than a method on `PikkuWorkflowService`: the trail is a separate
+concern from running the workflow, and the service is already at the 2000-line
+limit `source-files-stay-composable.test.ts` enforces.
+
+**A sink that fails is logged, never thrown.** The trail must not be the reason a
+decision is lost. A project with no `audit` service wired records nothing and is
+otherwise unaffected — the sink is opt-in, and `auditSchema` is deliberately not
+in `pikkuSchemas`.
+
+**What this rules out:** a dedicated `workflowApprovals` table. It would have to
+be implemented in all seven backends and would still be deleted with the run
+unless it deliberately broke the cascade — at which point it is the audit table
+with extra steps. If approvals later need to be *queried* as a first-class
+entity rather than read back from the trail, that is when to revisit.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
     "./dist/errors/errors.js",
     "./dist/wirings/rpc/rpc-runner.js",
     "./dist/wirings/rpc/remote-addon-auth.js",
+    "./dist/wirings/workflow/workflow-approval-policy.js",
     "./dist/wirings/workflow/workflow-errors.js",
     "./dist/wirings/workflow/workflow-run-ownership.js",
     "./dist/wirings/workflow/pikku-scenario-service.js"

--- a/packages/core/src/public-surface.json
+++ b/packages/core/src/public-surface.json
@@ -152,6 +152,7 @@
     "DEFAULT_STEP_RETRIES",
     "PikkuWorkflowService",
     "SCENARIO_SURFACES",
+    "WorkflowApprovalForbiddenError",
     "WorkflowApprovalResolvedError",
     "WorkflowCancelledException",
     "WorkflowDispatchException",

--- a/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
+++ b/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
@@ -129,11 +129,43 @@ export type WorkflowWireSleep = (
 export type WorkflowWireSuspend = (reason: string) => Promise<void>
 
 /**
+ * Who is allowed to answer an approval gate, relative to the user who started
+ * the run.
+ *
+ * - `any` — anyone the approve entrypoint lets through. The gate is a pause for
+ *   a decision, not an authorization boundary.
+ * - `owner` — only the user who started the run, so a gate can be used to
+ *   confirm an action against the same person who requested it.
+ * - `not-initiator` — anyone *except* the user who started the run: four-eyes.
+ *   A run with no recorded initiator has nobody to exclude, so this degrades to
+ *   requiring a signed-in decider.
+ */
+export type WorkflowApprovalApprovers = 'any' | 'owner' | 'not-initiator'
+
+/**
+ * Who may answer an approval gate. Declared on the gate rather than the
+ * entrypoint because it is a property of the decision being made, and because
+ * one workflow can hold several gates with different requirements.
+ */
+export interface WorkflowApprovalPolicy {
+  /**
+   * Defaults to `any`. See {@link WorkflowApprovalApprovers}.
+   */
+  approvers?: WorkflowApprovalApprovers
+  /**
+   * Additionally require the decider's session to hold this scope, so
+   * "a second pair of eyes" can be narrowed to "a second pair of *senior*
+   * eyes". Combines with `approvers` — both must pass.
+   */
+  approverScope?: string
+}
+
+/**
  * Options for workflow.approval().
  */
 export interface WorkflowApprovalOptions<
   TSchema extends StandardSchemaV1 = StandardSchemaV1,
-> {
+> extends WorkflowApprovalPolicy {
   /**
    * Schema the decision payload is validated against. This is a VALUE, not a
    * type generic: the payload arrives from an untrusted caller over the approve
@@ -430,6 +462,10 @@ export interface ApprovalStepMeta {
   outputVar?: string
   /** Expiry duration, when one was given */
   expiry?: string | number
+  /** Who may answer the gate, when the default was not used */
+  approvers?: WorkflowApprovalApprovers
+  /** Scope the decider must hold, when one was required */
+  approverScope?: string
 }
 
 /**

--- a/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
+++ b/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
@@ -161,6 +161,17 @@ export interface WorkflowApprovalPolicy {
 }
 
 /**
+ * The decider, reduced to the two facts a policy can be expressed in terms of.
+ * Recorded alongside the decision so the gate can be judged on replay — the
+ * session itself is long gone by then — and carried into the settled outcome so
+ * the answer keeps its provenance.
+ */
+export interface ApprovalDecider {
+  userId?: string
+  scopes?: string[]
+}
+
+/**
  * Options for workflow.approval().
  */
 export interface WorkflowApprovalOptions<
@@ -188,7 +199,18 @@ export interface WorkflowApprovalOptions<
  * carried in `data` and is the application's business, not the framework's.
  */
 export type ApprovalOutcome<T> =
-  | { status: 'decided'; data: T }
+  | {
+      status: 'decided'
+      data: T
+      /**
+       * Who answered, and when. Run state holds the decision only while the gate
+       * is open — it is overwritten by the next write and cleared outright when a
+       * decision is refused — so the settled answer carries its own provenance
+       * into the step result, which is append-only.
+       */
+      decidedBy?: ApprovalDecider
+      decidedAt?: string
+    }
   | { status: 'expired' }
 
 /**

--- a/packages/core/src/wirings/workflow/index.ts
+++ b/packages/core/src/wirings/workflow/index.ts
@@ -97,6 +97,7 @@ export type {
   WorkflowApprovalOptions,
   WorkflowApprovalApprovers,
   WorkflowApprovalPolicy,
+  ApprovalDecider,
   ApprovalOutcome,
   InputSource,
   OutputBinding,

--- a/packages/core/src/wirings/workflow/index.ts
+++ b/packages/core/src/wirings/workflow/index.ts
@@ -13,6 +13,7 @@ export {
   assertWorkflowRunOwner,
   WorkflowRunForbiddenError,
 } from './workflow-run-ownership.js'
+export { WorkflowApprovalForbiddenError } from './workflow-approval-policy.js'
 export type {
   RunLifecycleContext,
   WorkflowRunEngine,
@@ -94,6 +95,8 @@ export type {
   WorkflowWireSuspend,
   WorkflowWireApproval,
   WorkflowApprovalOptions,
+  WorkflowApprovalApprovers,
+  WorkflowApprovalPolicy,
   ApprovalOutcome,
   InputSource,
   OutputBinding,

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
@@ -661,12 +661,9 @@ describe('pikku-workflow-service approval', () => {
 
     const run = await ws.getRun(runId)
     assert.equal(run?.status, 'completed')
-    assert.deepEqual(run?.output, {
-      decision: {
-        status: 'decided',
-        data: { approved: true, comment: 'lgtm' },
-      },
-    })
+    const decision = (run?.output as any)?.decision
+    assert.equal(decision.status, 'decided')
+    assert.deepEqual(decision.data, { approved: true, comment: 'lgtm' })
 
     cleanup()
   })
@@ -714,9 +711,9 @@ describe('pikku-workflow-service approval', () => {
     await ws.runWorkflowJob(runId, {})
     const run = await ws.getRun(runId)
     assert.equal(run?.status, 'completed')
-    assert.deepEqual(run?.output, {
-      decision: { status: 'decided', data: { approved: false } },
-    })
+    const decision = (run?.output as any)?.decision
+    assert.equal(decision.status, 'decided')
+    assert.deepEqual(decision.data, { approved: false })
 
     cleanup()
   })
@@ -834,9 +831,13 @@ describe('pikku-workflow-service approval', () => {
 
     const run = await ws.getRun(runId)
     assert.equal(run?.status, 'completed')
-    assert.deepEqual(run?.output, {
-      decision: { status: 'decided', data: { approved: true } },
-    })
+    const decision = (run?.output as any)?.decision
+    assert.equal(decision.status, 'decided')
+    assert.deepEqual(decision.data, { approved: true })
+    // Answered with no session, so there is nobody to name — but when the
+    // answer arrived is recorded either way.
+    assert.equal(decision.decidedBy, undefined)
+    assert.ok(!Number.isNaN(Date.parse(decision.decidedAt)))
 
     cleanup()
   })

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -95,6 +95,7 @@ import {
   recordApprovalDecision,
   type ApprovalStore,
 } from './workflow-approval.js'
+import { auditApprovalDecision } from './workflow-approval-audit.js'
 import { recordSuspension, suspendStepNameFor } from './workflow-suspend.js'
 import {
   RedispatchBackoff,
@@ -1858,6 +1859,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       scheduleRunWake: (runId, delay) => this.scheduleRunWake(runId, delay),
       getRunOwner: async (runId) =>
         (await this.getRunIdentity(runId))?.wire?.pikkuUserId,
+      auditApproval: (event) => auditApprovalDecision(event),
     }
   }
 

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -47,7 +47,7 @@ import { PikkuMissingMetaError } from '../../errors/errors.js'
 import { RPCNotFoundError } from '../rpc/rpc-runner.js'
 import type { PikkuRPC } from '../rpc/rpc-types.js'
 import { deriveInvocationId } from './workflow-invocation-id.js'
-import { assertWorkflowRunOwner } from './workflow-run-ownership.js'
+import { approvalDeciderFrom } from './workflow-approval-policy.js'
 import {
   buildRunTimeline,
   reconstructStateAt,
@@ -1856,6 +1856,8 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         this.updateRunState(runId, key, value),
       resumeWorkflow: (runId) => this.resumeWorkflow(runId),
       scheduleRunWake: (runId, delay) => this.scheduleRunWake(runId, delay),
+      getRunOwner: async (runId) =>
+        (await this.getRunIdentity(runId))?.wire?.pikkuUserId,
     }
   }
 
@@ -1865,9 +1867,13 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     decision: unknown,
     session?: CoreUserSession
   ): Promise<void> {
-    assertWorkflowRunOwner((await this.getRunIdentity(runId))?.wire, session)
-
-    return recordApprovalDecision(this.approvalStore, runId, reason, decision)
+    return recordApprovalDecision(
+      this.approvalStore,
+      runId,
+      reason,
+      decision,
+      approvalDeciderFrom(session)
+    )
   }
 
   private async approvalStep(

--- a/packages/core/src/wirings/workflow/workflow-approval-audit.ts
+++ b/packages/core/src/wirings/workflow/workflow-approval-audit.ts
@@ -1,0 +1,47 @@
+import { getSingletonServices } from '../../pikku-state.js'
+import type { ApprovalAuditEvent } from './workflow-approval.js'
+
+/** The audit type an answer to an approval gate is recorded under. */
+export const APPROVAL_AUDIT_TYPE = 'workflow.approval.decided'
+
+/**
+ * Record an answer to an approval gate where it outlives the run.
+ *
+ * The step result carries the settled decision, but it is deleted with the run
+ * — `deleteRun` cascades to steps and to history — and a refused attempt never
+ * reaches a step at all. An approval is asked for precisely so it can be
+ * answered for afterwards, so the answer also goes to the audit sink, which
+ * holds no foreign key to the run.
+ *
+ * A project with no sink wired records nothing, and a sink that fails is logged
+ * rather than thrown: the trail must not be the reason a decision is lost.
+ */
+export const auditApprovalDecision = async (
+  event: ApprovalAuditEvent
+): Promise<void> => {
+  const services = getSingletonServices()
+  if (!services?.audit) {
+    return
+  }
+  try {
+    await services.audit.audit({
+      type: APPROVAL_AUDIT_TYPE,
+      source: 'explicit',
+      outcome: event.outcome,
+      occurredAt: new Date().toISOString(),
+      wireType: 'workflow',
+      userIdentity: { pikkuUserId: event.decidedBy?.userId },
+      metadata: {
+        runId: event.runId,
+        reason: event.reason,
+        scopes: event.decidedBy?.scopes,
+        refusal: event.refusal,
+      },
+    })
+  } catch (error) {
+    services.logger?.warn(
+      `Failed to audit the decision on approval '${event.reason}' for run ${event.runId}`,
+      error
+    )
+  }
+}

--- a/packages/core/src/wirings/workflow/workflow-approval-policy.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-approval-policy.test.ts
@@ -1,0 +1,292 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState } from '../../pikku-state.js'
+import { addWorkflow } from './dsl/workflow-runner.js'
+import { WorkflowSuspendedException } from './workflow-errors.js'
+import {
+  approvalPolicyRefusal,
+  WorkflowApprovalForbiddenError,
+} from './workflow-approval-policy.js'
+import { approvalStateKey, approvalStepNameFor } from './workflow-approval.js'
+import type {
+  PikkuWorkflowWire,
+  WorkflowApprovalOptions,
+} from './workflow.types.js'
+
+const anySchema: StandardSchemaV1<unknown, unknown> = {
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: (value) => ({ value }),
+  },
+}
+
+const registerApprovalWorkflow = (
+  workflowName: string,
+  graphHash: string,
+  options: Omit<WorkflowApprovalOptions, 'schema'>
+) => {
+  pikkuState(null, 'package', 'singletonServices', {
+    logger: { error() {}, info() {}, warn() {}, debug() {} },
+    queueService: { add: async () => {} },
+  } as any)
+
+  const metaState = pikkuState(null, 'workflows', 'meta')
+  metaState[workflowName] = {
+    name: workflowName,
+    pikkuFuncId: workflowName,
+    source: 'dsl',
+    graphHash,
+  }
+  const functionMetaState = pikkuState(null, 'function', 'meta')
+  functionMetaState[workflowName] = {
+    name: workflowName,
+    sessionless: true,
+    permissions: [],
+  } as any
+
+  addWorkflow(workflowName, {
+    func: async (
+      _services: any,
+      _data: any,
+      { workflow }: { workflow: PikkuWorkflowWire }
+    ) => {
+      const decision = await workflow.approval('Release funds', {
+        schema: anySchema,
+        ...options,
+      })
+      return { decision }
+    },
+  })
+
+  return () => {
+    delete metaState[workflowName]
+    delete functionMetaState[workflowName]
+    pikkuState(null, 'workflows', 'registrations').delete(workflowName)
+  }
+}
+
+/** Run until the gate suspends, so the gate has published its policy. */
+const runToGate = async (ws: InMemoryWorkflowService, runId: string) => {
+  await assert.rejects(
+    ws.runWorkflowJob(runId, {}),
+    (error: unknown) => error instanceof WorkflowSuspendedException
+  )
+}
+
+describe('approval policy', () => {
+  test('the default lets anyone the entrypoint admitted answer', () => {
+    assert.equal(approvalPolicyRefusal({}, 'owner', undefined), undefined)
+    assert.equal(
+      approvalPolicyRefusal({}, 'owner', { userId: 'someone-else' }),
+      undefined
+    )
+  })
+
+  test('owner admits only the user who started the run', () => {
+    const policy = { approvers: 'owner' as const }
+    assert.equal(
+      approvalPolicyRefusal(policy, 'owner', { userId: 'owner' }),
+      undefined
+    )
+    assert.match(
+      approvalPolicyRefusal(policy, 'owner', { userId: 'other' })!,
+      /Only the user who started this run/
+    )
+    assert.match(
+      approvalPolicyRefusal(policy, 'owner', undefined)!,
+      /Only the user who started this run/
+    )
+  })
+
+  test('a run with no initiator has no owner to compare against', () => {
+    assert.equal(
+      approvalPolicyRefusal({ approvers: 'owner' }, undefined, {
+        userId: 'anyone',
+      }),
+      undefined
+    )
+  })
+
+  test('not-initiator excludes the user who started the run', () => {
+    const policy = { approvers: 'not-initiator' as const }
+    assert.match(
+      approvalPolicyRefusal(policy, 'owner', { userId: 'owner' })!,
+      /may not answer/
+    )
+    assert.equal(
+      approvalPolicyRefusal(policy, 'owner', { userId: 'reviewer' }),
+      undefined
+    )
+  })
+
+  test('not-initiator still requires a signed-in decider on an unowned run', () => {
+    assert.match(
+      approvalPolicyRefusal({ approvers: 'not-initiator' }, undefined, {})!,
+      /requires a signed-in user/
+    )
+  })
+
+  test('approverScope is required on top of the approvers rule', () => {
+    const policy = { approvers: 'not-initiator' as const, approverScope: 'sre' }
+    assert.match(
+      approvalPolicyRefusal(policy, 'owner', { userId: 'reviewer' })!,
+      /requires the 'sre' scope/
+    )
+    assert.equal(
+      approvalPolicyRefusal(policy, 'owner', {
+        userId: 'reviewer',
+        scopes: ['sre'],
+      }),
+      undefined
+    )
+    assert.match(
+      approvalPolicyRefusal(policy, 'owner', {
+        userId: 'owner',
+        scopes: ['sre'],
+      })!,
+      /may not answer/
+    )
+  })
+})
+
+describe('approval policy enforcement', () => {
+  test('a gate with no declared policy accepts a caller who does not own the run', async () => {
+    const ws = new InMemoryWorkflowService()
+    const cleanup = registerApprovalWorkflow('openGate', 'open-gate', {})
+
+    const runId = await ws.createRun('openGate', {}, false, 'open-gate', {
+      type: 'http',
+      pikkuUserId: 'initiator',
+    })
+    await runToGate(ws, runId)
+
+    await ws.approveStep(runId, 'Release funds', { ok: true }, {
+      userId: 'someone-else',
+    })
+    await ws.runWorkflowJob(runId, {})
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    cleanup()
+  })
+
+  test('a four-eyes gate refuses the initiator and admits a second user', async () => {
+    const ws = new InMemoryWorkflowService()
+    const cleanup = registerApprovalWorkflow('fourEyes', 'four-eyes', {
+      approvers: 'not-initiator',
+    })
+
+    const runId = await ws.createRun('fourEyes', {}, false, 'four-eyes', {
+      type: 'http',
+      pikkuUserId: 'initiator',
+    })
+    await runToGate(ws, runId)
+
+    await assert.rejects(
+      ws.approveStep(runId, 'Release funds', { ok: true }, {
+        userId: 'initiator',
+      }),
+      WorkflowApprovalForbiddenError
+    )
+
+    await ws.approveStep(runId, 'Release funds', { ok: true }, {
+      userId: 'reviewer',
+    })
+    await ws.runWorkflowJob(runId, {})
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    cleanup()
+  })
+
+  test('an owner-only gate refuses a caller who did not start the run', async () => {
+    const ws = new InMemoryWorkflowService()
+    const cleanup = registerApprovalWorkflow('ownerGate', 'owner-gate', {
+      approvers: 'owner',
+    })
+
+    const runId = await ws.createRun('ownerGate', {}, false, 'owner-gate', {
+      type: 'http',
+      pikkuUserId: 'initiator',
+    })
+    await runToGate(ws, runId)
+
+    await assert.rejects(
+      ws.approveStep(runId, 'Release funds', { ok: true }, {
+        userId: 'attacker',
+      }),
+      WorkflowApprovalForbiddenError
+    )
+
+    await ws.approveStep(runId, 'Release funds', { ok: true }, {
+      userId: 'initiator',
+    })
+    await ws.runWorkflowJob(runId, {})
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    cleanup()
+  })
+
+  test('a scoped gate refuses a decider without the scope', async () => {
+    const ws = new InMemoryWorkflowService()
+    const cleanup = registerApprovalWorkflow('scopedGate', 'scoped-gate', {
+      approverScope: 'payments:approve',
+    })
+
+    const runId = await ws.createRun('scopedGate', {}, false, 'scoped-gate', {
+      type: 'http',
+      pikkuUserId: 'initiator',
+    })
+    await runToGate(ws, runId)
+
+    await assert.rejects(
+      ws.approveStep(runId, 'Release funds', { ok: true }, {
+        userId: 'reviewer',
+        scopes: ['payments:read'],
+      }),
+      WorkflowApprovalForbiddenError
+    )
+
+    await ws.approveStep(runId, 'Release funds', { ok: true }, {
+      userId: 'reviewer',
+      scopes: ['payments:approve'],
+    })
+    await ws.runWorkflowJob(runId, {})
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    cleanup()
+  })
+
+  test('a decision recorded before the run reaches the gate is still judged', async () => {
+    const ws = new InMemoryWorkflowService()
+    const cleanup = registerApprovalWorkflow('earlyGate', 'early-gate', {
+      approvers: 'not-initiator',
+    })
+
+    const runId = await ws.createRun('earlyGate', {}, false, 'early-gate', {
+      type: 'http',
+      pikkuUserId: 'initiator',
+    })
+
+    // The gate has not been reached, so no policy has been published and the
+    // submission cannot be judged here — it is accepted and judged on replay.
+    await ws.approveStep(runId, 'Release funds', { ok: true }, {
+      userId: 'initiator',
+    })
+
+    await runToGate(ws, runId)
+
+    const stateKey = approvalStateKey(approvalStepNameFor('Release funds'))
+    const record = (await ws.getRunState(runId))[stateKey] as {
+      decision?: unknown
+      error?: Array<{ message: string }>
+    }
+    assert.equal(record.decision, undefined, 'the decision was cleared')
+    assert.match(record.error?.[0]?.message ?? '', /may not answer/)
+    assert.equal((await ws.getRun(runId))?.status, 'suspended')
+
+    cleanup()
+  })
+})

--- a/packages/core/src/wirings/workflow/workflow-approval-policy.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-approval-policy.test.ts
@@ -27,11 +27,13 @@ const anySchema: StandardSchemaV1<unknown, unknown> = {
 const registerApprovalWorkflow = (
   workflowName: string,
   graphHash: string,
-  options: Omit<WorkflowApprovalOptions, 'schema'>
+  options: Omit<WorkflowApprovalOptions, 'schema'>,
+  audit?: { audit: (event: unknown) => Promise<void> }
 ) => {
   pikkuState(null, 'package', 'singletonServices', {
     logger: { error() {}, info() {}, warn() {}, debug() {} },
     queueService: { add: async () => {} },
+    audit,
   } as any)
 
   const metaState = pikkuState(null, 'workflows', 'meta')
@@ -259,6 +261,75 @@ describe('approval policy enforcement', () => {
     cleanup()
   })
 
+  /**
+   * Run state is where a decision waits, not where it is kept: the record is
+   * overwritten by the next write to that key and cleared outright whenever a
+   * decision is refused. Four-eyes exists to be audited, so who signed and when
+   * has to reach the step result, which is append-only and carried into
+   * workflowStepHistory.
+   */
+  test('the decider and the moment reach the step result, not just run state', async () => {
+    const ws = new InMemoryWorkflowService()
+    const cleanup = registerApprovalWorkflow('signedGate', 'signed-gate', {
+      approvers: 'not-initiator',
+    })
+
+    const runId = await ws.createRun('signedGate', {}, false, 'signed-gate', {
+      type: 'http',
+      pikkuUserId: 'initiator',
+    })
+    await runToGate(ws, runId)
+
+    await ws.approveStep(runId, 'Release funds', { ok: true }, {
+      userId: 'reviewer',
+      scopes: ['payments:approve'],
+    })
+    await ws.runWorkflowJob(runId, {})
+
+    const step = await ws.getStepState(
+      runId,
+      approvalStepNameFor('Release funds')
+    )
+    const outcome = step.result as {
+      status: string
+      decidedBy?: { userId?: string; scopes?: string[] }
+      decidedAt?: string
+    }
+
+    assert.equal(outcome.status, 'decided')
+    assert.equal(outcome.decidedBy?.userId, 'reviewer')
+    assert.deepEqual(outcome.decidedBy?.scopes, ['payments:approve'])
+    assert.ok(
+      outcome.decidedAt && !Number.isNaN(Date.parse(outcome.decidedAt)),
+      'decidedAt is an ISO timestamp'
+    )
+
+    cleanup()
+  })
+
+  test('an expired gate has nobody to record', async () => {
+    const ws = new InMemoryWorkflowService()
+    const cleanup = registerApprovalWorkflow('expiredGate', 'expired-gate', {
+      expiry: 100,
+    })
+
+    const runId = await ws.createRun('expiredGate', {}, false, 'expired-gate', {
+      type: 'http',
+      pikkuUserId: 'initiator',
+    })
+    await runToGate(ws, runId)
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    await ws.runWorkflowJob(runId, {})
+
+    const step = await ws.getStepState(
+      runId,
+      approvalStepNameFor('Release funds')
+    )
+    assert.deepEqual(step.result, { status: 'expired' })
+
+    cleanup()
+  })
+
   test('a decision recorded before the run reaches the gate is still judged', async () => {
     const ws = new InMemoryWorkflowService()
     const cleanup = registerApprovalWorkflow('earlyGate', 'early-gate', {
@@ -287,6 +358,167 @@ describe('approval policy enforcement', () => {
     assert.match(record.error?.[0]?.message ?? '', /may not answer/)
     assert.equal((await ws.getRun(runId))?.status, 'suspended')
 
+    cleanup()
+  })
+})
+
+/**
+ * The step result is deleted with the run — `deleteRun` cascades to steps and
+ * to history — and a refused attempt never reaches a step at all. An approval
+ * is asked for so it can be answered for afterwards, so it also goes to the
+ * audit sink, which holds no foreign key to the run.
+ */
+describe('approval audit trail', () => {
+  const collectingAudit = () => {
+    const events: any[] = []
+    return {
+      events,
+      sink: { audit: async (event: any) => void events.push(event) },
+    }
+  }
+
+  test('an accepted decision is recorded against the user who made it', async () => {
+    const ws = new InMemoryWorkflowService()
+    const { events, sink } = collectingAudit()
+    const cleanup = registerApprovalWorkflow(
+      'auditedGate',
+      'audited-gate',
+      { approvers: 'not-initiator' },
+      sink
+    )
+
+    const runId = await ws.createRun('auditedGate', {}, false, 'audited-gate', {
+      type: 'http',
+      pikkuUserId: 'initiator',
+    })
+    await runToGate(ws, runId)
+    await ws.approveStep(runId, 'Release funds', { ok: true }, {
+      userId: 'reviewer',
+      scopes: ['payments:approve'],
+    })
+    await ws.runWorkflowJob(runId, {})
+
+    assert.equal(events.length, 1)
+    assert.equal(events[0].type, 'workflow.approval.decided')
+    assert.equal(events[0].outcome, 'success')
+    assert.equal(events[0].wireType, 'workflow')
+    assert.equal(events[0].userIdentity.pikkuUserId, 'reviewer')
+    assert.equal(events[0].metadata.runId, runId)
+    assert.equal(events[0].metadata.reason, 'Release funds')
+    assert.deepEqual(events[0].metadata.scopes, ['payments:approve'])
+    assert.ok(!Number.isNaN(Date.parse(events[0].occurredAt)))
+
+    cleanup()
+  })
+
+  test('a refused attempt is recorded too — that is the one worth keeping', async () => {
+    const ws = new InMemoryWorkflowService()
+    const { events, sink } = collectingAudit()
+    const cleanup = registerApprovalWorkflow(
+      'refusedGate',
+      'refused-gate',
+      { approvers: 'not-initiator' },
+      sink
+    )
+
+    const runId = await ws.createRun('refusedGate', {}, false, 'refused-gate', {
+      type: 'http',
+      pikkuUserId: 'initiator',
+    })
+    await runToGate(ws, runId)
+
+    await assert.rejects(
+      ws.approveStep(runId, 'Release funds', { ok: true }, {
+        userId: 'initiator',
+      }),
+      WorkflowApprovalForbiddenError
+    )
+
+    assert.equal(events.length, 1)
+    assert.equal(events[0].outcome, 'denied')
+    assert.equal(events[0].userIdentity.pikkuUserId, 'initiator')
+    assert.match(events[0].metadata.refusal, /may not answer/)
+
+    cleanup()
+  })
+
+  test('a decision refused on replay is recorded, having been refused nowhere else', async () => {
+    const ws = new InMemoryWorkflowService()
+    const { events, sink } = collectingAudit()
+    const cleanup = registerApprovalWorkflow(
+      'replayRefused',
+      'replay-refused',
+      { approvers: 'not-initiator' },
+      sink
+    )
+
+    const runId = await ws.createRun(
+      'replayRefused',
+      {},
+      false,
+      'replay-refused',
+      { type: 'http', pikkuUserId: 'initiator' }
+    )
+
+    // Submitted before the gate published its policy, so it is accepted here
+    // and only refused on replay.
+    await ws.approveStep(runId, 'Release funds', { ok: true }, {
+      userId: 'initiator',
+    })
+    assert.equal(events[0].outcome, 'success')
+
+    await runToGate(ws, runId)
+
+    assert.equal(events.length, 2)
+    assert.equal(events[1].outcome, 'denied')
+    assert.equal(events[1].userIdentity.pikkuUserId, 'initiator')
+    assert.match(events[1].metadata.refusal, /may not answer/)
+
+    cleanup()
+  })
+
+  test('a failing sink does not cost the decision', async () => {
+    const ws = new InMemoryWorkflowService()
+    const cleanup = registerApprovalWorkflow(
+      'brokenSink',
+      'broken-sink',
+      {},
+      {
+        audit: async () => {
+          throw new Error('sink is down')
+        },
+      }
+    )
+
+    const runId = await ws.createRun('brokenSink', {}, false, 'broken-sink', {
+      type: 'http',
+      pikkuUserId: 'initiator',
+    })
+    await runToGate(ws, runId)
+    await ws.approveStep(runId, 'Release funds', { ok: true }, {
+      userId: 'reviewer',
+    })
+    await ws.runWorkflowJob(runId, {})
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    cleanup()
+  })
+
+  test('a project with no audit sink wired is unaffected', async () => {
+    const ws = new InMemoryWorkflowService()
+    const cleanup = registerApprovalWorkflow('noSink', 'no-sink', {})
+
+    const runId = await ws.createRun('noSink', {}, false, 'no-sink', {
+      type: 'http',
+      pikkuUserId: 'initiator',
+    })
+    await runToGate(ws, runId)
+    await ws.approveStep(runId, 'Release funds', { ok: true }, {
+      userId: 'reviewer',
+    })
+    await ws.runWorkflowJob(runId, {})
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
     cleanup()
   })
 })

--- a/packages/core/src/wirings/workflow/workflow-approval-policy.ts
+++ b/packages/core/src/wirings/workflow/workflow-approval-policy.ts
@@ -1,7 +1,10 @@
 import { ForbiddenError } from '../../errors/errors.js'
 import { addError } from '../../errors/error-handler.js'
 import type { CoreUserSession } from '../../types/core.types.js'
-import type { WorkflowApprovalPolicy } from './workflow.types.js'
+import type {
+  ApprovalDecider,
+  WorkflowApprovalPolicy,
+} from './workflow.types.js'
 
 export class WorkflowApprovalForbiddenError extends ForbiddenError {
   public payload: { reason: string; detail: string }
@@ -14,16 +17,6 @@ addError(WorkflowApprovalForbiddenError, {
   status: 403,
   message: 'Not authorized to answer this approval.',
 })
-
-/**
- * The decider, reduced to the two facts a policy can be expressed in terms of.
- * Recorded alongside the decision so the gate can be judged on replay — the
- * session itself is long gone by then.
- */
-export interface ApprovalDecider {
-  userId?: string
-  scopes?: string[]
-}
 
 export const approvalDeciderFrom = (
   session: CoreUserSession | undefined

--- a/packages/core/src/wirings/workflow/workflow-approval-policy.ts
+++ b/packages/core/src/wirings/workflow/workflow-approval-policy.ts
@@ -1,0 +1,75 @@
+import { ForbiddenError } from '../../errors/errors.js'
+import { addError } from '../../errors/error-handler.js'
+import type { CoreUserSession } from '../../types/core.types.js'
+import type { WorkflowApprovalPolicy } from './workflow.types.js'
+
+export class WorkflowApprovalForbiddenError extends ForbiddenError {
+  public payload: { reason: string; detail: string }
+  constructor(reason: string, detail: string) {
+    super(detail)
+    this.payload = { reason, detail }
+  }
+}
+addError(WorkflowApprovalForbiddenError, {
+  status: 403,
+  message: 'Not authorized to answer this approval.',
+})
+
+/**
+ * The decider, reduced to the two facts a policy can be expressed in terms of.
+ * Recorded alongside the decision so the gate can be judged on replay — the
+ * session itself is long gone by then.
+ */
+export interface ApprovalDecider {
+  userId?: string
+  scopes?: string[]
+}
+
+export const approvalDeciderFrom = (
+  session: CoreUserSession | undefined
+): ApprovalDecider | undefined =>
+  session ? { userId: session.userId, scopes: session.scopes } : undefined
+
+/**
+ * Judge a decision against the gate's declared policy, returning the reason it
+ * is refused or `undefined` if it stands.
+ *
+ * Returns a message rather than throwing because the same judgement is needed
+ * in two places with different outcomes: refusing a live submission with a 403,
+ * and clearing an already-recorded decision on replay.
+ */
+export const approvalPolicyRefusal = (
+  policy: WorkflowApprovalPolicy,
+  owner: string | undefined,
+  decider: ApprovalDecider | undefined
+): string | undefined => {
+  if (
+    policy.approverScope &&
+    !decider?.scopes?.includes(policy.approverScope)
+  ) {
+    return `Answering this approval requires the '${policy.approverScope}' scope`
+  }
+
+  switch (policy.approvers ?? 'any') {
+    case 'owner':
+      if (!owner) {
+        return undefined
+      }
+      if (!decider?.userId || decider.userId !== owner) {
+        return 'Only the user who started this run may answer this approval'
+      }
+      return undefined
+
+    case 'not-initiator':
+      if (!decider?.userId) {
+        return 'Answering this approval requires a signed-in user'
+      }
+      if (owner && decider.userId === owner) {
+        return 'The user who started this run may not answer this approval'
+      }
+      return undefined
+
+    case 'any':
+      return undefined
+  }
+}

--- a/packages/core/src/wirings/workflow/workflow-approval.ts
+++ b/packages/core/src/wirings/workflow/workflow-approval.ts
@@ -7,7 +7,13 @@ import type {
   ApprovalOutcome,
   StepState,
   WorkflowApprovalOptions,
+  WorkflowApprovalPolicy,
 } from './workflow.types.js'
+import {
+  approvalPolicyRefusal,
+  WorkflowApprovalForbiddenError,
+  type ApprovalDecider,
+} from './workflow-approval-policy.js'
 
 /** The durable step name an approval point is recorded under. */
 export const approvalStepNameFor = (reason: string): string =>
@@ -45,6 +51,17 @@ export type ApprovalStore = {
   updateRunState: (runId: string, key: string, value: unknown) => Promise<void>
   resumeWorkflow: (runId: string) => Promise<void>
   scheduleRunWake: (runId: string, delay: number) => Promise<void>
+  getRunOwner: (runId: string) => Promise<string | undefined>
+}
+
+/** What run state holds for an approval point between suspension and replay. */
+type ApprovalRecord = {
+  decision?: unknown
+  decidedAt?: string
+  decidedBy?: ApprovalDecider
+  policy?: WorkflowApprovalPolicy
+  expiresAt?: string
+  error?: unknown
 }
 
 /**
@@ -53,12 +70,19 @@ export type ApprovalStore = {
  * A decision arriving for an already-settled approval is refused rather than
  * overwriting it: the run has moved on, and a second answer would be recorded
  * against a gate nobody is waiting at.
+ *
+ * The decider is recorded rather than judged here, for the same reason the
+ * payload is: the gate's policy is a value on the workflow, and a decision can
+ * legitimately arrive before the run has ever reached the gate. Where the run
+ * has already published its policy, it is applied eagerly so a caller who
+ * cannot answer is told so rather than left waiting.
  */
 export const recordApprovalDecision = async (
   store: ApprovalStore,
   runId: string,
   reason: string,
-  decision: unknown
+  decision: unknown,
+  decidedBy?: ApprovalDecider
 ): Promise<void> => {
   const stepName = approvalStepNameFor(reason)
   const stateKey = approvalStateKey(stepName)
@@ -78,13 +102,26 @@ export const recordApprovalDecision = async (
   }
 
   const state = await store.getRunState(runId)
-  const record = (state[stateKey] ?? {}) as Record<string, unknown>
+  const record = (state[stateKey] ?? {}) as ApprovalRecord
+
+  if (record.policy) {
+    const refusal = approvalPolicyRefusal(
+      record.policy,
+      await store.getRunOwner(runId),
+      decidedBy
+    )
+    if (refusal) {
+      throw new WorkflowApprovalForbiddenError(reason, refusal)
+    }
+  }
+
   await store.updateRunState(runId, stateKey, {
     ...record,
     decision,
     decidedAt: new Date().toISOString(),
+    decidedBy,
     error: undefined,
-  })
+  } satisfies ApprovalRecord)
   await store.resumeWorkflow(runId)
 }
 
@@ -95,6 +132,11 @@ export const recordApprovalDecision = async (
  * schema is a value on the workflow and only the workflow has it. A payload
  * that fails validation is cleared and the run suspends again, so a bad
  * submission cannot settle the gate.
+ *
+ * The decider is judged here for the same reason, and for one more: a decision
+ * can be recorded before the run has ever reached the gate, so submission time
+ * is not a point at which the policy is reliably knowable. Judging on replay is
+ * what makes the policy hold in every ordering.
  */
 export const evaluateApprovalStep = async (
   store: ApprovalStore,
@@ -109,7 +151,12 @@ export const evaluateApprovalStep = async (
       runId,
       approvalStepName,
       'pikkuWorkflowApproval',
-      { reason, expiry: options.expiry },
+      {
+        reason,
+        expiry: options.expiry,
+        approvers: options.approvers,
+        approverScope: options.approverScope,
+      },
       undefined,
       fromStepName
     )
@@ -129,15 +176,16 @@ export const evaluateApprovalStep = async (
   }
 
   const stateKey = approvalStateKey(approvalStepName)
-  let record = ((await store.getRunState(runId))[stateKey] ?? {}) as {
-    decision?: unknown
-    decidedAt?: string
-    expiresAt?: string
-    error?: unknown
+  let record = ((await store.getRunState(runId))[stateKey] ?? {}) as ApprovalRecord
+
+  const policy: WorkflowApprovalPolicy = {
+    approvers: options.approvers,
+    approverScope: options.approverScope,
   }
 
   if (stepState.status === 'pending') {
     await store.setStepRunning(stepState.stepId)
+    record = { ...record, policy }
     if (options.expiry !== undefined && !record.expiresAt) {
       const expiry = getDurationInMilliseconds(options.expiry)
       record = {
@@ -146,10 +194,28 @@ export const evaluateApprovalStep = async (
       }
       await store.updateRunState(runId, stateKey, record)
       await store.scheduleRunWake(runId, expiry)
+    } else {
+      await store.updateRunState(runId, stateKey, record)
     }
   }
 
   if (record.decision !== undefined) {
+    const refusal = approvalPolicyRefusal(
+      policy,
+      await store.getRunOwner(runId),
+      record.decidedBy
+    )
+    if (refusal) {
+      await store.updateRunState(runId, stateKey, {
+        ...record,
+        decision: undefined,
+        decidedAt: undefined,
+        decidedBy: undefined,
+        error: [{ message: refusal }],
+      } satisfies ApprovalRecord)
+      throw new WorkflowSuspendedException(runId, reason)
+    }
+
     const validation = await options.schema['~standard'].validate(
       record.decision
     )
@@ -158,6 +224,7 @@ export const evaluateApprovalStep = async (
         ...record,
         decision: undefined,
         decidedAt: undefined,
+        decidedBy: undefined,
         error: validation.issues.map((issue) => ({
           message: issue.message,
           path: issue.path?.map((segment) =>

--- a/packages/core/src/wirings/workflow/workflow-approval.ts
+++ b/packages/core/src/wirings/workflow/workflow-approval.ts
@@ -4,6 +4,7 @@ import {
   WorkflowSuspendedException,
 } from './workflow-errors.js'
 import type {
+  ApprovalDecider,
   ApprovalOutcome,
   StepState,
   WorkflowApprovalOptions,
@@ -12,7 +13,6 @@ import type {
 import {
   approvalPolicyRefusal,
   WorkflowApprovalForbiddenError,
-  type ApprovalDecider,
 } from './workflow-approval-policy.js'
 
 /** The durable step name an approval point is recorded under. */
@@ -34,6 +34,21 @@ export const approvalStateKey = (stepName: string): string => {
   return `__approval_${hex}`
 }
 
+/**
+ * An answer to an approval gate, as the audit trail sees it.
+ *
+ * `denied` covers both a submission refused at the door and a decision cleared
+ * on replay — from the trail's point of view they are the same event, someone
+ * tried to answer a gate they could not.
+ */
+export type ApprovalAuditEvent = {
+  runId: string
+  reason: string
+  outcome: 'success' | 'denied'
+  decidedBy?: ApprovalDecider
+  refusal?: string
+}
+
 /** What the approval gate needs from the workflow service. */
 export type ApprovalStore = {
   getStepState: (runId: string, stepName: string) => Promise<StepState>
@@ -52,6 +67,7 @@ export type ApprovalStore = {
   resumeWorkflow: (runId: string) => Promise<void>
   scheduleRunWake: (runId: string, delay: number) => Promise<void>
   getRunOwner: (runId: string) => Promise<string | undefined>
+  auditApproval: (event: ApprovalAuditEvent) => Promise<void>
 }
 
 /** What run state holds for an approval point between suspension and replay. */
@@ -111,6 +127,13 @@ export const recordApprovalDecision = async (
       decidedBy
     )
     if (refusal) {
+      await store.auditApproval({
+        runId,
+        reason,
+        outcome: 'denied',
+        decidedBy,
+        refusal,
+      })
       throw new WorkflowApprovalForbiddenError(reason, refusal)
     }
   }
@@ -122,6 +145,7 @@ export const recordApprovalDecision = async (
     decidedBy,
     error: undefined,
   } satisfies ApprovalRecord)
+  await store.auditApproval({ runId, reason, outcome: 'success', decidedBy })
   await store.resumeWorkflow(runId)
 }
 
@@ -213,6 +237,13 @@ export const evaluateApprovalStep = async (
         decidedBy: undefined,
         error: [{ message: refusal }],
       } satisfies ApprovalRecord)
+      await store.auditApproval({
+        runId,
+        reason,
+        outcome: 'denied',
+        decidedBy: record.decidedBy,
+        refusal,
+      })
       throw new WorkflowSuspendedException(runId, reason)
     }
 
@@ -234,9 +265,13 @@ export const evaluateApprovalStep = async (
       })
       throw new WorkflowSuspendedException(runId, reason)
     }
+    // Spread rather than assigned, so a gate answered without a session keeps
+    // the shape it had before there was anything to record.
     const outcome: ApprovalOutcome<unknown> = {
       status: 'decided',
       data: validation.value,
+      ...(record.decidedBy ? { decidedBy: record.decidedBy } : {}),
+      ...(record.decidedAt ? { decidedAt: record.decidedAt } : {}),
     }
     await store.setStepResult(stepState.stepId, outcome)
     return outcome

--- a/packages/core/src/wirings/workflow/workflow-run-authority.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-run-authority.test.ts
@@ -160,7 +160,7 @@ describe('workflow run ownership', () => {
     )
   })
 
-  test('approveStep refuses a caller who does not own the run', async () => {
+  test('approveStep does not impose ownership on a gate that did not ask for it', async () => {
     seedSingletons()
     const ws = new InMemoryWorkflowService()
     const runId = await ws.createRun('flow', {}, false, 'hash', {
@@ -168,23 +168,20 @@ describe('workflow run ownership', () => {
       pikkuUserId: 'owner',
     })
 
-    await assert.rejects(
-      ws.approveStep(
-        runId,
-        'release-funds',
-        { ok: true },
-        {
-          userId: 'attacker',
-        }
-      ),
-      ForbiddenError
+    await ws.approveStep(
+      runId,
+      'release-funds',
+      { ok: true },
+      {
+        userId: 'not-the-owner',
+      }
     )
 
     const state = await ws.getRunState(runId)
-    assert.deepEqual(
-      Object.keys(state),
-      [],
-      'no decision was recorded for the run'
+    assert.equal(
+      Object.keys(state).length,
+      1,
+      'the decision was recorded, to be judged against the gate on replay'
     )
   })
 

--- a/packages/core/src/wirings/workflow/workflow-run-ownership.ts
+++ b/packages/core/src/wirings/workflow/workflow-run-ownership.ts
@@ -15,7 +15,8 @@ addError(WorkflowRunForbiddenError, {
 
 /**
  * A run started through a session records that session's user as its owner, and
- * only that user may read it or answer its approval gates.
+ * only that user may read it. Who may *answer* a run's approval gates is the
+ * gate's own declaration — see `approvers` on `workflow.approval()`.
  *
  * A run with no recorded owner — started by a trigger, a scheduler, or a route
  * wired without auth — has nobody to compare a caller against, so ownership is

--- a/packages/core/src/wirings/workflow/workflow.types.ts
+++ b/packages/core/src/wirings/workflow/workflow.types.ts
@@ -21,6 +21,7 @@ export type {
   WorkflowApprovalOptions,
   WorkflowApprovalApprovers,
   WorkflowApprovalPolicy,
+  ApprovalDecider,
   ApprovalOutcome,
   InputSource,
   OutputBinding,

--- a/packages/core/src/wirings/workflow/workflow.types.ts
+++ b/packages/core/src/wirings/workflow/workflow.types.ts
@@ -19,6 +19,8 @@ export type {
   WorkflowWireSuspend,
   WorkflowWireApproval,
   WorkflowApprovalOptions,
+  WorkflowApprovalApprovers,
+  WorkflowApprovalPolicy,
   ApprovalOutcome,
   InputSource,
   OutputBinding,

--- a/packages/inspector/src/utils/workflow/dsl/extract-approval-policy.test.ts
+++ b/packages/inspector/src/utils/workflow/dsl/extract-approval-policy.test.ts
@@ -1,0 +1,68 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import * as ts from 'typescript'
+import { extractDSLWorkflow } from './extract-dsl-workflow.js'
+import type { ApprovalStepMeta } from '@pikku/core/workflow'
+
+const checker = {
+  getSymbolAtLocation: () => undefined,
+  getAliasedSymbol: () => undefined,
+  getShorthandAssignmentValueSymbol: () => undefined,
+  getTypeAtLocation: () => undefined,
+} as unknown as ts.TypeChecker
+
+/** Extracts the single approval step from a workflow body. */
+const approvalStepFor = (options: string): ApprovalStepMeta => {
+  const file = ts.createSourceFile(
+    'wf.ts',
+    `const wf = pikkuWorkflowFunc({
+      func: async (services, data, { workflow }) => {
+        await workflow.approval('Release funds', ${options})
+      },
+    })`,
+    ts.ScriptTarget.Latest,
+    true
+  )
+
+  let node: ts.Node | undefined
+  const visit = (n: ts.Node) => {
+    if (ts.isCallExpression(n) && n.expression.getText() === 'pikkuWorkflowFunc') {
+      node = n
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(file)
+  assert.ok(node, 'failed to find the workflow definition')
+
+  const result = extractDSLWorkflow(node, checker)
+  assert.equal(result.status, 'ok', JSON.stringify(result))
+  const step = result.steps?.find(
+    (s): s is ApprovalStepMeta => s.type === 'approval'
+  )
+  assert.ok(step, 'no approval step was extracted')
+  return step
+}
+
+describe('an approval gate carries its policy into the graph', () => {
+  test('approvers and approverScope survive extraction', () => {
+    const step = approvalStepFor(
+      `{ schema: DecisionSchema, approvers: 'not-initiator', approverScope: 'payments:approve' }`
+    )
+    assert.equal(step.approvers, 'not-initiator')
+    assert.equal(step.approverScope, 'payments:approve')
+  })
+
+  test('expiry still survives alongside them', () => {
+    const step = approvalStepFor(
+      `{ schema: DecisionSchema, expiry: '3d', approvers: 'owner' }`
+    )
+    assert.equal(step.expiry, '3d')
+    assert.equal(step.approvers, 'owner')
+  })
+
+  test('a gate declaring no policy records none', () => {
+    const step = approvalStepFor(`{ schema: DecisionSchema }`)
+    assert.equal(step.approvers, undefined)
+    assert.equal(step.approverScope, undefined)
+  })
+})

--- a/packages/inspector/src/utils/workflow/dsl/extract-dsl-workflow.ts
+++ b/packages/inspector/src/utils/workflow/dsl/extract-dsl-workflow.ts
@@ -1051,20 +1051,28 @@ function extractApprovalStep(
       step.outputVar = outputVar
     }
     // The `schema` option is a runtime value validated inside the workflow body,
-    // so it is deliberately not serialized here — only `expiry`, which the graph
-    // and planned-step ladder need in order to describe the gate.
+    // so it is deliberately not serialized here — only the literal options the
+    // graph and planned-step ladder need in order to describe the gate.
     const options = args[1]
     if (options && ts.isObjectLiteralExpression(options)) {
       for (const prop of options.properties) {
+        if (!ts.isPropertyAssignment(prop)) continue
+        const name = prop.name.getText()
         if (
-          ts.isPropertyAssignment(prop) &&
-          prop.name.getText() === 'expiry' &&
+          name === 'expiry' &&
           (ts.isStringLiteral(prop.initializer) ||
             ts.isNumericLiteral(prop.initializer))
         ) {
           step.expiry = ts.isNumericLiteral(prop.initializer)
             ? Number(prop.initializer.text)
             : prop.initializer.text
+        }
+        if (name === 'approvers' && ts.isStringLiteral(prop.initializer)) {
+          step.approvers = prop.initializer
+            .text as ApprovalStepMeta['approvers']
+        }
+        if (name === 'approverScope' && ts.isStringLiteral(prop.initializer)) {
+          step.approverScope = prop.initializer.text
         }
       }
     }

--- a/packages/skills/skills/pikku-workflow/SKILL.md
+++ b/packages/skills/skills/pikku-workflow/SKILL.md
@@ -162,6 +162,24 @@ fails the schema does.
 A gate declaring neither option accepts a decision from anyone the approve
 route lets through; gate the route with `auth`/`permissions` to narrow that.
 
+#### What survives the run
+
+A settled decision carries `decidedBy` and `decidedAt`, so the answer keeps its
+provenance in the step result:
+
+```typescript
+if (signOff.status === 'decided') {
+  logger.info(`signed by ${signOff.decidedBy?.userId} at ${signOff.decidedAt}`)
+}
+```
+
+That record is deleted with the run, though — `deleteRun` cascades to steps and
+history — and an attempt that was *refused* never reaches a step at all. So
+every answer is also written to the audit sink as `workflow.approval.decided`,
+with `outcome: 'success' | 'denied'`, the decider under `userIdentity`, and the
+run, reason and refusal in `metadata`. Wire an `audit` service to keep it; a
+project without one records nothing and is otherwise unaffected.
+
 ### Error handling: `onError`, never try/catch
 
 **Do not wrap steps in try/catch.** The DSL extractor serialises the body into a

--- a/packages/skills/skills/pikku-workflow/SKILL.md
+++ b/packages/skills/skills/pikku-workflow/SKILL.md
@@ -129,6 +129,39 @@ await workflow.approval('Manager sign-off', { ... })
 `workflow.name`, `workflow.runId` and `await workflow.getRun()` identify the
 current run if a step needs to reference it.
 
+### Approval gates: who may answer
+
+`workflow.approval(reason, options)` takes a `schema` (a runtime value — the
+payload arrives from an untrusted caller, so a type generic would validate
+nothing), an optional `expiry`, and an optional policy for **who** may answer:
+
+```typescript
+const signOff = await workflow.approval('Manager sign-off', {
+  schema: SignOffSchema,
+  expiry: '3d',
+  approvers: 'not-initiator',      // four-eyes: anyone but whoever started the run
+  approverScope: 'payments:approve', // and they must hold this scope
+})
+if (signOff.status === 'expired') { ... }
+```
+
+`approvers` is one of:
+
+| value | who may answer |
+| --- | --- |
+| `any` *(default)* | anyone the approve entrypoint admits — the gate is a pause for a decision, not an authorization boundary |
+| `owner` | only the user who started the run |
+| `not-initiator` | anyone **except** the user who started the run |
+
+Both options are enforced when the workflow replays the gate, not when the
+decision is submitted — a decision can legitimately arrive before the run has
+reached the gate, and only the workflow holds the policy. A decision that fails
+the policy is discarded and the gate stays closed, exactly as a decision that
+fails the schema does.
+
+A gate declaring neither option accepts a decision from anyone the approve
+route lets through; gate the route with `auth`/`permissions` to narrow that.
+
 ### Error handling: `onError`, never try/catch
 
 **Do not wrap steps in try/catch.** The DSL extractor serialises the body into a

--- a/packages/skills/skills/pikku-workflow/SKILL.md
+++ b/packages/skills/skills/pikku-workflow/SKILL.md
@@ -29,11 +29,11 @@ Build durable, multi-step workflows with automatic retry, sleep, suspend/resume,
 
 ## Choosing the right factory
 
-| Factory | When to use | Step-graph view? |
-|---|---|---|
-| `pikkuWorkflowFunc` | **Default for all new workflows.** Sequential + conditional logic; DSL mode (serialisable, replay-safe). ALL `const`/`let` declarations must be at the top level of the function body (not inside blocks). | ✅ Yes |
-| `pikkuWorkflowGraph` | DAG / fan-out with nodes and typed refs between them. | ✅ Yes |
-| `pikkuWorkflowComplexFunc` | Escape hatch only — arbitrary TypeScript, no top-level restriction (e.g. dynamic inline functions the DSL extractor cannot handle). | ❌ No (loses step-graph view) |
+| Factory                    | When to use                                                                                                                                                                                                | Step-graph view?              |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `pikkuWorkflowFunc`        | **Default for all new workflows.** Sequential + conditional logic; DSL mode (serialisable, replay-safe). ALL `const`/`let` declarations must be at the top level of the function body (not inside blocks). | ✅ Yes                        |
+| `pikkuWorkflowGraph`       | DAG / fan-out with nodes and typed refs between them.                                                                                                                                                      | ✅ Yes                        |
+| `pikkuWorkflowComplexFunc` | Escape hatch only — arbitrary TypeScript, no top-level restriction (e.g. dynamic inline functions the DSL extractor cannot handle).                                                                        | ❌ No (loses step-graph view) |
 
 **Default to `pikkuWorkflowFunc`.** Use `pikkuWorkflowGraph` ONLY with explicit user approval AND only for a genuine cyclic dependency or Node.js-only import DSL cannot express. Use `pikkuWorkflowComplexFunc` ONLY with explicit user approval — a last-resort escape hatch. Never switch to either just to dodge a PKU641 error; restructure the code instead.
 
@@ -58,7 +58,11 @@ if (priority === 'high') {
 
 ```typescript
 // CORRECT — workflow factories come from the generated types file
-import { pikkuWorkflowFunc, pikkuWorkflowGraph, pikkuWorkflowComplexFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
+import {
+  pikkuWorkflowFunc,
+  pikkuWorkflowGraph,
+  pikkuWorkflowComplexFunc,
+} from '#pikku/workflow/pikku-workflow-types.gen.js'
 
 // WRONG — '#pikku' does not re-export them (TS2305)
 import { pikkuWorkflowFunc } from '#pikku'
@@ -73,7 +77,10 @@ import { z } from 'zod'
 import { pikkuWorkflowFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
 
 const ProcessOrderInput = z.object({ orderId: z.string(), amount: z.number() })
-const ProcessOrderOutput = z.object({ status: z.string(), discount: z.number().optional() })
+const ProcessOrderOutput = z.object({
+  status: z.string(),
+  discount: z.number().optional(),
+})
 
 export const processOrder = pikkuWorkflowFunc({
   description: 'Process an order through payment and fulfillment',
@@ -86,7 +93,9 @@ export const processOrder = pikkuWorkflowFunc({
     let status: string
 
     if (data.amount > 1000) {
-      const d = await workflow.do('Apply bulk discount', 'calcDiscount', { amount: data.amount })
+      const d = await workflow.do('Apply bulk discount', 'calcDiscount', {
+        amount: data.amount,
+      })
       discount = d.discountPercent
     }
 
@@ -147,17 +156,25 @@ if (signOff.status === 'expired') { ... }
 
 `approvers` is one of:
 
-| value | who may answer |
-| --- | --- |
-| `any` *(default)* | anyone the approve entrypoint admits — the gate is a pause for a decision, not an authorization boundary |
-| `owner` | only the user who started the run |
-| `not-initiator` | anyone **except** the user who started the run |
+| value             | who may answer                                                                                           |
+| ----------------- | -------------------------------------------------------------------------------------------------------- |
+| `any` _(default)_ | anyone the approve entrypoint admits — the gate is a pause for a decision, not an authorization boundary |
+| `owner`           | only the user who started the run                                                                        |
+| `not-initiator`   | anyone **except** the user who started the run                                                           |
 
-Both options are enforced when the workflow replays the gate, not when the
-decision is submitted — a decision can legitimately arrive before the run has
-reached the gate, and only the workflow holds the policy. A decision that fails
-the policy is discarded and the gate stays closed, exactly as a decision that
-fails the schema does.
+Both options are enforced in two phases, because a decision can legitimately
+arrive before the run has reached the gate:
+
+- **At submission**, if the run has already reached the gate. Reaching it
+  publishes the policy into the run state, so the approve entrypoint can judge
+  the caller against it and refuse with a **403**.
+- **On replay**, for a decision that arrived before the gate — there was no
+  policy to judge it against yet, so it is accepted and judged when the workflow
+  reaches the gate. Failing there discards the decision and leaves the gate
+  closed, exactly as a decision that fails the schema does.
+
+So the same rejected decision surfaces as an HTTP error or as a silently
+re-closed gate depending on timing. Both are audited.
 
 A gate declaring neither option accepts a decision from anyone the approve
 route lets through; gate the route with `auth`/`permissions` to narrow that.
@@ -174,7 +191,7 @@ if (signOff.status === 'decided') {
 ```
 
 That record is deleted with the run, though — `deleteRun` cascades to steps and
-history — and an attempt that was *refused* never reaches a step at all. So
+history — and an attempt that was _refused_ never reaches a step at all. So
 every answer is also written to the audit sink as `workflow.approval.decided`,
 with `outcome: 'success' | 'denied'`, the decider under `userIdentity`, and the
 run, reason and refusal in `metadata`. Wire an `audit` service to keep it; a
@@ -188,14 +205,19 @@ graph would no longer describe what actually runs, which is the whole point of
 the DSL mode. This is a settled design decision, not a temporary limitation.
 
 Use the `onError` step option instead: it names an RPC to invoke when the step
-has failed *after* exhausting its retries.
+has failed _after_ exhausting its retries.
 
 ```typescript
-await workflow.do('Charge', 'chargePayment', { orderId }, {
-  retries: 3,
-  retryDelay: '1s',
-  onError: 'refundReservation',   // compensation RPC
-})
+await workflow.do(
+  'Charge',
+  'chargePayment',
+  { orderId },
+  {
+    retries: 3,
+    retryDelay: '1s',
+    onError: 'refundReservation', // compensation RPC
+  }
+)
 ```
 
 The handler receives `{ error: { message } }`, and the original error is still
@@ -212,7 +234,9 @@ Full step options: `description`, `retries`, `retryDelay`, `onError` (plus
 
 ```typescript
 const users = await Promise.all(
-  data.userIds.map((userId) => workflow.do(`Fetch user ${userId}`, 'getUser', { userId }))
+  data.userIds.map((userId) =>
+    workflow.do(`Fetch user ${userId}`, 'getUser', { userId })
+  )
 )
 ```
 
@@ -233,7 +257,10 @@ export const userOnboarding = pikkuWorkflowGraph({
   config: {
     createProfile: { next: ['sendWelcome', 'setupDefaults'] }, // run in parallel
     sendWelcome: {
-      input: (ref) => ({ to: ref('createProfile', 'email'), subject: 'Welcome!' }),
+      input: (ref) => ({
+        to: ref('createProfile', 'email'),
+        subject: 'Welcome!',
+      }),
     },
   },
 })


### PR DESCRIPTION
Closes #1217.

Approval gates had exactly one authorization rule, hard-coded in core: only the run's initiator could answer one (`assertWorkflowRunOwner` inside `approveStep`, from #1159). That is the right rule for "confirm your own action" and exactly the wrong one for four-eyes sign-off, where the initiator is the one person who must not sign. Both are legitimate, and which applies is a property of the decision — so it is now declared on the gate.

```typescript
await workflow.approval('Release funds', {
  schema: DecisionSchema,
  approvers: 'not-initiator',        // 'any' (default) | 'owner' | 'not-initiator'
  approverScope: 'payments:approve', // optional: decider must hold this scope
})
```

| `approvers` | who may answer |
| --- | --- |
| `any` *(default)* | anyone the approve entrypoint admits |
| `owner` | only the user who started the run |
| `not-initiator` | anyone **except** the user who started the run |

`approverScope` combines with `approvers` — both must pass.

## Where it is enforced, and why

On replay, inside the workflow, alongside payload validation. Two reasons, the second being the one that forced it:

1. The policy is a value on the workflow — only the workflow has it, exactly as with `schema`.
2. A decision can legitimately be recorded *before* the run has ever reached the gate (`recordApprovalDecision` deliberately tolerates a missing step state). So submission time is not a point at which the policy is reliably knowable, and enforcing only there would leave a pre-approval bypass.

A decision that fails the policy is discarded, an `error` is recorded against the gate, and the run suspends again — the same shape as a decision that fails the schema. Where the run *has* already reached the gate, it publishes its policy into run state, so the check also runs eagerly at submission and the caller gets a `WorkflowApprovalForbiddenError` (403) instead of silence.

## Behaviour change

**The default loosens.** `approveStep` previously refused anyone but the initiator, unconditionally; a gate declaring no `approvers` now accepts a decision from anyone the approve route admits. Restore the old rule per-gate with `approvers: 'owner'`, or gate the route with `auth`/`permissions`. Called out in the changeset. Pre-0.13, so no compat shim.

Ownership still gates *reads* of a run (`assertWorkflowRunOwner` is untouched on the status/stream paths); only its doc comment changed, since it no longer speaks for approvals.

## Tests

- `packages/core/src/wirings/workflow/workflow-approval-policy.test.ts` — 11 tests: the policy predicate per branch, plus end-to-end enforcement through `InMemoryWorkflowService` for four-eyes, owner-only, scoped gates, the open default, and the pre-approval case where a decision recorded before the gate is reached is cleared on replay.
- `packages/inspector/src/utils/workflow/dsl/extract-approval-policy.test.ts` — the policy survives DSL extraction into `ApprovalStepMeta`, alongside `expiry`.
- The two tests in `workflow-run-authority.test.ts` that encoded the old unconditional default were rewritten to the new one.

Full suites green: core 2060 pass / 0 fail, inspector 663 pass / 0 fail. `tsc` clean on core and inspector. The CLI's repo-wide `tsc` failures are the pre-existing stale gitignored `.pikku` codegen; none are in the file touched here (a doc comment in the generated approve route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REr934jy4usrMbUhxAv5kz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable workflow approval policies for any approver, the run owner, or a non-initiator.
  - Added optional scope requirements and enforcement during submission and workflow replay.
  - Approval decisions now retain responder identity and timestamps.
  - Added audit events for accepted and refused approval attempts.
  - Unauthorized approvals return a clear forbidden response.
  - Added public workflow types and error details for approval authorization.

- **Documentation**
  - Updated workflow approval guidance, policy behavior, scope requirements, replay enforcement, and invalid-decision handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->