### PR TITLE
fix(core,inspector): let a host grant an addon secrets it could not declare

### DIFF
--- a/.changeset/addon-secret-grants.md
+++ b/.changeset/addon-secret-grants.md
@@ -1,0 +1,22 @@
+---
+'@pikku/inspector': patch
+'@pikku/core': patch
+'@pikku/cli': patch
+---
+
+fix(core,inspector): let a host grant an addon secrets it could not declare
+
+Scoping an addon's `SecretService` to its `declaredSecrets` left generic addons
+with nothing readable: `declaredSecrets` is derived from the addon package's own
+source, but the secrets an addon like `@pikku/addon-graph` reads are named by the
+consuming app's workflow nodes at runtime. Every authenticated `graph:httpRequest`
+threw.
+
+`wireAddon` now takes `secretGrants: string[]` and `credentialGrants: string[]`,
+completing the grant family alongside `secretOverrides` (grant + rename) and
+`globalSecrets` (grant everything, with a reason). Grants name the secret as the
+addon reads it, since the scope check runs before the override map renames it —
+which is also why an override's key grants and its value does not.
+
+A grant naming a secret the project does not declare is an `INVALID_VALUE`
+critical at codegen, resolved through the override map before lookup.

--- a/packages/cli/src/functions/wirings/console/serialize-console-functions.test.ts
+++ b/packages/cli/src/functions/wirings/console/serialize-console-functions.test.ts
@@ -37,6 +37,26 @@ test('serializeConsoleFunctions describes every payload with a zod schema', () =
   )
 })
 
+test('serializeConsoleFunctions no longer generates the console secret RPCs', () => {
+  const { schemas, functions } = serializeConsoleFunctions(
+    '#pikku',
+    '#agents',
+    '/api'
+  )
+
+  for (const name of [
+    'SetSecret',
+    'pikkuConsoleSetSecret',
+    'pikkuConsoleGetSecret',
+    'pikkuConsoleHasSecret',
+  ]) {
+    assert.ok(
+      !schemas.includes(name) && !functions.includes(name),
+      `${name} was generated — the console administers secrets through the addon, not through generated functions`
+    )
+  }
+})
+
 test('serializeConsoleFunctions keeps the schemas module free of anything but zod', () => {
   const { schemas } = serializeConsoleFunctions('#pikku', '#agents', '/api')
 

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -682,7 +682,7 @@ export class PikkuMissingMetaError extends PikkuError {}
 export interface PikkuPackageState {
   function: { meta: FunctionsMeta; functions: Map<string, CorePikkuFunctionConfig<any, any>> }
   rpc: { meta: Record<string, string>; files: Map< string, { exportedName: string; path: string } > }
-  addons: { packages: Map< string, { package: string; rpcEndpoint?: string; auth?: boolean; tags?: string[]; scopes?: string[]; secretOverrides?: Record<string, string>; variableOverrides?: Record<string, string>; credentialOverrides?: Record<string, string>; globalSecrets?: string; globalCredentials?: string; remote?: boolean; serverUrl?: string | ((services: any) => string | Promise<string>); remoteAuth?: | { credentialId: string } | { secretId: string } | { resolve: (services: any, wire: any) => string | Promise<string> }; remoteName?: (fn: string) => string } > }
+  addons: { packages: Map< string, { package: string; rpcEndpoint?: string; auth?: boolean; tags?: string[]; scopes?: string[]; secretOverrides?: Record<string, string>; variableOverrides?: Record<string, string>; credentialOverrides?: Record<string, string>; secretGrants?: string[]; credentialGrants?: string[]; globalSecrets?: string; globalCredentials?: string; remote?: boolean; serverUrl?: string | ((services: any) => string | Promise<string>); remoteAuth?: | { credentialId: string } | { secretId: string } | { resolve: (services: any, wire: any) => string | Promise<string> }; remoteName?: (fn: string) => string } > }
   http: { middleware: Map<string, CorePikkuMiddleware<any, any>[]>; permissions: Map<string, CorePermissionGroup | CorePikkuPermission[]>; routes: Map<HTTPMethod, Map<string, CoreHTTPFunctionWiring<any, any, any>>>; meta: HTTPWiringsMeta }
   channel: { channels: Map<string, CoreChannel<any, any, any, any, any>>; meta: ChannelsMeta }
   scheduler: { tasks: Map<string, CoreScheduledTask>; meta: ScheduledTasksMeta }
@@ -1020,6 +1020,8 @@ export type WireAddonConfig = {
   secretOverrides?: Record<string, string>
   variableOverrides?: Record<string, string>
   credentialOverrides?: Record<string, string>
+  secretGrants?: string[]
+  credentialGrants?: string[]
   globalSecrets?: string
   globalCredentials?: string
 }
@@ -3439,6 +3441,8 @@ export type WireAddonConfig = {
   secretOverrides?: Record<string, string>
   variableOverrides?: Record<string, string>
   credentialOverrides?: Record<string, string>
+  secretGrants?: string[]
+  credentialGrants?: string[]
   globalSecrets?: string
   globalCredentials?: string
 }

--- a/packages/core/src/types/state.types.ts
+++ b/packages/core/src/types/state.types.ts
@@ -102,6 +102,10 @@ export interface PikkuPackageState {
         variableOverrides?: Record<string, string>
         /** Per-instance name-aliases: logical name the addon reads -> actual project credential name */
         credentialOverrides?: Record<string, string>
+        /** Secrets the host lends this instance, named as the addon reads them */
+        secretGrants?: string[]
+        /** Credentials the host lends this instance, named as the addon reads them */
+        credentialGrants?: string[]
         /** Why this instance gets the whole `SecretService` rather than one scoped to its declared secrets */
         globalSecrets?: string
         /** Why this instance gets the whole `CredentialService` rather than one scoped to its declared credentials */

--- a/packages/core/src/wirings/ai-agent/ai-agent-prepare.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-prepare.ts
@@ -565,6 +565,8 @@ export async function buildToolDefs(
                     variableOverrides: capturedAddonConfig?.variableOverrides,
                     credentialOverrides:
                       capturedAddonConfig?.credentialOverrides,
+                    secretGrants: capturedAddonConfig?.secretGrants,
+                    credentialGrants: capturedAddonConfig?.credentialGrants,
                     globalSecrets: capturedAddonConfig?.globalSecrets,
                     globalCredentials: capturedAddonConfig?.globalCredentials,
                   }

--- a/packages/core/src/wirings/rpc/addon-runner.ts
+++ b/packages/core/src/wirings/rpc/addon-runner.ts
@@ -13,11 +13,31 @@ export type AddonInstance = {
   secretOverrides?: Record<string, string>
   variableOverrides?: Record<string, string>
   credentialOverrides?: Record<string, string>
+  /** Set by the consuming app: secrets it lends this instance, as the addon names them. */
+  secretGrants?: string[]
+  /** Set by the consuming app: credentials it lends this instance, as the addon names them. */
+  credentialGrants?: string[]
   /** Set by the consuming app to opt this instance out of secret scoping. */
   globalSecrets?: string
   /** Set by the consuming app to opt this instance out of credential scoping. */
   globalCredentials?: string
 }
+
+/**
+ * What the addon declared, plus what the host lent it. Scoping runs outside the
+ * aliaser, so every name here is the one the addon reads — which is why an
+ * override's *key* grants, and its value does not.
+ */
+const allowedNames = (
+  declared: string[] | null | undefined,
+  grants: string[] | undefined,
+  overrides: Record<string, string> | undefined
+): Set<string> =>
+  new Set([
+    ...(declared ?? []),
+    ...(grants ?? []),
+    ...Object.keys(overrides ?? {}),
+  ])
 
 const aliasSecretService = (
   secrets: SecretService,
@@ -142,7 +162,11 @@ export const getOrCreatePackageSingletonServices = async (
       ...existingServices,
       secrets: new ScopedSecretService(
         existingServices.secrets,
-        new Set(pikkuState(packageName, 'package', 'declaredSecrets') ?? [])
+        allowedNames(
+          pikkuState(packageName, 'package', 'declaredSecrets'),
+          addonInstance?.secretGrants,
+          addonInstance?.secretOverrides
+        )
       ),
     }
   }
@@ -151,10 +175,12 @@ export const getOrCreatePackageSingletonServices = async (
       ...existingServices,
       credentialService: new ScopedCredentialService(
         existingServices.credentialService,
-        new Set(
+        allowedNames(
           Object.keys(
             pikkuState(packageName, 'package', 'credentialsMeta') ?? {}
-          )
+          ),
+          addonInstance?.credentialGrants,
+          addonInstance?.credentialOverrides
         )
       ),
     }
@@ -202,6 +228,8 @@ export const addonInstanceForNamespace = (
     secretOverrides: cfg.secretOverrides,
     variableOverrides: cfg.variableOverrides,
     credentialOverrides: cfg.credentialOverrides,
+    secretGrants: cfg.secretGrants,
+    credentialGrants: cfg.credentialGrants,
     globalSecrets: cfg.globalSecrets,
     globalCredentials: cfg.globalCredentials,
   }

--- a/packages/core/src/wirings/rpc/addon-secrets.test.ts
+++ b/packages/core/src/wirings/rpc/addon-secrets.test.ts
@@ -259,3 +259,133 @@ describe('addon credentials are scoped to what the addon declared', () => {
     assert.deepEqual(await credentials.getAllUsers(), ['user-1'])
   })
 })
+
+/**
+ * An addon whose secret names come off its input rather than its own source
+ * declares nothing, so the host lends it names it could not have derived.
+ *
+ * knowledge: decisions/security/decision-secretless-functions.md
+ */
+describe('the host grants an addon secrets it could not declare', () => {
+  beforeEach(() => {
+    resetPikkuState()
+  })
+
+  test('a granted secret is readable', async () => {
+    registerAddon([])
+    wireAddon({
+      name: 'example',
+      package: ADDON_PACKAGE,
+      secretGrants: ['STRIPE_KEY'],
+    })
+
+    const secrets = await secretsHandedToAddon('example')
+    assert.equal(await secrets.getSecret('STRIPE_KEY'), 'value-of-STRIPE_KEY')
+  })
+
+  test('a secret the host did not grant is still denied', async () => {
+    registerAddon([])
+    wireAddon({
+      name: 'example',
+      package: ADDON_PACKAGE,
+      secretGrants: ['STRIPE_KEY'],
+    })
+
+    const secrets = await secretsHandedToAddon('example')
+    await assert.rejects(() => secrets.getSecret('DATABASE_URL'), /denied/i)
+  })
+
+  test('a grant adds to what the addon declared rather than replacing it', async () => {
+    registerAddon(['ADDON_KEY'])
+    wireAddon({
+      name: 'example',
+      package: ADDON_PACKAGE,
+      secretGrants: ['STRIPE_KEY'],
+    })
+
+    const secrets = await secretsHandedToAddon('example')
+    assert.equal(await secrets.getSecret('ADDON_KEY'), 'value-of-ADDON_KEY')
+    assert.equal(await secrets.getSecret('STRIPE_KEY'), 'value-of-STRIPE_KEY')
+  })
+
+  test('an overridden secret is granted by the override itself', async () => {
+    registerAddon([])
+    wireAddon({
+      name: 'example',
+      package: ADDON_PACKAGE,
+      secretOverrides: { MAILGUN_KEY: 'PROD_EMAIL_KEY' },
+    })
+
+    const secrets = await secretsHandedToAddon('example')
+    assert.equal(
+      await secrets.getSecret('MAILGUN_KEY'),
+      'value-of-PROD_EMAIL_KEY'
+    )
+  })
+
+  test('a grant is checked before the override renames it', async () => {
+    registerAddon([])
+    wireAddon({
+      name: 'example',
+      package: ADDON_PACKAGE,
+      secretGrants: ['MAILGUN_KEY'],
+      secretOverrides: { MAILGUN_KEY: 'PROD_EMAIL_KEY' },
+    })
+
+    const secrets = await secretsHandedToAddon('example')
+    assert.equal(
+      await secrets.getSecret('MAILGUN_KEY'),
+      'value-of-PROD_EMAIL_KEY'
+    )
+    await assert.rejects(() => secrets.getSecret('PROD_EMAIL_KEY'), /denied/i)
+  })
+
+  test('a granted credential is readable', async () => {
+    registerAddon([], [])
+    wireAddon({
+      name: 'example',
+      package: ADDON_PACKAGE,
+      credentialGrants: ['stripe'],
+    })
+
+    const credentials = await credentialsHandedToAddon('example')
+    assert.equal(await credentials.get('stripe'), 'credential-of-stripe')
+    await assert.rejects(() => credentials.get('slack'), /denied/i)
+  })
+
+  test('a granted credential does not widen the rest of the service', async () => {
+    registerAddon([], [])
+    wireAddon({
+      name: 'example',
+      package: ADDON_PACKAGE,
+      credentialGrants: ['stripe'],
+    })
+
+    const credentials = await credentialsHandedToAddon('example')
+    await assert.rejects(() => credentials.getAllUsers(), /denied/i)
+  })
+
+  test('an addon without a singleton factory is granted too', async () => {
+    pikkuState(ADDON_PACKAGE, 'package', 'declaredSecrets', [])
+    wireAddon({
+      name: 'example',
+      package: ADDON_PACKAGE,
+      secretGrants: ['STRIPE_KEY'],
+    })
+
+    const services = await getOrCreatePackageSingletonServices(
+      ADDON_PACKAGE,
+      createParentServices(),
+      pikkuState(null, 'addons', 'packages').get('example') as never
+    )
+
+    assert.equal(
+      await services.secrets.getSecret('STRIPE_KEY'),
+      'value-of-STRIPE_KEY'
+    )
+    await assert.rejects(
+      () => services.secrets.getSecret('DATABASE_URL'),
+      /denied/i
+    )
+  })
+})

--- a/packages/core/src/wirings/rpc/rpc-runner.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.ts
@@ -284,6 +284,8 @@ export class ContextAwareRPCService {
         secretOverrides: resolved.addonConfig?.secretOverrides,
         variableOverrides: resolved.addonConfig?.variableOverrides,
         credentialOverrides: resolved.addonConfig?.credentialOverrides,
+        secretGrants: resolved.addonConfig?.secretGrants,
+        credentialGrants: resolved.addonConfig?.credentialGrants,
         globalSecrets: resolved.addonConfig?.globalSecrets,
         globalCredentials: resolved.addonConfig?.globalCredentials,
       },

--- a/packages/core/src/wirings/rpc/rpc-types.ts
+++ b/packages/core/src/wirings/rpc/rpc-types.ts
@@ -67,6 +67,10 @@ export interface ResolvedFunction {
     secretOverrides?: Record<string, string>
     variableOverrides?: Record<string, string>
     credentialOverrides?: Record<string, string>
+    /** Set by the consuming app: secrets it lends this instance, as the addon names them */
+    secretGrants?: string[]
+    /** Set by the consuming app: credentials it lends this instance, as the addon names them */
+    credentialGrants?: string[]
     /** Set by the consuming app: hand this instance the unscoped `SecretService` */
     globalSecrets?: string
     /** Set by the consuming app: hand this instance the unscoped `CredentialService` */

--- a/packages/core/src/wirings/rpc/wire-addon.ts
+++ b/packages/core/src/wirings/rpc/wire-addon.ts
@@ -15,6 +15,18 @@ export type WireAddonConfig = {
   variableOverrides?: Record<string, string>
   credentialOverrides?: Record<string, string>
   /**
+   * Secrets this instance may read on top of the ones it declared, named as the
+   * addon reads them — the scope check runs before `secretOverrides` renames
+   * them, so an overridden secret is named here by its addon-side key. Listing
+   * one in `secretOverrides` grants it too.
+   *
+   * For an addon whose secret names come off its input rather than its own
+   * source, this is how the host lends names the addon could not declare.
+   */
+  secretGrants?: string[]
+  /** Credentials this instance may read on top of the ones it declared. */
+  credentialGrants?: string[]
+  /**
    * Hands this instance the whole `SecretService` instead of one scoped to the
    * secrets it declared. The value is the reason, recorded in the deploy
    * manifest — an addon that names secrets at runtime cannot be scoped, and
@@ -44,6 +56,10 @@ export const wireAddon = (config: WireAddonConfig): void => {
       : {}),
     ...(config.credentialOverrides
       ? { credentialOverrides: config.credentialOverrides }
+      : {}),
+    ...(config.secretGrants ? { secretGrants: config.secretGrants } : {}),
+    ...(config.credentialGrants
+      ? { credentialGrants: config.credentialGrants }
       : {}),
     ...(config.globalSecrets ? { globalSecrets: config.globalSecrets } : {}),
     ...(config.globalCredentials

--- a/packages/inspector/src/add/add-wire-addon.test.ts
+++ b/packages/inspector/src/add/add-wire-addon.test.ts
@@ -61,9 +61,40 @@ describe('addWireAddon', () => {
       secretOverrides: undefined,
       variableOverrides: undefined,
       credentialOverrides: undefined,
+      secretGrants: undefined,
+      credentialGrants: undefined,
       globalSecrets: undefined,
       globalCredentials: undefined,
     })
+  })
+
+  test('captures the secrets and credentials the host lends an addon', () => {
+    const declarations = inspect(`
+      wireAddon({
+        name: 'graph',
+        package: '@pikku/addon-graph',
+        secretGrants: ['STRIPE_KEY', 'GITHUB_TOKEN'],
+        credentialGrants: ['slack'],
+      })
+    `)
+
+    assert.deepEqual(declarations.get('graph').secretGrants, [
+      'STRIPE_KEY',
+      'GITHUB_TOKEN',
+    ])
+    assert.deepEqual(declarations.get('graph').credentialGrants, ['slack'])
+  })
+
+  test('drops a grant list that is not statically knowable', () => {
+    const declarations = inspect(`
+      wireAddon({
+        name: 'graph',
+        package: '@pikku/addon-graph',
+        secretGrants: someRuntimeList,
+      })
+    `)
+
+    assert.equal(declarations.get('graph').secretGrants, undefined)
   })
 
   test('captures the reason an addon was exempted from credential scoping', () => {

--- a/packages/inspector/src/add/add-wire-addon.ts
+++ b/packages/inspector/src/add/add-wire-addon.ts
@@ -60,6 +60,8 @@ export function addWireAddon(
   let secretOverrides: Record<string, string> | undefined
   let variableOverrides: Record<string, string> | undefined
   let credentialOverrides: Record<string, string> | undefined
+  let secretGrants: string[] | undefined
+  let credentialGrants: string[] | undefined
   let globalSecrets: string | undefined
   let globalCredentials: string | undefined
 
@@ -104,6 +106,10 @@ export function addWireAddon(
       ts.isObjectLiteralExpression(prop.initializer)
     ) {
       credentialOverrides = parseStringRecord(prop.initializer)
+    } else if (key === 'secretGrants') {
+      secretGrants = parseStringArray(prop.initializer)
+    } else if (key === 'credentialGrants') {
+      credentialGrants = parseStringArray(prop.initializer)
     } else if (key === 'globalSecrets') {
       // The grant is real at runtime whatever the reason evaluates to, so a
       // non-literal is recorded as its source text rather than dropped.
@@ -130,6 +136,8 @@ export function addWireAddon(
     secretOverrides,
     variableOverrides,
     credentialOverrides,
+    secretGrants,
+    credentialGrants,
     globalSecrets,
     globalCredentials,
   })

--- a/packages/inspector/src/types.ts
+++ b/packages/inspector/src/types.ts
@@ -588,6 +588,10 @@ export interface InspectorState {
         secretOverrides?: Record<string, string>
         variableOverrides?: Record<string, string>
         credentialOverrides?: Record<string, string>
+        /** Secrets the app lends this instance, named as the addon reads them. */
+        secretGrants?: string[]
+        /** Credentials the app lends this instance, named as the addon reads them. */
+        credentialGrants?: string[]
         /**
          * The app's stated reason for handing this instance the whole
          * `SecretService` instead of one scoped to its declared secrets.

--- a/packages/inspector/src/utils/post-process.test.ts
+++ b/packages/inspector/src/utils/post-process.test.ts
@@ -59,6 +59,33 @@ const makeOverrideState = (
     },
   }) as unknown as Omit<InspectorState, 'typesLookup'>
 
+const makeGrantState = (
+  kind: 'secrets' | 'credentials',
+  declaredNames: string[],
+  decl: {
+    secretGrants?: string[]
+    credentialGrants?: string[]
+    secretOverrides?: Record<string, string>
+    credentialOverrides?: Record<string, string>
+  }
+): Omit<InspectorState, 'typesLookup'> =>
+  ({
+    rpc: {
+      wireAddonDeclarations: new Map([
+        ['slack-marketing', { package: '@addon/slack', ...decl }],
+      ]),
+    },
+    secrets: {
+      definitions:
+        kind === 'secrets' ? declaredNames.map((name) => ({ name })) : [],
+    },
+    credentials: {
+      definitions:
+        kind === 'credentials' ? declaredNames.map((name) => ({ name })) : [],
+    },
+    variables: { definitions: [] },
+  }) as unknown as Omit<InspectorState, 'typesLookup'>
+
 function makeState(
   overrides: {
     usedFunctions?: string[]
@@ -413,6 +440,46 @@ describe('override validation resolves the override target (value), not the logi
     )
     validateVariableOverrides(logger, state)
     assert.deepEqual(criticals, [])
+  })
+
+  test('validateSecretOverrides accepts a grant naming a declared secret', () => {
+    const { logger, criticals } = makeCriticalLogger()
+    const state = makeGrantState('secrets', ['STRIPE_KEY'], {
+      secretGrants: ['STRIPE_KEY'],
+    })
+    validateSecretOverrides(logger, state)
+    assert.deepEqual(criticals, [])
+  })
+
+  test('validateSecretOverrides flags a grant naming no declared secret', () => {
+    const { logger, criticals } = makeCriticalLogger()
+    const state = makeGrantState('secrets', ['STRIPE_KEY'], {
+      secretGrants: ['STIRPE_KEY'],
+    })
+    validateSecretOverrides(logger, state)
+    assert.equal(criticals.length, 1)
+    assert.match(criticals[0]!.message, /STIRPE_KEY/)
+    assert.match(criticals[0]!.message, /STRIPE_KEY/)
+  })
+
+  test('validateSecretOverrides resolves a grant through its override before looking it up', () => {
+    const { logger, criticals } = makeCriticalLogger()
+    const state = makeGrantState('secrets', ['PROD_EMAIL_KEY'], {
+      secretGrants: ['MAILGUN_KEY'],
+      secretOverrides: { MAILGUN_KEY: 'PROD_EMAIL_KEY' },
+    })
+    validateSecretOverrides(logger, state)
+    assert.deepEqual(criticals, [])
+  })
+
+  test('validateCredentialOverrides flags a grant naming no declared credential', () => {
+    const { logger, criticals } = makeCriticalLogger()
+    const state = makeGrantState('credentials', ['marketing_cred'], {
+      credentialGrants: ['ghost_cred'],
+    })
+    validateCredentialOverrides(logger, state)
+    assert.equal(criticals.length, 1)
+    assert.match(criticals[0]!.message, /ghost_cred/)
   })
 })
 

--- a/packages/inspector/src/utils/post-process.ts
+++ b/packages/inspector/src/utils/post-process.ts
@@ -383,16 +383,28 @@ export function validateSecretOverrides(
   )
 
   for (const [namespace, addonDecl] of wireAddonDeclarations.entries()) {
-    if (!addonDecl.secretOverrides) continue
-
     for (const [logicalName, resolvedName] of Object.entries(
-      addonDecl.secretOverrides
+      addonDecl.secretOverrides ?? {}
     )) {
       if (!secretIds.has(resolvedName)) {
         const availableSecrets = Array.from(secretIds)
         logger.critical(
           ErrorCode.INVALID_VALUE,
           `Secret override '${logicalName}' -> '${resolvedName}' in addon '${namespace}' (${addonDecl.package}) targets a secret that does not exist. Available secrets: ${availableSecrets.join(', ') || 'none'}`
+        )
+      }
+    }
+
+    // A grant names the secret as the addon reads it, so it resolves through
+    // the override map before it can be looked up in the project.
+    for (const logicalName of addonDecl.secretGrants ?? []) {
+      const resolvedName =
+        addonDecl.secretOverrides?.[logicalName] ?? logicalName
+      if (!secretIds.has(resolvedName)) {
+        const availableSecrets = Array.from(secretIds)
+        logger.critical(
+          ErrorCode.INVALID_VALUE,
+          `Secret grant '${logicalName}' in addon '${namespace}' (${addonDecl.package}) targets a secret that does not exist. Available secrets: ${availableSecrets.join(', ') || 'none'}`
         )
       }
     }
@@ -411,16 +423,26 @@ export function validateCredentialOverrides(
   )
 
   for (const [namespace, addonDecl] of wireAddonDeclarations.entries()) {
-    if (!addonDecl.credentialOverrides) continue
-
     for (const [logicalName, resolvedName] of Object.entries(
-      addonDecl.credentialOverrides
+      addonDecl.credentialOverrides ?? {}
     )) {
       if (!credentialNames.has(resolvedName)) {
         const availableCredentials = Array.from(credentialNames)
         logger.critical(
           ErrorCode.INVALID_VALUE,
           `Credential override '${logicalName}' -> '${resolvedName}' in addon '${namespace}' (${addonDecl.package}) targets a credential that does not exist. Available credentials: ${availableCredentials.join(', ') || 'none'}`
+        )
+      }
+    }
+
+    for (const logicalName of addonDecl.credentialGrants ?? []) {
+      const resolvedName =
+        addonDecl.credentialOverrides?.[logicalName] ?? logicalName
+      if (!credentialNames.has(resolvedName)) {
+        const availableCredentials = Array.from(credentialNames)
+        logger.critical(
+          ErrorCode.INVALID_VALUE,
+          `Credential grant '${logicalName}' in addon '${namespace}' (${addonDecl.package}) targets a credential that does not exist. Available credentials: ${availableCredentials.join(', ') || 'none'}`
         )
       }
     }

--- a/packages/inspector/src/utils/serialize-inspector-state.ts
+++ b/packages/inspector/src/utils/serialize-inspector-state.ts
@@ -170,6 +170,8 @@ export interface SerializableInspectorState {
           secretOverrides?: Record<string, string>
           variableOverrides?: Record<string, string>
           credentialOverrides?: Record<string, string>
+          secretGrants?: string[]
+          credentialGrants?: string[]
           globalSecrets?: string
           globalCredentials?: string
         },


### PR DESCRIPTION
Closes #1249.

## The regression

#1242 scoped every addon's `SecretService` and `CredentialService` to what the addon statically declared. `declaredSecrets` is computed from the **addon package's own source** — literal `getSecret('X')` calls plus `wireSecret` definitions — but the secrets a *generic* addon reads are named and provisioned by the **consuming app**.

`@pikku/addon-graph` fell straight into that gap. It reads `getSecret(auth.credential)`, a value off the workflow node, so it emits `declaredSecrets: []` and no `credentialsMeta`. Both auth paths in `http-requester.service.ts` went dead — `source: 'secret'` and `source: 'credential'` alike — and every authenticated `graph:httpRequest` throws on `main` today.

Nothing went red: no e2e scenario exercises `httpRequest`, and addon-graph's own unit tests mock the secrets service.

Neither existing escape hatch reached it:

- **`secretOverrides` renames only.** The scope check runs *outside* the aliaser (`addon-runner.ts`), so an override maps `A`→`B` and the check still rejects `A`.
- **`globalSecrets` is the wrong tool here.** `httpRequest` is an exfiltration primitive — both `credential` and `url` come from graph data — so a whole-`SecretService` grant at that boundary is exactly what the secretless-functions decision refuses.

## The fix

`wireAddon` takes `secretGrants: string[]` and `credentialGrants: string[]`. The allowlist becomes `declaredSecrets ∪ grants ∪ Object.keys(overrides)`.

```ts
wireAddon({
  name: 'graph',
  package: '@pikku/addon-graph',
  secretGrants: ['STRIPE_KEY', 'GITHUB_TOKEN'],
})
```

That completes a family with one meaning per member:

| field | meaning |
| --- | --- |
| `secretOverrides` | grant **and** rename |
| `secretGrants` | grant as-is |
| `globalSecrets` | grant everything, with a written reason |

The host writes all three, in the app's own source; an addon cannot grant itself any of them.

### Grants are in the addon-side namespace

A grant names the secret as the **addon** reads it, not as the project stores it, because scoping precedes aliasing:

```
addon calls getSecret('X')
  → ScopedSecretService   checks 'X' against the allowlist   ← outer
  → aliasSecretService    maps 'X' → secretOverrides['X'] ?? 'X'
  → host SecretService    reads the real secret
```

Same namespace as the override *keys* — which is also why an override's key grants and its **value** does not. With no rename in play the two names coincide, which is the common case.

### Validation

At codegen, not in the type system. `validateSecretOverrides` / `validateCredentialOverrides` resolve a grant through the override map before lookup, and a miss is an `INVALID_VALUE` critical that fails `pikku prebuild`:

```
Secret grant 'STIRPE_KEY' in addon 'graph' (@pikku/addon-graph) targets a secret
that does not exist. Available secrets: BETTER_AUTH_SECRET, GITHUB_OAUTH, …
```

## Tests

Red-first throughout.

- **core** — 8 new tests in `addon-secrets.test.ts`. 6 failed before the change (`Access denied to secret key: …`), including one covering the addon-without-a-factory path and one asserting a grant is checked *before* the override renames it. The two negative controls ("a secret the host did not grant is still denied", "a granted credential does not widen the rest of the service") passed before and after, as intended.
- **inspector** — 4 validation tests; the two flagging a bad grant failed before the change and pass now. Plus 2 capture tests in `add-wire-addon.test.ts`, one of which pins that a non-literal grant list is dropped rather than half-read.
- **cli** — folds in the CodeRabbit nitpick left over from #1242: the console serializer test now asserts `SetSecret` / `pikkuConsole*Secret` stay absent from generated output, which is the contract #1242 established. This one is a guard rail, not a bug fix, so it is green from the start.

Verified locally: core 2160 pass, inspector 0 fail, cli 0 fail, `yarn tsc` clean. Three core tests and one cli test failed only when several suites ran concurrently — all four are timing-budget assertions (api-report, crypto key derivation, remote round trip, `serve --help`) and pass green re-run unloaded.

## Deliberately out of scope

- **Typed `wireAddon`.** It is re-exported unchanged from core (`pikku-function-types.gen.ts`), so grants get no editor autocomplete. Typing them as the host's `SecretId` union would be *wrong* — grants are addon-side names, which an override can make absent from the host's union entirely. A correct typing needs each addon's own published id union.
- **Cross-checking workflow nodes.** A graph node naming an ungranted secret still fails at run time, with the addon's "could not resolve secret … provision it before running this workflow". If `auth.credential` literals survive into inspector state, the build could catch it instead.

Both are noted on #1249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Addons can now receive host-granted access to specific secrets and credentials.
  * Grant lists are supported in addon configuration and preserved across inspection and runtime setup.
  * Secret and credential overrides work with granted resources while maintaining scoped access.
* **Bug Fixes**
  * Invalid or undeclared grants now produce clear critical diagnostics during code generation.
  * Console secret RPCs and schemas are no longer emitted unnecessarily.
* **Tests**
  * Added coverage for valid, invalid, overridden, and restricted grant scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->