### PR TITLE
perf(cli): only resolve symlinks when scanning for external dependencies

### DIFF
--- a/.changeset/type-identity-symlink-scan.md
+++ b/.changeset/type-identity-symlink-scan.md
@@ -1,0 +1,21 @@
+---
+'@pikku/cli': patch
+---
+
+perf(cli): only resolve symlinks when scanning for external dependencies
+
+The split-type-identity check called `realpath` on every installed package.
+`realpath` lstats every component of the path it is given, so the scan scaled
+with the install layout rather than with anything interesting: 143ms on a
+hoisted tree (1781 packages at the root) against 7ms on an isolated one (35).
+
+A path that traverses no symlink cannot leave the project, and `readdir` already
+hands back the entry type, so ruling a package out costs nothing. Now 45ms
+hoisted and 3.5ms isolated — cheap enough to consider running before codegen
+rather than only in `validate`, which matters because the failure it detects
+kills the process rather than failing it.
+
+The two-hop case is what makes this fiddly, and it is the common one: bun links
+`node_modules/@scope/pkg` into an in-project store and the link out of the tree
+is the `dist` inside that target, so the first hop lands inside the project and
+proves nothing.

--- a/packages/cli/src/functions/validate/type-identity-checks.test.ts
+++ b/packages/cli/src/functions/validate/type-identity-checks.test.ts
@@ -88,6 +88,46 @@ describe('split type identity via a linked dependency', () => {
     })
   })
 
+  // Bun's isolated layout: node_modules/@scope/linked is itself a symlink into
+  // an in-project store, and the link out of the tree is the `dist` inside that
+  // target. Both hops have to be followed — the first one lands inside the
+  // project and proves nothing.
+  test('finds the link through an in-project store symlink', async () => {
+    await withTmpPair(async (root, external) => {
+      await writeJson(join(root, 'node_modules', 'better-auth', 'package.json'), {
+        name: 'better-auth',
+        version: '1.6.23',
+      })
+      await writeJson(
+        join(external, 'node_modules', 'better-auth', 'package.json'),
+        { name: 'better-auth', version: '1.6.27' }
+      )
+      const externalDist = join(external, 'packages', 'linked', 'dist')
+      await mkdir(externalDist, { recursive: true })
+      await writeJson(join(external, 'packages', 'linked', 'package.json'), {
+        name: '@scope/linked',
+        version: '1.0.0',
+      })
+
+      const store = join(root, 'node_modules', '.store', 'linked@1.0.0')
+      await mkdir(store, { recursive: true })
+      await writeJson(join(store, 'package.json'), {
+        name: '@scope/linked',
+        version: '1.0.0',
+      })
+      await symlink(externalDist, join(store, 'dist'), 'dir')
+
+      await mkdir(join(root, 'node_modules', '@scope'), { recursive: true })
+      await symlink(store, join(root, 'node_modules', '@scope', 'linked'), 'dir')
+
+      const findings = await runTypeIdentityChecks(root)
+      assert.ok(
+        findings.some((f) => f.id.startsWith('split-type-identity')),
+        `expected a finding, got: ${JSON.stringify(findings.map((f) => f.id))}`
+      )
+    })
+  })
+
   test('no linked dependency → no finding', async () => {
     await withTmpPair(async (root) => {
       await writeJson(

--- a/packages/cli/src/functions/validate/type-identity-checks.ts
+++ b/packages/cli/src/functions/validate/type-identity-checks.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { readdir, realpath } from 'node:fs/promises'
+import { lstat, readdir, realpath } from 'node:fs/promises'
 import { dirname, join, relative } from 'node:path'
 import { readJsonSafe } from './shared-checks.js'
 import type { ValidateFinding } from './persona-checks.js'
@@ -90,6 +90,12 @@ async function projectResolvedVersion(
  * (`node_modules/@scope/pkg/dist -> ../../../other-repo/packages/pkg/dist`),
  * which still moves type resolution to the other tree since TypeScript resolves
  * symlinks to their realpath. So each candidate subdir is probed too.
+ *
+ * Only symlinks are resolved. `realpath` lstats every component of the path, so
+ * running it over every installed package costs 20x more on a hoisted install
+ * (1781 packages at the root) than on an isolated one (35) — and a path that
+ * traverses no symlink cannot leave the project anyway. `readdir` already hands
+ * back the entry type, so ruling a package out is free.
  */
 async function externalDependencyRoots(
   root: string
@@ -105,7 +111,7 @@ async function externalDependencyRoots(
   const topLevel = await readdir(nodeModules, { withFileTypes: true }).catch(
     () => []
   )
-  const pkgDirs: string[] = []
+  const pkgDirs: Array<{ dir: string; link: boolean }> = []
   for (const entry of topLevel) {
     if (entry.name.startsWith('.')) continue
     if (entry.name.startsWith('@')) {
@@ -113,20 +119,37 @@ async function externalDependencyRoots(
         withFileTypes: true,
       }).catch(() => [])
       for (const inner of scoped) {
-        pkgDirs.push(join(nodeModules, entry.name, inner.name))
+        pkgDirs.push({
+          dir: join(nodeModules, entry.name, inner.name),
+          link: inner.isSymbolicLink(),
+        })
       }
     } else {
-      pkgDirs.push(join(nodeModules, entry.name))
+      pkgDirs.push({
+        dir: join(nodeModules, entry.name),
+        link: entry.isSymbolicLink(),
+      })
     }
   }
 
-  for (const pkgDir of pkgDirs) {
-    for (const candidate of [pkgDir, join(pkgDir, 'dist')]) {
-      if (!existsSync(candidate)) continue
-      const real = await realpath(candidate).catch(() => null)
-      if (!real) continue
-      const rel = relative(realRoot, real)
-      if (!rel.startsWith('..')) continue
+  const linkTarget = async (path: string): Promise<string | null> => {
+    const stats = await lstat(path).catch(() => null)
+    if (!stats?.isSymbolicLink()) return null
+    return realpath(path).catch(() => null)
+  }
+  const isExternal = (real: string) => relative(realRoot, real).startsWith('..')
+
+  for (const { dir: pkgDir, link } of pkgDirs) {
+    // A package linked to a path inside the project (bun's .bun store) is not
+    // external, but the build output *inside* that target still can be.
+    const target = link ? await realpath(pkgDir).catch(() => null) : null
+    if (link && !target) continue
+    const candidates: Array<string | null> = [
+      target && isExternal(target) ? target : null,
+      await linkTarget(join(target ?? pkgDir, 'dist')),
+    ]
+    for (const real of candidates) {
+      if (!real || !isExternal(real)) continue
       const name = relative(nodeModules, pkgDir)
       // `real` may point at a build output (…/pkg/dist); report the linked
       // package's own root so the message names something a reader can act on.


### PR DESCRIPTION
Follow-up to #1248.

## What

The split-type-identity check called `realpath` on every installed package. `realpath` lstats every component of the path it is given, so the scan scaled with the install layout rather than with anything interesting:

| tree | top-level packages | before | after |
|---|---|---|---|
| isolated (bun) | 35 | 7.3ms | **3.5ms** |
| hoisted (yarn) | 1781 | 143.6ms | **45.5ms** |

A path that traverses no symlink cannot leave the project, and `readdir` already hands back the entry type, so ruling a package out costs nothing.

## Why it matters

#1248 reports this only from `validate`, which the person hitting the problem has no reason to run — the symptom is a codegen process that dies of memory pressure, and a V8 heap OOM aborts, so nothing can print an explanation after the fact. The fix has to run *before* the expensive work.

That makes the scan cost the gating question. 143ms on every `pikku all` in a hoisted monorepo, paid by every project whether or not it has a linked dependency, is too much to put on the hot path. 45ms is arguable; 3.5ms on the layout that actually hits this is not.

This PR does not add the preflight — it makes it affordable.

## The two-hop case

What makes the gate fiddly, and it is the common one. Bun links `node_modules/@scope/pkg` into an in-project store, and the link out of the tree is the `dist` inside that target:

```
node_modules/@scope/pkg -> node_modules/.bun/…/@scope/pkg   (inside the project)
node_modules/.bun/…/@scope/pkg/dist -> ../../other-repo/…/dist   (outside)
```

The first hop proves nothing — resolving it and stopping there reports no finding. Both hops are followed, and there is a test for exactly this shape.

## Verification

- `packages/cli`: **952 tests, 952 pass, 0 fail**; `tsc --noEmit` clean
- Timings above are medians of 7 runs against two real trees, warm cache, local SSD

🤖 Generated with [Claude Code](https://claude.com/claude-code)