### PR TITLE
ci: raise the per-package unit-coverage cap past the slowest suite

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -316,6 +316,13 @@ jobs:
         # Each package is also capped with `timeout`, because a package whose
         # test process never exits otherwise burns the whole job's 20 minutes
         # and every package sorted after it is never run at all.
+        #
+        # The cap is a hang detector, not a performance budget, so it sits well
+        # above the slowest suite rather than near it. packages/inspector runs
+        # 672 tests over real TypeScript programs — 141s plain, 338s under
+        # coverage instrumentation — and at 300s it began being killed on every
+        # branch at once. CI never runs on main, so a suite creeping past the
+        # cap first appears as every open PR going red together.
         env:
           NODE_OPTIONS: --enable-source-maps
         run: |
@@ -323,7 +330,7 @@ jobs:
           while IFS= read -r script; do
             dir=$(dirname "$script")
             echo "::group::coverage ${dir}"
-            (cd "$dir" && timeout --signal=KILL 300 bash run-tests.sh --coverage) || { status=$?; [ "$status" = 137 ] && echo "::error::unit tests timed out after 300s in ${dir}" || echo "::error::unit tests failed in ${dir}"; echo "$dir" >> unit-test-failures.txt; }
+            (cd "$dir" && timeout --signal=KILL 600 bash run-tests.sh --coverage) || { status=$?; [ "$status" = 137 ] && echo "::error::unit tests timed out after 600s in ${dir}" || echo "::error::unit tests failed in ${dir}"; echo "$dir" >> unit-test-failures.txt; }
             echo "::endgroup::"
           done < <(find packages -name run-tests.sh -not -path '*/node_modules/*' | sort)
       - name: Merge lcov reports and re-root paths to repo root


### PR DESCRIPTION
`Unit Coverage` is red on every open PR right now, and none of them touched the package that fails.

`packages/inspector` runs 672 tests over real TypeScript programs. Measured on this checkout:

| | time |
|---|---|
| plain | 141s |
| under `--experimental-test-coverage` | 338s |

The per-package cap was `timeout --signal=KILL 300`, so the suite is killed and the job exits 1. It is not a new break — the same suite took **214s** on the runner yesterday (#1225's 2026-08-12 22:16 run), already 71% of the cap. It grew past it.

The cap exists as a hang detector, so it should sit well above the slowest suite rather than a minute above it. Raised to 600s; the job's own `timeout-minutes: 20` is still the real ceiling, and the whole sweep runs in ~7 minutes.

One thing this exposes: CI is `branches-ignore: main`, so nothing measures main. A suite creeping past the cap is invisible until every open PR goes red at the same time, which reads like anything but a timeout.

Once this lands, the open PRs need a rebase to pick it up — for `push` events the workflow runs from the branch's own ref, not main's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the unit test workflow timeout to 10 minutes.
  * Updated timeout error messaging to reflect the new limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->