### PR TITLE
feat(cli): warn before codegen when a linked dep splits a package's type identity

### DIFF
--- a/.changeset/type-identity-preflight.md
+++ b/.changeset/type-identity-preflight.md
@@ -1,0 +1,25 @@
+---
+'@pikku/cli': patch
+'@pikku/inspector': patch
+---
+
+feat(cli): warn before codegen when a linked dependency splits a package's type identity
+
+`pikku all` now runs the split-type-identity check as a preflight, beside the
+existing `@pikku/core` one, and warns with `PKU719` naming each package, both
+versions and both paths.
+
+It has to run *before* the work rather than after it fails. The failure it
+explains is a V8 heap OOM, which aborts the process — `process.on('exit')`,
+`uncaughtException` and `finally` never run, so nothing printed after the fact is
+ever seen. By the time there is a symptom, the only thing that can help is
+already on screen above it. Without this the user sees a codegen step that dies
+of memory pressure with no indication that two copies of one package are the
+reason, and the obvious next move is to raise `--max-old-space-size`, which
+hides it further.
+
+Warns rather than throws: a skewed linked dependency is a strong signal, not a
+certainty, and refusing to build on a heuristic would break working setups.
+`PIKKU_SKIP_TYPE_IDENTITY_CHECK=1` silences it, matching
+`PIKKU_ALLOW_DUPLICATE_CORE`. It also swallows its own errors — it runs on every
+codegen, so it must never be the reason a build stops.

--- a/packages/cli/src/functions/validate/type-identity-checks.test.ts
+++ b/packages/cli/src/functions/validate/type-identity-checks.test.ts
@@ -3,7 +3,10 @@ import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, test } from 'node:test'
-import { runTypeIdentityChecks } from './type-identity-checks.js'
+import {
+  runTypeIdentityChecks,
+  warnOnSplitTypeIdentity,
+} from './type-identity-checks.js'
 import { planValidation } from './validate-registry.js'
 
 const makeTmp = () => mkdtemp(join(tmpdir(), 'pikku-type-identity-'))
@@ -186,6 +189,55 @@ describe('split type identity via a linked dependency', () => {
       )
       assert.equal(planned.length, 1)
       assert.equal(planned[0]?.target.label, '.')
+    })
+  })
+})
+
+describe('warnOnSplitTypeIdentity (codegen preflight)', () => {
+  const collect = () => {
+    const warnings: string[] = []
+    return { warnings, logger: { warn: (m: string) => warnings.push(m) } }
+  }
+
+  test('warns, naming the code and both versions', async () => {
+    await withTmpPair(async (root, external) => {
+      await linkExternal(root, external, '1.6.27')
+      const { warnings, logger } = collect()
+      await warnOnSplitTypeIdentity(root, logger)
+      assert.equal(warnings.length, 1)
+      assert.match(warnings[0]!, /PKU719/)
+      assert.match(warnings[0]!, /1\.6\.27/)
+      assert.match(warnings[0]!, /1\.6\.23/)
+    })
+  })
+
+  test('says nothing when the versions agree', async () => {
+    await withTmpPair(async (root, external) => {
+      await linkExternal(root, external, '1.6.23')
+      const { warnings, logger } = collect()
+      await warnOnSplitTypeIdentity(root, logger)
+      assert.deepEqual(warnings, [])
+    })
+  })
+
+  // It runs on every codegen, so it must never be the reason a build stops.
+  test('never throws, even on an unreadable root', async () => {
+    const { warnings, logger } = collect()
+    await warnOnSplitTypeIdentity('/definitely/not/a/path', logger)
+    assert.deepEqual(warnings, [])
+  })
+
+  test('PIKKU_SKIP_TYPE_IDENTITY_CHECK silences it', async () => {
+    await withTmpPair(async (root, external) => {
+      await linkExternal(root, external, '1.6.27')
+      const { warnings, logger } = collect()
+      process.env.PIKKU_SKIP_TYPE_IDENTITY_CHECK = '1'
+      try {
+        await warnOnSplitTypeIdentity(root, logger)
+      } finally {
+        delete process.env.PIKKU_SKIP_TYPE_IDENTITY_CHECK
+      }
+      assert.deepEqual(warnings, [])
     })
   })
 })

--- a/packages/cli/src/functions/validate/type-identity-checks.ts
+++ b/packages/cli/src/functions/validate/type-identity-checks.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs'
 import { lstat, readdir, realpath } from 'node:fs/promises'
 import { dirname, join, relative } from 'node:path'
+import { ErrorCode } from '@pikku/inspector'
 import { readJsonSafe } from './shared-checks.js'
 import type { ValidateFinding } from './persona-checks.js'
 
@@ -205,4 +206,33 @@ export async function runTypeIdentityChecks(
     }
   }
   return findings
+}
+
+/**
+ * Preflight for codegen. Runs BEFORE the typecheck, because the failure it
+ * explains kills the process rather than failing it: a V8 heap OOM aborts, so
+ * nothing printed after the fact is ever seen. By the time the user has a
+ * symptom, the only thing that can help them is already on screen above it.
+ *
+ * Warns rather than throws. A skewed linked dependency is a strong signal, not
+ * a certainty — plenty of them are harmless, and refusing to build on one would
+ * break working setups over a heuristic.
+ */
+export async function warnOnSplitTypeIdentity(
+  rootDir: string,
+  logger: { warn: (message: string) => void }
+): Promise<void> {
+  if (process.env?.PIKKU_SKIP_TYPE_IDENTITY_CHECK) return
+  const findings = await runTypeIdentityChecks(rootDir).catch(() => [])
+  if (findings.length === 0) return
+
+  logger.warn(
+    `[${ErrorCode.SPLIT_TYPE_IDENTITY}] ${findings.length === 1 ? 'A linked dependency resolves a shared package' : 'Linked dependencies resolve shared packages'} at a different version than this project:\n` +
+      findings.map((f) => `  ${f.message}`).join('\n') +
+      `\nTypeScript treats each pair as two unrelated types and structurally compares them\n` +
+      `wherever they meet, which inside a generic inference chain can exhaust the heap —\n` +
+      `codegen then dies of memory pressure instead of reporting an error.\n\n` +
+      `Fix: align the versions so both trees resolve one copy, or drop the link and\n` +
+      `reinstall. Set PIKKU_SKIP_TYPE_IDENTITY_CHECK=1 to silence this.`
+  )
 }

--- a/packages/cli/src/functions/workflows/all.workflow.ts
+++ b/packages/cli/src/functions/workflows/all.workflow.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs'
 import { pikkuWorkflowComplexFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
 import { assertSingleCoreVersion } from '../../utils/assert-single-core-version.js'
+import { warnOnSplitTypeIdentity } from '../validate/type-identity-checks.js'
 import {
   pruneLegacyScaffoldFiles,
   removeRetiredScaffoldFiles,
@@ -66,6 +67,10 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
     // Preflight: a split @pikku/core install silently breaks wiring registration
     // (workflows/RPCs "disappear"), so refuse to codegen against it.
     await assertSingleCoreVersion(config.rootDir, logger)
+    // Preflight: a linked dependency at a skewed version can exhaust the heap
+    // during the typecheck below, and an OOM aborts before anything can explain
+    // it. Say it now or never.
+    await warnOnSplitTypeIdentity(config.rootDir, logger)
 
     await pruneLegacyScaffoldFiles(config)
     await removeRetiredScaffoldFiles(config)

--- a/packages/inspector/src/error-codes.ts
+++ b/packages/inspector/src/error-codes.ts
@@ -105,6 +105,7 @@ export enum ErrorCode {
   // Dependency integrity errors
   DUPLICATE_CORE_VERSION = 'PKU717',
   CORE_VERSION_SKEW = 'PKU718',
+  SPLIT_TYPE_IDENTITY = 'PKU719',
 
   // Data classification errors
   PII_IN_OUTPUT = 'PKU910',


### PR DESCRIPTION
Completes the thread from #1248 (the check) and #1254 (making it cheap enough to run here).

## What

`pikku all` runs the split-type-identity check as a preflight, beside the existing `@pikku/core` one, and warns with `PKU719`:

```
[PKU719] Linked dependencies resolve shared packages at a different version than this project:
  "@pikku/better-auth" is linked to <worktree>/packages/services/better-auth and
    resolves @pikku/core@0.12.81 there, while this project resolves @pikku/core@0.12.82
    — two type identities for @pikku/core
  "@pikku/better-auth" is linked to <worktree>/packages/services/better-auth and
    resolves zod@4.3.6 there, while this project resolves zod@4.4.3 — two type
    identities for zod
TypeScript treats each pair as two unrelated types and structurally compares them
wherever they meet, which inside a generic inference chain can exhaust the heap —
codegen then dies of memory pressure instead of reporting an error.

Fix: align the versions so both trees resolve one copy, or drop the link and
reinstall. Set PIKKU_SKIP_TYPE_IDENTITY_CHECK=1 to silence this.
```

That is real output against a real linked project, produced in **19.7ms**.

## Why a preflight and not a handler

The failure it explains is a V8 heap OOM, which **aborts** the process — `FATAL ERROR: Ineffective mark-compacts`, SIGABRT, exit 134. `process.on('exit')`, `uncaughtException` and `finally` do not run. There is no "catch the OOM and explain it" option in-process, and `pikku all` does the typecheck in-process, so there is no surviving parent either. Either the explanation is printed before the work starts, or it is never printed.

The alternative is forking the heavy phase so a supervisor survives to explain the exit code. That is a real option and strictly better diagnostics, but it is a process-model change: exit-code fidelity (a signal death mapped to 1 turns an OOM into a green CI run), signal forwarding, and `stdio: 'inherit'` all become load-bearing. Not worth it for a message that a preflight delivers at 19.7ms.

Without this, the symptom is codegen dying of memory pressure with nothing pointing at two copies of one package — and the obvious next move is raising `--max-old-space-size`, which hides it further. That is exactly how the original instance went: a day of heap bisection and trace analysis to reach "two copies of one package."

## Warns, never blocks

- **Warn, not throw.** A skewed linked dependency is a strong signal, not a certainty; plenty are harmless, and refusing to build on a heuristic would break working setups. Contrast the `@pikku/core` split beside it, which is deterministic and does throw.
- **`PIKKU_SKIP_TYPE_IDENTITY_CHECK=1`** silences it, matching `PIKKU_ALLOW_DUPLICATE_CORE`.
- **It swallows its own errors.** It runs on every codegen, so it must never be the reason a build stops. Covered by a test against an unreadable root.

## Verification

- 4 new preflight tests (warns naming code and both versions; silent when aligned; never throws; env var silences), on top of the 7 for the check
- `packages/cli`: **956 tests, 956 pass, 0 fail**; `tsc --noEmit` clean
- End-to-end against a real linked project: 2 findings, 19.7ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)