### PR TITLE
fix(cli): declare pgliteExtensions in pikku.config.json, not createConfig

### DIFF
--- a/.changeset/pglite-extensions-move-to-cli-config.md
+++ b/.changeset/pglite-extensions-move-to-cli-config.md
@@ -1,0 +1,18 @@
+---
+'@pikku/cli': patch
+---
+
+Declare `pgliteExtensions` in pikku.config.json's `db` block rather than in
+`createConfig`. It only ever configured the CLI's embedded PGlite databases, and
+reading it from the runtime config meant a project pointed at a server through
+`DATABASE_URL` lost its declaration — the shadow database the CLI migrates is
+PGlite either way, so the extensions went missing exactly where they were needed.
+`pikku db export` now picks them up too.
+
+```json
+{
+  "db": {
+    "pgliteExtensions": ["@electric-sql/pglite-pgvector", "hstore"]
+  }
+}
+```

--- a/packages/cli/src/functions/commands/db-export.ts
+++ b/packages/cli/src/functions/commands/db-export.ts
@@ -17,7 +17,10 @@ import { exportSchema } from '../db/local-db.js'
 export const dbExport = pikkuSessionlessFunc<{}, void>({
   remote: true,
   func: async ({ logger, config }) => {
-    const artifact = await exportSchema(config.rootDir)
+    const artifact = await exportSchema(
+      config.rootDir,
+      config.db?.pgliteExtensions
+    )
     const dialects = Object.keys(artifact)
 
     if (dialects.length === 0) {

--- a/packages/cli/src/functions/commands/db-shared.ts
+++ b/packages/cli/src/functions/commands/db-shared.ts
@@ -5,20 +5,6 @@ import { loadUserModule } from './load-user-project.js'
 export interface UserConfigShape {
   sqliteDb?: string
   postgresUrl?: string
-  /**
-   * Postgres extensions the CLI's embedded PGlite databases must load — the
-   * local dev database, and the shadow one every `db` command migrates to type
-   * and diff a schema.
-   *
-   * A bare name is one of PGlite's bundled contrib extensions (`hstore`,
-   * `citext`, `uuid_ossp`, …) and needs nothing installed. Anything else is a
-   * package the project depends on, such as `@electric-sql/pglite-pgvector`.
-   *
-   * Needed even when `postgresUrl` points at a server that already has the
-   * extension: the shadow database is PGlite regardless, so a `CREATE EXTENSION`
-   * in a migration fails there unless it is declared here.
-   */
-  pgliteExtensions?: string[]
   [key: string]: unknown
 }
 

--- a/packages/cli/src/functions/db/local-db.test.ts
+++ b/packages/cli/src/functions/db/local-db.test.ts
@@ -480,7 +480,9 @@ test('scratch codegen types the postgres migrations without touching the configu
 test('resolveDb carries the declared PGlite extensions onto the postgres descriptor', () => {
   usePostgresProject()
 
-  const local = resolveDb({ pgliteExtensions: ['hstore'] }, root, root)!
+  const local = resolveDb({}, root, root, undefined, {
+    pgliteExtensions: ['hstore'],
+  })!
   assert.equal(local.dialect, 'postgres')
   if (local.dialect !== 'postgres') throw new Error('expected postgres')
   assert.deepEqual(local.pgliteExtensions, ['hstore'])
@@ -488,12 +490,11 @@ test('resolveDb carries the declared PGlite extensions onto the postgres descrip
   // A project on a real Postgres server still needs them: the shadow database
   // the CLI diffs against is PGlite either way.
   const remote = resolveDb(
-    {
-      postgresUrl: 'postgres://user:pass@localhost:5432/mydb',
-      pgliteExtensions: ['hstore'],
-    },
+    { postgresUrl: 'postgres://user:pass@localhost:5432/mydb' },
     root,
-    root
+    root,
+    undefined,
+    { pgliteExtensions: ['hstore'] }
   )!
   if (remote.dialect !== 'postgres') throw new Error('expected postgres')
   assert.deepEqual(remote.pgliteExtensions, ['hstore'])
@@ -514,7 +515,9 @@ CREATE TABLE docs (
     devSeedSql: '',
   })
 
-  const resolved = resolveDb({ pgliteExtensions: ['hstore'] }, root, root)!
+  const resolved = resolveDb({}, root, root, undefined, {
+    pgliteExtensions: ['hstore'],
+  })!
   const scratch = await migrateAndCodegen(resolved, { scratch: true })
   assert.deepEqual(scratch.migrate.applied, ['0001-init.sql'])
   assert.match(readFileSync(resolved.schemaFile, 'utf8'), /Docs/)
@@ -531,7 +534,9 @@ CREATE TABLE docs (
     devSeedSql: '',
   })
 
-  const resolved = resolveDb({ pgliteExtensions: ['hstore'] }, root, root)!
+  const resolved = resolveDb({}, root, root, undefined, {
+    pgliteExtensions: ['hstore'],
+  })!
   await migrateAndCodegen(resolved)
 
   const kysely = await createKysely<{ docs: { id: number } }>(resolved)
@@ -562,11 +567,9 @@ test('an undeclared extension fails with guidance rather than a bare Postgres er
 
 test('an unresolvable extension specifier says where it was looked for', async () => {
   usePostgresProject()
-  const resolved = resolveDb(
-    { pgliteExtensions: ['@not-installed/pglite-nothing'] },
-    root,
-    root
-  )!
+  const resolved = resolveDb({}, root, root, undefined, {
+    pgliteExtensions: ['@not-installed/pglite-nothing'],
+  })!
 
   await assert.rejects(
     () => migrateAndCodegen(resolved, { scratch: true }),
@@ -585,11 +588,9 @@ test('a module that exports no PGlite extension is rejected by name', async () =
     'export const nope = { hello: "world" }\n'
   )
 
-  const resolved = resolveDb(
-    { pgliteExtensions: ['./not-an-extension.mjs'] },
-    root,
-    root
-  )!
+  const resolved = resolveDb({}, root, root, undefined, {
+    pgliteExtensions: ['./not-an-extension.mjs'],
+  })!
 
   await assert.rejects(
     () => migrateAndCodegen(resolved, { scratch: true }),

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -81,7 +81,7 @@ export interface ResolvedPostgresDb extends ResolvedDbBase {
   devSeedFile: string
   /**
    * Postgres extensions the embedded PGlite databases must load, as declared by
-   * `pgliteExtensions` in the project's config. See
+   * `db.pgliteExtensions` in the project's pikku.config.json. See
    * {@link loadPGliteExtensions}.
    *
    * Carried even in `url` mode: the shadow database the CLI migrates and
@@ -126,7 +126,9 @@ export function resolveDb(
   rootDir: string,
   outDir: string,
   runtimeDir?: string,
-  dbConfig?: { schema?: string; defaultSchema?: string } | string
+  dbConfig?:
+    | { schema?: string; defaultSchema?: string; pgliteExtensions?: string[] }
+    | string
 ): ResolvedDb | null {
   // The parameter took a bare schema string before `defaultSchema` existed;
   // both forms are accepted so callers outside this repo keep working.
@@ -162,7 +164,8 @@ export function resolveDb(
     )
   }
 
-  const pgliteExtensions = userConfig.pgliteExtensions ?? []
+  const pgliteExtensions =
+    (typeof dbConfig === 'string' ? undefined : dbConfig?.pgliteExtensions) ?? []
 
   if (userConfig.postgresUrl) {
     return {
@@ -456,7 +459,7 @@ function explainMissingExtension(error: unknown, declared: string[]): unknown {
     `The embedded PGlite database has no '${name}' extension. ` +
       `The CLI migrates a PGlite shadow database to type and diff your schema, ` +
       `so every extension your migrations use has to be declared as ` +
-      `pgliteExtensions in createConfig — e.g. pgliteExtensions: ['${name}'] ` +
+      `db.pgliteExtensions in pikku.config.json — e.g. "db": { "pgliteExtensions": ["${name}"] } ` +
       `for a PGlite contrib extension, or the package that publishes it ` +
       `('@electric-sql/pglite-pgvector' for pgvector).` +
       (declared.length > 0

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -398,6 +398,21 @@ export type PikkuCLIInput = {
      * every query compiles and then fails to find its table at runtime.
      */
     defaultSchema?: string
+
+    /**
+     * Postgres extensions the CLI's embedded PGlite databases must load — the
+     * local dev database, and the shadow one every `db` command migrates to type
+     * and diff a schema.
+     *
+     * A bare name is one of PGlite's bundled contrib extensions (`hstore`,
+     * `citext`, `uuid_ossp`, …) and needs nothing installed. Anything else is a
+     * package the project depends on, such as `@electric-sql/pglite-pgvector`.
+     *
+     * Needed even when the project runs against a Postgres server that already
+     * has the extension: the shadow database is PGlite regardless, so a
+     * `CREATE EXTENSION` in a migration fails there unless it is declared here.
+     */
+    pgliteExtensions?: string[]
   }
 
   cli?: {


### PR DESCRIPTION
Closes #1236.

`pgliteExtensions` only ever configured the CLI's embedded PGlite databases — the local dev database, and the shadow one every `db` command migrates to type and diff a schema — so it moves out of the project's runtime `createConfig()` and into `pikku.config.json` beside `db.schema`:

```json
{
  "db": {
    "pgliteExtensions": ["@electric-sql/pglite-pgvector", "hstore"]
  }
}
```

Reading it from the runtime config also lost it wherever that config was bypassed:

- `dev` and `serve` replace the user config with `parseDatabaseUrl(DATABASE_URL)` when that env var is set, dropping the declaration — and the shadow database is PGlite whichever server the project itself runs against, so the extensions went missing exactly where they were needed.
- `db export` called `exportSchema(rootDir)` with no extensions at all; it now passes `config.db?.pgliteExtensions`.

Every `resolveDb` call site already threaded `config.db` through, so the move is a change of source, not of plumbing. The missing-extension error message now points at the new location.

## Testing

`packages/cli/src/functions/db/local-db.test.ts` — the extension tests declare through the CLI config argument now, and cover the declared/undeclared/unresolvable/not-an-extension paths as before. 59/59 pass, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)