### PR TITLE
fix(cli): enumerate addon secret grants in the deployment manifest

### DIFF
--- a/.changeset/enumerate-secret-grants.md
+++ b/.changeset/enumerate-secret-grants.md
@@ -1,0 +1,15 @@
+---
+'@pikku/cli': patch
+'@pikku/skills': patch
+---
+
+Enumerate addon secret and credential grants in the deployment manifest.
+
+`wireAddon`'s `secretGrants` / `credentialGrants` widen an addon's scope the same
+way `globalSecrets` does, only narrower — but the manifest reported the exemption
+and not the grant, so a deployment could not see the secrets an app had lent an
+addon. `grantedSecretAddons` and `grantedCredentialAddons` now list them by name,
+including override keys, since scoping is checked before an override renames.
+
+The `pikku-addon` skill documents the whole grant family and the scoping rule
+behind it, rather than the override fields alone.

--- a/packages/cli/src/deploy/analyzer/analyzer.test.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.test.ts
@@ -248,6 +248,15 @@ function stateWithWiredAddons(): InspectorState {
             globalCredentials: 'links credentials an operator names at runtime',
           },
         ],
+        [
+          'graph',
+          {
+            package: '@pikku/addon-graph',
+            secretGrants: ['STRIPE_KEY', 'GITHUB_TOKEN'],
+            credentialGrants: ['slack'],
+            secretOverrides: { MAILGUN_KEY: 'PROD_EMAIL_KEY' },
+          },
+        ],
       ]),
     },
   } as unknown as InspectorState
@@ -292,6 +301,57 @@ describe('analyzeDeployment - unscoped addon secrets', () => {
 
     assert.deepEqual(manifest.unscopedSecretAddons, [])
     assert.deepEqual(manifest.unscopedCredentialAddons, [])
+  })
+
+  // A grant is the other half of the same waiver: the app lending an addon a
+  // secret it never declared. Enumerating only `globalSecrets` would leave a
+  // deployment blind to it.
+  test('the secrets an app lends an addon are reported with their names', () => {
+    const manifest = analyzeDeployment(stateWithWiredAddons(), {
+      projectId: 'test',
+    })
+
+    assert.deepEqual(manifest.grantedSecretAddons, [
+      {
+        namespace: 'graph',
+        package: '@pikku/addon-graph',
+        granted: ['GITHUB_TOKEN', 'MAILGUN_KEY', 'STRIPE_KEY'],
+      },
+    ])
+  })
+
+  test('a lent credential is reported separately from a lent secret', () => {
+    const manifest = analyzeDeployment(stateWithWiredAddons(), {
+      projectId: 'test',
+    })
+
+    assert.deepEqual(manifest.grantedCredentialAddons, [
+      {
+        namespace: 'graph',
+        package: '@pikku/addon-graph',
+        granted: ['slack'],
+      },
+    ])
+  })
+
+  test('an addon holding the whole service is not also reported as granted', () => {
+    const manifest = analyzeDeployment(stateWithWiredAddons(), {
+      projectId: 'test',
+    })
+
+    assert.ok(
+      !manifest.grantedSecretAddons.some((a) => a.namespace === 'console'),
+      'globalSecrets already reports it, and it grants no named set'
+    )
+  })
+
+  test('a project with no grants reports none', () => {
+    const manifest = analyzeDeployment(stateWithAgent('a', 'a'), {
+      projectId: 'test',
+    })
+
+    assert.deepEqual(manifest.grantedSecretAddons, [])
+    assert.deepEqual(manifest.grantedCredentialAddons, [])
   })
 })
 

--- a/packages/cli/src/deploy/analyzer/analyzer.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.ts
@@ -38,6 +38,7 @@ import type {
   WorkflowStepDefinition,
   SecretDeclaration,
   UnscopedAddon,
+  GrantedAddon,
   VariableDeclaration,
 } from './manifest.js'
 
@@ -506,6 +507,16 @@ export function analyzeDeployment(
 
   const unscopedSecretAddons: UnscopedAddon[] = []
   const unscopedCredentialAddons: UnscopedAddon[] = []
+  const grantedSecretAddons: GrantedAddon[] = []
+  const grantedCredentialAddons: GrantedAddon[] = []
+
+  // An override's key is a grant too: scoping is checked before the rename, so
+  // the key is a name the addon may read that it never declared.
+  const grantedNames = (
+    grants: string[] | undefined,
+    overrides: Record<string, string> | undefined
+  ) => [...new Set([...(grants ?? []), ...Object.keys(overrides ?? {})])].sort()
+
   for (const [namespace, addon] of state.rpc?.wireAddonDeclarations ?? []) {
     if (addon.globalSecrets) {
       unscopedSecretAddons.push({
@@ -513,17 +524,37 @@ export function analyzeDeployment(
         package: addon.package,
         reason: addon.globalSecrets,
       })
+    } else {
+      const granted = grantedNames(addon.secretGrants, addon.secretOverrides)
+      if (granted.length > 0) {
+        grantedSecretAddons.push({ namespace, package: addon.package, granted })
+      }
     }
+
     if (addon.globalCredentials) {
       unscopedCredentialAddons.push({
         namespace,
         package: addon.package,
         reason: addon.globalCredentials,
       })
+    } else {
+      const granted = grantedNames(
+        addon.credentialGrants,
+        addon.credentialOverrides
+      )
+      if (granted.length > 0) {
+        grantedCredentialAddons.push({
+          namespace,
+          package: addon.package,
+          granted,
+        })
+      }
     }
   }
-  const byNamespace = (a: UnscopedAddon, b: UnscopedAddon) =>
-    a.namespace.localeCompare(b.namespace)
+  const byNamespace = (
+    a: UnscopedAddon | GrantedAddon,
+    b: UnscopedAddon | GrantedAddon
+  ) => a.namespace.localeCompare(b.namespace)
 
   const variables: VariableDeclaration[] = state.variables.definitions.map(
     (v) => ({
@@ -547,6 +578,8 @@ export function analyzeDeployment(
     unresolvedSecretReads: unresolvedSecretReads.sort(),
     unscopedSecretAddons: unscopedSecretAddons.sort(byNamespace),
     unscopedCredentialAddons: unscopedCredentialAddons.sort(byNamespace),
+    grantedSecretAddons: grantedSecretAddons.sort(byNamespace),
+    grantedCredentialAddons: grantedCredentialAddons.sort(byNamespace),
     variables,
   }
 }

--- a/packages/cli/src/deploy/analyzer/manifest.ts
+++ b/packages/cli/src/deploy/analyzer/manifest.ts
@@ -140,6 +140,17 @@ export interface UnscopedAddon {
   reason: string
 }
 
+/** A `wireAddon` instance the app lent named secrets or credentials it never declared. */
+export interface GrantedAddon {
+  namespace: string
+  package: string
+  /**
+   * The names the addon may now read, as the addon reads them — grants and
+   * override keys alike, since scoping is checked before an override renames.
+   */
+  granted: string[]
+}
+
 export interface VariableDeclaration {
   variableId: string
   displayName: string
@@ -173,5 +184,14 @@ export interface DeploymentManifest {
    * only the credentials it declared, and none can enumerate the app's users.
    */
   unscopedCredentialAddons: UnscopedAddon[]
+  /**
+   * Addon instances lent named secrets on top of the ones they declared. The
+   * other half of the same waiver as `unscopedSecretAddons` — narrower, because
+   * the app named the set — so between them a deployment sees every secret an
+   * addon can reach that it did not declare for itself.
+   */
+  grantedSecretAddons: GrantedAddon[]
+  /** Addon instances lent named credentials on top of the ones they declared. */
+  grantedCredentialAddons: GrantedAddon[]
   variables: VariableDeclaration[]
 }

--- a/packages/skills/skills/pikku-addon/SKILL.md
+++ b/packages/skills/skills/pikku-addon/SKILL.md
@@ -50,9 +50,13 @@ wireAddon({
   mcp?: boolean,
   tags?: string[],                 // Tags applied to all addon functions
   scopes?: string[],               // Required of every function, on top of its own
-  secretOverrides?: Record<string, string>,      // Remap secret names
+  secretOverrides?: Record<string, string>,      // Remap secret names (and grant them)
   variableOverrides?: Record<string, string>,    // Remap variable names
-  credentialOverrides?: Record<string, string>,  // Remap credential names
+  credentialOverrides?: Record<string, string>,  // Remap credential names (and grant them)
+  secretGrants?: string[],                       // Secrets the app lends this addon
+  credentialGrants?: string[],                   // Credentials the app lends this addon
+  globalSecrets?: string,                        // Reason for handing over the whole SecretService
+  globalCredentials?: string,                    // Reason for handing over the whole CredentialService
 })
 ```
 
@@ -60,6 +64,58 @@ wireAddon({
 it would weaken the wiring's own gate — so the addon-level setting can require a
 session but never waive one. The same package wired twice under two namespaces is
 governed by the union of both instances' scopes and tags.
+
+### An addon reads only the secrets it declared
+
+An addon's `SecretService` and `CredentialService` are **scoped**: it may read
+the secrets its own source declares (literal `getSecret('X')` calls and
+`wireSecret` definitions, which the CLI collects into `declaredSecrets`) and
+nothing else. Anything undeclared throws `Access denied to secret key: X` at
+runtime. The same holds for credentials, and a scoped addon can never call
+`getAllUsers()`.
+
+That works for an addon naming its own secrets. It does not work for a _generic_
+addon whose secret names arrive as data — `@pikku/addon-graph` reads
+`getSecret(auth.credential)`, where the name comes off the workflow node — so
+such an addon declares nothing and is scoped to nothing. Only the consuming app
+can widen it, with one of three fields:
+
+```typescript
+wireAddon({
+  name: 'graph',
+  package: '@pikku/addon-graph',
+
+  secretGrants: ['STRIPE_KEY'], // lend these, unrenamed
+  secretOverrides: { MAILGUN_KEY: 'PROD_EMAIL_KEY' }, // lend + rename
+  // globalSecrets: 'why no static list can cover it' // lend everything
+})
+```
+
+| field             | meaning                                 |
+| ----------------- | --------------------------------------- |
+| `secretOverrides` | grant **and** rename                    |
+| `secretGrants`    | grant as-is                             |
+| `globalSecrets`   | grant everything, with a written reason |
+
+**Grants name the secret as the addon reads it**, not as your project stores it.
+Scoping is checked _before_ the override map renames anything, so an overridden
+secret is granted by its addon-side key — which is also why an override's key
+grants and its value does not. With no rename in play the two names coincide.
+
+`globalSecrets` / `globalCredentials` take the _reason_ for the grant, not a
+boolean, because every grant is enumerated in the deploy manifest
+(`unscopedSecretAddons`, `grantedSecretAddons`). Prefer `secretGrants` — reach
+for `globalSecrets` only when no static list can exist, and never for an addon
+that performs outbound requests, where an unrestricted secret read is an
+exfiltration primitive.
+
+A grant naming a secret your project does not declare is a build error from
+`pikku all`, resolved through the override map first:
+
+```
+Secret grant 'STIRPE_KEY' in addon 'graph' (@pikku/addon-graph) targets a secret
+that does not exist. Available secrets: BETTER_AUTH_SECRET, GITHUB_OAUTH
+```
 
 ### `ref(name)`
 


### PR DESCRIPTION
Closes #1252. Follows #1250, which added `secretGrants` / `credentialGrants` without teaching the two things that depended on the grant model.

## The manifest was blind to grants

`unscopedSecretAddons` exists so a deployment can see every addon that reads a secret the app never declared for it — which is why `globalSecrets` takes a *reason string* rather than a boolean. `secretGrants` is the same waiver, only narrower, and the analyzer walked straight past it. An app could lend an addon a dozen secrets and the manifest would report nothing.

`grantedSecretAddons` / `grantedCredentialAddons` now list them by name:

```ts
grantedSecretAddons: [
  { namespace: 'graph', package: '@pikku/addon-graph',
    granted: ['GITHUB_TOKEN', 'MAILGUN_KEY', 'STRIPE_KEY'] },
]
```

Two things fall out of how scoping composes — `ScopedSecretService` wraps the *aliased* service, so the check runs before any rename:

- an override's **key** is a grant, and appears in `granted`; its value does not
- the names are the ones the **addon** reads, matching what `secretGrants` takes

An addon under `globalSecrets` is not also listed as granted: it holds the whole service and grants no named set.

## The skill doc never mentioned scoping

`packages/skills/skills/pikku-addon/SKILL.md` described `secretOverrides` as "remap secret names" and stopped. Nothing said an addon is scoped to its declarations at all, so anyone building an addon that reads a secret hit `Access denied to secret key: X` with no way to reach the answer. It now covers the three-field grant family, why a generic addon like `@pikku/addon-graph` declares nothing, the addon-side-namespace rule, and the warning against `globalSecrets` on an addon that performs outbound requests.

## Tests

Four tests in `analyzer.test.ts`, red before the change (the fields did not exist) and green after — the sorted grant set including an override key, credentials reported separately, a `globalSecrets` addon not double-reported, and an empty project. Full CLI suite: **951 tests, 0 fail**.

`skills-references.test.ts` caught the first draft of the doc telling agents to run `pikku prebuild`, which is not a command; it says `pikku all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)