### PR TITLE
Feat/knowledge profile scalars

### DIFF
--- a/.changeset/knowledge-slice-is-now-milestone.md
+++ b/.changeset/knowledge-slice-is-now-milestone.md
@@ -1,0 +1,23 @@
+---
+'@pikku/knowledge': patch
+---
+
+feat(knowledge): a slice is now a milestone
+
+One concept, two words. The profile called the unit of buildable work a `slice`
+while everything a user reads called it a milestone, so every console rendering
+this graph carried a relabel to hide the difference. The word is now milestone
+everywhere, and a bundle written before the rename still reads.
+
+Renamed: `SLICE_STATUSES` → `MILESTONE_STATUSES`, `SliceStatus` →
+`MilestoneStatus`, the `slices` section → `milestones`, `type: slice` →
+`type: milestone`, and the `knowledge-slice-*` findings → `knowledge-milestone-*`.
+Anything matching on a finding id needs the new prefix.
+
+**Existing bundles keep working.** `isMilestone()` accepts `type: slice`
+alongside `type: milestone`, and a `knowledge/slices/` directory keeps the
+milestone description and its place in the reading order rather than sorting to
+the end as a section nothing declares. Writers emit the new names; readers
+accept both, so a base migrates as its notes are rewritten rather than in one
+cutover. `MILESTONE_TYPE`, `MILESTONE_SECTION` and `canonicalSection()` are
+exported for a profile that has to write or resolve those names itself.

--- a/packages/knowledge/src/check-resources.test.ts
+++ b/packages/knowledge/src/check-resources.test.ts
@@ -33,8 +33,8 @@ describe('checkKnowledgeResources', () => {
   test('passes when every resource resolves', async () => {
     const root = await project({
       ...FUNC_META,
-      'knowledge/slices/01-a.md':
-        '---\ntype: slice\nresource: func:createEntry, func:listEntries\n---\nx',
+      'knowledge/milestones/01-a.md':
+        '---\ntype: milestone\nresource: func:createEntry, func:listEntries\n---\nx',
     })
     const result = await check(root)
     assert.deepEqual(result.problems, [])
@@ -46,8 +46,8 @@ describe('checkKnowledgeResources', () => {
   test('reports a dangling id — the note survived a rename the code did not keep', async () => {
     const root = await project({
       ...FUNC_META,
-      'knowledge/slices/01-a.md':
-        '---\ntype: slice\nresource: func:createEntrey\n---\nx',
+      'knowledge/milestones/01-a.md':
+        '---\ntype: milestone\nresource: func:createEntrey\n---\nx',
     })
     const result = await check(root)
     assert.equal(result.ok, false)
@@ -73,8 +73,8 @@ describe('checkKnowledgeResources', () => {
     // to ignore the check.
     const root = await project({
       ...FUNC_META,
-      'knowledge/slices/01-a.md':
-        '---\ntype: slice\nresource: queue:nightly-digest\n---\nx',
+      'knowledge/milestones/01-a.md':
+        '---\ntype: milestone\nresource: queue:nightly-digest\n---\nx',
     })
     const result = await check(root)
     assert.equal(result.ok, true)
@@ -85,8 +85,8 @@ describe('checkKnowledgeResources', () => {
   test('checks a resolvable prefix even when another in the same note is skipped', async () => {
     const root = await project({
       ...FUNC_META,
-      'knowledge/slices/01-a.md':
-        '---\ntype: slice\nresource: queue:nightly, func:gone\n---\nx',
+      'knowledge/milestones/01-a.md':
+        '---\ntype: milestone\nresource: queue:nightly, func:gone\n---\nx',
     })
     const result = await check(root)
     assert.equal(result.skipped, 1)
@@ -99,8 +99,8 @@ describe('checkKnowledgeResources', () => {
     const root = await project({
       ...FUNC_META,
       'knowledge/index.md': '---\ntype: overview\n---\nx',
-      'knowledge/slices/01-a.md':
-        '---\ntype: slice\nresource: func:createEntry\n---\nx',
+      'knowledge/milestones/01-a.md':
+        '---\ntype: milestone\nresource: func:createEntry\n---\nx',
     })
     assert.equal((await check(root)).notes, 1)
   })
@@ -134,8 +134,8 @@ describe('resource URIs in the prose', () => {
   test('an inline link is checked like a resource field', async () => {
     const root = await project({
       ...FUNC_META,
-      'knowledge/slices/01-a.md':
-        '---\ntype: slice\n---\nWritten by [createEntry](func:createEntry).',
+      'knowledge/milestones/01-a.md':
+        '---\ntype: milestone\n---\nWritten by [createEntry](func:createEntry).',
     })
     const result = await check(root)
     assert.deepEqual(result.problems, [])
@@ -145,8 +145,8 @@ describe('resource URIs in the prose', () => {
   test('an inline link to a function nobody exports is drift', async () => {
     const root = await project({
       ...FUNC_META,
-      'knowledge/slices/01-a.md':
-        '---\ntype: slice\n---\nWritten by [saveEntry](func:saveEntry).',
+      'knowledge/milestones/01-a.md':
+        '---\ntype: milestone\n---\nWritten by [saveEntry](func:saveEntry).',
     })
     const result = await check(root)
     assert.equal(result.problems.length, 1)
@@ -157,8 +157,8 @@ describe('resource URIs in the prose', () => {
   test('a mistyped kind is reported rather than passed over', async () => {
     const root = await project({
       ...FUNC_META,
-      'knowledge/slices/01-a.md':
-        '---\ntype: slice\n---\nWritten by [createEntry](fun:createEntry).',
+      'knowledge/milestones/01-a.md':
+        '---\ntype: milestone\n---\nWritten by [createEntry](fun:createEntry).',
     })
     const result = await check(root)
     assert.equal(result.problems[0]?.reason, 'unknown-prefix')
@@ -167,9 +167,9 @@ describe('resource URIs in the prose', () => {
   test('ordinary links are left alone', async () => {
     const root = await project({
       ...FUNC_META,
-      'knowledge/slices/01-a.md': [
+      'knowledge/milestones/01-a.md': [
         '---',
-        'type: slice',
+        'type: milestone',
         '---',
         'See [the docs](https://pikku.dev/docs), the [decision](../decisions/why.md),',
         'the [section](#how-it-works) and [us](mailto:hi@example.com).',
@@ -182,9 +182,9 @@ describe('resource URIs in the prose', () => {
   test('an example inside code is an example, not a claim', async () => {
     const root = await project({
       ...FUNC_META,
-      'knowledge/slices/01-a.md': [
+      'knowledge/milestones/01-a.md': [
         '---',
-        'type: slice',
+        'type: milestone',
         '---',
         'Write it as `[label](func:someFunction)`, like this:',
         '',

--- a/packages/knowledge/src/graph.test.ts
+++ b/packages/knowledge/src/graph.test.ts
@@ -20,8 +20,8 @@ describe('outboundLinks', () => {
     assert.deepEqual(
       outboundLinks(
         note(
-          'knowledge/slices/01-a.md',
-          '---\ntype: slice\n---\nSee [why](../decisions/why.md).'
+          'knowledge/milestones/01-a.md',
+          '---\ntype: milestone\n---\nSee [why](../decisions/why.md).'
         )
       ),
       ['knowledge/decisions/why.md']
@@ -33,10 +33,10 @@ describe('outboundLinks', () => {
       outboundLinks(
         note(
           'knowledge/index.md',
-          '---\ntype: overview\n---\n[a](slices/01-a.md#top)'
+          '---\ntype: overview\n---\n[a](milestones/01-a.md#top)'
         )
       ),
-      ['knowledge/slices/01-a.md']
+      ['knowledge/milestones/01-a.md']
     )
   })
 
@@ -63,15 +63,15 @@ describe('outboundLinks', () => {
   })
 
   test('does not read links out of a fenced block', () => {
-    // A slice body is mostly gherkin, and decisions quote paths. Bracket-and-paren
+    // A milestone body is mostly gherkin, and decisions quote paths. Bracket-and-paren
     // text in there is not a link a reader can click.
     assert.deepEqual(
       outboundLinks(
         note(
-          'knowledge/slices/01-a.md',
+          'knowledge/milestones/01-a.md',
           [
             '---',
-            'type: slice',
+            'type: milestone',
             '---',
             '```gherkin',
             "Given 'owner' opens [the day](../decisions/why.md)",
@@ -89,10 +89,10 @@ describe('outboundLinks', () => {
       outboundLinks(
         note(
           'knowledge/index.md',
-          '---\ntype: overview\n---\n[a](slices/01-a.md) and [again](slices/01-a.md)'
+          '---\ntype: overview\n---\n[a](milestones/01-a.md) and [again](milestones/01-a.md)'
         )
       ),
-      ['knowledge/slices/01-a.md']
+      ['knowledge/milestones/01-a.md']
     )
   })
 })
@@ -101,14 +101,14 @@ describe('buildKnowledgeGraph', () => {
   const bundle = () => [
     note(
       'knowledge/index.md',
-      '---\ntype: overview\ntitle: Knowledge\n---\n[slices](slices/index.md)'
+      '---\ntype: overview\ntitle: Knowledge\n---\n[milestones](milestones/index.md)'
     ),
-    note('knowledge/slices/index.md', '---\ntype: overview\n---\nPieces.'),
+    note('knowledge/milestones/index.md', '---\ntype: overview\n---\nPieces.'),
     note(
-      'knowledge/slices/01-a.md',
+      'knowledge/milestones/01-a.md',
       [
         '---',
-        'type: slice',
+        'type: milestone',
         'title: The daily entry',
         'description: One piece.',
         'status: proposed',
@@ -129,11 +129,11 @@ describe('buildKnowledgeGraph', () => {
     // Inbound is the half a markdown file cannot express: a note has no way to
     // say what points at it, and that is exactly what a reader wants to know.
     const graph = buildKnowledgeGraph(bundle())
-    assert.deepEqual(find(graph, 'knowledge/slices/01-a.md').outbound, [
+    assert.deepEqual(find(graph, 'knowledge/milestones/01-a.md').outbound, [
       'knowledge/decisions/why.md',
     ])
     assert.deepEqual(find(graph, 'knowledge/decisions/why.md').inbound, [
-      'knowledge/slices/01-a.md',
+      'knowledge/milestones/01-a.md',
     ])
   })
 
@@ -141,7 +141,7 @@ describe('buildKnowledgeGraph', () => {
     // OKF permits it: a link to a note nobody has written marks something worth
     // writing. It is surfaced, not failed.
     const graph = buildKnowledgeGraph(bundle())
-    assert.deepEqual(find(graph, 'knowledge/slices/01-a.md').dangling, [
+    assert.deepEqual(find(graph, 'knowledge/milestones/01-a.md').dangling, [
       'knowledge/decisions/later.md',
     ])
     assert.equal(graph.stats.dangling, 1)
@@ -149,20 +149,20 @@ describe('buildKnowledgeGraph', () => {
   })
 
   test('splits resource: and entities so a reader gets lists, not strings', () => {
-    const slice = find(
+    const milestone = find(
       buildKnowledgeGraph(bundle()),
-      'knowledge/slices/01-a.md'
+      'knowledge/milestones/01-a.md'
     )
-    assert.deepEqual(slice.resource, ['func:createEntry', 'table:entry'])
-    assert.deepEqual(slice.entities, ['entry', 'day'])
+    assert.deepEqual(milestone.resource, ['func:createEntry', 'table:entry'])
+    assert.deepEqual(milestone.entities, ['entry', 'day'])
   })
 
   test('counts sections without counting their own index.md', () => {
     const graph = buildKnowledgeGraph(bundle())
     assert.deepEqual(graph.sections, [
       {
-        name: 'slices',
-        description: KNOWLEDGE_SECTIONS['slices'],
+        name: 'milestones',
+        description: KNOWLEDGE_SECTIONS['milestones'],
         count: 1,
       },
       {
@@ -174,28 +174,46 @@ describe('buildKnowledgeGraph', () => {
   })
 
   test('orders sections the way the profile declares them, not alphabetically', () => {
-    // Alphabetical leads with `decisions` and buries `slices` last, which is the
-    // reverse of how a base is read: the slice first, then what governs it.
+    // Alphabetical leads with `decisions` and buries `milestones` last, which is the
+    // reverse of how a base is read: the milestone first, then what governs it.
     const graph = buildKnowledgeGraph([
       note('knowledge/questions/open.md', '---\ntype: question\n---\nq'),
       note('knowledge/decisions/why.md', '---\ntype: decision\n---\nd'),
       note('knowledge/entities/entry.md', '---\ntype: entity\n---\ne'),
+      note('knowledge/milestones/01-a.md', '---\ntype: milestone\n---\ns'),
+    ])
+    assert.deepEqual(
+      graph.sections.map((section) => section.name),
+      ['milestones', 'entities', 'decisions', 'questions']
+    )
+  })
+
+  test('a legacy slices/ sorts and reads as the milestones section it is', () => {
+    // Otherwise the rename demotes every bundle written before it: `slices/` is
+    // a section the profile no longer names, so it would sort last, behind
+    // `questions`, and lose the description the navigator shows under it.
+    const graph = buildKnowledgeGraph([
+      note('knowledge/questions/open.md', '---\ntype: question\n---\nq'),
       note('knowledge/slices/01-a.md', '---\ntype: slice\n---\ns'),
     ])
     assert.deepEqual(
       graph.sections.map((section) => section.name),
-      ['slices', 'entities', 'decisions', 'questions']
+      ['slices', 'questions']
+    )
+    assert.equal(
+      graph.sections[0]!.description,
+      'one buildable piece of the app, with the scenario that proves it'
     )
   })
 
   test('a section not in the profile sorts after the ones that are', () => {
     const graph = buildKnowledgeGraph([
       note('knowledge/archive/old.md', '---\ntype: note\n---\na'),
-      note('knowledge/slices/01-a.md', '---\ntype: slice\n---\ns'),
+      note('knowledge/milestones/01-a.md', '---\ntype: milestone\n---\ns'),
     ])
     assert.deepEqual(
       graph.sections.map((section) => section.name),
-      ['slices', 'archive']
+      ['milestones', 'archive']
     )
   })
 

--- a/packages/knowledge/src/graph.ts
+++ b/packages/knowledge/src/graph.ts
@@ -1,7 +1,7 @@
 import { posix } from 'node:path'
 import { z } from 'zod'
 import { type KnowledgeNote, resourceIds, sectionOf, toPosix } from './notes.js'
-import { KNOWLEDGE_SECTIONS } from './validate.js'
+import { KNOWLEDGE_SECTIONS, canonicalSection } from './validate.js'
 
 /**
  * Declared rather than inferred, for the reason given on `KnowledgeFinding`:
@@ -101,7 +101,7 @@ export const KnowledgeGraphSchema = z.object({
 /**
  * Fenced and inline code, removed before links are read.
  *
- * A slice body is mostly a gherkin block and decisions quote paths; both contain
+ * A milestone body is mostly a gherkin block and decisions quote paths; both contain
  * bracket-and-paren text that reads as a markdown link. Counting those would put
  * edges in the graph that no reader can click.
  */
@@ -134,10 +134,10 @@ export const outboundLinks = (note: KnowledgeNote): string[] => {
 
 /**
  * Where a section sorts: the order the profile declares them in, which is the
- * order they are read in — a slice, the entities it is about, the decisions that
- * govern it, then what is still open. Alphabetical would lead with `decisions`
- * and bury `slices` at the end, and would separate `decisions` from
- * `decisions/security` by everything in between.
+ * order they are read in — a milestone, the entities it is about, the decisions
+ * that govern it, then what is still open. Alphabetical would lead with
+ * `decisions` and bury `milestones` in the middle, and would separate `decisions`
+ * from `decisions/security` by everything in between.
  *
  * A section the profile does not name sorts after all of them, alphabetically,
  * which puts a parent ahead of its own children for free.
@@ -147,7 +147,7 @@ const SECTION_RANK = new Map(
 )
 
 const sectionRank = (name: string): number =>
-  SECTION_RANK.get(name) ?? SECTION_RANK.size
+  SECTION_RANK.get(canonicalSection(name)) ?? SECTION_RANK.size
 
 /**
  * The notes, the links between them, and the counts a browser needs — derived in
@@ -236,7 +236,7 @@ export const buildKnowledgeGraph = (notes: KnowledgeNote[]): KnowledgeGraph => {
     .sort(([a], [b]) => sectionRank(a) - sectionRank(b) || a.localeCompare(b))
     .map(([name, count]) => ({
       name,
-      description: KNOWLEDGE_SECTIONS[name],
+      description: KNOWLEDGE_SECTIONS[canonicalSection(name)],
       count,
     }))
 

--- a/packages/knowledge/src/index.ts
+++ b/packages/knowledge/src/index.ts
@@ -2,6 +2,8 @@ export {
   KNOWLEDGE_DIR,
   type KnowledgeNote,
   type ProfileNote,
+  MILESTONE_TYPE,
+  isMilestone,
   readKnowledgeNotes,
   resourceIds,
 } from './notes.js'
@@ -13,10 +15,7 @@ export {
   parseDecisionFence,
 } from './decision-fence.js'
 
-export {
-  type ResourcePrefix,
-  type ResourceUri,
-} from './resource-uri.js'
+export { type ResourcePrefix, type ResourceUri } from './resource-uri.js'
 
 export {
   type ResourceCheck,
@@ -27,8 +26,10 @@ export {
 } from './check-resources.js'
 
 export {
-  SLICE_STATUSES,
-  type SliceStatus,
+  MILESTONE_SECTION,
+  MILESTONE_STATUSES,
+  type MilestoneStatus,
+  canonicalSection,
   KnowledgeValidateInput,
   KnowledgeValidateOutput,
   type KnowledgeFinding,

--- a/packages/knowledge/src/notes.test.ts
+++ b/packages/knowledge/src/notes.test.ts
@@ -5,14 +5,14 @@ import { join } from 'node:path'
 import { describe, test, type TestContext } from 'node:test'
 import { parseNote, readKnowledgeNotes, resourceIds } from './notes.js'
 
-const note = (body: string) => parseNote('knowledge/slices/01-a.md', body)
+const note = (body: string) => parseNote('knowledge/milestones/01-a.md', body)
 
 describe('parseNote', () => {
   test('reads the scalars and leaves the body', () => {
     const parsed = note(
       [
         '---',
-        'type: slice',
+        'type: milestone',
         'title: The daily entry',
         'description: One buildable piece.',
         'resource: func:createEntry',
@@ -24,7 +24,7 @@ describe('parseNote', () => {
         'Body text.',
       ].join('\n')
     )
-    assert.equal(parsed.type, 'slice')
+    assert.equal(parsed.type, 'milestone')
     assert.equal(parsed.title, 'The daily entry')
     assert.equal(parsed.description, 'One buildable piece.')
     assert.equal(parsed.resource, 'func:createEntry')
@@ -33,15 +33,17 @@ describe('parseNote', () => {
   })
 
   test('lowercases type and status, because every gate compares them literally', () => {
-    // A title-cased `type: Slice` read as a different type entirely, so readiness
-    // gates saw zero slices against a file that plainly was one.
-    const parsed = note('---\ntype: Slice\nstatus: Proposed\n---\nbody')
-    assert.equal(parsed.type, 'slice')
+    // A title-cased `type: Milestone` read as a different type entirely, so readiness
+    // gates saw zero milestones against a file that plainly was one.
+    const parsed = note('---\ntype: Milestone\nstatus: Proposed\n---\nbody')
+    assert.equal(parsed.type, 'milestone')
     assert.equal(parsed.status, 'proposed')
   })
 
   test('keeps the case of every other scalar, which is prose', () => {
-    const parsed = note('---\ntype: slice\ntitle: The Daily Entry\n---\nbody')
+    const parsed = note(
+      '---\ntype: milestone\ntitle: The Daily Entry\n---\nbody'
+    )
     assert.equal(parsed.title, 'The Daily Entry')
   })
 
@@ -62,33 +64,33 @@ describe('parseNote', () => {
     // Reading only the scalar form left `entities` unset on a note that listed
     // them, and the readiness gate refused a correct file.
     const parsed = note(
-      '---\ntype: slice\nentities:\n  - entry\n  - day\n---\nx'
+      '---\ntype: milestone\nentities:\n  - entry\n  - day\n---\nx'
     )
     assert.equal(parsed.entities, 'entry, day')
   })
 
   test('strips quotes from values', () => {
-    const parsed = note('---\ntype: "slice"\ntitle: \'Quoted\'\n---\nx')
-    assert.equal(parsed.type, 'slice')
+    const parsed = note('---\ntype: "milestone"\ntitle: \'Quoted\'\n---\nx')
+    assert.equal(parsed.type, 'milestone')
     assert.equal(parsed.title, 'Quoted')
   })
 
   test('ignores an empty value rather than storing an empty string', () => {
-    assert.equal(note('---\ntype: slice\ntitle:\n---\nx').title, undefined)
+    assert.equal(note('---\ntype: milestone\ntitle:\n---\nx').title, undefined)
   })
 
   test('leaves unknown keys alone — OKF permits them and profiles add their own', () => {
     const parsed = note(
-      '---\ntype: slice\ndesign: design/a.tsx#Option B\n---\nx'
+      '---\ntype: milestone\ndesign: design/a.tsx#Option B\n---\nx'
     )
-    assert.equal(parsed.type, 'slice')
+    assert.equal(parsed.type, 'milestone')
     assert.equal((parsed as Record<string, unknown>).design, undefined)
   })
 
   test("reads a profile's own scalars when it names them", () => {
     const parsed = parseNote(
-      'knowledge/slices/01-a.md',
-      '---\ntype: slice\ndesign: design/a.tsx#Option B\nroute: /entries\n---\nx',
+      'knowledge/milestones/01-a.md',
+      '---\ntype: milestone\ndesign: design/a.tsx#Option B\nroute: /entries\n---\nx',
       ['design', 'route'] as const
     )
     assert.equal(parsed.design, 'design/a.tsx#Option B')
@@ -97,21 +99,21 @@ describe('parseNote', () => {
 
   test("a profile's scalars keep their case — only this profile's vocabularies are closed", () => {
     const parsed = parseNote(
-      'knowledge/slices/01-a.md',
-      '---\ntype: SLICE\nscreens: DailyEntry\n---\nx',
+      'knowledge/milestones/01-a.md',
+      '---\ntype: MILESTONE\nscreens: DailyEntry\n---\nx',
       ['screens'] as const
     )
-    assert.equal(parsed.type, 'slice')
+    assert.equal(parsed.type, 'milestone')
     assert.equal(parsed.screens, 'DailyEntry')
   })
 
   test('a named scalar this profile already owns is read by this profile, not overwritten', () => {
     const parsed = parseNote(
-      'knowledge/slices/01-a.md',
-      '---\ntype: SLICE\n---\nx',
+      'knowledge/milestones/01-a.md',
+      '---\ntype: MILESTONE\n---\nx',
       ['type'] as const
     )
-    assert.equal(parsed.type, 'slice')
+    assert.equal(parsed.type, 'milestone')
   })
 
   test('tolerates CRLF frontmatter', () => {
@@ -131,9 +133,15 @@ describe('parseNote', () => {
 
   test('marks the reserved filenames, case-insensitively', () => {
     assert.equal(parseNote('knowledge/index.md', 'x').reserved, 'index')
-    assert.equal(parseNote('knowledge/slices/INDEX.md', 'x').reserved, 'index')
+    assert.equal(
+      parseNote('knowledge/milestones/INDEX.md', 'x').reserved,
+      'index'
+    )
     assert.equal(parseNote('knowledge/log.md', 'x').reserved, 'log')
-    assert.equal(parseNote('knowledge/slices/01-a.md', 'x').reserved, undefined)
+    assert.equal(
+      parseNote('knowledge/milestones/01-a.md', 'x').reserved,
+      undefined
+    )
   })
 })
 
@@ -179,7 +187,7 @@ describe('readKnowledgeNotes', () => {
   test('reads nested notes, path-sorted, with paths relative to the root', async (t) => {
     const root = await bundle(t, {
       'knowledge/index.md': '---\ntype: overview\n---\nroot',
-      'knowledge/slices/01-a.md': '---\ntype: slice\n---\na',
+      'knowledge/milestones/01-a.md': '---\ntype: milestone\n---\na',
       'knowledge/decisions/why.md': '---\ntype: decision\n---\nwhy',
     })
     assert.deepEqual(
@@ -187,7 +195,7 @@ describe('readKnowledgeNotes', () => {
       [
         join('knowledge', 'decisions', 'why.md'),
         join('knowledge', 'index.md'),
-        join('knowledge', 'slices', '01-a.md'),
+        join('knowledge', 'milestones', '01-a.md'),
       ]
     )
   })

--- a/packages/knowledge/src/notes.ts
+++ b/packages/knowledge/src/notes.ts
@@ -26,8 +26,8 @@ export const sectionOf = (path: string): string => {
  * bundle: a markdown file whose **path is its identity**, carrying YAML
  * frontmatter plus a body. Only `type` is required.
  *
- * `status`, `entities` and `statusAt` apply to `type: slice`, which is a piece of
- * work rather than a fact — so unlike every other note it has a state, a size,
+ * `status`, `entities` and `statusAt` apply to `type: milestone`, which is a piece
+ * of work rather than a fact — so unlike every other note it has a state, a size,
  * and a time its state last changed.
  */
 export const KnowledgeNoteSchema = z.object({
@@ -58,6 +58,18 @@ export type KnowledgeNote = z.infer<typeof KnowledgeNoteSchema>
  */
 export type ProfileNote<Key extends string = never> = KnowledgeNote &
   Partial<Record<Key, string>>
+
+/**
+ * The type a milestone note carries, and the name it used to carry. A bundle
+ * written before the rename says `slice`, and its notes are the same notes —
+ * reading only the new name would drop every milestone in every knowledge base
+ * that already exists. Writers emit `MILESTONE_TYPE`; readers ask this.
+ */
+export const MILESTONE_TYPE = 'milestone'
+const LEGACY_MILESTONE_TYPE = 'slice'
+
+export const isMilestone = (note: Pick<KnowledgeNote, 'type'>): boolean =>
+  note.type === MILESTONE_TYPE || note.type === LEGACY_MILESTONE_TYPE
 
 /**
  * The scalars this profile reads. A caller's own keys are passed to `parseNote`

--- a/packages/knowledge/src/reindex.test.ts
+++ b/packages/knowledge/src/reindex.test.ts
@@ -18,14 +18,14 @@ const project = async (files: Record<string, string>): Promise<string> => {
 const read = (root: string, rel: string) =>
   readFile(join(root, ...rel.split('/')), 'utf8')
 
-const slice = (title: string, description: string) =>
-  `---\ntype: slice\ntitle: ${title}\ndescription: ${description}\nstatus: proposed\n---\nbody`
+const milestone = (title: string, description: string) =>
+  `---\ntype: milestone\ntitle: ${title}\ndescription: ${description}\nstatus: proposed\n---\nbody`
 
 describe('runKnowledgeIndex', () => {
   test('creates a missing section index listing its notes', async () => {
     const root = await project({
       'knowledge/index.md': '---\ntype: overview\n---\nThe app.',
-      'knowledge/slices/01-a.md': slice(
+      'knowledge/milestones/01-a.md': milestone(
         'The daily entry',
         'One buildable piece.'
       ),
@@ -35,10 +35,10 @@ describe('runKnowledgeIndex', () => {
       result.files.map((f) => [f.path, f.action]),
       [
         ['knowledge/index.md', 'updated'],
-        ['knowledge/slices/index.md', 'created'],
+        ['knowledge/milestones/index.md', 'created'],
       ]
     )
-    const created = await read(root, 'knowledge/slices/index.md')
+    const created = await read(root, 'knowledge/milestones/index.md')
     assert.match(created, /^type: overview$/m)
     assert.match(
       created,
@@ -49,17 +49,17 @@ describe('runKnowledgeIndex', () => {
   test('the root index maps the sections before any loose note', async () => {
     const root = await project({
       'knowledge/index.md': '---\ntype: overview\n---\nThe app.',
-      'knowledge/slices/index.md': '---\ntype: overview\n---\nPieces.',
-      'knowledge/slices/01-a.md': slice('A', 'a'),
+      'knowledge/milestones/index.md': '---\ntype: overview\n---\nPieces.',
+      'knowledge/milestones/01-a.md': milestone('A', 'a'),
       'knowledge/entities/index.md': '---\ntype: overview\n---\nThings.',
       'knowledge/entities/entry.md': '---\ntype: entity\ntitle: Entry\n---\nx',
     })
     await runKnowledgeIndex(root)
     const index = await read(root, 'knowledge/index.md')
     assert.match(index, /- \[entities\]\(entities\/index\.md\)/)
-    assert.match(index, /- \[slices\]\(slices\/index\.md\)/)
+    assert.match(index, /- \[milestones\]\(milestones\/index\.md\)/)
     assert.ok(
-      index.indexOf('entities/index.md') < index.indexOf('slices/index.md')
+      index.indexOf('entities/index.md') < index.indexOf('milestones/index.md')
     )
   })
 
@@ -109,12 +109,12 @@ describe('runKnowledgeIndex', () => {
   test('replaces only the generated block, keeping the prose a human wrote', async () => {
     const root = await project({
       'knowledge/index.md': '---\ntype: overview\n---\nx',
-      'knowledge/slices/index.md': [
+      'knowledge/milestones/index.md': [
         '---',
         'type: overview',
         '---',
         '',
-        '# Slices',
+        '# Milestones',
         '',
         'Read these in order — each one builds on the last.',
         '',
@@ -124,10 +124,13 @@ describe('runKnowledgeIndex', () => {
         '',
         'Anything below survives too.',
       ].join('\n'),
-      'knowledge/slices/01-a.md': slice('The daily entry', 'One piece.'),
+      'knowledge/milestones/01-a.md': milestone(
+        'The daily entry',
+        'One piece.'
+      ),
     })
     await runKnowledgeIndex(root)
-    const index = await read(root, 'knowledge/slices/index.md')
+    const index = await read(root, 'knowledge/milestones/index.md')
     assert.match(index, /Read these in order/)
     assert.match(index, /Anything below survives too\./)
     assert.match(index, /The daily entry/)
@@ -137,12 +140,12 @@ describe('runKnowledgeIndex', () => {
   test('appends the block to an index that has no markers, destroying nothing', async () => {
     const root = await project({
       'knowledge/index.md': '---\ntype: overview\n---\nx',
-      'knowledge/slices/index.md':
-        '---\ntype: overview\n---\n\n# Slices\n\nHand written.\n',
-      'knowledge/slices/01-a.md': slice('A', 'a'),
+      'knowledge/milestones/index.md':
+        '---\ntype: overview\n---\n\n# Milestones\n\nHand written.\n',
+      'knowledge/milestones/01-a.md': milestone('A', 'a'),
     })
     await runKnowledgeIndex(root)
-    const index = await read(root, 'knowledge/slices/index.md')
+    const index = await read(root, 'knowledge/milestones/index.md')
     assert.match(index, /Hand written\./)
     assert.match(index, /<!-- pikku:knowledge-index -->/)
   })
@@ -150,33 +153,33 @@ describe('runKnowledgeIndex', () => {
   test('is idempotent — a second run changes nothing', async () => {
     const root = await project({
       'knowledge/index.md': '---\ntype: overview\n---\nx',
-      'knowledge/slices/01-a.md': slice('A', 'a'),
+      'knowledge/milestones/01-a.md': milestone('A', 'a'),
     })
     await runKnowledgeIndex(root)
-    const first = await read(root, 'knowledge/slices/index.md')
+    const first = await read(root, 'knowledge/milestones/index.md')
     const second = await runKnowledgeIndex(root)
     assert.deepEqual(
       second.files.map((f) => f.action),
       ['unchanged', 'unchanged']
     )
-    assert.equal(await read(root, 'knowledge/slices/index.md'), first)
+    assert.equal(await read(root, 'knowledge/milestones/index.md'), first)
   })
 
   test('check mode reports staleness and writes nothing', async () => {
     const root = await project({
       'knowledge/index.md': '---\ntype: overview\n---\nx',
-      'knowledge/slices/01-a.md': slice('A', 'a'),
+      'knowledge/milestones/01-a.md': milestone('A', 'a'),
     })
     const result = await runKnowledgeIndex(root, true)
     assert.equal(result.ok, false)
     assert.equal(result.check, true)
-    await assert.rejects(() => read(root, 'knowledge/slices/index.md'))
+    await assert.rejects(() => read(root, 'knowledge/milestones/index.md'))
   })
 
   test('check mode passes once the indexes are current', async () => {
     const root = await project({
       'knowledge/index.md': '---\ntype: overview\n---\nx',
-      'knowledge/slices/01-a.md': slice('A', 'a'),
+      'knowledge/milestones/01-a.md': milestone('A', 'a'),
     })
     await runKnowledgeIndex(root)
     assert.equal((await runKnowledgeIndex(root, true)).ok, true)
@@ -185,11 +188,13 @@ describe('runKnowledgeIndex', () => {
   test('falls back to the first heading, then the filename, for a note with no title', async () => {
     const root = await project({
       'knowledge/index.md': '---\ntype: overview\n---\nx',
-      'knowledge/slices/01-a.md': '---\ntype: slice\n---\n# From the heading\n',
-      'knowledge/slices/02-b.md': '---\ntype: slice\n---\nNo heading at all.',
+      'knowledge/milestones/01-a.md':
+        '---\ntype: milestone\n---\n# From the heading\n',
+      'knowledge/milestones/02-b.md':
+        '---\ntype: milestone\n---\nNo heading at all.',
     })
     await runKnowledgeIndex(root)
-    const index = await read(root, 'knowledge/slices/index.md')
+    const index = await read(root, 'knowledge/milestones/index.md')
     assert.match(index, /- \[From the heading\]\(01-a\.md\)/)
     assert.match(index, /- \[02-b\]\(02-b\.md\)/)
   })
@@ -198,8 +203,8 @@ describe('runKnowledgeIndex', () => {
     const root = await project({
       'knowledge/index.md': '---\ntype: overview\n---\nx',
       'knowledge/log.md': '---\ntype: note\n---\nx',
-      'knowledge/slices/index.md': '---\ntype: overview\n---\nx',
-      'knowledge/slices/01-a.md': slice('A', 'a'),
+      'knowledge/milestones/index.md': '---\ntype: overview\n---\nx',
+      'knowledge/milestones/01-a.md': milestone('A', 'a'),
     })
     await runKnowledgeIndex(root)
     const index = await read(root, 'knowledge/index.md')

--- a/packages/knowledge/src/reindex.ts
+++ b/packages/knowledge/src/reindex.ts
@@ -8,7 +8,7 @@ import {
   sectionOf,
   toPosix,
 } from './notes.js'
-import { KNOWLEDGE_SECTIONS } from './validate.js'
+import { KNOWLEDGE_SECTIONS, canonicalSection } from './validate.js'
 
 /**
  * The listing in an `index.md` is generated; the prose around it is not.
@@ -173,7 +173,11 @@ export const runKnowledgeIndex = async (
     const entries = [
       ...childSections(section).map((name) => {
         const leaf = name.split(posix.sep).at(-1)!
-        return line(leaf, `${leaf}/index.md`, KNOWLEDGE_SECTIONS[name])
+        return line(
+          leaf,
+          `${leaf}/index.md`,
+          KNOWLEDGE_SECTIONS[canonicalSection(name)]
+        )
       }),
       ...sectionNotes.map((note) =>
         line(labelOf(note), basename(note.path), note.description)
@@ -189,7 +193,8 @@ export const runKnowledgeIndex = async (
       : scaffold(
           section ? section.split(posix.sep).at(-1)! : 'Knowledge',
           section
-            ? (KNOWLEDGE_SECTIONS[section] ?? `Notes in ${section}`)
+            ? (KNOWLEDGE_SECTIONS[canonicalSection(section)] ??
+                `Notes in ${section}`)
             : 'What this app is, in the language its users use'
         )
     const after = spliceListing(before, listing)

--- a/packages/knowledge/src/validate.test.ts
+++ b/packages/knowledge/src/validate.test.ts
@@ -20,9 +20,9 @@ const validate = (root: string) =>
 
 const ids = (findings: { id: string }[]) => findings.map((f) => f.id)
 
-const SLICE = [
+const MILESTONE = [
   '---',
-  'type: slice',
+  'type: milestone',
   'status: proposed',
   'entities: entry',
   '---',
@@ -37,8 +37,9 @@ const SLICE = [
 /** The smallest bundle that should produce no findings at all. */
 const CLEAN = {
   'knowledge/index.md': '---\ntype: overview\n---\nThe app.',
-  'knowledge/slices/index.md': '---\ntype: overview\n---\nBuildable pieces.',
-  'knowledge/slices/01-the-daily-entry.md': SLICE,
+  'knowledge/milestones/index.md':
+    '---\ntype: overview\n---\nBuildable pieces.',
+  'knowledge/milestones/01-the-daily-entry.md': MILESTONE,
 }
 
 describe('runKnowledgeValidate', () => {
@@ -61,8 +62,8 @@ describe('runKnowledgeValidate', () => {
   test('a bundle with no index.md has no entry point', async () => {
     const result = await validate(
       await project({
-        'knowledge/slices/index.md': '---\ntype: overview\n---\nx',
-        'knowledge/slices/01-a.md': SLICE,
+        'knowledge/milestones/index.md': '---\ntype: overview\n---\nx',
+        'knowledge/milestones/01-a.md': MILESTONE,
       })
     )
     assert.ok(ids(result.findings).includes('knowledge-no-index'))
@@ -73,11 +74,11 @@ describe('runKnowledgeValidate', () => {
     const result = await validate(
       await project({
         'knowledge/index.md': '---\ntype: overview\n---\nx',
-        'knowledge/slices/01-a.md': SLICE,
+        'knowledge/milestones/01-a.md': MILESTONE,
       })
     )
     assert.deepEqual(ids(result.findings), [
-      'knowledge-section-no-index-slices',
+      'knowledge-section-no-index-milestones',
     ])
     assert.equal(result.findings[0]!.severity, 'warn')
     assert.equal(result.ok, true)
@@ -197,106 +198,110 @@ describe('runKnowledgeValidate', () => {
   })
 })
 
-describe('runKnowledgeValidate on slices', () => {
-  const withSlice = async (body: string) =>
+describe('runKnowledgeValidate on milestones', () => {
+  const withMilestone = async (body: string) =>
     validate(
       await project({
         'knowledge/index.md': '---\ntype: overview\n---\nx',
-        'knowledge/slices/index.md': '---\ntype: overview\n---\nx',
-        'knowledge/slices/01-a.md': body,
+        'knowledge/milestones/index.md': '---\ntype: overview\n---\nx',
+        'knowledge/milestones/01-a.md': body,
       })
     )
 
-  test('a slice with no status cannot be gated on', async () => {
-    const result = await withSlice(SLICE.replace('status: proposed\n', ''))
+  test('a milestone with no status cannot be gated on', async () => {
+    const result = await withMilestone(
+      MILESTONE.replace('status: proposed\n', '')
+    )
     assert.ok(
       ids(result.findings).some((id) =>
-        id.startsWith('knowledge-slice-no-status-')
+        id.startsWith('knowledge-milestone-no-status-')
       )
     )
   })
 
   test('a status outside the vocabulary fails, because gates compare it literally', async () => {
-    const result = await withSlice(
-      SLICE.replace('status: proposed', 'status: in-progress')
+    const result = await withMilestone(
+      MILESTONE.replace('status: proposed', 'status: in-progress')
     )
     assert.ok(
       ids(result.findings).some((id) =>
-        id.startsWith('knowledge-slice-bad-status-')
+        id.startsWith('knowledge-milestone-bad-status-')
       )
     )
   })
 
-  test('a slice still being designed passes — it is written down, not yet buildable', async () => {
-    const result = await withSlice(
-      SLICE.replace('status: proposed', 'status: designing')
+  test('a milestone still being designed passes — it is written down, not yet buildable', async () => {
+    const result = await withMilestone(
+      MILESTONE.replace('status: proposed', 'status: designing')
     )
     assert.deepEqual(result.findings, [])
   })
 
   test('a title-cased status still passes, because the parser lowercases it', async () => {
-    const result = await withSlice(
-      SLICE.replace('status: proposed', 'status: Built')
+    const result = await withMilestone(
+      MILESTONE.replace('status: proposed', 'status: Built')
     )
     assert.deepEqual(result.findings, [])
   })
 
-  test('a slice naming no entities warns — its size cannot be judged', async () => {
-    const result = await withSlice(SLICE.replace('entities: entry\n', ''))
+  test('a milestone naming no entities warns — its size cannot be judged', async () => {
+    const result = await withMilestone(
+      MILESTONE.replace('entities: entry\n', '')
+    )
     assert.ok(
       ids(result.findings).some((id) =>
-        id.startsWith('knowledge-slice-no-entities-')
+        id.startsWith('knowledge-milestone-no-entities-')
       )
     )
     assert.equal(result.ok, true)
   })
 
-  test('a slice touching more than three entities is not one buildable piece', async () => {
-    const result = await withSlice(
-      SLICE.replace('entities: entry', 'entities: entry, day, user, grant')
+  test('a milestone touching more than three entities is not one buildable piece', async () => {
+    const result = await withMilestone(
+      MILESTONE.replace('entities: entry', 'entities: entry, day, user, grant')
     )
     assert.ok(
       ids(result.findings).some((id) =>
-        id.startsWith('knowledge-slice-too-big-')
+        id.startsWith('knowledge-milestone-too-big-')
       )
     )
     assert.equal(result.ok, false)
   })
 
-  test('a slice with no gherkin block has nothing to verify against', async () => {
-    const result = await withSlice(
-      '---\ntype: slice\nstatus: proposed\nentities: entry\n---\n\nJust prose.'
+  test('a milestone with no gherkin block has nothing to verify against', async () => {
+    const result = await withMilestone(
+      '---\ntype: milestone\nstatus: proposed\nentities: entry\n---\n\nJust prose.'
     )
     assert.ok(
       ids(result.findings).some((id) =>
-        id.startsWith('knowledge-slice-no-scenario-')
+        id.startsWith('knowledge-milestone-no-scenario-')
       )
     )
   })
 
   test('a first-person scenario hides who is acting', async () => {
-    const result = await withSlice(
-      SLICE.replace(
+    const result = await withMilestone(
+      MILESTONE.replace(
         "Given 'owner' has no entry for today",
         'Given I have no entry'
       )
     )
     assert.ok(
       ids(result.findings).some((id) =>
-        id.startsWith('knowledge-slice-first-person-')
+        id.startsWith('knowledge-milestone-first-person-')
       )
     )
     assert.equal(result.ok, false)
   })
 
   test('a quoted persona named Ida is not the pronoun I', async () => {
-    const result = await withSlice(
-      SLICE.replace("Given 'owner'", "Given 'ida'")
+    const result = await withMilestone(
+      MILESTONE.replace("Given 'owner'", "Given 'ida'")
     )
     assert.deepEqual(result.findings, [])
   })
 
-  test('only slices are held to the slice rules', async () => {
+  test('only milestones are held to the milestone rules', async () => {
     const result = await validate(
       await project({
         'knowledge/index.md': '---\ntype: overview\n---\nx',
@@ -309,12 +314,49 @@ describe('runKnowledgeValidate on slices', () => {
   })
 })
 
+describe('runKnowledgeValidate on a bundle written before the rename', () => {
+  const LEGACY = {
+    'knowledge/index.md': '---\ntype: overview\n---\nThe app.',
+    'knowledge/slices/index.md': '---\ntype: overview\n---\nBuildable pieces.',
+    'knowledge/slices/01-a.md': MILESTONE.replace(
+      'type: milestone',
+      'type: slice'
+    ),
+  }
+
+  test('slices/ holding type: slice is a clean bundle, not an unknown section', async () => {
+    const result = await validate(await project(LEGACY))
+    assert.deepEqual(result.findings, [])
+    assert.equal(result.ok, true)
+  })
+
+  test('a legacy milestone is still held to the milestone rules', async () => {
+    // The rename cannot be a way to stop being checked: a note that was a slice
+    // yesterday is a milestone today, and dropping it from the type test would
+    // silently retire every gate on every bundle already written.
+    const result = await validate(
+      await project({
+        ...LEGACY,
+        'knowledge/slices/01-a.md': MILESTONE.replace(
+          'type: milestone\nstatus: proposed\n',
+          'type: slice\n'
+        ),
+      })
+    )
+    assert.ok(
+      ids(result.findings).some((id) =>
+        id.startsWith('knowledge-milestone-no-status-')
+      )
+    )
+  })
+})
+
 describe('runKnowledgeValidate on resources', () => {
   test('a dangling resource is reported as an error against the note', async () => {
     const root = await project({
       ...CLEAN,
       '.pikku/function/pikku-functions-meta.gen.json': '{"createEntry":{}}',
-      'knowledge/slices/02-b.md': SLICE.replace(
+      'knowledge/milestones/02-b.md': MILESTONE.replace(
         'entities: entry',
         'entities: entry\nresource: func:gone'
       ),
@@ -332,15 +374,15 @@ describe('runKnowledgeValidate on resources', () => {
     // Each note is its own thing to fix, so each needs an id something can key
     // on — an id built from the uri alone made the second finding a duplicate of
     // the first.
-    const dangling = SLICE.replace(
+    const dangling = MILESTONE.replace(
       'entities: entry',
       'entities: entry\nresource: func:gone'
     )
     const root = await project({
       ...CLEAN,
       '.pikku/function/pikku-functions-meta.gen.json': '{"createEntry":{}}',
-      'knowledge/slices/02-b.md': dangling,
-      'knowledge/slices/03-c.md': dangling,
+      'knowledge/milestones/02-b.md': dangling,
+      'knowledge/milestones/03-c.md': dangling,
     })
     const resourceIds = ids((await validate(root)).findings).filter((id) =>
       id.startsWith('knowledge-resource-')
@@ -353,7 +395,7 @@ describe('runKnowledgeValidate on resources', () => {
     const root = await project({
       ...CLEAN,
       '.pikku/function/pikku-functions-meta.gen.json': '{"createEntry":{}}',
-      'knowledge/slices/02-b.md': SLICE.replace(
+      'knowledge/milestones/02-b.md': MILESTONE.replace(
         'entities: entry',
         'entities: entry\nresource: func:createEntry'
       ),
@@ -443,13 +485,13 @@ describe('runKnowledgeValidate on decisions', () => {
     assert.equal(new Set(ids(result.findings)).size, 2)
   })
 
-  test('a slice may state a decision too', async () => {
+  test('a milestone may state a decision too', async () => {
     const root = await project({
       ...CLEAN,
-      'knowledge/slices/02-b.md': `${SLICE}\n\n\`\`\`decision\nchosen: One entry per day\n\`\`\``,
+      'knowledge/milestones/02-b.md': `${MILESTONE}\n\n\`\`\`decision\nchosen: One entry per day\n\`\`\``,
     })
     assert.deepEqual(ids((await validate(root)).findings), [
-      'knowledge-decision-nothing-ruled-out-knowledge/slices/02-b.md-1',
+      'knowledge-decision-nothing-ruled-out-knowledge/milestones/02-b.md-1',
     ])
   })
 })

--- a/packages/knowledge/src/validate.ts
+++ b/packages/knowledge/src/validate.ts
@@ -5,6 +5,7 @@ import { decisionFences } from './decision-fence.js'
 import {
   KNOWLEDGE_DIR,
   type KnowledgeNote,
+  isMilestone,
   readKnowledgeNotes,
   sectionOf,
   toPosix,
@@ -50,7 +51,8 @@ export type KnowledgeValidateResult = z.infer<typeof KnowledgeValidateOutput>
  * app, which is what keeps a note findable without an index of indexes.
  */
 export const KNOWLEDGE_SECTIONS: Record<string, string> = {
-  slices: 'one buildable piece of the app, with the scenario that proves it',
+  milestones:
+    'one buildable piece of the app, with the scenario that proves it',
   entities: 'a thing the app is about, in the language users use for it',
   decisions: 'a rule that was chosen, and what it rules out',
   'decisions/design': 'a rule about how the app looks and behaves',
@@ -66,7 +68,7 @@ export const KNOWLEDGE_SECTIONS: Record<string, string> = {
  */
 const FORBIDDEN_SECTIONS: Record<string, string> = {
   personas: "`definePersonas()` in the project's own code",
-  scenarios: 'the gherkin block inside the slice the scenario belongs to',
+  scenarios: 'the gherkin block inside the milestone the scenario belongs to',
   permissions: 'a decision note under decisions/security/',
   schemas: '`pikku meta` — the generated schema is the schema',
   tables: '`pikku meta` — the generated db schema is the schema',
@@ -74,22 +76,38 @@ const FORBIDDEN_SECTIONS: Record<string, string> = {
 }
 
 /**
- * `designing` sits before `proposed`: the slice is written down but is NOT to be
- * built yet, because whoever is being shown its looks has not picked one. Only
- * `proposed` is dispatchable, so the two cannot be one status without a slice
+ * `designing` sits before `proposed`: the milestone is written down but is NOT to
+ * be built yet, because whoever is being shown its looks has not picked one. Only
+ * `proposed` is dispatchable, so the two cannot be one status without a milestone
  * being built out from under the person still choosing how it should look.
  */
-export const SLICE_STATUSES = [
+export const MILESTONE_STATUSES = [
   'designing',
   'proposed',
   'dispatched',
   'built',
 ] as const
 
-export type SliceStatus = (typeof SLICE_STATUSES)[number]
+export type MilestoneStatus = (typeof MILESTONE_STATUSES)[number]
 
-/** Max entities per slice: more than three and it is not one buildable piece. */
-const MAX_SLICE_ENTITIES = 3
+/** Max entities per milestone: more than three and it is not one buildable piece. */
+const MAX_MILESTONE_ENTITIES = 3
+
+/**
+ * The directory milestones live in, and the one they used to live in. A bundle
+ * written before the rename holds `knowledge/slices/`; those notes are still
+ * milestones, so the section keeps its description and its place in the reading
+ * order instead of sorting to the end as a section nothing declares.
+ */
+export const MILESTONE_SECTION = 'milestones'
+const LEGACY_SECTIONS: Record<string, string> = { slices: MILESTONE_SECTION }
+
+export const canonicalSection = (section: string): string => {
+  const parts = section.split(posix.sep)
+  const top = parts[0]
+  if (!top || !LEGACY_SECTIONS[top]) return section
+  return [LEGACY_SECTIONS[top], ...parts.slice(1)].join(posix.sep)
+}
 
 const isGherkinFirstPerson = (body: string): boolean =>
   /^\s*(given|when|then|and|but)\s+(i|we|my|our)\b/im.test(body)
@@ -171,7 +189,9 @@ export const runKnowledgeValidate = async (
         `${KNOWLEDGE_DIR}/${section}/ has no index.md, so nothing says what belongs in it`,
         `${KNOWLEDGE_DIR}/${section}/index.md`,
         `Add ${section}/index.md the same turn you create the section — one line on what it holds${
-          KNOWLEDGE_SECTIONS[section] ? `: ${KNOWLEDGE_SECTIONS[section]}` : ''
+          KNOWLEDGE_SECTIONS[canonicalSection(section)]
+            ? `: ${KNOWLEDGE_SECTIONS[canonicalSection(section)]}`
+            : ''
         }`
       )
     }
@@ -198,7 +218,7 @@ export const runKnowledgeValidate = async (
         `knowledge-no-type-${note.path}`,
         `${note.path} has no \`type\` — it is the one field OKF requires, and every reader groups on it`,
         note.path,
-        'Add frontmatter with a `type` (slice, entity, decision, note, overview)'
+        'Add frontmatter with a `type` (milestone, entity, decision, note, overview)'
       )
     }
 
@@ -219,7 +239,7 @@ export const runKnowledgeValidate = async (
       )
     }
 
-    // Every note, not only `type: decision`: a slice states a decision about as
+    // Every note, not only `type: decision`: a milestone states a decision about as
     // often, and a fence that does not parse renders as a code block wherever it
     // sits. Nothing here requires a fence — a decision argued in prose is a
     // decision, and demanding one per note would be a finding against every
@@ -251,23 +271,25 @@ export const runKnowledgeValidate = async (
       }
     }
 
-    if (note.type !== 'slice') continue
+    if (!isMilestone(note)) continue
 
     if (!note.status) {
       add(
         'error',
-        `knowledge-slice-no-status-${note.path}`,
-        `${note.path} is a slice with no \`status\`, so nothing can tell whether it is built`,
+        `knowledge-milestone-no-status-${note.path}`,
+        `${note.path} is a milestone with no \`status\`, so nothing can tell whether it is built`,
         note.path,
-        `Add \`status:\` — one of ${SLICE_STATUSES.join(', ')}`
+        `Add \`status:\` — one of ${MILESTONE_STATUSES.join(', ')}`
       )
-    } else if (!(SLICE_STATUSES as readonly string[]).includes(note.status)) {
+    } else if (
+      !(MILESTONE_STATUSES as readonly string[]).includes(note.status)
+    ) {
       add(
         'error',
-        `knowledge-slice-bad-status-${note.path}`,
+        `knowledge-milestone-bad-status-${note.path}`,
         `${note.path} has status "${note.status}", which no gate recognises`,
         note.path,
-        `Use one of ${SLICE_STATUSES.join(', ')}`
+        `Use one of ${MILESTONE_STATUSES.join(', ')}`
       )
     }
 
@@ -278,33 +300,33 @@ export const runKnowledgeValidate = async (
     if (entities.length === 0) {
       add(
         'warn',
-        `knowledge-slice-no-entities-${note.path}`,
-        `${note.path} is a slice that names no entities, so its size cannot be judged`,
+        `knowledge-milestone-no-entities-${note.path}`,
+        `${note.path} is a milestone that names no entities, so its size cannot be judged`,
         note.path,
         'Add `entities:` listing the entities it touches, comma-separated'
       )
-    } else if (entities.length > MAX_SLICE_ENTITIES) {
+    } else if (entities.length > MAX_MILESTONE_ENTITIES) {
       add(
         'error',
-        `knowledge-slice-too-big-${note.path}`,
-        `${note.path} touches ${entities.length} entities — past ${MAX_SLICE_ENTITIES} it is not one buildable piece`,
+        `knowledge-milestone-too-big-${note.path}`,
+        `${note.path} touches ${entities.length} entities — past ${MAX_MILESTONE_ENTITIES} it is not one buildable piece`,
         note.path,
-        `Split it into slices of at most ${MAX_SLICE_ENTITIES} entities each`
+        `Split it into milestones of at most ${MAX_MILESTONE_ENTITIES} entities each`
       )
     }
 
     if (!hasGherkinBlock(note.body)) {
       add(
         'error',
-        `knowledge-slice-no-scenario-${note.path}`,
-        `${note.path} is a slice with no \`\`\`gherkin scenario, so there is nothing to build against or verify`,
+        `knowledge-milestone-no-scenario-${note.path}`,
+        `${note.path} is a milestone with no \`\`\`gherkin scenario, so there is nothing to build against or verify`,
         note.path,
-        'Add a fenced ```gherkin block with the Given/When/Then that proves the slice'
+        'Add a fenced ```gherkin block with the Given/When/Then that proves the milestone'
       )
     } else if (isGherkinFirstPerson(note.body)) {
       add(
         'error',
-        `knowledge-slice-first-person-${note.path}`,
+        `knowledge-milestone-first-person-${note.path}`,
         `${note.path} writes its scenario in the first person, which hides who is acting`,
         note.path,
         `Write it in the third person, naming the persona in quotes: Given 'owner' has an entry for today`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renamed knowledge “slices” to “milestones” across note types, sections, statuses, validation, indexing, and graph views.
  * Added milestone constants and helpers for identifying milestones and normalizing section names.
* **Bug Fixes**
  * Preserved compatibility with legacy `slice` notes and `slices/` directories.
  * Maintained legacy directory ordering while supporting new milestone formats.
* **Tests**
  * Expanded coverage for milestone validation, ordering, links, metadata, indexing, and backward compatibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->