### PR TITLE
feat(cli): validate catches a linked dep that splits a package's type identity

### DIFF
--- a/.changeset/validate-split-type-identity.md
+++ b/.changeset/validate-split-type-identity.md
@@ -1,0 +1,28 @@
+---
+'@pikku/cli': patch
+---
+
+feat(fabric): validate catches a linked dependency that splits a package's type identity
+
+A dependency linked into the project from another checkout (`link:`, `portal:`,
+or a hand-made `dist` symlink) resolves its own imports from that other tree's
+`node_modules`. When both trees carry the same package at different versions,
+TypeScript ends up with two unrelated declarations of the same interface and
+structurally compares them wherever they meet — which inside a generic
+inference chain compounds badly. Fabric's `api-functions` went from
+1.3GB/13s to a typecheck that never finished (8GB and 12GB heap ceilings both
+died, 7.7M types, single assignability checks taking eight seconds) because one
+package's `dist` pointed at a sibling checkout carrying its own `better-auth`.
+
+The failure mode is what makes it worth a check: it presents as "codegen is
+slow" or an out-of-memory crash, never as a version mismatch, and no existing
+check looked at it. `pikku fabric validate` now reports
+`split-type-identity-<dep>-<pkg>` for each type-identity-sensitive package
+(`better-auth`, `@better-auth/core`, `@pikku/core`, `kysely`, `zod`) that a
+linked dependency resolves at a different version than the project does, naming
+both versions and both paths.
+
+This is distinct from the existing duplicate-copy check, which is about two
+physical copies of the *same* version splitting module state at runtime. Dependency
+lookup probes workspace package directories as well as the root, so it also works
+under isolated/pnpm-style installs that never hoist to the root `node_modules`.

--- a/.changeset/validate-split-type-identity.md
+++ b/.changeset/validate-split-type-identity.md
@@ -2,7 +2,7 @@
 '@pikku/cli': patch
 ---
 
-feat(fabric): validate catches a linked dependency that splits a package's type identity
+feat(cli): validate catches a linked dependency that splits a package's type identity
 
 A dependency linked into the project from another checkout (`link:`, `portal:`,
 or a hand-made `dist` symlink) resolves its own imports from that other tree's
@@ -16,11 +16,20 @@ package's `dist` pointed at a sibling checkout carrying its own `better-auth`.
 
 The failure mode is what makes it worth a check: it presents as "codegen is
 slow" or an out-of-memory crash, never as a version mismatch, and no existing
-check looked at it. `pikku fabric validate` now reports
+check looked at it. Both `pikku validate` and `pikku fabric validate` now report
 `split-type-identity-<dep>-<pkg>` for each type-identity-sensitive package
 (`better-auth`, `@better-auth/core`, `@pikku/core`, `kysely`, `zod`) that a
 linked dependency resolves at a different version than the project does, naming
 both versions and both paths.
+
+Nothing about this is fabric-specific — linking a package from a sibling checkout
+is the normal way to develop a pikku package against a consuming app, which is
+exactly the population that hits it — so the check lives in the shared registry
+and runs for any project.
+
+It runs at the workspace root only: a linked dependency is a property of the
+install as a whole, so running it per workspace package would report the same
+pair once per package.
 
 This is distinct from the existing duplicate-copy check, which is about two
 physical copies of the *same* version splitting module state at runtime. Dependency

--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -1,6 +1,13 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert'
-import { mkdtemp, mkdir, readFile, writeFile, rm } from 'node:fs/promises'
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  writeFile,
+  rm,
+  symlink,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import {
@@ -2165,6 +2172,87 @@ describe('declared frontends + type-check (live validate.function)', () => {
       )
     } finally {
       await rm(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('split type identity via a linked dependency (live validate.function)', () => {
+  // Mirrors the real shape: node_modules/@scope/linked is a genuine directory
+  // whose `dist` symlinks into a sibling checkout, so TypeScript resolves that
+  // package's imports from the other tree's node_modules.
+  const setup = async (
+    root: string,
+    external: string,
+    externalVersion: string
+  ) => {
+    await mkdir(join(root, 'node_modules', 'better-auth'), { recursive: true })
+    await writeJson(join(root, 'node_modules', 'better-auth', 'package.json'), {
+      name: 'better-auth',
+      version: '1.6.23',
+    })
+
+    const linkedPkg = join(external, 'packages', 'linked')
+    await mkdir(join(linkedPkg, 'dist'), { recursive: true })
+    await writeJson(join(linkedPkg, 'package.json'), {
+      name: '@scope/linked',
+      version: '1.0.0',
+    })
+    await mkdir(join(external, 'node_modules', 'better-auth'), {
+      recursive: true,
+    })
+    await writeJson(
+      join(external, 'node_modules', 'better-auth', 'package.json'),
+      { name: 'better-auth', version: externalVersion }
+    )
+
+    const inNodeModules = join(root, 'node_modules', '@scope', 'linked')
+    await mkdir(inNodeModules, { recursive: true })
+    await writeJson(join(inNodeModules, 'package.json'), {
+      name: '@scope/linked',
+      version: '1.0.0',
+    })
+    await symlink(join(linkedPkg, 'dist'), join(inNodeModules, 'dist'), 'dir')
+  }
+
+  test('linked dep resolving a different version → error', async () => {
+    const tmp = await makeTmp()
+    const external = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await setup(tmp, external, '1.6.27')
+      const result = await runLiveValidate(tmp, { skipTypecheck: true })
+      const finding = result.findings.find((f) =>
+        f.id.startsWith('split-type-identity')
+      )
+      assert.ok(
+        finding,
+        `expected a split-type-identity finding, got: ${JSON.stringify(
+          result.findings.map((f) => f.id)
+        )}`
+      )
+      assert.equal(finding.severity, 'error')
+      assert.match(finding.message, /1\.6\.27/)
+      assert.match(finding.message, /1\.6\.23/)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+      await rm(external, { recursive: true, force: true })
+    }
+  })
+
+  test('linked dep resolving the same version → no finding', async () => {
+    const tmp = await makeTmp()
+    const external = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await setup(tmp, external, '1.6.23')
+      const result = await runLiveValidate(tmp, { skipTypecheck: true })
+      const ids = result.findings
+        .map((f) => f.id)
+        .filter((id) => id.startsWith('split-type-identity'))
+      assert.deepEqual(ids, [])
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+      await rm(external, { recursive: true, force: true })
     }
   })
 })

--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -1,13 +1,6 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert'
-import {
-  mkdtemp,
-  mkdir,
-  readFile,
-  writeFile,
-  rm,
-  symlink,
-} from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import {
@@ -2176,83 +2169,3 @@ describe('declared frontends + type-check (live validate.function)', () => {
   })
 })
 
-describe('split type identity via a linked dependency (live validate.function)', () => {
-  // Mirrors the real shape: node_modules/@scope/linked is a genuine directory
-  // whose `dist` symlinks into a sibling checkout, so TypeScript resolves that
-  // package's imports from the other tree's node_modules.
-  const setup = async (
-    root: string,
-    external: string,
-    externalVersion: string
-  ) => {
-    await mkdir(join(root, 'node_modules', 'better-auth'), { recursive: true })
-    await writeJson(join(root, 'node_modules', 'better-auth', 'package.json'), {
-      name: 'better-auth',
-      version: '1.6.23',
-    })
-
-    const linkedPkg = join(external, 'packages', 'linked')
-    await mkdir(join(linkedPkg, 'dist'), { recursive: true })
-    await writeJson(join(linkedPkg, 'package.json'), {
-      name: '@scope/linked',
-      version: '1.0.0',
-    })
-    await mkdir(join(external, 'node_modules', 'better-auth'), {
-      recursive: true,
-    })
-    await writeJson(
-      join(external, 'node_modules', 'better-auth', 'package.json'),
-      { name: 'better-auth', version: externalVersion }
-    )
-
-    const inNodeModules = join(root, 'node_modules', '@scope', 'linked')
-    await mkdir(inNodeModules, { recursive: true })
-    await writeJson(join(inNodeModules, 'package.json'), {
-      name: '@scope/linked',
-      version: '1.0.0',
-    })
-    await symlink(join(linkedPkg, 'dist'), join(inNodeModules, 'dist'), 'dir')
-  }
-
-  test('linked dep resolving a different version → error', async () => {
-    const tmp = await makeTmp()
-    const external = await makeTmp()
-    try {
-      await makeValidProject(tmp)
-      await setup(tmp, external, '1.6.27')
-      const result = await runLiveValidate(tmp, { skipTypecheck: true })
-      const finding = result.findings.find((f) =>
-        f.id.startsWith('split-type-identity')
-      )
-      assert.ok(
-        finding,
-        `expected a split-type-identity finding, got: ${JSON.stringify(
-          result.findings.map((f) => f.id)
-        )}`
-      )
-      assert.equal(finding.severity, 'error')
-      assert.match(finding.message, /1\.6\.27/)
-      assert.match(finding.message, /1\.6\.23/)
-    } finally {
-      await rm(tmp, { recursive: true, force: true })
-      await rm(external, { recursive: true, force: true })
-    }
-  })
-
-  test('linked dep resolving the same version → no finding', async () => {
-    const tmp = await makeTmp()
-    const external = await makeTmp()
-    try {
-      await makeValidProject(tmp)
-      await setup(tmp, external, '1.6.23')
-      const result = await runLiveValidate(tmp, { skipTypecheck: true })
-      const ids = result.findings
-        .map((f) => f.id)
-        .filter((id) => id.startsWith('split-type-identity'))
-      assert.deepEqual(ids, [])
-    } finally {
-      await rm(tmp, { recursive: true, force: true })
-      await rm(external, { recursive: true, force: true })
-    }
-  })
-})

--- a/packages/cli/src/fabric/functions/validate.function.ts
+++ b/packages/cli/src/fabric/functions/validate.function.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
-import { readFile, readdir, realpath } from 'node:fs/promises'
+import { readFile, readdir } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
-import { dirname, join, relative } from 'node:path'
+import { dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
 import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
 import { added, changed, removed, dim } from '../lib/output.js'
@@ -11,6 +11,7 @@ import {
   readTextSafe,
   runSharedProjectChecks,
 } from '../../functions/validate/shared-checks.js'
+import { runTypeIdentityChecks } from '../../functions/validate/type-identity-checks.js'
 
 const FindingSchema = z.object({
   id: z.string(),
@@ -136,26 +137,6 @@ const SINGLETON_SENSITIVE_PKGS = [
   'react-dom',
 ]
 
-// Type-identity-sensitive packages: two copies at DIFFERENT versions give
-// TypeScript two unrelated declarations of the same interface, and every place
-// they meet becomes a structural comparison of the full shape. Inside a generic
-// inference chain that compounds — fabric's api-functions went from 1.3GB/13s
-// to an unbounded OOM (8GB and 12GB ceilings both died, 7.7M types, single
-// assignability checks taking 8s) because one dependency's `dist` was symlinked
-// into a sibling checkout that carried its own better-auth. It reads as "codegen
-// is slow", never as a version problem, which is why it is worth a check.
-//
-// Distinct from SINGLETON_SENSITIVE_PKGS above: that one is two copies of the
-// SAME version splitting module state at runtime. This one is a compile-time
-// blow-up and only fires when the versions differ.
-const TYPE_IDENTITY_PKGS = [
-  'better-auth',
-  '@better-auth/core',
-  '@pikku/core',
-  'kysely',
-  'zod',
-]
-
 // A file whose name says "this is the login surface". Used to decide whether an
 // app needs the actor quick-login control — an app with no login screen has
 // nothing to attach it to. Matched against the path relative to the app root, so
@@ -218,116 +199,6 @@ async function installedSemver(
     join(root, 'node_modules', pkg, 'package.json')
   )
   return j?.version ? parseSemver(j.version) : null
-}
-
-// Installed version of `pkg` as seen FROM `fromDir`, walking parent
-// node_modules the way node resolution does. Used to ask what a linked
-// dependency resolves in its own checkout, which is not what the project
-// resolves.
-async function versionResolvedFrom(
-  fromDir: string,
-  pkg: string
-): Promise<string | null> {
-  let dir = fromDir
-  for (;;) {
-    const j = await readJsonSafe<{ version?: string }>(
-      join(dir, 'node_modules', pkg, 'package.json')
-    )
-    if (j?.version) return j.version
-    const parent = dirname(dir)
-    if (parent === dir) return null
-    dir = parent
-  }
-}
-
-// Where `pkg` resolves for the project itself. The root alone is not enough:
-// an isolated/pnpm-style install (bun's default) links dependencies under the
-// workspace package that declares them and leaves the root node_modules
-// without them, so probing only the root silently finds nothing.
-async function projectResolvedVersion(
-  root: string,
-  pkg: string
-): Promise<{ version: string; from: string } | null> {
-  const bases = [root]
-  for (const group of ['packages', 'apps', 'backends']) {
-    const groupDir = join(root, group)
-    if (!existsSync(groupDir)) continue
-    const entries = await readdir(groupDir, { withFileTypes: true }).catch(
-      () => []
-    )
-    for (const d of entries) {
-      if (d.isDirectory()) bases.push(join(groupDir, d.name))
-    }
-  }
-  for (const base of bases) {
-    const j = await readJsonSafe<{ version?: string }>(
-      join(base, 'node_modules', pkg, 'package.json')
-    )
-    if (j?.version) return { version: j.version, from: base }
-  }
-  return null
-}
-
-// Dependencies whose code physically lives outside the project: a `link:` or
-// `portal:` dep, or a hand-made symlink into a sibling checkout. Only these can
-// introduce a second version of a type-identity package, because a normal
-// install dedupes through the lockfile.
-//
-// The symlink is often NOT the package directory but a build output inside it
-// (`node_modules/@scope/pkg/dist -> ../../../other-repo/packages/pkg/dist`),
-// which still moves type resolution to the other tree since TypeScript resolves
-// symlinks to their realpath. So each candidate subdir is probed too.
-async function externalDependencyRoots(
-  root: string
-): Promise<Map<string, string>> {
-  const found = new Map<string, string>()
-  const nodeModules = join(root, 'node_modules')
-  if (!existsSync(nodeModules)) return found
-  // Compare realpath against realpath: on macOS the temp/project path is often
-  // itself a symlink (/var -> /private/var), which would otherwise make every
-  // dependency look external.
-  const realRoot = await realpath(root).catch(() => root)
-
-  const topLevel = await readdir(nodeModules, { withFileTypes: true }).catch(
-    () => []
-  )
-  const pkgDirs: string[] = []
-  for (const entry of topLevel) {
-    if (entry.name.startsWith('.')) continue
-    if (entry.name.startsWith('@')) {
-      const scoped = await readdir(join(nodeModules, entry.name), {
-        withFileTypes: true,
-      }).catch(() => [])
-      for (const inner of scoped) {
-        pkgDirs.push(join(nodeModules, entry.name, inner.name))
-      }
-    } else {
-      pkgDirs.push(join(nodeModules, entry.name))
-    }
-  }
-
-  for (const pkgDir of pkgDirs) {
-    for (const candidate of [pkgDir, join(pkgDir, 'dist')]) {
-      if (!existsSync(candidate)) continue
-      const real = await realpath(candidate).catch(() => null)
-      if (!real) continue
-      const rel = relative(realRoot, real)
-      if (!rel.startsWith('..')) continue
-      const name = relative(nodeModules, pkgDir)
-      // `real` may point at a build output (…/pkg/dist); report the linked
-      // package's own root so the message names something a reader can act on.
-      let owner = real
-      while (
-        !existsSync(join(owner, 'package.json')) &&
-        dirname(owner) !== owner
-      ) {
-        owner = dirname(owner)
-      }
-      if (!found.has(name)) found.set(name, owner)
-      break
-    }
-  }
-  return found
 }
 
 // PostgreSQL-specific syntax that won't work on SQLite/libSQL (Turso)
@@ -565,36 +436,7 @@ export async function runValidate(
     }
   }
 
-  // ── split type identity via a linked dependency ────────────────────────
-  // See TYPE_IDENTITY_PKGS. A linked dependency resolves its own imports from
-  // its own checkout, so it can hand the project types built against a
-  // different version of a shared package. The symptom is a typecheck that
-  // OOMs rather than one that fails, so nothing else in this validator would
-  // catch it.
-  {
-    const external = await externalDependencyRoots(root)
-    if (external.size > 0) {
-      for (const pkg of TYPE_IDENTITY_PKGS) {
-        const local = await projectResolvedVersion(root, pkg)
-        if (!local) continue
-        const ours = local.version
-        for (const [depName, depRoot] of external) {
-          const theirs = await versionResolvedFrom(depRoot, pkg)
-          if (!theirs || theirs === ours) continue
-          e(
-            `split-type-identity-${depName.replace(/[@/]/g, '-')}-${pkg.replace(/[@/]/g, '-')}`,
-            `"${depName}" is linked to ${depRoot} and resolves ${pkg}@${theirs} there, while this project resolves ${pkg}@${ours} — two type identities for ${pkg}`,
-            join(root, 'node_modules', depName),
-            lines(
-              `TypeScript treats the two ${pkg} declarations as unrelated types and structurally compares them wherever they meet, which can make a typecheck OOM instead of fail.`,
-              `Align the versions so both trees resolve one ${pkg}: either bump ${pkg} to ${theirs} here, or to ${ours} in ${depRoot}.`,
-              `If the link is no longer needed, remove it and reinstall so "${depName}" comes from the registry.`
-            )
-          )
-        }
-      }
-    }
-  }
+  findings.push(...(await runTypeIdentityChecks(root)))
 
   // ── scaffold-implied dependencies ──────────────────────────────────────
   // `scaffold.console` makes codegen import

--- a/packages/cli/src/fabric/functions/validate.function.ts
+++ b/packages/cli/src/fabric/functions/validate.function.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
-import { readFile, readdir } from 'node:fs/promises'
+import { readFile, readdir, realpath } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { dirname, join, relative } from 'node:path'
 import { createRequire } from 'node:module'
 import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
 import { added, changed, removed, dim } from '../lib/output.js'
@@ -136,6 +136,26 @@ const SINGLETON_SENSITIVE_PKGS = [
   'react-dom',
 ]
 
+// Type-identity-sensitive packages: two copies at DIFFERENT versions give
+// TypeScript two unrelated declarations of the same interface, and every place
+// they meet becomes a structural comparison of the full shape. Inside a generic
+// inference chain that compounds — fabric's api-functions went from 1.3GB/13s
+// to an unbounded OOM (8GB and 12GB ceilings both died, 7.7M types, single
+// assignability checks taking 8s) because one dependency's `dist` was symlinked
+// into a sibling checkout that carried its own better-auth. It reads as "codegen
+// is slow", never as a version problem, which is why it is worth a check.
+//
+// Distinct from SINGLETON_SENSITIVE_PKGS above: that one is two copies of the
+// SAME version splitting module state at runtime. This one is a compile-time
+// blow-up and only fires when the versions differ.
+const TYPE_IDENTITY_PKGS = [
+  'better-auth',
+  '@better-auth/core',
+  '@pikku/core',
+  'kysely',
+  'zod',
+]
+
 // A file whose name says "this is the login surface". Used to decide whether an
 // app needs the actor quick-login control — an app with no login screen has
 // nothing to attach it to. Matched against the path relative to the app root, so
@@ -198,6 +218,116 @@ async function installedSemver(
     join(root, 'node_modules', pkg, 'package.json')
   )
   return j?.version ? parseSemver(j.version) : null
+}
+
+// Installed version of `pkg` as seen FROM `fromDir`, walking parent
+// node_modules the way node resolution does. Used to ask what a linked
+// dependency resolves in its own checkout, which is not what the project
+// resolves.
+async function versionResolvedFrom(
+  fromDir: string,
+  pkg: string
+): Promise<string | null> {
+  let dir = fromDir
+  for (;;) {
+    const j = await readJsonSafe<{ version?: string }>(
+      join(dir, 'node_modules', pkg, 'package.json')
+    )
+    if (j?.version) return j.version
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+// Where `pkg` resolves for the project itself. The root alone is not enough:
+// an isolated/pnpm-style install (bun's default) links dependencies under the
+// workspace package that declares them and leaves the root node_modules
+// without them, so probing only the root silently finds nothing.
+async function projectResolvedVersion(
+  root: string,
+  pkg: string
+): Promise<{ version: string; from: string } | null> {
+  const bases = [root]
+  for (const group of ['packages', 'apps', 'backends']) {
+    const groupDir = join(root, group)
+    if (!existsSync(groupDir)) continue
+    const entries = await readdir(groupDir, { withFileTypes: true }).catch(
+      () => []
+    )
+    for (const d of entries) {
+      if (d.isDirectory()) bases.push(join(groupDir, d.name))
+    }
+  }
+  for (const base of bases) {
+    const j = await readJsonSafe<{ version?: string }>(
+      join(base, 'node_modules', pkg, 'package.json')
+    )
+    if (j?.version) return { version: j.version, from: base }
+  }
+  return null
+}
+
+// Dependencies whose code physically lives outside the project: a `link:` or
+// `portal:` dep, or a hand-made symlink into a sibling checkout. Only these can
+// introduce a second version of a type-identity package, because a normal
+// install dedupes through the lockfile.
+//
+// The symlink is often NOT the package directory but a build output inside it
+// (`node_modules/@scope/pkg/dist -> ../../../other-repo/packages/pkg/dist`),
+// which still moves type resolution to the other tree since TypeScript resolves
+// symlinks to their realpath. So each candidate subdir is probed too.
+async function externalDependencyRoots(
+  root: string
+): Promise<Map<string, string>> {
+  const found = new Map<string, string>()
+  const nodeModules = join(root, 'node_modules')
+  if (!existsSync(nodeModules)) return found
+  // Compare realpath against realpath: on macOS the temp/project path is often
+  // itself a symlink (/var -> /private/var), which would otherwise make every
+  // dependency look external.
+  const realRoot = await realpath(root).catch(() => root)
+
+  const topLevel = await readdir(nodeModules, { withFileTypes: true }).catch(
+    () => []
+  )
+  const pkgDirs: string[] = []
+  for (const entry of topLevel) {
+    if (entry.name.startsWith('.')) continue
+    if (entry.name.startsWith('@')) {
+      const scoped = await readdir(join(nodeModules, entry.name), {
+        withFileTypes: true,
+      }).catch(() => [])
+      for (const inner of scoped) {
+        pkgDirs.push(join(nodeModules, entry.name, inner.name))
+      }
+    } else {
+      pkgDirs.push(join(nodeModules, entry.name))
+    }
+  }
+
+  for (const pkgDir of pkgDirs) {
+    for (const candidate of [pkgDir, join(pkgDir, 'dist')]) {
+      if (!existsSync(candidate)) continue
+      const real = await realpath(candidate).catch(() => null)
+      if (!real) continue
+      const rel = relative(realRoot, real)
+      if (!rel.startsWith('..')) continue
+      const name = relative(nodeModules, pkgDir)
+      // `real` may point at a build output (…/pkg/dist); report the linked
+      // package's own root so the message names something a reader can act on.
+      let owner = real
+      while (
+        !existsSync(join(owner, 'package.json')) &&
+        dirname(owner) !== owner
+      ) {
+        owner = dirname(owner)
+      }
+      if (!found.has(name)) found.set(name, owner)
+      break
+    }
+  }
+  return found
 }
 
 // PostgreSQL-specific syntax that won't work on SQLite/libSQL (Turso)
@@ -431,6 +561,37 @@ export async function runValidate(
             'Then run `yarn install` and re-run `pikku fabric validate`.'
           )
         )
+      }
+    }
+  }
+
+  // ── split type identity via a linked dependency ────────────────────────
+  // See TYPE_IDENTITY_PKGS. A linked dependency resolves its own imports from
+  // its own checkout, so it can hand the project types built against a
+  // different version of a shared package. The symptom is a typecheck that
+  // OOMs rather than one that fails, so nothing else in this validator would
+  // catch it.
+  {
+    const external = await externalDependencyRoots(root)
+    if (external.size > 0) {
+      for (const pkg of TYPE_IDENTITY_PKGS) {
+        const local = await projectResolvedVersion(root, pkg)
+        if (!local) continue
+        const ours = local.version
+        for (const [depName, depRoot] of external) {
+          const theirs = await versionResolvedFrom(depRoot, pkg)
+          if (!theirs || theirs === ours) continue
+          e(
+            `split-type-identity-${depName.replace(/[@/]/g, '-')}-${pkg.replace(/[@/]/g, '-')}`,
+            `"${depName}" is linked to ${depRoot} and resolves ${pkg}@${theirs} there, while this project resolves ${pkg}@${ours} — two type identities for ${pkg}`,
+            join(root, 'node_modules', depName),
+            lines(
+              `TypeScript treats the two ${pkg} declarations as unrelated types and structurally compares them wherever they meet, which can make a typecheck OOM instead of fail.`,
+              `Align the versions so both trees resolve one ${pkg}: either bump ${pkg} to ${theirs} here, or to ${ours} in ${depRoot}.`,
+              `If the link is no longer needed, remove it and reinstall so "${depName}" comes from the registry.`
+            )
+          )
+        }
       }
     }
   }

--- a/packages/cli/src/functions/validate/type-identity-checks.test.ts
+++ b/packages/cli/src/functions/validate/type-identity-checks.test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, test } from 'node:test'
+import { runTypeIdentityChecks } from './type-identity-checks.js'
+import { planValidation } from './validate-registry.js'
+
+const makeTmp = () => mkdtemp(join(tmpdir(), 'pikku-type-identity-'))
+
+const writeJson = async (path: string, value: unknown) => {
+  await mkdir(join(path, '..'), { recursive: true })
+  await writeFile(path, JSON.stringify(value, null, 2))
+}
+
+/**
+ * Mirrors the real shape: node_modules/@scope/linked is a genuine directory
+ * whose `dist` symlinks into a sibling checkout, so TypeScript resolves that
+ * package's imports from the other tree's node_modules.
+ */
+const linkExternal = async (
+  root: string,
+  external: string,
+  externalVersion: string,
+  ourVersion = '1.6.23'
+) => {
+  await writeJson(join(root, 'node_modules', 'better-auth', 'package.json'), {
+    name: 'better-auth',
+    version: ourVersion,
+  })
+
+  const linkedPkg = join(external, 'packages', 'linked')
+  await mkdir(join(linkedPkg, 'dist'), { recursive: true })
+  await writeJson(join(linkedPkg, 'package.json'), {
+    name: '@scope/linked',
+    version: '1.0.0',
+  })
+  await writeJson(
+    join(external, 'node_modules', 'better-auth', 'package.json'),
+    { name: 'better-auth', version: externalVersion }
+  )
+
+  const inNodeModules = join(root, 'node_modules', '@scope', 'linked')
+  await mkdir(inNodeModules, { recursive: true })
+  await writeJson(join(inNodeModules, 'package.json'), {
+    name: '@scope/linked',
+    version: '1.0.0',
+  })
+  await symlink(join(linkedPkg, 'dist'), join(inNodeModules, 'dist'), 'dir')
+}
+
+const withTmpPair = async (
+  fn: (root: string, external: string) => Promise<void>
+) => {
+  const root = await makeTmp()
+  const external = await makeTmp()
+  try {
+    await fn(root, external)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+    await rm(external, { recursive: true, force: true })
+  }
+}
+
+describe('split type identity via a linked dependency', () => {
+  test('linked dep resolving a different version → error naming both', async () => {
+    await withTmpPair(async (root, external) => {
+      await linkExternal(root, external, '1.6.27')
+      const findings = await runTypeIdentityChecks(root)
+      const finding = findings.find((f) =>
+        f.id.startsWith('split-type-identity')
+      )
+      assert.ok(
+        finding,
+        `expected a finding, got: ${JSON.stringify(findings.map((f) => f.id))}`
+      )
+      assert.equal(finding.severity, 'error')
+      assert.match(finding.message, /1\.6\.27/)
+      assert.match(finding.message, /1\.6\.23/)
+      assert.match(finding.message, /@scope\/linked/)
+    })
+  })
+
+  test('linked dep resolving the same version → no finding', async () => {
+    await withTmpPair(async (root, external) => {
+      await linkExternal(root, external, '1.6.23')
+      assert.deepEqual(await runTypeIdentityChecks(root), [])
+    })
+  })
+
+  test('no linked dependency → no finding', async () => {
+    await withTmpPair(async (root) => {
+      await writeJson(
+        join(root, 'node_modules', 'better-auth', 'package.json'),
+        { name: 'better-auth', version: '1.6.23' }
+      )
+      assert.deepEqual(await runTypeIdentityChecks(root), [])
+    })
+  })
+
+  // The version the project resolves is the one the workspace package sees. An
+  // isolated install (bun's default) never hoists it to the root, so a root-only
+  // probe finds nothing and the check silently passes.
+  test('finds the project version under a workspace package, not just the root', async () => {
+    await withTmpPair(async (root, external) => {
+      await writeJson(join(root, 'package.json'), { name: 'root' })
+      await writeJson(
+        join(root, 'packages', 'api', 'node_modules', 'kysely', 'package.json'),
+        { name: 'kysely', version: '0.29.2' }
+      )
+      await linkExternal(root, external, '1.6.23')
+      await writeJson(
+        join(external, 'node_modules', 'kysely', 'package.json'),
+        { name: 'kysely', version: '0.28.0' }
+      )
+      const ids = (await runTypeIdentityChecks(root)).map((f) => f.id)
+      assert.ok(
+        ids.some((id) => id.endsWith('kysely')),
+        `expected a kysely finding, got: ${JSON.stringify(ids)}`
+      )
+    })
+  })
+
+  test('is not planned at all when nothing is installed', async () => {
+    await withTmpPair(async (root) => {
+      await writeJson(join(root, 'package.json'), { name: 'root' })
+      const planned = (await planValidation(root)).filter(
+        ({ check }) => check.id === 'type-identity'
+      )
+      assert.deepEqual(planned, [])
+    })
+  })
+
+  test('runs once per install, at the root, not per workspace package', async () => {
+    await withTmpPair(async (root) => {
+      await writeJson(join(root, 'package.json'), { name: 'root' })
+      await writeJson(join(root, 'packages', 'api', 'package.json'), {
+        name: 'api',
+      })
+      await writeJson(join(root, 'packages', 'web', 'package.json'), {
+        name: 'web',
+      })
+      await mkdir(join(root, 'node_modules'), { recursive: true })
+      const planned = (await planValidation(root)).filter(
+        ({ check }) => check.id === 'type-identity'
+      )
+      assert.equal(planned.length, 1)
+      assert.equal(planned[0]?.target.label, '.')
+    })
+  })
+})

--- a/packages/cli/src/functions/validate/type-identity-checks.ts
+++ b/packages/cli/src/functions/validate/type-identity-checks.ts
@@ -1,0 +1,185 @@
+import { existsSync } from 'node:fs'
+import { readdir, realpath } from 'node:fs/promises'
+import { dirname, join, relative } from 'node:path'
+import { readJsonSafe } from './shared-checks.js'
+import type { ValidateFinding } from './persona-checks.js'
+
+/**
+ * Packages whose TYPE identity matters, not just their runtime identity.
+ *
+ * Two copies of one of these at different versions give TypeScript two
+ * unrelated declarations of the same interface, and every place they meet
+ * becomes a structural comparison of the full shape. Inside a generic inference
+ * chain that compounds: one project went from a 1.3GB/13s typecheck to an
+ * unbounded OOM (8GB and 12GB ceilings both died, 7.7M types, single
+ * assignability checks taking 8s) because one dependency's `dist` was symlinked
+ * into a sibling checkout that carried its own better-auth. It reads as "codegen
+ * is slow", never as a version problem, which is why it is worth a check.
+ *
+ * Distinct from the duplicate-copy check, which is two copies of the SAME
+ * version splitting module state at runtime. This is a compile-time blow-up and
+ * only fires when the versions differ.
+ */
+const TYPE_IDENTITY_PKGS = [
+  'better-auth',
+  '@better-auth/core',
+  '@pikku/core',
+  'kysely',
+  'zod',
+]
+
+/**
+ * Installed version of `pkg` as seen FROM `fromDir`, walking parent
+ * node_modules the way node resolution does. Used to ask what a linked
+ * dependency resolves in its own checkout, which is not what the project
+ * resolves.
+ */
+async function versionResolvedFrom(
+  fromDir: string,
+  pkg: string
+): Promise<string | null> {
+  let dir = fromDir
+  for (;;) {
+    const j = await readJsonSafe<{ version?: string }>(
+      join(dir, 'node_modules', pkg, 'package.json')
+    )
+    if (j?.version) return j.version
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+/**
+ * Where `pkg` resolves for the project itself. The root alone is not enough:
+ * an isolated/pnpm-style install (bun's default) links dependencies under the
+ * workspace package that declares them and leaves the root node_modules
+ * without them, so probing only the root silently finds nothing.
+ */
+async function projectResolvedVersion(
+  root: string,
+  pkg: string
+): Promise<{ version: string; from: string } | null> {
+  const bases = [root]
+  for (const group of ['packages', 'apps', 'backends']) {
+    const groupDir = join(root, group)
+    if (!existsSync(groupDir)) continue
+    const entries = await readdir(groupDir, { withFileTypes: true }).catch(
+      () => []
+    )
+    for (const d of entries) {
+      if (d.isDirectory()) bases.push(join(groupDir, d.name))
+    }
+  }
+  for (const base of bases) {
+    const j = await readJsonSafe<{ version?: string }>(
+      join(base, 'node_modules', pkg, 'package.json')
+    )
+    if (j?.version) return { version: j.version, from: base }
+  }
+  return null
+}
+
+/**
+ * Dependencies whose code physically lives outside the project: a `link:` or
+ * `portal:` dep, or a hand-made symlink into a sibling checkout. Only these can
+ * introduce a second version of a type-identity package, because a normal
+ * install dedupes through the lockfile.
+ *
+ * The symlink is often NOT the package directory but a build output inside it
+ * (`node_modules/@scope/pkg/dist -> ../../../other-repo/packages/pkg/dist`),
+ * which still moves type resolution to the other tree since TypeScript resolves
+ * symlinks to their realpath. So each candidate subdir is probed too.
+ */
+async function externalDependencyRoots(
+  root: string
+): Promise<Map<string, string>> {
+  const found = new Map<string, string>()
+  const nodeModules = join(root, 'node_modules')
+  if (!existsSync(nodeModules)) return found
+  // Compare realpath against realpath: on macOS the temp/project path is often
+  // itself a symlink (/var -> /private/var), which would otherwise make every
+  // dependency look external.
+  const realRoot = await realpath(root).catch(() => root)
+
+  const topLevel = await readdir(nodeModules, { withFileTypes: true }).catch(
+    () => []
+  )
+  const pkgDirs: string[] = []
+  for (const entry of topLevel) {
+    if (entry.name.startsWith('.')) continue
+    if (entry.name.startsWith('@')) {
+      const scoped = await readdir(join(nodeModules, entry.name), {
+        withFileTypes: true,
+      }).catch(() => [])
+      for (const inner of scoped) {
+        pkgDirs.push(join(nodeModules, entry.name, inner.name))
+      }
+    } else {
+      pkgDirs.push(join(nodeModules, entry.name))
+    }
+  }
+
+  for (const pkgDir of pkgDirs) {
+    for (const candidate of [pkgDir, join(pkgDir, 'dist')]) {
+      if (!existsSync(candidate)) continue
+      const real = await realpath(candidate).catch(() => null)
+      if (!real) continue
+      const rel = relative(realRoot, real)
+      if (!rel.startsWith('..')) continue
+      const name = relative(nodeModules, pkgDir)
+      // `real` may point at a build output (…/pkg/dist); report the linked
+      // package's own root so the message names something a reader can act on.
+      let owner = real
+      while (
+        !existsSync(join(owner, 'package.json')) &&
+        dirname(owner) !== owner
+      ) {
+        owner = dirname(owner)
+      }
+      if (!found.has(name)) found.set(name, owner)
+      break
+    }
+  }
+  return found
+}
+
+/**
+ * A linked dependency resolves its own imports from its own checkout, so it can
+ * hand the project types built against a different version of a shared package.
+ * The symptom is a typecheck that OOMs rather than one that fails, so nothing
+ * else in this validator would catch it.
+ *
+ * Runs against the workspace root only. The mismatch is a property of the
+ * install, not of any one package in it, so running per workspace package would
+ * report the same pair once per package.
+ */
+export async function runTypeIdentityChecks(
+  root: string
+): Promise<ValidateFinding[]> {
+  const findings: ValidateFinding[] = []
+  const external = await externalDependencyRoots(root)
+  if (external.size === 0) return findings
+
+  for (const pkg of TYPE_IDENTITY_PKGS) {
+    const local = await projectResolvedVersion(root, pkg)
+    if (!local) continue
+    const ours = local.version
+    for (const [depName, depRoot] of external) {
+      const theirs = await versionResolvedFrom(depRoot, pkg)
+      if (!theirs || theirs === ours) continue
+      findings.push({
+        id: `split-type-identity-${depName.replace(/[@/]/g, '-')}-${pkg.replace(/[@/]/g, '-')}`,
+        severity: 'error',
+        message: `"${depName}" is linked to ${depRoot} and resolves ${pkg}@${theirs} there, while this project resolves ${pkg}@${ours} — two type identities for ${pkg}`,
+        path: join(root, 'node_modules', depName),
+        fixHint: [
+          `TypeScript treats the two ${pkg} declarations as unrelated types and structurally compares them wherever they meet, which can make a typecheck OOM instead of fail.`,
+          `Align the versions so both trees resolve one ${pkg}: either bump ${pkg} to ${theirs} here, or to ${ours} in ${depRoot}.`,
+          `If the link is no longer needed, remove it and reinstall so "${depName}" comes from the registry.`,
+        ].join('\n'),
+      })
+    }
+  }
+  return findings
+}

--- a/packages/cli/src/functions/validate/validate-registry.ts
+++ b/packages/cli/src/functions/validate/validate-registry.ts
@@ -6,6 +6,7 @@ import {
   runAddonPackageChecks,
 } from './addon-package-checks.js'
 import { runSharedProjectChecks } from './shared-checks.js'
+import { runTypeIdentityChecks } from './type-identity-checks.js'
 import type { ValidateFinding as Finding } from './persona-checks.js'
 
 export type ValidateTarget = {
@@ -102,6 +103,17 @@ export const CHECKS: ValidateCheck[] = [
     subject: 'addon',
     applies: async ({ dir }) => isAddonPackage(dir),
     run: async ({ dir }) => runAddonPackageChecks(dir),
+  },
+  {
+    id: 'type-identity',
+    subject: 'linked dependencies',
+    // Root of an installed tree only. A linked dependency is a property of the
+    // install as a whole, so running this per workspace package reports the
+    // same pair N times — and with nothing installed there is nothing to
+    // compare.
+    applies: async ({ dir, label }) =>
+      label === '.' && existsSync(join(dir, 'node_modules')),
+    run: async ({ dir }) => runTypeIdentityChecks(dir),
   },
 ]
 


### PR DESCRIPTION
## What

`pikku validate` and `pikku fabric validate` now report `split-type-identity-<dep>-<pkg>` when a dependency linked in from another checkout resolves a type-identity-sensitive package at a different version than the project does — naming both versions and both paths.

Covers `better-auth`, `@better-auth/core`, `@pikku/core`, `kysely`, `zod`.

## Why

A dependency linked from another tree (`link:`, `portal:`, or a hand-made `dist` symlink) resolves its own imports from *that* tree's `node_modules`, because TypeScript resolves symlinks to realpath. When both trees carry the same package at different versions, TS ends up with two unrelated declarations of one interface and structurally compares them wherever they meet. Inside a generic inference chain that compounds.

Found the hard way in fabric. `packages/api-functions` went from a 1.3GB / 13s typecheck to one that finished at no heap size — 8GB and 12GB both died — because one package's `dist` pointed at a sibling checkout carrying its own `better-auth`:

- `structuredTypeRelatedTo` was 81s of 100s traced
- single assignability checks took **eight seconds** each
- type ids reached **7.7 million**

What makes it worth a check is how it presents: as "codegen is slow" or an out-of-memory crash, never as a version mismatch. It invites a `--max-old-space-size` bump, which fixes nothing and hides it further. Aligning the two trees on one version brought it back to 1.30GB / 17.5s.

## Where it lives

The shared check registry, so both entry points run it. Nothing about the mechanism is fabric-specific — linking a package from a sibling checkout is the normal way to develop a pikku package against a consuming app, which is exactly the population that hits this.

Its precondition is **the root of an installed tree**. A linked dependency is a property of the install as a whole, so running it per workspace package would report the same pair once per package; with no `node_modules` there is nothing to compare and it isn't planned at all.

## Notes

- Distinct from the existing duplicate-copy check, which is about two *physical copies of the same version* splitting module state at runtime. This is one logical dependency at two versions splitting *type* identity at compile time.
- Dependency lookup probes workspace package directories as well as the root, so it works under isolated/pnpm-style installs that never hoist to the root `node_modules` — a root-only probe misses the common case.
- Externality is decided on `realpath`, compared against the project's own realpath, so macOS `/var` → `/private/var` doesn't produce false positives.

## Verification

- 6 tests in `type-identity-checks.test.ts`, building a real linked-package layout against a separate tmp checkout: differing version → error naming both; same version → none; no link → none; the version found under a workspace package rather than the root; planned once at the root; not planned with nothing installed
- `packages/cli`: **930 tests, 930 pass, 0 fail**; `tsc --noEmit` clean
- Verified firing against a real project, where it surfaced two mismatches beyond the one being chased (`@pikku/core`, `zod`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)