### PR TITLE
feat(console): export the knowledge workspace and link resolver

### DIFF
--- a/.changeset/console-export-knowledge-workspace.md
+++ b/.changeset/console-export-knowledge-workspace.md
@@ -1,0 +1,17 @@
+---
+'@pikku/console': patch
+---
+
+Export the knowledge surface from the package barrel.
+
+`KnowledgePage` was exported, but the workspace it renders, its bundle types and
+`resolveNoteLink` were not — so a host embedding the knowledge browser into its
+own shell could not mount the workspace, type the bundle it feeds in, or resolve
+a note link the same way the graph does. Resolving links differently is the
+subtle one: `inbound` and `dangling` are computed against this resolver, so a
+host with its own copy renders cross-links that have no backlink on the other
+side.
+
+Adds `KnowledgeWorkspace`, `KnowledgeWorkspaceProps`, `resolveNoteLink`, and the
+`KnowledgeBundle`, `KnowledgeFinding`, `KnowledgeNote`, `KnowledgeSection` and
+`KnowledgeSelection` types. No behaviour change.

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -151,10 +151,20 @@ export type { VirtualUserDoc } from './components/virtual-users/virtual-user-mod
 export { useVirtualUsers } from './hooks/useVirtualUsers'
 export { KnowledgePage } from './pages/KnowledgePage'
 export type { KnowledgePageProps } from './pages/KnowledgePage'
+export { KnowledgeWorkspace } from './components/knowledge/KnowledgeWorkspace'
+export type { KnowledgeWorkspaceProps } from './components/knowledge/KnowledgeWorkspace'
 export { KnowledgeBrowseRail } from './components/knowledge/KnowledgeBrowseRail'
 export type { KnowledgeBrowseRailProps } from './components/knowledge/KnowledgeBrowseRail'
 export { useKnowledgeBrowse } from './hooks/useKnowledgeBrowse'
 export type { KnowledgeBrowse } from './hooks/useKnowledgeBrowse'
+export { resolveNoteLink } from './lib/knowledge'
+export type {
+  KnowledgeBundle,
+  KnowledgeFinding,
+  KnowledgeNote,
+  KnowledgeSection,
+  KnowledgeSelection,
+} from './lib/knowledge'
 export { SecretsPage } from './pages/SecretsPage'
 export { VariablesPage } from './pages/VariablesPage'
 export { EmailsPage } from './pages/EmailsPage'


### PR DESCRIPTION
`KnowledgePage` is exported from the package barrel, but the workspace it renders is not — nor are the bundle types it takes, nor `resolveNoteLink`. A host that wants the knowledge browser inside its own shell (its own header, its own side panel, its own data source) can mount `KnowledgeBrowseRail` and call `useKnowledgeBrowse`, but has nothing to put in the content column.

Resolving links is the part that matters most. `inbound` and `dangling` are counted against this exact resolver, so a host that writes its own copy will eventually render a cross-link that has no backlink on the other side. Exporting it keeps one implementation.

Adds to `src/index.ts`:

- `KnowledgeWorkspace` + `KnowledgeWorkspaceProps`
- `resolveNoteLink`
- `KnowledgeBundle`, `KnowledgeFinding`, `KnowledgeNote`, `KnowledgeSection`, `KnowledgeSelection`

Same shape as the existing `VirtualUsersWorkspace` export, which sits alongside its page a few lines above. Barrel-only — no behaviour change, and `tsc --noEmit` is clean on the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)