### PR TITLE
feat(cli): add `pikku update` to move the @pikku/* set forward, with the peers it needs

### DIFF
--- a/.changeset/pikku-update-command.md
+++ b/.changeset/pikku-update-command.md
@@ -1,0 +1,10 @@
+---
+'@pikku/cli': patch
+'@pikku/skills': patch
+---
+
+Add `pikku update`: report which `@pikku/*` dependencies can move forward, and which peers those versions need.
+
+Reporting only by default. `--update` writes the new ranges into every covered package.json — the project root plus every workspace it declares — and then runs an install with the package manager the project names (`--no-install` to skip). `--update-peers` additionally writes the ranges unsatisfied peers require; it is separate because a peer bump can cross a major of a third-party package.
+
+Peers are read off the version the run lands on rather than the one installed, so an update that needs a companion bump says so before it is applied. Ranges that cannot be substituted into (`workspace:*`, `file:`, unions, x-ranges) are reported and left alone, and a package the registry could not answer for is reported as unresolved rather than current.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,6 +56,7 @@
     "openapi-types": "^12.1.3",
     "path-to-regexp": "^8.3.0",
     "pg": "^8.13.0",
+    "semver": "^7.7.3",
     "tinyglobby": "^0.2.12",
     "ts-json-schema-generator": "2.9.1-next.16",
     "tsx": "^4.21.0",
@@ -75,6 +76,7 @@
     "@types/istanbul-lib-instrument": "^1.7.7",
     "@types/node": "^24.11.0",
     "@types/pg": "^8.11.0",
+    "@types/semver": "^7.7.1",
     "@types/ws": "^8"
   },
   "files": [

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -45,6 +45,8 @@ import { pikkuVersionsInit } from './functions/commands/versions-init.js'
 import { pikkuEmailsInit } from './functions/commands/emails-init.js'
 import { pikkuVersionsCheck } from './functions/commands/versions-check.js'
 import { pikkuVersionsUpdate } from './functions/commands/versions-update.js'
+import { pikkuUpdate } from './functions/commands/update.js'
+import { renderUpdate } from './functions/commands/update-render.js'
 import { pikkuNewFunction } from './functions/commands/new-function.js'
 import { pikkuNewWiring } from './functions/commands/new-wiring.js'
 import { pikkuNewMiddleware } from './functions/commands/new-middleware.js'
@@ -266,6 +268,37 @@ wireCLI({
         outdated: {
           description: 'Also report available dependency updates',
           default: false,
+        },
+      },
+    }),
+    update: pikkuCLICommand({
+      func: pikkuUpdate,
+      render: renderUpdate,
+      description:
+        'Report which @pikku/* dependencies can be updated, and the peers those updates need. Reports only until --update is passed',
+      options: {
+        update: {
+          description:
+            'Write the new ranges into every package.json covered by the run. Without it, update only reports',
+          default: false,
+        },
+        updatePeers: {
+          description:
+            "Also write the ranges unsatisfied peers require (e.g. bumping 'ai' for @pikku/ai-vercel). Implies --update, and can cross a major version of a third-party package",
+          default: false,
+        },
+        install: {
+          description:
+            'After writing, run an install with the package manager the lockfile names. --no-install leaves node_modules alone',
+          default: true,
+        },
+        tag: {
+          description: "Dist-tag to update to (default: 'latest')",
+          default: 'latest',
+        },
+        registry: {
+          description:
+            'Registry to read versions from (default: npm_config_registry, else https://registry.npmjs.org)',
         },
       },
     }),

--- a/packages/cli/src/functions/commands/update-render.ts
+++ b/packages/cli/src/functions/commands/update-render.ts
@@ -1,0 +1,133 @@
+import { added, changed, dim, removed, table } from '../../fabric/lib/output.js'
+import type { UpdateResult, UpdateStatus } from './update.js'
+
+const STATUS_LABEL: Record<UpdateStatus, string> = {
+  current: dim('current'),
+  outdated: changed('outdated'),
+  'stale-install': changed('stale install'),
+  linked: dim('linked'),
+  manual: dim('manual'),
+  unresolved: removed('unresolved'),
+}
+
+/**
+ * A linked package is a deliberate local checkout, not a decision waiting on
+ * the user — so it is counted but never listed. Listing it buries the two rows
+ * that matter under twenty that don't, which is what a monorepo run looks like.
+ */
+const QUIET: UpdateStatus[] = ['current', 'linked']
+
+export const renderUpdate = (
+  _services: unknown,
+  result: UpdateResult
+): void => {
+  const { entries, peers, summary, applied } = result
+
+  if (entries.length === 0) {
+    console.log(dim('No @pikku/* dependencies found.'))
+    return
+  }
+
+  const multiManifest = new Set(entries.map((entry) => entry.manifest)).size > 1
+  const interesting = entries.filter((entry) => !QUIET.includes(entry.status))
+  const rows = (interesting.length > 0 ? interesting : entries).map((entry) => [
+    entry.package,
+    entry.range,
+    entry.installed ?? dim('—'),
+    entry.latest ?? dim('—'),
+    entry.target ? added(entry.target) : dim('—'),
+    STATUS_LABEL[entry.status],
+    ...(multiManifest ? [dim(entry.manifest)] : []),
+  ])
+
+  console.log(
+    table(
+      [
+        'Package',
+        'Range',
+        'Installed',
+        'Latest',
+        applied ? 'Written' : 'Update to',
+        'Status',
+        ...(multiManifest ? ['Manifest'] : []),
+      ],
+      rows
+    )
+  )
+
+  for (const entry of entries) {
+    if (
+      entry.reason &&
+      entry.status !== 'stale-install' &&
+      !QUIET.includes(entry.status)
+    ) {
+      console.log(`${dim('•')} ${entry.package}: ${dim(entry.reason)}`)
+    }
+  }
+
+  if (peers.length > 0) {
+    console.log()
+    console.log(changed(`${peers.length} unsatisfied peer requirement(s):`))
+    for (const peer of peers) {
+      const has = peer.found
+        ? `has ${peer.found}${peer.resolved ? dim(` (${peer.resolved})`) : ''}`
+        : removed('not declared')
+      console.log(
+        `  ${peer.package} needs ${peer.peer}@${peer.required} — ${has}`
+      )
+    }
+    if (!applied && peers.some((peer) => peer.found)) {
+      console.log(
+        dim('  run with --update-peers to write the ranges you already declare')
+      )
+    }
+    if (peers.some((peer) => !peer.found)) {
+      console.log(
+        dim(
+          '  a peer you do not declare is yours to add — update never adds one'
+        )
+      )
+    }
+  }
+
+  console.log('─'.repeat(40))
+  const counts = [
+    dim(
+      `${summary.checked} @pikku dependenc${summary.checked === 1 ? 'y' : 'ies'}`
+    ),
+  ]
+  if (summary.outdated > 0) counts.push(changed(`${summary.outdated} outdated`))
+  if (summary.staleInstall > 0)
+    counts.push(changed(`${summary.staleInstall} stale install`))
+  if (summary.linked > 0) counts.push(dim(`${summary.linked} linked`))
+  if (summary.manual > 0) counts.push(dim(`${summary.manual} manual`))
+  if (summary.unresolved > 0)
+    counts.push(removed(`${summary.unresolved} unresolved`))
+  console.log(counts.join('  '))
+
+  if (applied) {
+    if (result.written.length === 0) {
+      console.log(added('✓') + '  ' + dim('nothing to write — already current'))
+    } else {
+      console.log(
+        added('✓') +
+          `  ${result.written.length} package.json file${result.written.length !== 1 ? 's' : ''} updated`
+      )
+      console.log(
+        result.installed
+          ? added('✓') +
+              '  ' +
+              dim(`${result.packageManager} install completed`)
+          : dim(
+              result.packageManager === 'unknown'
+                ? '   no lockfile found — install with your package manager'
+                : `   skipped install — run \`${result.packageManager} install\``
+            )
+      )
+    }
+  } else if (summary.outdated > 0 || summary.staleInstall > 0) {
+    console.log(dim('   run `pikku update --update` to apply'))
+  } else {
+    console.log(added('✓') + '  ' + dim('every @pikku dependency is current'))
+  }
+}

--- a/packages/cli/src/functions/commands/update.test.ts
+++ b/packages/cli/src/functions/commands/update.test.ts
@@ -1,0 +1,473 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  collectManifestPaths,
+  findInstallRoot,
+  findProjectRoot,
+  resolveInstalled,
+  rewriteRange,
+  runUpdate,
+  type Packument,
+} from './update.js'
+
+const scratch = () => mkdtempSync(join(tmpdir(), 'pikku-update-'))
+
+const writeJson = (path: string, value: unknown) => {
+  mkdirSync(join(path, '..'), { recursive: true })
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, 'utf-8')
+}
+
+const packument = (
+  distTags: Record<string, string>,
+  versions: Packument['versions'] = {}
+): Packument => ({ 'dist-tags': distTags, versions })
+
+describe('rewriteRange', () => {
+  test('keeps the range operator when moving the floor', () => {
+    assert.equal(rewriteRange('^0.12.83', '0.12.99'), '^0.12.99')
+    assert.equal(rewriteRange('~0.12.83', '0.12.99'), '~0.12.99')
+    assert.equal(rewriteRange('>=0.12.83', '0.12.99'), '>=0.12.99')
+    assert.equal(rewriteRange('0.12.83', '0.12.99'), '0.12.99')
+  })
+
+  test('refuses ranges whose meaning a substitution would change', () => {
+    assert.equal(rewriteRange('workspace:*', '0.12.99'), null)
+    assert.equal(rewriteRange('^18 || ^19', '19.2.0'), null)
+    assert.equal(rewriteRange('0.12.x', '0.12.99'), null)
+    assert.equal(rewriteRange('*', '0.12.99'), null)
+    assert.equal(rewriteRange('file:../core', '0.12.99'), null)
+  })
+
+  test('carries prerelease and build metadata through', () => {
+    assert.equal(rewriteRange('^1.0.0', '2.0.0-rc.1'), '^2.0.0-rc.1')
+  })
+})
+
+describe('project layout discovery', () => {
+  test('finds the nearest package.json walking up', () => {
+    const root = scratch()
+    const nested = join(root, 'src', 'deep')
+    mkdirSync(nested, { recursive: true })
+    writeJson(join(root, 'package.json'), { name: 'app' })
+    assert.equal(findProjectRoot(nested), root)
+  })
+
+  test('install root is the directory holding the lockfile, not the package', () => {
+    const root = scratch()
+    const pkg = join(root, 'packages', 'api')
+    mkdirSync(pkg, { recursive: true })
+    writeFileSync(join(root, 'yarn.lock'), '', 'utf-8')
+    assert.deepEqual(findInstallRoot(pkg), {
+      dir: root,
+      packageManager: 'yarn',
+    })
+  })
+
+  test('the corepack packageManager field beats a stale lockfile', () => {
+    const root = scratch()
+    writeJson(join(root, 'package.json'), {
+      name: 'mono',
+      packageManager: 'bun@1.3.14',
+    })
+    writeFileSync(join(root, 'yarn.lock'), '', 'utf-8')
+    assert.deepEqual(findInstallRoot(root), {
+      dir: root,
+      packageManager: 'bun',
+    })
+  })
+
+  test('reports an unknown package manager when nothing names one', () => {
+    const root = scratch()
+    assert.equal(findInstallRoot(root).packageManager, 'unknown')
+  })
+
+  test('collects workspace manifests alongside the root', async () => {
+    const root = scratch()
+    writeJson(join(root, 'package.json'), {
+      name: 'mono',
+      workspaces: ['packages/*'],
+    })
+    writeJson(join(root, 'packages', 'api', 'package.json'), { name: 'api' })
+    writeJson(join(root, 'packages', 'web', 'package.json'), { name: 'web' })
+    writeJson(join(root, 'node_modules', 'ignored', 'package.json'), {
+      name: 'ignored',
+    })
+
+    const paths = await collectManifestPaths(root)
+    assert.deepEqual(paths, [
+      join(root, 'package.json'),
+      join(root, 'packages', 'api', 'package.json'),
+      join(root, 'packages', 'web', 'package.json'),
+    ])
+  })
+
+  test('resolves an installed version from a hoisted node_modules', () => {
+    const root = scratch()
+    const pkg = join(root, 'packages', 'api')
+    mkdirSync(pkg, { recursive: true })
+    writeJson(join(root, 'node_modules', '@pikku', 'core', 'package.json'), {
+      name: '@pikku/core',
+      version: '0.12.83',
+    })
+    assert.equal(resolveInstalled(pkg, '@pikku/core'), '0.12.83')
+    assert.equal(resolveInstalled(pkg, '@pikku/missing'), null)
+  })
+})
+
+describe('runUpdate', () => {
+  const base = {
+    apply: false,
+    updatePeers: false,
+    install: false,
+    tag: 'latest',
+    registry: 'https://registry.npmjs.org',
+  }
+
+  test('reports an outdated range without touching package.json', async () => {
+    const root = scratch()
+    writeJson(join(root, 'package.json'), {
+      name: 'app',
+      dependencies: { '@pikku/core': '^0.12.83', express: '^5.0.0' },
+    })
+
+    const result = await runUpdate({
+      ...base,
+      rootDir: root,
+      fetchPackument: async (name) =>
+        name === '@pikku/core' ? packument({ latest: '0.12.99' }) : null,
+    })
+
+    assert.equal(result.summary.checked, 1, 'only @pikku packages are checked')
+    assert.equal(result.summary.outdated, 1)
+    assert.equal(result.entries[0]!.target, '^0.12.99')
+    assert.equal(result.entries[0]!.status, 'outdated')
+    assert.deepEqual(result.written, [])
+    assert.match(
+      readFileSync(join(root, 'package.json'), 'utf-8'),
+      /"@pikku\/core": "\^0\.12\.83"/,
+      'a reporting run must not write'
+    )
+  })
+
+  test('flags a range that already allows latest but an install that does not', async () => {
+    const root = scratch()
+    writeJson(join(root, 'package.json'), {
+      name: 'app',
+      dependencies: { '@pikku/core': '^0.12.99' },
+    })
+    writeJson(join(root, 'node_modules', '@pikku', 'core', 'package.json'), {
+      name: '@pikku/core',
+      version: '0.12.90',
+    })
+
+    const result = await runUpdate({
+      ...base,
+      rootDir: root,
+      fetchPackument: async () => packument({ latest: '0.12.99' }),
+    })
+
+    assert.equal(result.entries[0]!.status, 'stale-install')
+    assert.equal(result.entries[0]!.target, null)
+    assert.equal(result.summary.staleInstall, 1)
+  })
+
+  test('leaves a range it cannot safely rewrite alone', async () => {
+    const root = scratch()
+    writeJson(join(root, 'package.json'), {
+      name: 'app',
+      dependencies: { '@pikku/core': '^0.12.0 || ^0.13.0' },
+    })
+
+    const result = await runUpdate({
+      ...base,
+      apply: true,
+      rootDir: root,
+      fetchPackument: async () => packument({ latest: '0.12.99' }),
+    })
+
+    assert.equal(result.entries[0]!.status, 'manual')
+    assert.equal(result.summary.manual, 1)
+    assert.deepEqual(result.written, [])
+    assert.match(
+      readFileSync(join(root, 'package.json'), 'utf-8'),
+      /\^0\.12\.0 \|\| \^0\.13\.0/
+    )
+  })
+
+  test('a locally linked package is reported apart from a range needing a decision', async () => {
+    const root = scratch()
+    writeJson(join(root, 'package.json'), {
+      name: 'app',
+      dependencies: {
+        '@pikku/core': 'workspace:*',
+        '@pikku/cli': 'file:../cli',
+        '@pikku/kysely': 'link:../kysely',
+      },
+    })
+
+    const result = await runUpdate({
+      ...base,
+      apply: true,
+      rootDir: root,
+      fetchPackument: async () => packument({ latest: '0.12.99' }),
+    })
+
+    assert.equal(result.summary.linked, 3)
+    assert.equal(
+      result.summary.manual,
+      0,
+      'a deliberate local checkout is not a decision waiting on the user'
+    )
+    assert.deepEqual(result.written, [])
+    assert.match(
+      readFileSync(join(root, 'package.json'), 'utf-8'),
+      /"workspace:\*"/
+    )
+  })
+
+  test('marks a package the registry has no such tag for as unresolved', async () => {
+    const root = scratch()
+    writeJson(join(root, 'package.json'), {
+      name: 'app',
+      dependencies: { '@pikku/core': '^0.12.83' },
+    })
+
+    const result = await runUpdate({
+      ...base,
+      rootDir: root,
+      tag: 'next',
+      fetchPackument: async () => packument({ latest: '0.12.99' }),
+    })
+
+    assert.equal(result.entries[0]!.status, 'unresolved')
+    assert.equal(result.summary.unresolved, 1)
+  })
+
+  test('--update writes every field and workspace, preserving formatting', async () => {
+    const root = scratch()
+    writeJson(join(root, 'package.json'), {
+      name: 'mono',
+      workspaces: ['packages/*'],
+      devDependencies: { '@pikku/cli': '~0.12.100' },
+    })
+    writeJson(join(root, 'packages', 'api', 'package.json'), {
+      name: 'api',
+      dependencies: { '@pikku/core': '^0.12.83' },
+      peerDependencies: { '@pikku/core': '^0.12.83' },
+    })
+
+    const result = await runUpdate({
+      ...base,
+      apply: true,
+      rootDir: root,
+      fetchPackument: async (name) =>
+        packument({
+          latest: name === '@pikku/cli' ? '0.12.103' : '0.12.99',
+        }),
+    })
+
+    assert.deepEqual(result.written.sort(), [
+      'package.json',
+      'packages/api/package.json',
+    ])
+
+    const rootRaw = readFileSync(join(root, 'package.json'), 'utf-8')
+    assert.match(rootRaw, /"@pikku\/cli": "~0\.12\.103"/)
+    assert.ok(rootRaw.endsWith('\n'), 'trailing newline is preserved')
+    assert.match(rootRaw, /\n  "name"/, 'two-space indentation is preserved')
+
+    const api = JSON.parse(
+      readFileSync(join(root, 'packages', 'api', 'package.json'), 'utf-8')
+    )
+    assert.equal(api.dependencies['@pikku/core'], '^0.12.99')
+    assert.equal(
+      api.peerDependencies['@pikku/core'],
+      '^0.12.99',
+      'an addon’s own peer range is a declared range too'
+    )
+  })
+
+  test('reports a peer the target version needs but the project does not satisfy', async () => {
+    const root = scratch()
+    writeJson(join(root, 'package.json'), {
+      name: 'app',
+      dependencies: { '@pikku/ai-vercel': '^0.12.10', ai: '^5.0.0' },
+    })
+
+    const result = await runUpdate({
+      ...base,
+      rootDir: root,
+      fetchPackument: async (name) =>
+        name === '@pikku/ai-vercel'
+          ? packument(
+              { latest: '0.12.20' },
+              { '0.12.20': { peerDependencies: { ai: '^6.0.0' } } }
+            )
+          : null,
+    })
+
+    assert.equal(result.summary.peerIssues, 1)
+    assert.deepEqual(
+      {
+        package: result.peers[0]!.package,
+        peer: result.peers[0]!.peer,
+        required: result.peers[0]!.required,
+        found: result.peers[0]!.found,
+      },
+      {
+        package: '@pikku/ai-vercel',
+        peer: 'ai',
+        required: '^6.0.0',
+        found: '^5.0.0',
+      }
+    )
+  })
+
+  test('reads peers off the version being moved to, not the one installed', async () => {
+    const root = scratch()
+    writeJson(join(root, 'package.json'), {
+      name: 'app',
+      dependencies: { '@pikku/ai-vercel': '^0.12.10', ai: '^5.0.0' },
+    })
+    writeJson(
+      join(root, 'node_modules', '@pikku', 'ai-vercel', 'package.json'),
+      { name: '@pikku/ai-vercel', version: '0.12.10' }
+    )
+
+    const result = await runUpdate({
+      ...base,
+      rootDir: root,
+      fetchPackument: async (name) =>
+        name === '@pikku/ai-vercel'
+          ? packument(
+              { latest: '0.12.20' },
+              {
+                '0.12.10': { peerDependencies: { ai: '^5.0.0' } },
+                '0.12.20': { peerDependencies: { ai: '^6.0.0' } },
+              }
+            )
+          : null,
+    })
+
+    assert.equal(
+      result.summary.peerIssues,
+      1,
+      'the installed version is satisfied, the target is not'
+    )
+    assert.equal(result.peers[0]!.required, '^6.0.0')
+  })
+
+  test('does not report an @pikku peer the same run already brings forward', async () => {
+    const root = scratch()
+    writeJson(join(root, 'package.json'), {
+      name: 'app',
+      dependencies: {
+        '@pikku/kysely': '^0.12.1',
+        '@pikku/core': '^0.12.40',
+      },
+    })
+
+    const result = await runUpdate({
+      ...base,
+      rootDir: root,
+      fetchPackument: async (name) =>
+        name === '@pikku/kysely'
+          ? packument(
+              { latest: '0.13.15' },
+              { '0.13.15': { peerDependencies: { '@pikku/core': '^0.12.82' } } }
+            )
+          : packument({ latest: '0.12.99' }),
+    })
+
+    assert.deepEqual(result.peers, [])
+  })
+
+  test('skips an optional peer the project does not declare', async () => {
+    const root = scratch()
+    writeJson(join(root, 'package.json'), {
+      name: 'app',
+      dependencies: { '@pikku/uws-handler': '^0.12.1' },
+    })
+
+    const result = await runUpdate({
+      ...base,
+      rootDir: root,
+      fetchPackument: async () =>
+        packument(
+          { latest: '0.12.9' },
+          {
+            '0.12.9': {
+              peerDependencies: { 'uWebSockets.js': '*' },
+              peerDependenciesMeta: { 'uWebSockets.js': { optional: true } },
+            },
+          }
+        ),
+    })
+
+    assert.deepEqual(result.peers, [])
+  })
+
+  test('--update alone leaves peer ranges alone; --update-peers writes them', async () => {
+    const manifest = {
+      name: 'app',
+      dependencies: { '@pikku/ai-vercel': '^0.12.10', ai: '^5.0.0' },
+    }
+    const fetchPackument = async (name: string) =>
+      name === '@pikku/ai-vercel'
+        ? packument(
+            { latest: '0.12.20' },
+            { '0.12.20': { peerDependencies: { ai: '^6.0.0' } } }
+          )
+        : null
+
+    const reportOnly = scratch()
+    writeJson(join(reportOnly, 'package.json'), manifest)
+    await runUpdate({
+      ...base,
+      apply: true,
+      rootDir: reportOnly,
+      fetchPackument,
+    })
+    assert.equal(
+      JSON.parse(readFileSync(join(reportOnly, 'package.json'), 'utf-8'))
+        .dependencies.ai,
+      '^5.0.0',
+      'a third-party major bump is not something --update decides'
+    )
+
+    const withPeers = scratch()
+    writeJson(join(withPeers, 'package.json'), manifest)
+    await runUpdate({
+      ...base,
+      apply: true,
+      updatePeers: true,
+      rootDir: withPeers,
+      fetchPackument,
+    })
+    const written = JSON.parse(
+      readFileSync(join(withPeers, 'package.json'), 'utf-8')
+    )
+    assert.equal(written.dependencies.ai, '^6.0.0')
+    assert.equal(written.dependencies['@pikku/ai-vercel'], '^0.12.20')
+  })
+
+  test('a registry that answers nothing leaves everything unresolved rather than current', async () => {
+    const root = scratch()
+    writeJson(join(root, 'package.json'), {
+      name: 'app',
+      dependencies: { '@pikku/core': '^0.12.83' },
+    })
+
+    const result = await runUpdate({
+      ...base,
+      rootDir: root,
+      fetchPackument: async () => null,
+    })
+
+    assert.equal(result.summary.unresolved, 1)
+    assert.equal(result.summary.outdated, 0)
+  })
+})

--- a/packages/cli/src/functions/commands/update.ts
+++ b/packages/cli/src/functions/commands/update.ts
@@ -1,0 +1,571 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, relative, resolve, sep } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { glob } from 'tinyglobby'
+import semver from 'semver'
+import { pikkuSessionlessFunc } from '#pikku'
+
+export type PackageManager = 'bun' | 'npm' | 'yarn' | 'pnpm' | 'unknown'
+
+export type DependencyField =
+  | 'dependencies'
+  | 'devDependencies'
+  | 'peerDependencies'
+  | 'optionalDependencies'
+
+export type UpdateStatus =
+  | 'current'
+  | 'outdated'
+  | 'stale-install'
+  | 'linked'
+  | 'manual'
+  | 'unresolved'
+
+export type UpdateEntry = {
+  package: string
+  /** package.json holding the range, relative to the project root. */
+  manifest: string
+  field: DependencyField
+  range: string
+  /** Version resolved in node_modules, when the project has been installed. */
+  installed: string | null
+  latest: string | null
+  /** The range `--update` would write, or null when there is nothing to write. */
+  target: string | null
+  status: UpdateStatus
+  reason?: string
+}
+
+export type PeerFinding = {
+  /** The @pikku package that declares the peer. */
+  package: string
+  peer: string
+  required: string
+  /** The range the project declares for the peer, or null when it declares none. */
+  found: string | null
+  resolved: string | null
+  manifest: string
+  optional: boolean
+  /** The range `--update-peers` would write. */
+  target: string
+}
+
+export type UpdateResult = {
+  root: string
+  registry: string
+  tag: string
+  packageManager: PackageManager
+  entries: UpdateEntry[]
+  peers: PeerFinding[]
+  applied: boolean
+  /** Manifests rewritten by `--update`, relative to the project root. */
+  written: string[]
+  installed: boolean
+  summary: {
+    checked: number
+    outdated: number
+    staleInstall: number
+    linked: number
+    manual: number
+    unresolved: number
+    peerIssues: number
+  }
+}
+
+export type UpdateInput = {
+  update?: boolean
+  updatePeers?: boolean
+  install?: boolean
+  tag?: string
+  registry?: string
+}
+
+const DEPENDENCY_FIELDS: DependencyField[] = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+]
+
+const LOCKFILES: Array<[string, PackageManager]> = [
+  ['bun.lock', 'bun'],
+  ['bun.lockb', 'bun'],
+  ['pnpm-lock.yaml', 'pnpm'],
+  ['yarn.lock', 'yarn'],
+  ['package-lock.json', 'npm'],
+]
+
+/**
+ * Ranges we can rewrite without changing what the range *means*: a caret, a
+ * tilde, a `>=` floor, or an exact pin. Anything else — a union, an x-range, a
+ * `workspace:`/`file:` protocol — is reported and left alone, because moving
+ * its floor is a judgement call rather than a substitution.
+ */
+const SIMPLE_RANGE = /^(\^|~|>=|)(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z-.]+)?)$/
+
+/**
+ * A range that resolves to a checkout on disk rather than to the registry. The
+ * project is deliberately on a local copy, so there is nothing to update and
+ * nothing for the user to decide — it is reported apart from the ranges we
+ * genuinely cannot rewrite.
+ */
+const LINK_PROTOCOL = /^(workspace|file|link|portal):/
+
+export type Packument = {
+  'dist-tags'?: Record<string, string>
+  versions?: Record<
+    string,
+    {
+      peerDependencies?: Record<string, string>
+      peerDependenciesMeta?: Record<string, { optional?: boolean }>
+    }
+  >
+}
+
+export type FetchPackument = (name: string) => Promise<Packument | null>
+
+/** The range `--update` writes for `latest`, or null when the range is not ours to move. */
+export const rewriteRange = (range: string, latest: string): string | null => {
+  const match = SIMPLE_RANGE.exec(range.trim())
+  if (!match) {
+    return null
+  }
+  return `${match[1]}${latest}`
+}
+
+/** The lowest version a range admits — what the project is pinned *at least* to. */
+const floorOf = (range: string): string | null => {
+  try {
+    return semver.minVersion(range)?.version ?? null
+  } catch {
+    return null
+  }
+}
+
+export const findProjectRoot = (
+  startDir: string,
+  exists: (path: string) => boolean = existsSync
+): string => {
+  let dir = resolve(startDir)
+  for (let i = 0; i < 12; i++) {
+    if (exists(join(dir, 'package.json'))) {
+      return dir
+    }
+    const parent = dirname(dir)
+    if (parent === dir) {
+      break
+    }
+    dir = parent
+  }
+  return resolve(startDir)
+}
+
+const readJson = (path: string): any | null => {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'))
+  } catch {
+    return null
+  }
+}
+
+const KNOWN_MANAGERS: PackageManager[] = ['bun', 'yarn', 'pnpm', 'npm']
+
+/**
+ * Where `install` has to run: the nearest directory at or above the project
+ * root that says which package manager owns the tree. In a monorepo that is the
+ * workspace root, not the package the command was invoked in.
+ *
+ * The corepack `packageManager` field wins over lockfiles — it states intent
+ * before a lockfile exists, and a project can carry a stale one from another
+ * tool. Guessing wrong is not a soft failure: the install spawns a binary that
+ * isn't on PATH.
+ */
+export const findInstallRoot = (
+  root: string,
+  exists: (path: string) => boolean = existsSync,
+  read: (path: string) => any | null = readJson
+): { dir: string; packageManager: PackageManager } => {
+  let dir = resolve(root)
+  for (let i = 0; i < 12; i++) {
+    const declared = read(join(dir, 'package.json'))?.packageManager
+    const name = typeof declared === 'string' ? declared.split('@')[0] : null
+    if (name && (KNOWN_MANAGERS as string[]).includes(name)) {
+      return { dir, packageManager: name as PackageManager }
+    }
+    for (const [file, pm] of LOCKFILES) {
+      if (exists(join(dir, file))) {
+        return { dir, packageManager: pm }
+      }
+    }
+    const parent = dirname(dir)
+    if (parent === dir) {
+      break
+    }
+    dir = parent
+  }
+  return { dir: resolve(root), packageManager: 'unknown' }
+}
+
+const workspacePatterns = (manifest: any): string[] => {
+  const workspaces = manifest?.workspaces
+  if (Array.isArray(workspaces)) {
+    return workspaces
+  }
+  if (Array.isArray(workspaces?.packages)) {
+    return workspaces.packages
+  }
+  return []
+}
+
+/** Every package.json the run covers: the project root, plus its workspaces. */
+export const collectManifestPaths = async (root: string): Promise<string[]> => {
+  const rootManifest = join(root, 'package.json')
+  const paths = existsSync(rootManifest) ? [rootManifest] : []
+  const patterns = workspacePatterns(readJson(rootManifest))
+  if (patterns.length === 0) {
+    return paths
+  }
+  const matches = await glob(
+    patterns.map((pattern) => `${pattern.replace(/\/$/, '')}/package.json`),
+    { cwd: root, absolute: true, ignore: ['**/node_modules/**'] }
+  )
+  for (const match of matches.sort()) {
+    if (!paths.includes(match)) {
+      paths.push(match)
+    }
+  }
+  return paths
+}
+
+/** Version resolved in node_modules, walking up from the manifest's own directory. */
+export const resolveInstalled = (
+  manifestDir: string,
+  name: string,
+  read: (path: string) => any | null = readJson
+): string | null => {
+  let dir = resolve(manifestDir)
+  for (let i = 0; i < 12; i++) {
+    const candidate = read(
+      join(dir, 'node_modules', ...name.split('/'), 'package.json')
+    )
+    if (candidate?.version) {
+      return String(candidate.version)
+    }
+    const parent = dirname(dir)
+    if (parent === dir) {
+      break
+    }
+    dir = parent
+  }
+  return null
+}
+
+const isPikkuPackage = (name: string) => name.startsWith('@pikku/')
+
+const defaultFetchPackument =
+  (registry: string): FetchPackument =>
+  async (name) => {
+    try {
+      const response = await fetch(`${registry.replace(/\/$/, '')}/${name}`, {
+        headers: { accept: 'application/vnd.npm.install-v1+json' },
+      })
+      if (!response.ok) {
+        return null
+      }
+      return (await response.json()) as Packument
+    } catch {
+      return null
+    }
+  }
+
+type ManifestRecord = {
+  path: string
+  relative: string
+  dir: string
+  json: any
+}
+
+/**
+ * Rewrite a manifest's ranges in place, keeping the file's own indentation and
+ * key order — a package.json is hand-edited far more often than it is
+ * generated, so a version bump must not reformat it.
+ */
+const writeManifest = (
+  path: string,
+  edits: Array<{ field: DependencyField; package: string; range: string }>
+): void => {
+  const raw = readFileSync(path, 'utf-8')
+  const json = JSON.parse(raw)
+  for (const edit of edits) {
+    if (json[edit.field]?.[edit.package] !== undefined) {
+      json[edit.field][edit.package] = edit.range
+    }
+  }
+  const indentMatch = raw.match(/\n(\s+)"/)
+  const indent = indentMatch ? indentMatch[1] : '  '
+  const trailing = raw.endsWith('\n') ? '\n' : ''
+  writeFileSync(
+    path,
+    `${JSON.stringify(json, null, indent)}${trailing}`,
+    'utf-8'
+  )
+}
+
+export const runUpdate = async ({
+  rootDir,
+  apply,
+  updatePeers,
+  install,
+  tag,
+  registry,
+  fetchPackument,
+}: {
+  rootDir: string
+  apply: boolean
+  updatePeers: boolean
+  install: boolean
+  tag: string
+  registry: string
+  fetchPackument?: FetchPackument
+}): Promise<UpdateResult> => {
+  const root = findProjectRoot(rootDir)
+  const { dir: installDir, packageManager } = findInstallRoot(root)
+  const fetchOne = fetchPackument ?? defaultFetchPackument(registry)
+
+  const manifests: ManifestRecord[] = []
+  for (const path of await collectManifestPaths(root)) {
+    const json = readJson(path)
+    if (json) {
+      manifests.push({
+        path,
+        relative: relative(root, path).split(sep).join('/') || 'package.json',
+        dir: dirname(path),
+        json,
+      })
+    }
+  }
+
+  const names = new Set<string>()
+  for (const manifest of manifests) {
+    for (const field of DEPENDENCY_FIELDS) {
+      for (const name of Object.keys(manifest.json[field] ?? {})) {
+        if (isPikkuPackage(name)) {
+          names.add(name)
+        }
+      }
+    }
+  }
+
+  const packuments = new Map<string, Packument | null>()
+  await Promise.all(
+    [...names].map(async (name) => {
+      packuments.set(name, await fetchOne(name))
+    })
+  )
+
+  const entries: UpdateEntry[] = []
+  for (const manifest of manifests) {
+    for (const field of DEPENDENCY_FIELDS) {
+      const deps: Record<string, string> = manifest.json[field] ?? {}
+      for (const [name, range] of Object.entries(deps)) {
+        if (!isPikkuPackage(name)) {
+          continue
+        }
+        const installedVersion = resolveInstalled(manifest.dir, name)
+        const latest = packuments.get(name)?.['dist-tags']?.[tag] ?? null
+        const entry: UpdateEntry = {
+          package: name,
+          manifest: manifest.relative,
+          field,
+          range,
+          installed: installedVersion,
+          latest,
+          target: null,
+          status: 'current',
+        }
+        if (LINK_PROTOCOL.test(range.trim())) {
+          entry.status = 'linked'
+        } else if (!latest) {
+          entry.status = 'unresolved'
+          entry.reason = `no '${tag}' release found on ${registry}`
+        } else {
+          const rewritten = rewriteRange(range, latest)
+          if (rewritten === null) {
+            entry.status = 'manual'
+            entry.reason = `'${range}' is not a plain caret, tilde, >= or exact range`
+          } else if (rewritten !== range) {
+            entry.status = 'outdated'
+            entry.target = rewritten
+          } else if (installedVersion && semver.lt(installedVersion, latest)) {
+            entry.status = 'stale-install'
+            entry.reason = 'the range already allows it — run an install'
+          }
+        }
+        entries.push(entry)
+      }
+    }
+  }
+
+  /**
+   * Peers are read off the version the run lands on, not the one installed —
+   * the point is what the *target* needs. So resolve every @pikku package to
+   * its post-update version first, then read that version's peers.
+   */
+  const targetVersion = (entry: UpdateEntry): string | null =>
+    entry.status === 'outdated' || entry.status === 'stale-install'
+      ? entry.latest
+      : (entry.installed ?? floorOf(entry.range))
+
+  const pikkuTargets = new Map<string, string>()
+  for (const entry of entries) {
+    const version = targetVersion(entry)
+    if (version && semver.valid(version)) {
+      const existing = pikkuTargets.get(entry.package)
+      if (!existing || semver.gt(version, existing)) {
+        pikkuTargets.set(entry.package, version)
+      }
+    }
+  }
+
+  const peers: PeerFinding[] = []
+  for (const manifest of manifests) {
+    const declared = new Map<
+      string,
+      { field: DependencyField; range: string }
+    >()
+    for (const field of DEPENDENCY_FIELDS) {
+      for (const [name, range] of Object.entries<string>(
+        manifest.json[field] ?? {}
+      )) {
+        if (!declared.has(name)) {
+          declared.set(name, { field, range })
+        }
+      }
+    }
+
+    for (const [name] of declared) {
+      if (!isPikkuPackage(name)) {
+        continue
+      }
+      const version = pikkuTargets.get(name)
+      const versionMeta = version
+        ? packuments.get(name)?.versions?.[version]
+        : undefined
+      for (const [peer, required] of Object.entries(
+        versionMeta?.peerDependencies ?? {}
+      )) {
+        const optional =
+          versionMeta?.peerDependenciesMeta?.[peer]?.optional === true
+        const found = declared.get(peer)?.range ?? null
+        const resolved =
+          pikkuTargets.get(peer) ??
+          resolveInstalled(manifest.dir, peer) ??
+          (found ? floorOf(found) : null)
+        if (
+          resolved &&
+          semver.satisfies(resolved, required, { includePrerelease: true })
+        ) {
+          continue
+        }
+        if (!found && optional) {
+          continue
+        }
+        peers.push({
+          package: name,
+          peer,
+          required,
+          found,
+          resolved,
+          manifest: manifest.relative,
+          optional,
+          target: required,
+        })
+      }
+    }
+  }
+
+  const written: string[] = []
+  if (apply) {
+    for (const manifest of manifests) {
+      const edits = entries
+        .filter((entry) => entry.manifest === manifest.relative && entry.target)
+        .map((entry) => ({
+          field: entry.field,
+          package: entry.package,
+          range: entry.target!,
+        }))
+      if (updatePeers) {
+        for (const peer of peers) {
+          if (peer.manifest !== manifest.relative || !peer.found) {
+            continue
+          }
+          const field = DEPENDENCY_FIELDS.find(
+            (candidate) => manifest.json[candidate]?.[peer.peer] !== undefined
+          )
+          if (field) {
+            edits.push({ field, package: peer.peer, range: peer.target })
+          }
+        }
+      }
+      if (edits.length > 0) {
+        writeManifest(manifest.path, edits)
+        written.push(manifest.relative)
+      }
+    }
+  }
+
+  let ranInstall = false
+  if (apply && install && written.length > 0 && packageManager !== 'unknown') {
+    const result = spawnSync(packageManager, ['install'], {
+      cwd: installDir,
+      stdio: 'inherit',
+    })
+    if (result.error || result.status !== 0) {
+      throw new Error(
+        `${packageManager} install failed: ${result.error?.message ?? `exit ${result.status}`}`
+      )
+    }
+    ranInstall = true
+  }
+
+  const count = (status: UpdateStatus) =>
+    entries.filter((entry) => entry.status === status).length
+
+  return {
+    root,
+    registry,
+    tag,
+    packageManager,
+    entries,
+    peers,
+    applied: apply,
+    written,
+    installed: ranInstall,
+    summary: {
+      checked: entries.length,
+      outdated: count('outdated'),
+      staleInstall: count('stale-install'),
+      linked: count('linked'),
+      manual: count('manual'),
+      unresolved: count('unresolved'),
+      peerIssues: peers.length,
+    },
+  }
+}
+
+export const pikkuUpdate = pikkuSessionlessFunc<UpdateInput, UpdateResult>({
+  func: async ({ config }, input) => {
+    const updatePeers = input?.updatePeers === true
+    return runUpdate({
+      rootDir: config.rootDir,
+      apply: input?.update === true || updatePeers,
+      updatePeers,
+      install: input?.install !== false,
+      tag: input?.tag || 'latest',
+      registry:
+        input?.registry ||
+        process.env.npm_config_registry ||
+        'https://registry.npmjs.org',
+    })
+  },
+})

--- a/packages/skills/skills/pikku-deps/SKILL.md
+++ b/packages/skills/skills/pikku-deps/SKILL.md
@@ -4,8 +4,11 @@ description: >-
   Use for the Pikku dependency security audit: the `pikku audit` CLI command, the
   `.pikku/audit.json` artifact, the `SecurityAuditReport` type in @pikku/core, and the console
   Security screen (getSecurityAudit / runSecurityAudit / updateDependency + SecurityAuditView).
-  TRIGGER when: user asks about `pikku audit`, dependency vulnerabilities/advisories, outdated
-  dependencies, the Security screen/page in the console, updating a vulnerable dependency, or
+  Also covers `pikku update`, which moves the @pikku/* dependency set forward and reports the
+  peers those versions need.
+  TRIGGER when: user asks about `pikku audit` or `pikku update`, dependency
+  vulnerabilities/advisories, outdated dependencies, upgrading Pikku itself, peer dependency
+  conflicts, the Security screen/page in the console, updating a vulnerable dependency, or
   reading/rendering audit.json. DO NOT TRIGGER when: user asks about authentication/sessions/JWT
   (use pikku-security), permissions (use pikku-permissions), or secrets/env vars (use
   pikku-config).
@@ -43,10 +46,46 @@ installGroups: [core]
   `bun outdated`, normalised into one `SecurityAuditReport` with per-severity /
   per-update-level counts). Other PMs are detected but **stubbed** with a `note`
   field until their shapes are normalised — issues/updates come back empty.
-- `bun audit` exits non-zero when it *finds* advisories but still writes the
+- `bun audit` exits non-zero when it _finds_ advisories but still writes the
   payload to stdout, so a non-zero exit **with output** is data. A non-zero exit
   with **no** output — or a launch failure, timeout, or a blown 32MB buffer —
   throws, precisely so a failed run can't masquerade as "0 advisories".
+
+## The `pikku update` command
+
+Narrower than `audit --outdated`, and the only one that writes: it moves the
+**@pikku/\* set** forward and reports the peers those versions need. Use `audit`
+to learn a dependency is vulnerable; use `update` to move Pikku itself.
+
+- `pikku update` — reports only. Nothing is written without `--update`.
+- `pikku update --update` — writes the new ranges into every covered
+  package.json, then runs an install. `--no-install` writes and stops.
+- `pikku update --update-peers` — implies `--update` and additionally writes the
+  ranges unsatisfied peers require, **for peers the project already declares**.
+  A peer it does not declare is reported and never added — adding a dependency
+  is not an update. Separate from `--update` because a peer bump can cross a
+  **major** of a third-party package (`ai` 5 → 6), which is not a call to make
+  on the user's behalf.
+- `--tag <dist-tag>` (default `latest`) reads each package's own dist-tag, so
+  `--tag next` moves the whole set onto prereleases. `--registry <url>` defaults
+  to `npm_config_registry`.
+- Coverage is the nearest package.json walking up from the project root, plus
+  every workspace it declares — a monorepo updates in one pass. All four
+  dependency fields are read, `peerDependencies` included, so an addon's own
+  declared peer range moves with it.
+
+Statuses, per dependency: `outdated` (the range floor is behind latest — this is
+what `--update` writes), `stale-install` (the range already admits latest but
+node_modules is behind — an install fixes it, no edit needed), `linked` (a
+`workspace:`/`file:`/`link:`/`portal:` range — a deliberate local checkout,
+counted but never listed), `manual` (a registry range we refuse to substitute
+into: a union, an x-range, a `*`), `unresolved` (the registry had no such tag —
+this must **never** read as "current", the same rule as a failed audit).
+
+Peers are read off the version the run **lands on**, not the one installed —
+the point is what the target needs. An @pikku peer the same run already brings
+forward is not reported, and an unsatisfied _optional_ peer the project never
+declared is skipped.
 
 ## Console integration (@pikku/addon-console)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5949,6 +5949,7 @@ __metadata:
     "@types/json-schema": "npm:^7.0.15"
     "@types/node": "npm:^24.11.0"
     "@types/pg": "npm:^8.11.0"
+    "@types/semver": "npm:^7.7.1"
     "@types/ws": "npm:^8"
     ai: "npm:^6.0.105"
     chalk: "npm:^5.6.2"
@@ -5959,6 +5960,7 @@ __metadata:
     openapi-types: "npm:^12.1.3"
     path-to-regexp: "npm:^8.3.0"
     pg: "npm:^8.13.0"
+    semver: "npm:^7.7.3"
     tinyglobby: "npm:^0.2.12"
     ts-json-schema-generator: "npm:2.9.1-next.16"
     tsx: "npm:^4.21.0"
@@ -12402,6 +12404,13 @@ __metadata:
   version: 0.12.0
   resolution: "@types/retry@npm:0.12.0"
   checksum: 10/bbd0b88f4b3eba7b7acfc55ed09c65ef6f2e1bcb4ec9b4dca82c66566934351534317d294a770a7cc6c0468d5573c5350abab6e37c65f8ef254443e1b028e44d
+  languageName: node
+  linkType: hard
+
+"@types/semver@npm:^7.7.1":
+  version: 7.8.0
+  resolution: "@types/semver@npm:7.8.0"
+  checksum: 10/bbb33a88cdbc72759cf6b2750f1a28468f4470a61a1543061f494c21a53ad53bb85976e5282d79c811579e7073db0ecb6643ee0bcbf0466e8b5b3cb57ea97de0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #1260.

`pikku audit --outdated` reports every dependency's available update, but it is a security artifact — bun-only, writes `.pikku/audit.json`, never writes to package.json. Upgrading Pikku itself was a manual sweep of every package.json in the tree, and two things made that sweep error-prone beyond bumping numbers: the `@pikku/*` packages version independently, so there is no single version to move to; and 48 of 65 declare `peerDependencies` that move with them, so bumping the Pikku package without its peer produces a project that installs and then fails at runtime.

`pikku update` reports by default and writes only when asked.

```
$ pikku update

Package                  Range  Installed  Latest  Update to  Status
@pikku/addon-email-send  0.1.2  0.1.2      0.1.5   0.1.5      outdated
@pikku/addon-gmail       0.1.2  0.1.2      0.1.4   0.1.4      outdated
@pikku/addon-mandrill    0.1.2  0.1.2      0.1.4   0.1.4      outdated
────────────────────────────────────────
20 @pikku dependencies  3 outdated  17 linked
   run `pikku update --update` to apply
```

## Flags

- `--update` — write the new ranges across the project root and every workspace it declares, then install with the package manager the project names. `--no-install` writes and stops.
- `--update-peers` — implies `--update` and also writes the ranges unsatisfied peers require, **for peers the project already declares**. Kept separate because a peer bump can cross a major of a third-party package (`ai` 5 → 6). A peer the project does not declare is reported, never added — adding a dependency is not an update.
- `--tag` — reads each package's own dist-tag (they version independently, so there is no single version to name), so `--tag next` moves the whole set onto prereleases. `--registry` defaults to `npm_config_registry`.

## Decisions worth reviewing

- **Peers are read off the version the run lands on**, not the one installed — the point is what the *target* needs. An `@pikku` peer the same run already brings forward is not reported, and an unsatisfied *optional* peer the project never declared is skipped.
- **`linked` is its own status.** A `workspace:`/`file:`/`link:`/`portal:` range is a deliberate local checkout — counted, never listed. In this monorepo that is 17 of 20 rows; listing them buries the three that matter.
- **A range we cannot substitute into is `manual`, not silently skipped**, and a package the registry could not answer for is `unresolved` — never `current`. Same rule the audit command already follows for a failed run.
- **Package-manager detection follows the corepack `packageManager` field before lockfiles**, matching `resolve-package-manager.ts` in the console addon: a project can carry a stale lockfile from another tool, and guessing wrong spawns a binary that isn't on PATH.
- **Writes preserve the file.** Indentation, key order and trailing newline are kept — a package.json is hand-edited far more often than generated. The verification run against `e2e/package.json` produced a three-line diff and nothing else.

## Verification

- 21 unit tests covering every status and peer case, plus range-rewrite and layout-discovery helpers.
- Two live runs against registry.npmjs.org: the e2e project (found 3 genuinely outdated addons, 17 linked) and a synthetic project reproducing the `ai` 5→6 peer conflict — which also confirmed npm's abbreviated packument carries `peerDependencies`, the assumption the peer feature rests on.
- End-to-end through the built binary after `yarn build:packages`: `update`, `--help`, `--json`, and `--update --no-install` against `e2e/package.json` (diff inspected, then reverted).
- prettier, oxlint, and `tsc --noEmit` clean on the new files.

## Known, for the reviewer

The build's **PKU463** now names `pikkuUpdate.input → 'UpdateInput'` and `pikkuUpdate.output → 'UpdateResult'`, joining 12 commands already on that list (`pikkuAudit`, `login`, `scenarioRun`, …). It is the generics-vs-zod-schema split: 39 of 42 commands in `functions/commands/` use generics and none of those generate a schema. It is not fatal — the CLI runner passes merged data through when a command has no input schema, which is why `pikku audit` works today and why the binary runs above are green. Converting this command to zod `input`/`output` schemas would clear it, but it is the same fix the other 12 need and felt like it belonged in its own change rather than smuggled into this one. Happy to do it here if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `pikku update` command to check for available package updates and peer dependency requirements.
  * Supports dry-run reporting, manifest updates, peer dependency updates, registry and distribution tag selection, and optional installation.
  * Covers project roots, workspaces, linked packages, and supported package managers.
  * Displays update statuses, reasons, peer requirements, and installation results.

* **Documentation**
  * Added guidance for update modes, dependency statuses, peer resolution, and audit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->