### PR TITLE
feat(better-auth): store-backed sessions with a header or cookie transport

### DIFF
--- a/.changeset/better-auth-store-backed-session.md
+++ b/.changeset/better-auth-store-backed-session.md
@@ -1,0 +1,37 @@
+---
+'@pikku/better-auth': patch
+---
+
+feat(better-auth): store-backed sessions with a header or cookie transport
+
+`betterAuthStatelessSession` verifies a signed cookie blob, which is why the
+package's `cross-site-cookies.ts` rejected better-auth's `bearer()` plugin:
+resolving an opaque `session_token` meant a database lookup, and that forces an
+app onto `betterAuthSession` and bundles the full better-auth server into every
+unit. That reasoning holds only while the session lives in the database.
+
+`betterAuthStoreSession` resolves a session through better-auth's
+`secondaryStorage` instead. There the session token IS the store key, so one
+`get` yields `{ session, user }` — no database read, and no better-auth server
+in the bundle. Because sign-out deletes the store entry, revocation is
+immediate, unlike the stateless middleware's cookie cache.
+
+The credential is better-auth's own signed session token, arriving on
+`Authorization: Bearer …` or on its session cookie, selectable per app via
+`transports`. That distinction is not a preference: a browser cannot set a
+header on a top-level navigation, so a server-rendered app has only the cookie,
+while a single-page app fetches everything from JavaScript and needs no cookie
+at all. Both carry the same value, verified with the same HMAC better-auth signs
+it with, so an app carries one path and never two.
+
+Enable better-auth's `bearer()` plugin to obtain the header form — it echoes the
+token on `set-auth-token`, which the better-auth clients already read. Because a
+header-carried credential is not tied to an origin, this also serves clients a
+cookie cannot reach: a third-party preview iframe under WebKit, or a native
+client whose webview origin is a custom scheme.
+
+`SessionStore` is deliberately the same `get`/`set`/`delete` triple better-auth
+already expects, so one object serves both. `inMemorySessionStore` is included
+for tests, and `prefixedSessionStore` namespaces keys so several tenants can
+share one backing store — pass the prefixed store to better-auth's
+`secondaryStorage` too, so both sides agree on the key.

--- a/packages/services/better-auth/src/auth-session-store.integration.test.ts
+++ b/packages/services/better-auth/src/auth-session-store.integration.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { betterAuth } from 'better-auth'
+import { memoryAdapter } from 'better-auth/adapters/memory'
+import { bearer } from 'better-auth/plugins/bearer'
+
+import { betterAuthStoreSession } from './auth-session-store.js'
+import { inMemorySessionStore } from './session-store.js'
+
+const SECRET = 'a-test-secret-for-store-backed-sessions'
+
+const signUp = async () => {
+  const store = inMemorySessionStore()
+  const auth = betterAuth({
+    baseURL: 'http://localhost',
+    secret: SECRET,
+    database: memoryAdapter({
+      user: [],
+      session: [],
+      account: [],
+      verification: [],
+    }),
+    emailAndPassword: { enabled: true },
+    plugins: [bearer()],
+    secondaryStorage: {
+      get: (key) => store.get(key),
+      set: (key, value, ttl) => store.set(key, value, ttl),
+      delete: (key) => store.delete(key),
+    },
+  })
+
+  const response = await auth.api.signUpEmail({
+    body: { email: 'user@example.com', password: 'password1234', name: 'User' },
+    asResponse: true,
+  })
+  assert.equal(response.status, 200)
+
+  const setCookie = response.headers.get('set-cookie') ?? ''
+  const cookieValue = /better-auth\.session_token=([^;]+)/.exec(setCookie)?.[1]
+  assert.ok(cookieValue, `no session cookie in ${setCookie}`)
+
+  const authToken = response.headers.get('set-auth-token')
+  assert.ok(authToken, 'bearer() did not echo set-auth-token')
+
+  return { auth, store, cookieValue, authToken, setCookie }
+}
+
+const resolve = async (
+  store: ReturnType<typeof inMemorySessionStore>,
+  headers: Record<string, string>
+) => {
+  const captured: any[] = []
+  const services: any = {
+    logger: { info() {}, warn() {}, error() {} },
+    secrets: { getSecret: async () => ({ reveal: () => SECRET }) },
+  }
+  const wire: any = {
+    http: {
+      request: {
+        header: (name: string) => headers[name.toLowerCase()],
+        headers: () => headers,
+      },
+    },
+    setSession: (s: any) => captured.push(s),
+  }
+  await betterAuthStoreSession({ store: () => store })(
+    services,
+    wire,
+    async () => {}
+  )
+  return captured[0] ?? null
+}
+
+describe('betterAuthStoreSession against a real better-auth secondaryStorage', () => {
+  test('a session better-auth wrote is resolvable by its cookie', async () => {
+    const { store, cookieValue } = await signUp()
+    const session = await resolve(store, {
+      cookie: `better-auth.session_token=${cookieValue}`,
+    })
+    assert.equal(typeof session?.userId, 'string')
+  })
+
+  test('the token bearer() echoes on set-auth-token resolves the same session', async () => {
+    const { store, authToken } = await signUp()
+    const session = await resolve(store, {
+      authorization: `Bearer ${authToken}`,
+    })
+    assert.equal(typeof session?.userId, 'string')
+  })
+
+  test('both transports resolve the same user', async () => {
+    const { store, cookieValue, authToken } = await signUp()
+    const viaCookie = await resolve(store, {
+      cookie: `better-auth.session_token=${cookieValue}`,
+    })
+    const viaHeader = await resolve(store, {
+      authorization: `Bearer ${authToken}`,
+    })
+    assert.deepEqual(viaCookie, viaHeader)
+  })
+
+  test('signing out makes both credentials resolve nothing', async () => {
+    const { auth, store, cookieValue, authToken, setCookie } = await signUp()
+    await auth.api.signOut({
+      headers: new Headers({ cookie: setCookie.split(';')[0] ?? '' }),
+    })
+    assert.equal(
+      await resolve(store, {
+        cookie: `better-auth.session_token=${cookieValue}`,
+      }),
+      null
+    )
+    assert.equal(
+      await resolve(store, { authorization: `Bearer ${authToken}` }),
+      null
+    )
+  })
+})

--- a/packages/services/better-auth/src/auth-session-store.test.ts
+++ b/packages/services/better-auth/src/auth-session-store.test.ts
@@ -1,0 +1,221 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { createHMAC } from '@better-auth/utils/hmac'
+import {
+  betterAuthStoreSession,
+  type SessionTransport,
+} from './auth-session-store.js'
+import { inMemorySessionStore, prefixedSessionStore } from './session-store.js'
+
+const SECRET = 'test-secret'
+const TOKEN = 'sess_abc'
+const USER = { id: 'u_1', email: 'a@b.c' }
+
+const sign = async (token: string, secret = SECRET) =>
+  `${token}.${await createHMAC('SHA-256', 'base64urlnopad').sign(secret, token)}`
+
+const storedSession = (overrides: Record<string, unknown> = {}) =>
+  JSON.stringify({ session: { id: TOKEN, ...overrides }, user: USER })
+
+async function run(opts: {
+  transports?: readonly SessionTransport[]
+  authorization?: string
+  cookie?: string
+  seed?: { key: string; value: string } | null
+  prefix?: string
+  secretMissing?: boolean
+  existingSession?: unknown
+}) {
+  const backing = inMemorySessionStore()
+  if (opts.seed !== null) {
+    const seed = opts.seed ?? { key: TOKEN, value: storedSession() }
+    await backing.set(seed.key, seed.value)
+  }
+
+  const captured: any[] = []
+  let errored = false
+  const services: any = {
+    logger: {
+      info() {},
+      warn() {},
+      error() {
+        errored = true
+      },
+    },
+    secrets: {
+      getSecret: async () => {
+        if (opts.secretMissing) {
+          throw new Error('Requested secret not found')
+        }
+        return { reveal: () => SECRET }
+      },
+    },
+  }
+
+  const headers: Record<string, string | undefined> = {
+    authorization: opts.authorization,
+    cookie: opts.cookie,
+  }
+
+  const wire: any = {
+    http: {
+      request: {
+        header: (name: string) => headers[name.toLowerCase()],
+        headers: () =>
+          Object.fromEntries(
+            Object.entries(headers).filter(([, v]) => v !== undefined)
+          ),
+      },
+    },
+    setSession: (s: any) => captured.push(s),
+    session: opts.existingSession,
+  }
+
+  let reachedNext = false
+  const mw = betterAuthStoreSession({
+    store: () =>
+      opts.prefix ? prefixedSessionStore(backing, opts.prefix) : backing,
+    ...(opts.transports ? { transports: opts.transports } : {}),
+  })
+  await mw(services, wire, async () => {
+    reachedNext = true
+  })
+
+  return { session: captured[0] ?? null, reachedNext, errored }
+}
+
+describe('betterAuthStoreSession header transport', () => {
+  test('resolves a session from a signed bearer token', async () => {
+    const { session, reachedNext } = await run({
+      authorization: `Bearer ${await sign(TOKEN)}`,
+    })
+    assert.deepEqual(session, { userId: 'u_1' })
+    assert.equal(reachedNext, true)
+  })
+
+  test('is case-insensitive on the Bearer prefix', async () => {
+    const { session } = await run({
+      authorization: `bearer ${await sign(TOKEN)}`,
+    })
+    assert.deepEqual(session, { userId: 'u_1' })
+  })
+
+  test('rejects a token signed with another secret', async () => {
+    const { session } = await run({
+      authorization: `Bearer ${await sign(TOKEN, 'other-secret')}`,
+    })
+    assert.equal(session, null)
+  })
+
+  test('rejects an unsigned bare token', async () => {
+    const { session } = await run({ authorization: `Bearer ${TOKEN}` })
+    assert.equal(session, null)
+  })
+
+  test('a valid credential for an evicted session resolves nothing', async () => {
+    const { session } = await run({
+      authorization: `Bearer ${await sign(TOKEN)}`,
+      seed: null,
+    })
+    assert.equal(session, null)
+  })
+
+  test('an expired stored session is not accepted', async () => {
+    const { session } = await run({
+      authorization: `Bearer ${await sign(TOKEN)}`,
+      seed: {
+        key: TOKEN,
+        value: storedSession({
+          expiresAt: new Date(Date.now() - 1000).toISOString(),
+        }),
+      },
+    })
+    assert.equal(session, null)
+  })
+
+  test('a missing secret skips the middleware without throwing', async () => {
+    const { session, errored, reachedNext } = await run({
+      authorization: `Bearer ${await sign(TOKEN)}`,
+      transports: ['header'],
+      secretMissing: true,
+    })
+    assert.equal(session, null)
+    assert.equal(errored, true)
+    assert.equal(reachedNext, true)
+  })
+
+  test('ignores the header when only the cookie transport is enabled', async () => {
+    const { session } = await run({
+      authorization: `Bearer ${await sign(TOKEN)}`,
+      transports: ['cookie'],
+    })
+    assert.equal(session, null)
+  })
+})
+
+describe('betterAuthStoreSession cookie transport', () => {
+  test('resolves a session from the better-auth cookie', async () => {
+    const { session } = await run({
+      cookie: `better-auth.session_token=${await sign(TOKEN)}`,
+    })
+    assert.deepEqual(session, { userId: 'u_1' })
+  })
+
+  test('rejects a cookie whose signature does not match', async () => {
+    const { session } = await run({
+      cookie: `better-auth.session_token=${TOKEN}.notasignature`,
+    })
+    assert.equal(session, null)
+  })
+
+  test('ignores the cookie when only the header transport is enabled', async () => {
+    const { session } = await run({
+      cookie: `better-auth.session_token=${await sign(TOKEN)}`,
+      transports: ['header'],
+    })
+    assert.equal(session, null)
+  })
+})
+
+describe('betterAuthStoreSession behaviour', () => {
+  test('both transports resolve the same session', async () => {
+    const credential = await sign(TOKEN)
+    const viaHeader = await run({ authorization: `Bearer ${credential}` })
+    const viaCookie = await run({
+      cookie: `better-auth.session_token=${credential}`,
+    })
+    assert.deepEqual(viaHeader.session, viaCookie.session)
+  })
+
+  test('an already-resolved session is left untouched', async () => {
+    const { session, reachedNext } = await run({
+      authorization: `Bearer ${await sign(TOKEN)}`,
+      existingSession: { userId: 'someone-else' },
+    })
+    assert.equal(session, null)
+    assert.equal(reachedNext, true)
+  })
+
+  test('no credential at all resolves nothing and continues', async () => {
+    const { session, reachedNext } = await run({})
+    assert.equal(session, null)
+    assert.equal(reachedNext, true)
+  })
+
+  test('a prefixed store cannot read an unprefixed key', async () => {
+    const { session } = await run({
+      authorization: `Bearer ${await sign(TOKEN)}`,
+      prefix: 'stage_1/',
+    })
+    assert.equal(session, null)
+  })
+
+  test('a prefixed store reads its own key', async () => {
+    const { session } = await run({
+      authorization: `Bearer ${await sign(TOKEN)}`,
+      prefix: 'stage_1/',
+      seed: { key: `stage_1/${TOKEN}`, value: storedSession() },
+    })
+    assert.deepEqual(session, { userId: 'u_1' })
+  })
+})

--- a/packages/services/better-auth/src/auth-session-store.ts
+++ b/packages/services/better-auth/src/auth-session-store.ts
@@ -1,0 +1,180 @@
+import type {
+  CoreUserSession,
+  CorePikkuMiddleware,
+  CoreServices,
+} from '@pikku/core'
+import { pikkuMiddleware } from '@pikku/core'
+import { getSessionCookie } from 'better-auth/cookies'
+import {
+  resolveImpersonatedSession,
+  type ImpersonationOptions,
+} from './auth-session-impersonation.js'
+import { stampActorFlag } from './stamp-actor-flag.js'
+import { withResolvedScopes } from './auth-session-scopes.js'
+import { verifySessionCredential } from './session-credential.js'
+import type { SessionStore } from './session-store.js'
+
+type StoredSession = { session: any; user: any }
+
+export type SessionTransport = 'header' | 'cookie'
+
+export type BetterAuthStoreSessionOptions = {
+  store: (services: CoreServices) => SessionStore | Promise<SessionStore>
+  transports?: readonly SessionTransport[]
+  headerName?: string
+  secretId?: string
+  mapSession?: (
+    result: StoredSession,
+    services: CoreServices
+  ) => CoreUserSession | Promise<CoreUserSession>
+  impersonation?: ImpersonationOptions
+}
+
+const bearerCredential = (raw: string | undefined | null): string | null => {
+  if (!raw) {
+    return null
+  }
+  const match = /^Bearer\s+(.+)$/i.exec(raw.trim())
+  return match?.[1]?.trim() || null
+}
+
+const notExpired = (stored: StoredSession, now: number): boolean => {
+  const expiresAt = stored.session?.expiresAt
+  if (expiresAt === undefined || expiresAt === null) {
+    return true
+  }
+  const at = new Date(expiresAt).getTime()
+  return Number.isNaN(at) || at > now
+}
+
+/**
+ * Store-backed better-auth session middleware: resolves a session through
+ * better-auth's `secondaryStorage` rather than the database or a signed cookie
+ * blob. Under `secondaryStorage` the session token IS the store key, so one
+ * `get` yields `{ session, user }` — no database read, and no better-auth
+ * server in the bundle.
+ *
+ * That is what retires the objection in `cross-site-cookies.ts` to better-auth's
+ * `bearer()` plugin: the opaque `session_token` needed a database lookup only
+ * while the session lived in the database.
+ *
+ * So the credential here is better-auth's own signed session token, arriving on
+ * `Authorization: Bearer …` or on its session cookie, selectable per app via
+ * `transports`. A browser cannot set a header on a top-level navigation, so a
+ * server-rendered app has only the cookie; a single-page app fetches everything
+ * from JavaScript and needs no cookie at all. Both transports carry the same
+ * value, verified the same way and resolved through the same store read, so an
+ * app carries one path and never two.
+ *
+ * Enable better-auth's `bearer()` plugin to obtain the header form: it echoes
+ * the token on `set-auth-token`, which the better-auth clients already read.
+ * Because a header-carried credential is not tied to an origin, it also serves
+ * clients a cookie cannot reach — a third-party preview iframe under WebKit, or
+ * a native client whose webview origin is a custom scheme.
+ *
+ * Revocation is immediate on both transports: signing out deletes the store
+ * entry and the next request finds nothing to resolve. That is the difference
+ * from {@link betterAuthStatelessSession}, which cannot see a revocation until
+ * its cookie cache ages out.
+ */
+export const betterAuthStoreSession = (
+  options: BetterAuthStoreSessionOptions
+): CorePikkuMiddleware => {
+  const {
+    store,
+    mapSession,
+    impersonation,
+    transports = ['header', 'cookie'] as const,
+    headerName = 'authorization',
+    secretId = 'BETTER_AUTH_SECRET',
+  } = options
+
+  const headerEnabled = transports.includes('header')
+  const cookieEnabled = transports.includes('cookie')
+
+  return pikkuMiddleware(
+    async (services, { http, setSession, session }, next) => {
+      if (!http?.request || !setSession || session) {
+        return next()
+      }
+      const request = http.request
+
+      const credential =
+        (headerEnabled ? bearerCredential(request.header(headerName)) : null) ??
+        (cookieEnabled
+          ? getSessionCookie(new Headers(request.headers()))
+          : null)
+
+      if (!credential) {
+        return next()
+      }
+
+      let secret: string | undefined
+      try {
+        secret = (
+          await (services as any).secrets?.getSecret(secretId)
+        )?.reveal()
+      } catch (e: any) {
+        if (e?.message !== 'Requested secret not found') {
+          throw e
+        }
+        services.logger?.error(
+          `betterAuthStoreSession: secret '${secretId}' not found — session middleware skipped. Ensure ${secretId} is configured.`
+        )
+        return next()
+      }
+      if (!secret) {
+        return next()
+      }
+
+      const token = await verifySessionCredential(credential, secret)
+      if (!token) {
+        return next()
+      }
+
+      let stored: StoredSession | null
+      try {
+        const raw = await (await store(services as CoreServices)).get(token)
+        stored = raw ? (JSON.parse(raw) as StoredSession) : null
+      } catch (e: any) {
+        services.logger?.error(
+          `better-auth store session read failed: ${e?.message ?? e}`
+        )
+        throw e
+      }
+
+      if (!stored?.user || !notExpired(stored, Date.now())) {
+        return next()
+      }
+
+      if (impersonation) {
+        const impersonated = await resolveImpersonatedSession(
+          stored,
+          impersonation,
+          services as CoreServices,
+          (name) => request.header(name),
+          mapSession
+        )
+        if (impersonated) {
+          setSession(
+            await withResolvedScopes(impersonated, services as CoreServices)
+          )
+          return next()
+        }
+      }
+
+      const mapped = mapSession
+        ? await mapSession(stored, services as CoreServices)
+        : ({ userId: stored.user.id } as CoreUserSession)
+
+      setSession(
+        await withResolvedScopes(
+          stampActorFlag(mapped, stored.user),
+          services as CoreServices
+        )
+      )
+
+      return next()
+    }
+  )
+}

--- a/packages/services/better-auth/src/cross-site-cookies.ts
+++ b/packages/services/better-auth/src/cross-site-cookies.ts
@@ -30,6 +30,12 @@
  * would force those apps onto `betterAuthSession`, which is the bundle weight
  * serverless targets cannot take. Relaying the whole jar is what keeps preview
  * and production on the same middleware.
+ *
+ * That objection holds only while the session lives in the database. Under
+ * `secondaryStorage` the `session_token` IS the store key, so resolving it costs
+ * one `get` and no server — which is what {@link betterAuthStoreSession} does.
+ * An app on `secondaryStorage` should use that middleware with `bearer()`
+ * enabled and skip the relay entirely.
  */
 
 /** Request header carrying the relayed `name=value; name=value` cookie pairs. */

--- a/packages/services/better-auth/src/index.ts
+++ b/packages/services/better-auth/src/index.ts
@@ -42,6 +42,14 @@ export type {
 export { stampActorFlag } from './stamp-actor-flag.js'
 export { betterAuthStatelessSession } from './auth-session-stateless.js'
 export type { BetterAuthStatelessSessionOptions } from './auth-session-stateless.js'
+export { betterAuthStoreSession } from './auth-session-store.js'
+export type {
+  BetterAuthStoreSessionOptions,
+  SessionTransport,
+} from './auth-session-store.js'
+export { inMemorySessionStore, prefixedSessionStore } from './session-store.js'
+export type { SessionStore, InMemorySessionStore } from './session-store.js'
+export { verifySessionCredential } from './session-credential.js'
 export { pikkuBetterAuth, PIKKU_BETTER_AUTH } from './define-auth.js'
 export type {
   PikkuBetterAuthFactory,

--- a/packages/services/better-auth/src/session-credential.test.ts
+++ b/packages/services/better-auth/src/session-credential.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { createHMAC } from '@better-auth/utils/hmac'
+import { verifySessionCredential } from './session-credential.js'
+
+const SECRET = 'test-secret'
+const TOKEN = 'sess_abc'
+
+const sign = async (token: string, secret = SECRET) =>
+  `${token}.${await createHMAC('SHA-256', 'base64urlnopad').sign(secret, token)}`
+
+describe('session credential', () => {
+  test('recovers the token from a signed value', async () => {
+    assert.equal(await verifySessionCredential(await sign(TOKEN), SECRET), TOKEN)
+  })
+
+  test('rejects a value signed with another secret', async () => {
+    const credential = await sign(TOKEN, 'other-secret')
+    assert.equal(await verifySessionCredential(credential, SECRET), null)
+  })
+
+  test('rejects a token swapped onto a valid signature', async () => {
+    const signature = (await sign(TOKEN)).split('.')[1]
+    assert.equal(
+      await verifySessionCredential(`sess_admin.${signature}`, SECRET),
+      null
+    )
+  })
+
+  test('rejects an unsigned bare token', async () => {
+    assert.equal(await verifySessionCredential(TOKEN, SECRET), null)
+  })
+
+  test('accepts a percent-encoded value', async () => {
+    const credential = await sign(TOKEN)
+    assert.equal(
+      await verifySessionCredential(encodeURIComponent(credential), SECRET),
+      TOKEN
+    )
+  })
+
+  test('rejects malformed input without throwing', async () => {
+    for (const bad of ['', '.', 'a.', '.b', 'a.b.c', 'not-a-credential']) {
+      assert.equal(await verifySessionCredential(bad, SECRET), null)
+    }
+  })
+})

--- a/packages/services/better-auth/src/session-credential.ts
+++ b/packages/services/better-auth/src/session-credential.ts
@@ -1,0 +1,49 @@
+import { createHMAC } from '@better-auth/utils/hmac'
+
+const tryDecode = (value: string): string => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+/**
+ * Recovers the better-auth session token from the `token.signature` pair the
+ * server issues, verifying the signature with the same HMAC better-auth signs
+ * it with — so a forged or truncated credential is rejected before it costs a
+ * store read.
+ *
+ * The same pair arrives on both transports: better-auth writes it as the
+ * session cookie value, and its `bearer()` plugin echoes that same value on
+ * `set-auth-token` for a client to send back on `Authorization`.
+ *
+ * A signature is required. `bearer()` will accept a bare unsigned token and
+ * sign it on the way in, which is safe there because the token is itself
+ * unguessable — but it gives up the cheap rejection that is the reason this
+ * middleware checks anything before touching the store.
+ */
+export const verifySessionCredential = async (
+  credential: string,
+  secret: string
+): Promise<string | null> => {
+  const value = credential.includes('%') ? tryDecode(credential) : credential
+  const parts = value.split('.')
+  if (parts.length !== 2) {
+    return null
+  }
+  const [token, signature] = parts as [string, string]
+  if (!token || !signature) {
+    return null
+  }
+  try {
+    const valid = await createHMAC('SHA-256', 'base64urlnopad').verify(
+      secret,
+      token,
+      signature
+    )
+    return valid ? token : null
+  } catch {
+    return null
+  }
+}

--- a/packages/services/better-auth/src/session-store.ts
+++ b/packages/services/better-auth/src/session-store.ts
@@ -1,0 +1,63 @@
+export interface SessionStore {
+  get(key: string): Promise<string | null>
+  set(key: string, value: string, ttlSeconds?: number): Promise<void>
+  delete(key: string): Promise<void>
+}
+
+export interface InMemorySessionStore extends SessionStore {
+  size(): number
+  clear(): void
+}
+
+export const inMemorySessionStore = (
+  now: () => number = Date.now
+): InMemorySessionStore => {
+  const entries = new Map<string, { value: string; expiresAt: number | null }>()
+
+  const live = (key: string) => {
+    const entry = entries.get(key)
+    if (!entry) {
+      return null
+    }
+    if (entry.expiresAt !== null && entry.expiresAt <= now()) {
+      entries.delete(key)
+      return null
+    }
+    return entry
+  }
+
+  return {
+    async get(key) {
+      return live(key)?.value ?? null
+    },
+    async set(key, value, ttlSeconds) {
+      entries.set(key, {
+        value,
+        expiresAt:
+          ttlSeconds === undefined ? null : now() + Math.max(0, ttlSeconds) * 1000,
+      })
+    },
+    async delete(key) {
+      entries.delete(key)
+    },
+    size() {
+      for (const key of [...entries.keys()]) {
+        live(key)
+      }
+      return entries.size
+    },
+    clear() {
+      entries.clear()
+    },
+  }
+}
+
+export const prefixedSessionStore = (
+  store: SessionStore,
+  prefix: string
+): SessionStore => ({
+  get: (key) => store.get(`${prefix}${key}`),
+  set: (key, value, ttlSeconds) =>
+    store.set(`${prefix}${key}`, value, ttlSeconds),
+  delete: (key) => store.delete(`${prefix}${key}`),
+})


### PR DESCRIPTION
## What

Adds `betterAuthStoreSession` — a session middleware that resolves a session through better-auth's `secondaryStorage` rather than the database or a signed cookie blob.

Under `secondaryStorage` **the session token IS the store key**, so a session resolves in one `get` that yields `{ session, user }`. No database read, and no better-auth server in the bundle.

## Why bearer was rejected before, and why that no longer binds

`cross-site-cookies.ts` explicitly ruled out better-auth's `bearer()` plugin: it carries an opaque `session_token`, and `betterAuthStatelessSession` reads `session_data` — the signed blob it can verify with the secret alone. Resolving a token meant a database lookup, forcing those apps onto `betterAuthSession` and the full better-auth server, which serverless targets cannot carry.

That objection is conditional on a DB-backed store. With `secondaryStorage` the token resolves through a `get`, and a lean middleware can do that `get` itself. The comment in `cross-site-cookies.ts` now carries the caveat so it stops steering people away for a reason that has stopped holding.

## The credential

It is better-auth's own signed session token — the `token.signature` pair — and nothing bespoke.

Enable better-auth's `bearer()` plugin and it echoes exactly that value on the `set-auth-token` response header, which the better-auth clients already read. So the header transport needs no issuance path of its own: better-auth already hands the client the credential this middleware accepts.

Both transports verify the signature with `createHMAC('SHA-256', 'base64urlnopad')` from `@better-auth/utils` — the same call `bearer()` makes — so a forged or truncated credential is rejected before it costs a store read.

A signature is required. `bearer()` will accept a bare unsigned token and sign it on the way in, which is safe there because the token is itself unguessable, but it gives up the cheap rejection that is the reason to check anything before touching the store.

## The two transports

The credential arrives on `Authorization: Bearer …` or on better-auth's session cookie, selectable per app via `transports`.

That split is not a preference. **A browser cannot set a header on a top-level navigation**, so a server-rendered app has only the cookie; a single-page app fetches everything from JavaScript and needs no cookie at all. Both transports carry the same value, verified the same way, resolved through the same store read — so an app carries one path, never two.

Because a header-carried credential is not tied to an origin, this also serves clients a cookie cannot reach — a third-party preview iframe under WebKit, or a native client whose webview origin is a custom scheme (`tauri://localhost`).

## Revocation

Immediate on both transports: signing out deletes the store entry and the next request finds nothing to resolve. That is the difference from `betterAuthStatelessSession`, which cannot see a revocation until its cookie cache ages out.

## Surface

| export | |
|---|---|
| `betterAuthStoreSession(options)` | the middleware |
| `SessionStore` | the same `get`/`set`/`delete` triple better-auth's `secondaryStorage` expects, so one object serves both |
| `inMemorySessionStore()` | for tests |
| `prefixedSessionStore(store, prefix)` | namespaces keys so several tenants share one backing store — pass the prefixed store to `secondaryStorage` too, so both sides agree on the key |
| `verifySessionCredential(credential, secret)` | recovers the token from the signed pair |

## Tests

26 new tests, 141 passing overall.

The unit tests cover both transports, a wrong-secret signature, a token swapped onto a valid signature, a bare unsigned token, a percent-encoded value, an evicted session, an expired stored session, a missing secret skipping rather than throwing, and prefix isolation.

`auth-session-store.integration.test.ts` drives a **real** `betterAuth` instance with `secondaryStorage` **and `bearer()` enabled**: it signs a user up, asserts `set-auth-token` is on the response, then resolves that exact token through the middleware — by cookie and by header — asserts both yield the same user, and asserts that signing out makes both resolve nothing. That is what pins the stored `{ session, user }` shape, and the wire compatibility with `bearer()`, rather than assuming either.

## Note on dependencies

`@better-auth/utils` is a devDependency here, but it is an exact-version hard dependency of `better-auth` itself, so it resolves wherever the peer is installed. Same footing as `@better-auth/core`, which `credential-oauth.plugin.ts` already imports from `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
