### PR TITLE
feat(cli): add `pikku semver` to derive a release's verdict from a diff against a deployed surface

### DIFF
--- a/.changeset/cli-better-auth-optional-peer.md
+++ b/.changeset/cli-better-auth-optional-peer.md
@@ -1,0 +1,12 @@
+---
+'@pikku/cli': patch
+---
+
+Declare `better-auth` as an optional peer dependency of the CLI.
+
+`pikku db generate` resolves `better-auth` with `require.resolve` from the CLI's
+own module so it can read the auth schema, but the CLI never declared it. Under
+a hoisted install it happened to resolve through `@pikku/better-auth`, which
+declares it as a peer; under a strict layout it does not resolve at all. Optional
+so the vast majority of projects, which do not use Better Auth, still install
+nothing extra — the same shape `@pikku/playwright` already has here.

--- a/.changeset/pikku-semver-command.md
+++ b/.changeset/pikku-semver-command.md
@@ -1,0 +1,10 @@
+---
+'@pikku/cli': patch
+'@pikku/skills': patch
+---
+
+Add `pikku semver`, which derives a release's semver from a diff against a deployed surface and writes `.pikku/changes.gen.json`
+
+A function or client-facing wiring that disappeared is major, an addition is minor, and a surface that did not move is patch. Where the generated JSON Schemas are available the verdict goes below the id level: a removed field or a newly required input field is breaking, an added optional one is not — direction-aware, so an output field going optional counts even though the same change on an input does not. `versions.pikku.json` is consumed, so a `@v2` bump does not read as a removal while v1 is still published.
+
+The baseline is `--against <path|url>`: another `.pikku` directory, a snapshot file, or a snapshot published by `pikku semver --emit`. `--fail-on <level>` turns the verdict into a CI gate.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,7 +69,8 @@
   },
   "peerDependencies": {
     "@pikku/core": "^0.12.83",
-    "@pikku/playwright": "^0.12.76"
+    "@pikku/playwright": "^0.12.76",
+    "better-auth": "^1.6.0"
   },
   "devDependencies": {
     "@pikku/core": "^0.12.83",
@@ -96,6 +97,9 @@
   },
   "peerDependenciesMeta": {
     "@pikku/playwright": {
+      "optional": true
+    },
+    "better-auth": {
       "optional": true
     }
   }

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -29,6 +29,8 @@ import { scopesPrune } from './functions/commands/scopes-prune.js'
 import { rolesAudit } from './functions/commands/roles-audit.js'
 import { rolesPrune } from './functions/commands/roles-prune.js'
 import { pikkuAudit } from './functions/commands/audit.js'
+import { pikkuSemver } from './functions/commands/semver.js'
+import { renderSemver } from './functions/commands/semver-render.js'
 import { validate, renderValidate } from './functions/commands/validate.js'
 import {
   knowledgeValidate,
@@ -299,6 +301,31 @@ wireCLI({
         registry: {
           description:
             'Registry to read versions from (default: npm_config_registry, else https://registry.npmjs.org)',
+        },
+      },
+    }),
+    semver: pikkuCLICommand({
+      func: pikkuSemver,
+      render: renderSemver,
+      description:
+        "Derive the release semver by comparing this build's surface against a deployed one; writes .pikku/changes.gen.json",
+      options: {
+        against: {
+          description:
+            'Baseline to compare against: a .pikku directory, a snapshot file, or a snapshot URL',
+        },
+        emit: {
+          description:
+            "Produce this build's surface snapshot instead of comparing — publish it to serve as a baseline. Pair with --out; without it the snapshot goes to stdout after the CLI banner",
+          default: false,
+        },
+        out: {
+          description:
+            'Where to write the output (defaults to .pikku/changes.gen.json; with --emit, stdout)',
+        },
+        failOn: {
+          description:
+            'Exit non-zero when the verdict is at or above this level: major, minor or patch',
         },
       },
     }),

--- a/packages/cli/src/functions/commands/semver-render.ts
+++ b/packages/cli/src/functions/commands/semver-render.ts
@@ -1,0 +1,91 @@
+import { added, changed, dim, removed, table } from '../../fabric/lib/output.js'
+import type { SurfaceChange } from '../../utils/surface-diff.js'
+import type { SemverResult } from './semver.js'
+
+const STATUS_COLOUR = {
+  added,
+  removed,
+  modified: changed,
+} as const
+
+const verdictColour = (verdict: string) =>
+  verdict === 'major'
+    ? removed(verdict)
+    : verdict === 'minor'
+      ? changed(verdict)
+      : dim(verdict)
+
+export const renderSemver = (
+  _services: unknown,
+  result: SemverResult
+): void => {
+  if (result.mode === 'emit') {
+    // No `--out`: the snapshot itself is the output, so it can be redirected.
+    if (!result.written) {
+      console.log(JSON.stringify(result.surface))
+      return
+    }
+    const counts = [
+      `${Object.keys(result.surface.functions).length} functions`,
+      `${Object.keys(result.surface.schemas).length} schemas`,
+    ].join(', ')
+    console.log(`Surface snapshot written to ${result.written}  ${dim(counts)}`)
+    return
+  }
+
+  const lines: string[] = ['']
+
+  if (result.changes.length === 0) {
+    lines.push(
+      `${verdictColour('patch')}  no surface change against ${result.baseline}`,
+      dim('   only internals moved'),
+      ''
+    )
+    lines.push(dim(`   written to ${result.written}`))
+    console.log(lines.join('\n'))
+    return
+  }
+
+  const rows = result.changes.map((change: SurfaceChange) => [
+    change.breaking ? removed('breaking') : dim('compatible'),
+    change.kind,
+    STATUS_COLOUR[change.status](change.status),
+    change.id,
+    change.reasons[0] ?? '',
+  ])
+
+  lines.push(table(['', 'Kind', 'Status', 'Id', 'Reason'], rows))
+
+  // Only the first reason fits the table; a function whose schema moved in
+  // several ways gets the rest listed underneath so nothing is lost to layout.
+  for (const change of result.changes) {
+    if (change.reasons.length <= 1) continue
+    lines.push('', `${change.kind} ${change.id}`)
+    for (const reason of change.reasons) {
+      lines.push(dim(`   ${reason}`))
+    }
+  }
+
+  const {
+    breaking,
+    added: addedCount,
+    removed: removedCount,
+    modified,
+  } = result.summary
+  const summary = [
+    `${breaking} breaking`,
+    `${addedCount} added`,
+    `${removedCount} removed`,
+    `${modified} modified`,
+  ].join('  ')
+
+  lines.push(
+    '',
+    '─'.repeat(40),
+    `${verdictColour(result.verdict)} against ${result.baseline}`,
+    dim(`   ${summary}`),
+    dim(`   written to ${result.written}`)
+  )
+
+  console.log(lines.join('\n'))
+}

--- a/packages/cli/src/functions/commands/semver.ts
+++ b/packages/cli/src/functions/commands/semver.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, writeFileSync } from 'fs'
+import { dirname, join, resolve } from 'path'
+import { pikkuSessionlessFunc } from '#pikku'
+import { loadManifest } from '../../utils/contract-versions.js'
+import { loadSurface, readSurface, type Surface } from '../../utils/surface.js'
+import {
+  computeSurfaceDiff,
+  type SurfaceChanges,
+} from '../../utils/surface-diff.js'
+
+/**
+ * `pikku semver` — what does this build owe the clients of another one?
+ *
+ * The baseline is deliberately external: a deployed environment, not the
+ * previous commit. Comparing against production is what makes the answer
+ * actionable, and pointing `--against` somewhere else is how you ask the same
+ * question about staging.
+ */
+
+export type SemverInput = {
+  against?: string
+  emit?: boolean
+  out?: string
+  failOn?: string
+}
+
+export type SemverResult =
+  | { mode: 'emit'; surface: Surface; written: string | null }
+  | ({ mode: 'compare'; written: string } & SurfaceChanges)
+
+const FAIL_LEVELS = ['major', 'minor', 'patch'] as const
+type FailLevel = (typeof FAIL_LEVELS)[number]
+
+// Ordered by severity, so `--fail-on minor` also fails on major.
+const SEVERITY: Record<FailLevel, number> = { patch: 0, minor: 1, major: 2 }
+
+async function currentSurface(
+  rootDir: string,
+  outDir: string
+): Promise<Surface> {
+  const manifest = await loadManifest(join(rootDir, 'versions.pikku.json'))
+  return readSurface(outDir, manifest)
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, JSON.stringify(value, null, 2) + '\n', 'utf-8')
+}
+
+export const pikkuSemver = pikkuSessionlessFunc<SemverInput, SemverResult>({
+  func: async ({ config }, input) => {
+    const outDir = resolve(config.rootDir, config.outDir)
+    const out = input?.out ? resolve(config.rootDir, input.out) : null
+
+    if (input?.emit === true) {
+      const surface = await currentSurface(config.rootDir, outDir)
+      if (out) writeJson(out, surface)
+      return { mode: 'emit', surface, written: out }
+    }
+
+    const against = input?.against
+    if (!against) {
+      throw new Error(
+        "Nothing to compare against. Pass `--against <path|url>` — a `.pikku` directory, a snapshot file, or a snapshot URL — or `--emit` to produce this build's snapshot."
+      )
+    }
+
+    const [before, after] = await Promise.all([
+      loadSurface(against),
+      currentSurface(config.rootDir, outDir),
+    ])
+
+    const changes = computeSurfaceDiff(before, after, against)
+    const changesPath = out ?? join(outDir, 'changes.gen.json')
+    writeJson(changesPath, changes)
+
+    const failOn = input?.failOn as FailLevel | undefined
+    if (failOn) {
+      if (!FAIL_LEVELS.includes(failOn)) {
+        throw new Error(
+          `--fail-on must be one of ${FAIL_LEVELS.join(', ')}, got '${failOn}'.`
+        )
+      }
+      if (SEVERITY[changes.verdict] >= SEVERITY[failOn]) {
+        throw new Error(
+          `Release is ${changes.verdict} against ${against}, at or above --fail-on ${failOn}. See ${changesPath}.`
+        )
+      }
+    }
+
+    return { mode: 'compare', written: changesPath, ...changes }
+  },
+})

--- a/packages/cli/src/utils/schema-diff.test.ts
+++ b/packages/cli/src/utils/schema-diff.test.ts
@@ -1,0 +1,254 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { diffSchema, type SchemaChange } from './schema-diff.js'
+
+const object = (
+  properties: Record<string, unknown>,
+  required: string[] = [],
+  extra: Record<string, unknown> = {}
+) => ({
+  type: 'object',
+  properties,
+  required,
+  additionalProperties: false,
+  ...extra,
+})
+
+const str = { type: 'string' }
+const num = { type: 'number' }
+
+const find = (changes: SchemaChange[], path: string) =>
+  changes.find((c) => c.path === path)
+
+describe('diffSchema — input (what callers send)', () => {
+  test('a removed field is breaking', () => {
+    const changes = diffSchema(
+      object({ a: str, b: str }, ['a']),
+      object({ a: str }, ['a']),
+      'input'
+    )
+    assert.equal(find(changes, 'b')?.breaking, true)
+    assert.equal(find(changes, 'b')?.reason, 'field removed')
+  })
+
+  test('a removed field is not breaking when the schema stays open', () => {
+    const changes = diffSchema(
+      object({ a: str, b: str }, ['a'], { additionalProperties: true }),
+      object({ a: str }, ['a'], { additionalProperties: true }),
+      'input'
+    )
+    assert.equal(find(changes, 'b')?.breaking, false)
+  })
+
+  test('a new required field is breaking', () => {
+    const changes = diffSchema(
+      object({ a: str }, ['a']),
+      object({ a: str, b: str }, ['a', 'b']),
+      'input'
+    )
+    assert.equal(find(changes, 'b')?.breaking, true)
+    assert.equal(find(changes, 'b')?.reason, 'required field added')
+  })
+
+  test('a new optional field is not breaking', () => {
+    const changes = diffSchema(
+      object({ a: str }, ['a']),
+      object({ a: str, b: str }, ['a']),
+      'input'
+    )
+    assert.equal(find(changes, 'b')?.breaking, false)
+  })
+
+  test('making a field optional is not breaking', () => {
+    const changes = diffSchema(
+      object({ a: str, b: str }, ['a', 'b']),
+      object({ a: str, b: str }, ['a']),
+      'input'
+    )
+    assert.equal(find(changes, 'b')?.breaking, false)
+  })
+
+  test('making an optional field required is breaking', () => {
+    const changes = diffSchema(
+      object({ a: str, b: str }, ['a']),
+      object({ a: str, b: str }, ['a', 'b']),
+      'input'
+    )
+    assert.equal(find(changes, 'b')?.breaking, true)
+  })
+
+  test('an identical schema produces no changes', () => {
+    const schema = object({ a: str, b: num }, ['a'])
+    assert.deepEqual(diffSchema(schema, structuredClone(schema), 'input'), [])
+  })
+})
+
+describe('diffSchema — output (what callers read)', () => {
+  test('a removed field is breaking even though the schema is open', () => {
+    const changes = diffSchema(
+      object({ a: str, b: str }, ['a'], { additionalProperties: true }),
+      object({ a: str }, ['a'], { additionalProperties: true }),
+      'output'
+    )
+    assert.equal(find(changes, 'b')?.breaking, true)
+  })
+
+  test('a new required field is not breaking', () => {
+    const changes = diffSchema(
+      object({ a: str }, ['a']),
+      object({ a: str, b: str }, ['a', 'b']),
+      'output'
+    )
+    assert.equal(find(changes, 'b')?.breaking, false)
+  })
+
+  test('a field that is no longer guaranteed is breaking', () => {
+    const changes = diffSchema(
+      object({ a: str, b: str }, ['a', 'b']),
+      object({ a: str, b: str }, ['a']),
+      'output'
+    )
+    assert.equal(find(changes, 'b')?.breaking, true)
+    assert.equal(
+      find(changes, 'b')?.reason,
+      'field is no longer guaranteed to be present'
+    )
+  })
+})
+
+describe('diffSchema — types, enums and nesting', () => {
+  test('a changed type is breaking in both directions', () => {
+    for (const direction of ['input', 'output'] as const) {
+      const changes = diffSchema(
+        object({ a: str }, ['a']),
+        object({ a: num }, ['a']),
+        direction
+      )
+      assert.equal(find(changes, 'a')?.breaking, true, direction)
+    }
+  })
+
+  test('removing an enum value breaks callers but not consumers', () => {
+    const before = object({ mode: { type: 'string', enum: ['a', 'b'] } }, [
+      'mode',
+    ])
+    const after = object({ mode: { type: 'string', enum: ['a'] } }, ['mode'])
+    assert.equal(
+      find(diffSchema(before, after, 'input'), 'mode')?.breaking,
+      true
+    )
+    assert.equal(
+      find(diffSchema(before, after, 'output'), 'mode')?.breaking,
+      false
+    )
+  })
+
+  test('adding an enum value breaks consumers but not callers', () => {
+    const before = object({ mode: { type: 'string', enum: ['a'] } }, ['mode'])
+    const after = object({ mode: { type: 'string', enum: ['a', 'b'] } }, [
+      'mode',
+    ])
+    assert.equal(
+      find(diffSchema(before, after, 'input'), 'mode')?.breaking,
+      false
+    )
+    assert.equal(
+      find(diffSchema(before, after, 'output'), 'mode')?.breaking,
+      true
+    )
+  })
+
+  test('nested and array-item fields are reported by path', () => {
+    const before = object(
+      { user: object({ name: str, email: str }, ['name', 'email']) },
+      ['user']
+    )
+    const after = object({ user: object({ name: str }, ['name']) }, ['user'])
+    const changes = diffSchema(before, after, 'output')
+    assert.equal(find(changes, 'user.email')?.breaking, true)
+
+    const beforeList = object(
+      {
+        items: {
+          type: 'array',
+          items: object({ id: str, label: str }, ['id']),
+        },
+      },
+      ['items']
+    )
+    const afterList = object(
+      { items: { type: 'array', items: object({ id: str }, ['id']) } },
+      ['items']
+    )
+    const listChanges = diffSchema(beforeList, afterList, 'output')
+    assert.equal(find(listChanges, 'items[].label')?.breaking, true)
+  })
+
+  test('local $refs are resolved against the schema they were authored in', () => {
+    const before = {
+      type: 'object',
+      properties: { user: { $ref: '#/definitions/User' } },
+      required: ['user'],
+      additionalProperties: false,
+      definitions: { User: object({ id: str, email: str }, ['id', 'email']) },
+    }
+    const after = {
+      type: 'object',
+      properties: { user: { $ref: '#/definitions/User' } },
+      required: ['user'],
+      additionalProperties: false,
+      definitions: { User: object({ id: str }, ['id']) },
+    }
+    assert.equal(
+      find(diffSchema(before, after, 'output'), 'user.email')?.breaking,
+      true
+    )
+  })
+
+  test('a self-referencing $ref terminates instead of recursing forever', () => {
+    const recursive = {
+      type: 'object',
+      properties: { child: { $ref: '#/definitions/Node' } },
+      additionalProperties: false,
+      definitions: {
+        Node: {
+          type: 'object',
+          properties: { child: { $ref: '#/definitions/Node' } },
+          additionalProperties: false,
+        },
+      },
+    }
+    assert.deepEqual(
+      diffSchema(recursive, structuredClone(recursive), 'output'),
+      []
+    )
+  })
+})
+
+describe('diffSchema — a schema appearing or disappearing', () => {
+  test('gaining a required input is breaking; gaining an optional one is not', () => {
+    assert.equal(
+      diffSchema(undefined, object({ a: str }, ['a']), 'input')[0].breaking,
+      true
+    )
+    assert.equal(
+      diffSchema(undefined, object({ a: str }, []), 'input')[0].breaking,
+      false
+    )
+  })
+
+  test('losing an output is breaking; losing an input is not', () => {
+    assert.equal(
+      diffSchema(object({ a: str }, ['a']), undefined, 'output')[0].breaking,
+      true
+    )
+    assert.equal(
+      diffSchema(object({ a: str }, ['a']), undefined, 'input')[0].breaking,
+      false
+    )
+  })
+
+  test('two absent schemas are not a change', () => {
+    assert.deepEqual(diffSchema(undefined, undefined, 'input'), [])
+  })
+})

--- a/packages/cli/src/utils/schema-diff.ts
+++ b/packages/cli/src/utils/schema-diff.ts
@@ -1,0 +1,267 @@
+/**
+ * Field-level compatibility diff between two JSON Schemas.
+ *
+ * Whether a change breaks anyone depends on which way the data flows, so every
+ * comparison carries a `direction`. An input schema is contravariant — the
+ * caller writes it, so tightening (a new required field, a narrower enum) is
+ * what breaks. An output schema is covariant — the caller reads it, so
+ * loosening (a field that may now be absent, a new enum member the consumer
+ * never handled) is what breaks. Removing a field breaks in both directions.
+ */
+
+export type SchemaDirection = 'input' | 'output'
+
+export interface SchemaChange {
+  /** Dotted path from the schema root, `[]` marking array items. */
+  path: string
+  breaking: boolean
+  reason: string
+}
+
+type Schema = Record<string, any>
+
+const isSchema = (value: unknown): value is Schema =>
+  !!value && typeof value === 'object' && !Array.isArray(value)
+
+const joinPath = (parent: string, key: string) =>
+  parent ? `${parent}.${key}` : key
+
+/**
+ * Resolve local `#/definitions/...` / `#/$defs/...` pointers against the root
+ * they were authored in. Anything non-local is left alone — an unresolvable
+ * `$ref` is compared as the opaque object it is rather than guessed at.
+ */
+function deref(schema: Schema, root: Schema, seen: Set<string>): Schema {
+  let current = schema
+  while (typeof current.$ref === 'string') {
+    const ref: string = current.$ref
+    if (!ref.startsWith('#/') || seen.has(ref)) return current
+    seen.add(ref)
+    let target: unknown = root
+    for (const rawSegment of ref.slice(2).split('/')) {
+      const segment = rawSegment.replace(/~1/g, '/').replace(/~0/g, '~')
+      if (!isSchema(target)) return current
+      target = (target as Schema)[segment]
+    }
+    if (!isSchema(target)) return current
+    current = target
+  }
+  return current
+}
+
+const typeOf = (schema: Schema): string | undefined => {
+  const type = schema.type
+  if (typeof type === 'string') return type
+  if (Array.isArray(type)) return [...type].sort().join('|')
+  return undefined
+}
+
+const requiredSet = (schema: Schema): Set<string> =>
+  new Set(Array.isArray(schema.required) ? schema.required : [])
+
+const propertiesOf = (schema: Schema): Schema =>
+  isSchema(schema.properties) ? schema.properties : {}
+
+/**
+ * `additionalProperties: false` is what makes an unknown key an error, so a
+ * removed input field only breaks callers when the schema is closed.
+ */
+const isClosed = (schema: Schema): boolean =>
+  schema.additionalProperties === false
+
+function compare(
+  beforeRaw: Schema,
+  afterRaw: Schema,
+  direction: SchemaDirection,
+  path: string,
+  beforeRoot: Schema,
+  afterRoot: Schema,
+  depth: number,
+  changes: SchemaChange[]
+): void {
+  // Deep enough to have left any sane generated schema behind; a cyclic pair of
+  // `$ref`s that dodges the per-branch guard stops here rather than recursing.
+  if (depth > 24) return
+
+  const before = deref(beforeRaw, beforeRoot, new Set())
+  const after = deref(afterRaw, afterRoot, new Set())
+
+  const beforeType = typeOf(before)
+  const afterType = typeOf(after)
+  if (beforeType !== afterType && (beforeType || afterType)) {
+    changes.push({
+      path,
+      breaking: true,
+      reason: `type changed from ${beforeType ?? 'unknown'} to ${afterType ?? 'unknown'}`,
+    })
+    return
+  }
+
+  compareEnums(before, after, direction, path, changes)
+
+  const beforeProps = propertiesOf(before)
+  const afterProps = propertiesOf(after)
+  const beforeRequired = requiredSet(before)
+  const afterRequired = requiredSet(after)
+
+  for (const key of Object.keys(beforeProps)) {
+    const childPath = joinPath(path, key)
+    if (!(key in afterProps)) {
+      // Dropping an input field only breaks callers that still send it, which
+      // is only an error against a closed schema.
+      const breaking = direction === 'output' || isClosed(after)
+      changes.push({
+        path: childPath,
+        breaking,
+        reason: breaking
+          ? 'field removed'
+          : 'field removed (schema accepts additional properties)',
+      })
+      continue
+    }
+    if (beforeRequired.has(key) && !afterRequired.has(key)) {
+      changes.push({
+        path: childPath,
+        breaking: direction === 'output',
+        reason:
+          direction === 'output'
+            ? 'field is no longer guaranteed to be present'
+            : 'field became optional',
+      })
+    } else if (!beforeRequired.has(key) && afterRequired.has(key)) {
+      changes.push({
+        path: childPath,
+        breaking: direction === 'input',
+        reason:
+          direction === 'input'
+            ? 'optional field became required'
+            : 'field is now always present',
+      })
+    }
+    compare(
+      beforeProps[key],
+      afterProps[key],
+      direction,
+      childPath,
+      beforeRoot,
+      afterRoot,
+      depth + 1,
+      changes
+    )
+  }
+
+  for (const key of Object.keys(afterProps)) {
+    if (key in beforeProps) continue
+    const childPath = joinPath(path, key)
+    const required = afterRequired.has(key)
+    const breaking = direction === 'input' && required
+    changes.push({
+      path: childPath,
+      breaking,
+      reason: breaking
+        ? 'required field added'
+        : `${required ? 'required' : 'optional'} field added`,
+    })
+  }
+
+  if (isSchema(before.items) && isSchema(after.items)) {
+    compare(
+      before.items,
+      after.items,
+      direction,
+      `${path}[]`,
+      beforeRoot,
+      afterRoot,
+      depth + 1,
+      changes
+    )
+  }
+}
+
+function compareEnums(
+  before: Schema,
+  after: Schema,
+  direction: SchemaDirection,
+  path: string,
+  changes: SchemaChange[]
+): void {
+  if (!Array.isArray(before.enum) || !Array.isArray(after.enum)) return
+  const beforeValues = before.enum.map((v: unknown) => JSON.stringify(v))
+  const afterValues = new Set(after.enum.map((v: unknown) => JSON.stringify(v)))
+  const beforeSet = new Set(beforeValues)
+
+  const removed = beforeValues.filter((v) => !afterValues.has(v))
+  const added = after.enum
+    .map((v: unknown) => JSON.stringify(v))
+    .filter((v: string) => !beforeSet.has(v))
+
+  if (removed.length > 0) {
+    changes.push({
+      path,
+      // A value the caller may still send is now rejected; a value the caller
+      // will simply never see again is not their problem.
+      breaking: direction === 'input',
+      reason: `enum values removed: ${removed.join(', ')}`,
+    })
+  }
+  if (added.length > 0) {
+    changes.push({
+      path,
+      // A new value in a response reaches consumers that never handled it.
+      breaking: direction === 'output',
+      reason: `enum values added: ${added.join(', ')}`,
+    })
+  }
+}
+
+/**
+ * Diff two schemas, either of which may be absent — a function that gained or
+ * lost an input/output entirely is a real compatibility event, not a no-op.
+ */
+export function diffSchema(
+  before: unknown,
+  after: unknown,
+  direction: SchemaDirection
+): SchemaChange[] {
+  const hasBefore = isSchema(before)
+  const hasAfter = isSchema(after)
+
+  if (!hasBefore && !hasAfter) return []
+
+  if (!hasBefore && hasAfter) {
+    const required = requiredSet(after as Schema)
+    const breaking = direction === 'input' && required.size > 0
+    return [
+      {
+        path: '',
+        breaking,
+        reason: breaking
+          ? `${direction} schema added with required fields: ${[...required].join(', ')}`
+          : `${direction} schema added`,
+      },
+    ]
+  }
+
+  if (hasBefore && !hasAfter) {
+    return [
+      {
+        path: '',
+        breaking: direction === 'output',
+        reason: `${direction} schema removed`,
+      },
+    ]
+  }
+
+  const changes: SchemaChange[] = []
+  compare(
+    before as Schema,
+    after as Schema,
+    direction,
+    '',
+    before as Schema,
+    after as Schema,
+    0,
+    changes
+  )
+  return changes
+}

--- a/packages/cli/src/utils/surface-diff.test.ts
+++ b/packages/cli/src/utils/surface-diff.test.ts
@@ -1,0 +1,281 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { computeSurfaceDiff } from './surface-diff.js'
+import type { Surface } from './surface.js'
+
+const surface = (partial: Partial<Surface> = {}): Surface => ({
+  schemaVersion: 1,
+  generatedAt: '2026-01-01T00:00:00.000Z',
+  functions: {},
+  schemas: {},
+  wirings: {},
+  publishedVersions: {},
+  ...partial,
+})
+
+const fn = (
+  key: string,
+  version = 1,
+  schemas: Partial<{ input: string; output: string }> = {}
+) => ({
+  key,
+  version,
+  inputSchemaName: schemas.input ?? null,
+  outputSchemaName: schemas.output ?? null,
+})
+
+const object = (
+  properties: Record<string, unknown>,
+  required: string[] = []
+) => ({
+  type: 'object',
+  properties,
+  required,
+  additionalProperties: false,
+})
+
+const str = { type: 'string' }
+
+const changeFor = (
+  changes: ReturnType<typeof computeSurfaceDiff>,
+  id: string
+) => changes.changes.find((c) => c.id === id)
+
+describe('computeSurfaceDiff — verdict', () => {
+  test('a removed function is major', () => {
+    const result = computeSurfaceDiff(
+      surface({ functions: { getUser: fn('getUser') } }),
+      surface(),
+      'prod'
+    )
+    assert.equal(result.verdict, 'major')
+    assert.equal(changeFor(result, 'getUser')?.breaking, true)
+    assert.equal(result.summary.removed, 1)
+  })
+
+  test('an added function is minor', () => {
+    const result = computeSurfaceDiff(
+      surface(),
+      surface({ functions: { archiveUser: fn('archiveUser') } }),
+      'prod'
+    )
+    assert.equal(result.verdict, 'minor')
+    assert.equal(changeFor(result, 'archiveUser')?.breaking, false)
+  })
+
+  test('an unchanged surface is patch — the release is internal work', () => {
+    const both = { functions: { getUser: fn('getUser') } }
+    const result = computeSurfaceDiff(surface(both), surface(both), 'prod')
+    assert.equal(result.verdict, 'patch')
+    assert.deepEqual(result.changes, [])
+  })
+
+  test('the baseline is recorded on the artifact', () => {
+    const result = computeSurfaceDiff(
+      surface(),
+      surface(),
+      'https://api.acme.com/surface.json'
+    )
+    assert.equal(result.baseline, 'https://api.acme.com/surface.json')
+  })
+})
+
+describe('computeSurfaceDiff — function schemas', () => {
+  const withSchemas = (
+    input: Record<string, unknown>,
+    output: Record<string, unknown>
+  ) =>
+    surface({
+      functions: {
+        getUser: fn('getUser', 1, {
+          input: 'GetUserInput',
+          output: 'GetUserOutput',
+        }),
+      },
+      schemas: { GetUserInput: input, GetUserOutput: output },
+    })
+
+  test('a newly required input field makes the release major', () => {
+    const result = computeSurfaceDiff(
+      withSchemas(object({ id: str }, ['id']), object({ name: str }, ['name'])),
+      withSchemas(
+        object({ id: str, tenant: str }, ['id', 'tenant']),
+        object({ name: str }, ['name'])
+      ),
+      'prod'
+    )
+    assert.equal(result.verdict, 'major')
+    assert.deepEqual(changeFor(result, 'getUser')?.reasons, [
+      'input.tenant: required field added',
+    ])
+  })
+
+  test('a new optional input field is minor, not major', () => {
+    const result = computeSurfaceDiff(
+      withSchemas(object({ id: str }, ['id']), object({ name: str }, ['name'])),
+      withSchemas(
+        object({ id: str, tenant: str }, ['id']),
+        object({ name: str }, ['name'])
+      ),
+      'prod'
+    )
+    assert.equal(result.verdict, 'minor')
+    assert.equal(changeFor(result, 'getUser')?.status, 'modified')
+    assert.equal(changeFor(result, 'getUser')?.breaking, false)
+  })
+
+  test('a removed output field makes the release major', () => {
+    const result = computeSurfaceDiff(
+      withSchemas(
+        object({ id: str }, ['id']),
+        object({ name: str, email: str }, ['name'])
+      ),
+      withSchemas(object({ id: str }, ['id']), object({ name: str }, ['name'])),
+      'prod'
+    )
+    assert.equal(result.verdict, 'major')
+    assert.deepEqual(changeFor(result, 'getUser')?.reasons, [
+      'output.email: field removed',
+    ])
+  })
+
+  test('an unavailable schema falls back to the contract hash and is treated as breaking', () => {
+    const before = surface({
+      functions: {
+        getUser: {
+          ...fn('getUser', 1, { input: 'GetUserInput' }),
+          contractHash: 'aaaa',
+        },
+      },
+    })
+    const after = surface({
+      functions: {
+        getUser: {
+          ...fn('getUser', 1, { input: 'GetUserInput' }),
+          contractHash: 'bbbb',
+        },
+      },
+    })
+    const result = computeSurfaceDiff(before, after, 'prod')
+    assert.equal(result.verdict, 'major')
+    assert.match(
+      changeFor(result, 'getUser')?.reasons[0] ?? '',
+      /contract hash changed/
+    )
+  })
+
+  test('an equal contract hash with no schemas is not a change', () => {
+    const both = surface({
+      functions: {
+        getUser: { ...fn('getUser'), contractHash: 'aaaa' },
+      },
+    })
+    const result = computeSurfaceDiff(both, both, 'prod')
+    assert.equal(result.verdict, 'patch')
+  })
+})
+
+describe('computeSurfaceDiff — the version manifest', () => {
+  test('a @v2 bump is minor while v1 is still published', () => {
+    const before = surface({
+      functions: { getUser: fn('getUser', 1) },
+      publishedVersions: { getUser: [1] },
+    })
+    const after = surface({
+      functions: { 'getUser@v2': fn('getUser', 2) },
+      publishedVersions: { getUser: [1, 2] },
+    })
+
+    const result = computeSurfaceDiff(before, after, 'prod')
+    assert.equal(result.verdict, 'minor')
+    assert.equal(changeFor(result, 'getUser')?.breaking, false)
+    assert.match(
+      changeFor(result, 'getUser')?.reasons[0] ?? '',
+      /still published in versions\.pikku\.json/
+    )
+    assert.equal(changeFor(result, 'getUser@v2')?.status, 'added')
+  })
+
+  test('without the manifest the same disappearance is major', () => {
+    const result = computeSurfaceDiff(
+      surface({ functions: { getUser: fn('getUser', 1) } }),
+      surface({ functions: { 'getUser@v2': fn('getUser', 2) } }),
+      'prod'
+    )
+    assert.equal(result.verdict, 'major')
+    assert.equal(changeFor(result, 'getUser')?.breaking, true)
+  })
+})
+
+describe('computeSurfaceDiff — wirings', () => {
+  const http = (entries: Record<string, unknown>) =>
+    surface({ wirings: { http: entries } })
+
+  test('a removed route is major even when the function survives', () => {
+    const result = computeSurfaceDiff(
+      http({ 'GET /users/:id': { pikkuFuncId: 'getUser' } }),
+      http({}),
+      'prod'
+    )
+    assert.equal(result.verdict, 'major')
+    assert.equal(changeFor(result, 'GET /users/:id')?.kind, 'http')
+  })
+
+  test('an added route is minor', () => {
+    const result = computeSurfaceDiff(
+      http({}),
+      http({ 'POST /users/:id/archive': { pikkuFuncId: 'archiveUser' } }),
+      'prod'
+    )
+    assert.equal(result.verdict, 'minor')
+  })
+
+  test('a route that starts requiring auth is major', () => {
+    const result = computeSurfaceDiff(
+      http({ 'GET /public': { pikkuFuncId: 'f', auth: false } }),
+      http({ 'GET /public': { pikkuFuncId: 'f', auth: true } }),
+      'prod'
+    )
+    assert.equal(result.verdict, 'major')
+    assert.match(
+      changeFor(result, 'GET /public')?.reasons[0] ?? '',
+      /requires authentication/
+    )
+  })
+
+  test('another wiring change is compatible', () => {
+    const result = computeSurfaceDiff(
+      http({ 'GET /x': { pikkuFuncId: 'f', middleware: [] } }),
+      http({ 'GET /x': { pikkuFuncId: 'f', middleware: ['rateLimit'] } }),
+      'prod'
+    )
+    assert.equal(result.verdict, 'minor')
+    assert.equal(changeFor(result, 'GET /x')?.breaking, false)
+  })
+})
+
+describe('computeSurfaceDiff — ordering', () => {
+  test('breaking changes come first, then removals before additions', () => {
+    const result = computeSurfaceDiff(
+      surface({
+        functions: { gone: fn('gone'), kept: fn('kept') },
+        wirings: { http: { 'GET /gone': { pikkuFuncId: 'gone' } } },
+      }),
+      surface({
+        functions: { kept: fn('kept'), fresh: fn('fresh') },
+        wirings: { http: { 'GET /fresh': { pikkuFuncId: 'fresh' } } },
+      }),
+      'prod'
+    )
+    assert.deepEqual(
+      result.changes.map((c) => [c.status, c.id]),
+      [
+        ['removed', 'gone'],
+        ['removed', 'GET /gone'],
+        ['added', 'fresh'],
+        ['added', 'GET /fresh'],
+      ]
+    )
+    assert.equal(result.summary.breaking, 2)
+  })
+})

--- a/packages/cli/src/utils/surface-diff.ts
+++ b/packages/cli/src/utils/surface-diff.ts
@@ -1,0 +1,268 @@
+import { diffSchema, type SchemaChange } from './schema-diff.js'
+import type { Surface, WiringCategory } from './surface.js'
+
+/**
+ * Turn two surfaces into the release verdict and the reasons behind it.
+ *
+ * The three rules, in order: anything a client depended on that is gone or
+ * tightened is **major**; anything new or compatibly loosened is **minor**;
+ * a surface that did not move at all is **patch** — the release is internal
+ * work, which is the only thing left for it to be.
+ */
+
+export type Verdict = 'major' | 'minor' | 'patch'
+export type ChangeKind = 'function' | WiringCategory
+export type ChangeStatus = 'added' | 'removed' | 'modified'
+
+export interface SurfaceChange {
+  kind: ChangeKind
+  id: string
+  status: ChangeStatus
+  breaking: boolean
+  reasons: string[]
+}
+
+export interface SurfaceChanges {
+  schemaVersion: number
+  generatedAt: string
+  /** The `--against` value, recorded so the artifact says what it is relative to. */
+  baseline: string
+  verdict: Verdict
+  summary: {
+    breaking: number
+    added: number
+    removed: number
+    modified: number
+  }
+  changes: SurfaceChange[]
+}
+
+export const CHANGES_SCHEMA_VERSION = 1
+
+const STATUS_ORDER: Record<ChangeStatus, number> = {
+  removed: 0,
+  modified: 1,
+  added: 2,
+}
+
+const describe = (change: SchemaChange, side: 'input' | 'output') =>
+  `${side}${change.path ? `.${change.path}` : ''}: ${change.reason}`
+
+/**
+ * Published versions are immutable, so a function id that vanished from the
+ * source is still being served while the manifest records it — that is a `@vN`
+ * bump, not a removal.
+ */
+function stillPublished(
+  surface: Surface,
+  key: string,
+  version: number
+): boolean {
+  return (surface.publishedVersions[key] ?? []).includes(version)
+}
+
+function diffFunctions(
+  before: Surface,
+  after: Surface,
+  changes: SurfaceChange[]
+): void {
+  const ids = new Set([
+    ...Object.keys(before.functions),
+    ...Object.keys(after.functions),
+  ])
+
+  for (const id of [...ids].sort()) {
+    const previous = before.functions[id]
+    const current = after.functions[id]
+
+    if (previous && !current) {
+      const superseded = stillPublished(after, previous.key, previous.version)
+      changes.push({
+        kind: 'function',
+        id,
+        status: 'removed',
+        breaking: !superseded,
+        reasons: [
+          superseded
+            ? `no longer in the source, but v${previous.version} is still published in versions.pikku.json`
+            : 'function removed',
+        ],
+      })
+      continue
+    }
+
+    if (!previous && current) {
+      const priorVersions = before.publishedVersions[current.key] ?? []
+      changes.push({
+        kind: 'function',
+        id,
+        status: 'added',
+        breaking: false,
+        reasons: [
+          priorVersions.length > 0
+            ? `new version of ${current.key} (previously v${priorVersions.join(', v')})`
+            : 'function added',
+        ],
+      })
+      continue
+    }
+
+    if (!previous || !current) continue
+
+    const reasons: string[] = []
+    let breaking = false
+
+    const pairs = [
+      {
+        side: 'input' as const,
+        before: previous.inputSchemaName,
+        after: current.inputSchemaName,
+      },
+      {
+        side: 'output' as const,
+        before: previous.outputSchemaName,
+        after: current.outputSchemaName,
+      },
+    ]
+
+    let unresolved = false
+    for (const pair of pairs) {
+      const beforeSchema = pair.before ? before.schemas[pair.before] : undefined
+      const afterSchema = pair.after ? after.schemas[pair.after] : undefined
+      // A named schema whose body did not travel with the snapshot cannot be
+      // compared; fall through to the hash so it is never silently "unchanged".
+      if (
+        (pair.before && beforeSchema === undefined) ||
+        (pair.after && afterSchema === undefined)
+      ) {
+        unresolved = true
+        continue
+      }
+      for (const change of diffSchema(beforeSchema, afterSchema, pair.side)) {
+        if (change.breaking) breaking = true
+        reasons.push(describe(change, pair.side))
+      }
+    }
+
+    if (
+      unresolved &&
+      previous.contractHash !== undefined &&
+      current.contractHash !== undefined &&
+      previous.contractHash !== current.contractHash
+    ) {
+      // The contract moved but the schemas were not available to say how.
+      // Treating that as compatible would be a guess in the unsafe direction.
+      breaking = true
+      reasons.push(
+        'contract hash changed, and the schemas were not available to determine whether it is breaking'
+      )
+    }
+
+    if (reasons.length > 0) {
+      changes.push({
+        kind: 'function',
+        id,
+        status: 'modified',
+        breaking,
+        reasons,
+      })
+    }
+  }
+}
+
+const authRequired = (meta: unknown): boolean =>
+  !!meta &&
+  typeof meta === 'object' &&
+  (meta as { auth?: boolean }).auth === true
+
+function diffWirings(
+  before: Surface,
+  after: Surface,
+  changes: SurfaceChange[]
+): void {
+  const categories = new Set<WiringCategory>([
+    ...(Object.keys(before.wirings) as WiringCategory[]),
+    ...(Object.keys(after.wirings) as WiringCategory[]),
+  ])
+
+  for (const category of [...categories].sort()) {
+    const previous = before.wirings[category] ?? {}
+    const current = after.wirings[category] ?? {}
+    const ids = new Set([...Object.keys(previous), ...Object.keys(current)])
+
+    for (const id of [...ids].sort()) {
+      const inBefore = id in previous
+      const inAfter = id in current
+
+      if (inBefore && !inAfter) {
+        changes.push({
+          kind: category,
+          id,
+          status: 'removed',
+          breaking: true,
+          reasons: [`${category} wiring removed`],
+        })
+      } else if (!inBefore && inAfter) {
+        changes.push({
+          kind: category,
+          id,
+          status: 'added',
+          breaking: false,
+          reasons: [`${category} wiring added`],
+        })
+      } else if (JSON.stringify(previous[id]) !== JSON.stringify(current[id])) {
+        // Requiring a session on something that did not is the one wiring-level
+        // change that shuts out existing callers outright.
+        const closed = !authRequired(previous[id]) && authRequired(current[id])
+        changes.push({
+          kind: category,
+          id,
+          status: 'modified',
+          breaking: closed,
+          reasons: [
+            closed
+              ? `${category} wiring now requires authentication`
+              : `${category} wiring changed`,
+          ],
+        })
+      }
+    }
+  }
+}
+
+export function computeSurfaceDiff(
+  before: Surface,
+  after: Surface,
+  baseline: string
+): SurfaceChanges {
+  const changes: SurfaceChange[] = []
+  diffFunctions(before, after, changes)
+  diffWirings(before, after, changes)
+
+  changes.sort(
+    (a, b) =>
+      Number(b.breaking) - Number(a.breaking) ||
+      STATUS_ORDER[a.status] - STATUS_ORDER[b.status] ||
+      a.kind.localeCompare(b.kind) ||
+      a.id.localeCompare(b.id)
+  )
+
+  const summary = {
+    breaking: changes.filter((c) => c.breaking).length,
+    added: changes.filter((c) => c.status === 'added').length,
+    removed: changes.filter((c) => c.status === 'removed').length,
+    modified: changes.filter((c) => c.status === 'modified').length,
+  }
+
+  const verdict: Verdict =
+    summary.breaking > 0 ? 'major' : changes.length > 0 ? 'minor' : 'patch'
+
+  return {
+    schemaVersion: CHANGES_SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    baseline,
+    verdict,
+    summary,
+    changes,
+  }
+}

--- a/packages/cli/src/utils/surface.test.ts
+++ b/packages/cli/src/utils/surface.test.ts
@@ -1,0 +1,169 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { loadSurface, readSurface, type FetchLike } from './surface.js'
+
+let root: string
+let pikkuDir: string
+
+const writeJson = (path: string, value: unknown) => {
+  mkdirSync(join(path, '..'), { recursive: true })
+  writeFileSync(path, JSON.stringify(value), 'utf-8')
+}
+
+before(() => {
+  root = mkdtempSync(join(tmpdir(), 'pikku-surface-'))
+  pikkuDir = join(root, '.pikku')
+
+  writeJson(join(pikkuDir, 'function', 'pikku-functions-meta.gen.json'), {
+    getUser: {
+      pikkuFuncId: 'getUser',
+      inputSchemaName: 'GetUserInput',
+      outputSchemaName: 'GetUserOutput',
+      contractHash: 'aaaa',
+    },
+    'getUser@v2': {
+      pikkuFuncId: 'getUser@v2',
+      inputSchemaName: 'GetUserV2Input',
+      outputSchemaName: null,
+    },
+    someoneElsesFunction: { pikkuFuncId: 'someoneElsesFunction', remote: true },
+  })
+
+  writeJson(join(pikkuDir, 'http', 'pikku-http-wirings-meta.gen.json'), {
+    get: { '/users/:id': { pikkuFuncId: 'getUser', route: '/users/:id' } },
+  })
+
+  const schemas = join(pikkuDir, 'schemas', 'schemas')
+  mkdirSync(schemas, { recursive: true })
+  writeJson(join(schemas, 'GetUserInput.schema.json'), {
+    type: 'object',
+    properties: { id: { type: 'string' } },
+    required: ['id'],
+  })
+  writeJson(join(schemas, 'GetUserOutput.schema.json'), { type: 'object' })
+  writeJson(join(schemas, 'GetUserV2Input.schema.json'), { type: 'object' })
+  // Referenced by nothing — the snapshot should not carry it.
+  writeJson(join(schemas, 'Unreferenced.schema.json'), { type: 'object' })
+
+  writeJson(join(root, 'versions.pikku.json'), {
+    manifestVersion: 1,
+    contracts: {
+      getUser: { latest: 2, versions: { '1': 'aaaa', '2': 'bbbb' } },
+    },
+  })
+})
+
+after(() => rmSync(root, { recursive: true, force: true }))
+
+describe('readSurface', () => {
+  test('splits functions from wirings and strips version suffixes into key/version', () => {
+    const surface = readSurface(pikkuDir)
+    assert.deepEqual(Object.keys(surface.functions).sort(), [
+      'getUser',
+      'getUser@v2',
+    ])
+    assert.equal(surface.functions['getUser'].key, 'getUser')
+    assert.equal(surface.functions['getUser'].version, 1)
+    assert.equal(surface.functions['getUser@v2'].key, 'getUser')
+    assert.equal(surface.functions['getUser@v2'].version, 2)
+    assert.deepEqual(Object.keys(surface.wirings), ['http'])
+    assert.deepEqual(Object.keys(surface.wirings.http ?? {}), [
+      'GET /users/:id',
+    ])
+  })
+
+  test('a remote function belongs to another service, not this surface', () => {
+    const surface = readSurface(pikkuDir)
+    assert.equal(surface.functions['someoneElsesFunction'], undefined)
+  })
+
+  test('only schemas some function references travel with the snapshot', () => {
+    const surface = readSurface(pikkuDir)
+    assert.deepEqual(Object.keys(surface.schemas).sort(), [
+      'GetUserInput',
+      'GetUserOutput',
+      'GetUserV2Input',
+    ])
+  })
+
+  test('the manifest supplies the published versions', () => {
+    const manifest = {
+      manifestVersion: 1 as const,
+      contracts: {
+        getUser: { latest: 2, versions: { '1': 'aaaa', '2': 'bbbb' } },
+      },
+    }
+    assert.deepEqual(readSurface(pikkuDir, manifest).publishedVersions, {
+      getUser: [1, 2],
+    })
+    assert.deepEqual(readSurface(pikkuDir).publishedVersions, {})
+  })
+})
+
+describe('loadSurface', () => {
+  test('a directory is read as a .pikku tree, with the sibling manifest', async () => {
+    const surface = await loadSurface(pikkuDir)
+    assert.deepEqual(surface.publishedVersions, { getUser: [1, 2] })
+    assert.ok(surface.functions['getUser'])
+  })
+
+  test('a file is read as a published snapshot', async () => {
+    const snapshotPath = join(root, 'surface.json')
+    writeJson(snapshotPath, readSurface(pikkuDir))
+    const surface = await loadSurface(snapshotPath)
+    assert.ok(surface.functions['getUser'])
+    assert.ok(surface.schemas['GetUserInput'])
+  })
+
+  test('an http url is fetched as a published snapshot', async () => {
+    const fetchImpl: FetchLike = async (url) => {
+      assert.equal(url, 'https://api.acme.com/surface.json')
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify(readSurface(pikkuDir)),
+      }
+    }
+    const surface = await loadSurface(
+      'https://api.acme.com/surface.json',
+      fetchImpl
+    )
+    assert.ok(surface.functions['getUser'])
+  })
+
+  test('a failed fetch throws rather than comparing against nothing', async () => {
+    const fetchImpl: FetchLike = async () => ({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: async () => '',
+    })
+    await assert.rejects(
+      () => loadSurface('https://api.acme.com/surface.json', fetchImpl),
+      /404 Not Found/
+    )
+  })
+
+  test('a json file that is not a snapshot is rejected by name', async () => {
+    const path = join(root, 'not-a-surface.json')
+    writeJson(path, { hello: 'world' })
+    await assert.rejects(() => loadSurface(path), /not a surface snapshot/)
+  })
+
+  test('a snapshot from a newer Pikku is refused rather than misread', async () => {
+    const path = join(root, 'future.json')
+    writeJson(path, { schemaVersion: 99, functions: {} })
+    await assert.rejects(() => loadSurface(path), /newer Pikku/)
+  })
+
+  test('a missing baseline is an error, not an empty comparison', async () => {
+    await assert.rejects(
+      () => loadSurface(join(root, 'nope')),
+      /Baseline not found/
+    )
+  })
+})

--- a/packages/cli/src/utils/surface.ts
+++ b/packages/cli/src/utils/surface.ts
@@ -1,0 +1,225 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs'
+import { join } from 'path'
+import { parseVersionedId } from '@pikku/core'
+import type { VersionManifest } from '@pikku/inspector'
+import {
+  readMetaSnapshot,
+  type MetaDiffCategoryName,
+  type MetaSnapshot,
+} from './meta-diff.js'
+
+/**
+ * A "surface" is everything about a build that a client can observe: the
+ * functions, the JSON Schemas of what they take and return, and the wirings
+ * that expose them. It is derived from `.pikku` rather than stored there, so a
+ * baseline can be a checkout on disk or a snapshot published from CI — the
+ * comparison is the same either way.
+ */
+
+export const SURFACE_SCHEMA_VERSION = 1
+
+/** Meta categories that expose a function to a client. */
+export type WiringCategory = Exclude<MetaDiffCategoryName, 'functions'>
+
+export interface SurfaceFunction {
+  /** Function id with any `@vN` suffix stripped. */
+  key: string
+  version: number
+  inputSchemaName: string | null
+  outputSchemaName: string | null
+  contractHash?: string
+}
+
+export interface Surface {
+  schemaVersion: number
+  generatedAt: string
+  /** Keyed by function id exactly as the meta records it, `@vN` included. */
+  functions: Record<string, SurfaceFunction>
+  /** Only the schemas some function actually references. */
+  schemas: Record<string, unknown>
+  wirings: Partial<Record<WiringCategory, Record<string, unknown>>>
+  /**
+   * `functionKey → published version numbers`, lifted from
+   * `versions.pikku.json`. Published versions are immutable, so a version the
+   * manifest still records is still being served even when the source has
+   * moved on — that is what stops a `@v2` bump reading as a removal.
+   */
+  publishedVersions: Record<string, number[]>
+}
+
+interface FunctionMetaEntry {
+  inputSchemaName?: string | null
+  outputSchemaName?: string | null
+  contractHash?: string
+  version?: number
+  remote?: boolean
+}
+
+const SCHEMA_SUFFIX = '.schema.json'
+
+function readJsonFile(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'))
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Generated schemas live at `<pikkuDir>/schemas/schemas/<Name>.schema.json`
+ * (the `schemaDirectory` default), each file one self-contained schema.
+ */
+function readSchemas(
+  pikkuDir: string,
+  wanted: Set<string>
+): Record<string, unknown> {
+  const dir = join(pikkuDir, 'schemas', 'schemas')
+  if (!existsSync(dir)) return {}
+  const schemas: Record<string, unknown> = {}
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith(SCHEMA_SUFFIX)) continue
+    const name = file.slice(0, -SCHEMA_SUFFIX.length)
+    if (!wanted.has(name)) continue
+    const schema = readJsonFile(join(dir, file))
+    if (schema !== undefined) schemas[name] = schema
+  }
+  return schemas
+}
+
+function readPublishedVersions(manifest: VersionManifest | null) {
+  const published: Record<string, number[]> = {}
+  if (!manifest) return published
+  for (const [key, entry] of Object.entries(manifest.contracts)) {
+    const versions = Object.keys(entry.versions)
+      .map(Number)
+      .filter((v) => Number.isInteger(v))
+      .sort((a, b) => a - b)
+    if (versions.length > 0) published[key] = versions
+  }
+  return published
+}
+
+/** Build a surface from a generated `.pikku` directory. */
+export function readSurface(
+  pikkuDir: string,
+  manifest: VersionManifest | null = null
+): Surface {
+  const snapshot: MetaSnapshot = readMetaSnapshot(pikkuDir)
+
+  const functions: Record<string, SurfaceFunction> = {}
+  const wanted = new Set<string>()
+
+  for (const [id, raw] of Object.entries(snapshot.functions ?? {})) {
+    const meta = (raw ?? {}) as FunctionMetaEntry
+    // A remote function is another service's surface, not this one's.
+    if (meta.remote === true) continue
+    const parsed = parseVersionedId(id)
+    const inputSchemaName = meta.inputSchemaName ?? null
+    const outputSchemaName = meta.outputSchemaName ?? null
+    if (inputSchemaName) wanted.add(inputSchemaName)
+    if (outputSchemaName) wanted.add(outputSchemaName)
+    functions[id] = {
+      key: parsed.baseName,
+      version: parsed.version ?? meta.version ?? 1,
+      inputSchemaName,
+      outputSchemaName,
+      contractHash: meta.contractHash,
+    }
+  }
+
+  const wirings: Surface['wirings'] = {}
+  for (const [category, entries] of Object.entries(snapshot)) {
+    if (category === 'functions' || !entries) continue
+    if (Object.keys(entries).length === 0) continue
+    wirings[category as WiringCategory] = entries
+  }
+
+  return {
+    schemaVersion: SURFACE_SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    functions,
+    schemas: readSchemas(pikkuDir, wanted),
+    wirings,
+    publishedVersions: readPublishedVersions(manifest),
+  }
+}
+
+function assertSurface(value: unknown, source: string): Surface {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Baseline at ${source} is not a surface snapshot.`)
+  }
+  const surface = value as Partial<Surface>
+  if (typeof surface.functions !== 'object' || surface.functions === null) {
+    throw new Error(
+      `Baseline at ${source} is not a surface snapshot (no "functions" map). Produce one with \`pikku semver --emit\`.`
+    )
+  }
+  if (
+    typeof surface.schemaVersion === 'number' &&
+    surface.schemaVersion > SURFACE_SCHEMA_VERSION
+  ) {
+    throw new Error(
+      `Baseline at ${source} was written by a newer Pikku (snapshot version ${surface.schemaVersion}, this CLI understands ${SURFACE_SCHEMA_VERSION}).`
+    )
+  }
+  return {
+    schemaVersion: surface.schemaVersion ?? SURFACE_SCHEMA_VERSION,
+    generatedAt: surface.generatedAt ?? '',
+    functions: surface.functions as Surface['functions'],
+    schemas: surface.schemas ?? {},
+    wirings: surface.wirings ?? {},
+    publishedVersions: surface.publishedVersions ?? {},
+  }
+}
+
+export type FetchLike = (url: string) => Promise<{
+  ok: boolean
+  status: number
+  statusText: string
+  text(): Promise<string>
+}>
+
+/**
+ * Resolve a baseline. A URL fetches a published snapshot; a path is read as a
+ * `.pikku` directory when it is one, and as a snapshot file otherwise — so
+ * `--against ../other-app/.pikku` and `--against ./prod-surface.json` both work
+ * without a second flag to say which is which.
+ */
+export async function loadSurface(
+  source: string,
+  fetchImpl: FetchLike = fetch as unknown as FetchLike
+): Promise<Surface> {
+  if (/^https?:\/\//.test(source)) {
+    const response = await fetchImpl(source)
+    if (!response.ok) {
+      throw new Error(
+        `Could not fetch baseline surface from ${source}: ${response.status} ${response.statusText}`
+      )
+    }
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(await response.text())
+    } catch {
+      throw new Error(`Baseline at ${source} is not valid JSON.`)
+    }
+    return assertSurface(parsed, source)
+  }
+
+  if (!existsSync(source)) {
+    throw new Error(`Baseline not found: ${source}`)
+  }
+
+  if (statSync(source).isDirectory()) {
+    const manifestPath = join(source, '..', 'versions.pikku.json')
+    const manifest = existsSync(manifestPath)
+      ? (readJsonFile(manifestPath) as VersionManifest | undefined)
+      : undefined
+    return readSurface(source, manifest ?? null)
+  }
+
+  const parsed = readJsonFile(source)
+  if (parsed === undefined) {
+    throw new Error(`Baseline at ${source} is not valid JSON.`)
+  }
+  return assertSurface(parsed, source)
+}

--- a/packages/skills/skills/pikku-versioning/SKILL.md
+++ b/packages/skills/skills/pikku-versioning/SKILL.md
@@ -3,10 +3,14 @@ name: pikku-versioning
 description: >-
   Use when versioning Pikku function contracts, detecting breaking changes, or managing API
   backward compatibility. Covers the version property, versions.pikku.json manifest, contract
-  hashing, and CI integration. TRIGGER when: code uses version: on a pikkuFunc, user asks about
-  API versioning, breaking changes, contract hashes, backward compatibility, or "pikku versions"
+  hashing, and CI integration. Also covers `pikku semver`, which derives a release's semver by
+  diffing this build's surface against a deployed one and writes .pikku/changes.gen.json.
+  TRIGGER when: code uses version: on a pikkuFunc, user asks about
+  API versioning, breaking changes, contract hashes, backward compatibility, what semver a
+  release should get, comparing against production/staging, or "pikku versions" / "pikku semver"
   CLI commands. DO NOT TRIGGER when: user asks about secrets/variables/OAuth2 (use pikku-config)
-  or general function definitions (use pikku-concepts).
+  or general function definitions (use pikku-concepts), or about updating dependency versions
+  (use pikku-deps).
 installGroups: [core]
 ---
 
@@ -145,6 +149,84 @@ the manifest alone. Fix the contract or bump the version, then run it again.
 4. If intentional: pin the old contract as `…V1` with `version: 1`, bump the
    live function to `version: 2`, then `pikku versions update`
 
+## The `pikku semver` command
+
+`versions check` and `semver` answer different questions and share no state.
+`check` is a within-repo gate — "you changed a contract without bumping
+`version:`". `semver` is a release question — "what does this build owe the
+clients of the one already deployed?" — and needs an **external baseline**,
+which is why the answer is always relative to an environment rather than to
+the previous commit.
+
+```bash
+npx pikku semver --against https://api.acme.com/surface.json  # vs production
+npx pikku semver --against ../other-app/.pikku                # vs a checkout
+npx pikku semver --emit --out surface.json                    # publish a baseline
+npx pikku semver --against ... --fail-on major                # CI gate
+```
+
+`--against` takes three things and tells them apart itself: a directory is read
+as a `.pikku` tree, an `http(s)` URL is fetched as a published snapshot, and any
+other file is read as a snapshot. `--emit` produces the snapshot; **use `--out`**
+— plain `--emit` writes to stdout _after_ the CLI banner, so a bare `> file.json`
+captures the banner too. Publish the snapshot from CI on deploy and it becomes
+the baseline everyone else compares against.
+
+The verdict, in order:
+
+- **major** — a function or client-facing wiring was removed, or a surviving
+  one tightened its contract.
+- **minor** — anything was added, or a contract loosened compatibly.
+- **patch** — the surface did not move; the release is internal work.
+
+Below the id level it reads the generated JSON Schemas, and **direction
+decides**. An input is contravariant (the caller writes it) and an output is
+covariant (the caller reads it), so the same edit is not the same event on both:
+
+| Change                         | On an input                          | On an output |
+| ------------------------------ | ------------------------------------ | ------------ |
+| field removed                  | breaking (when the schema is closed) | breaking     |
+| required field added           | breaking                             | compatible   |
+| field became optional          | compatible                           | breaking     |
+| optional field became required | breaking                             | compatible   |
+| enum value removed             | breaking                             | compatible   |
+| enum value added               | compatible                           | breaking     |
+| type changed                   | breaking                             | breaking     |
+
+It consumes `versions.pikku.json`: published versions are immutable, so a
+function id that left the source while the manifest still records it is a `@vN`
+bump, not a removal — that is what keeps a deliberate version bump at `minor`.
+Without the manifest the same disappearance reads as `major`, which is the safe
+reading rather than a wrong one.
+
+Two things it deliberately will not guess. A named schema whose body did not
+travel with the baseline falls back to `contractHash` and, if that moved, is
+reported **breaking with the reason stated** — never quietly "unchanged". And at
+the wiring level only `auth` going from absent/false to true is classified as
+breaking; every other metadata change is reported as compatible, because there
+is no general way to tell a cosmetic wiring edit from a restricting one.
+
+Output is `.pikku/changes.gen.json` (override with `--out`), so it rides the
+same meta pipeline as `audit.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "baseline": "https://api.acme.com/surface.json",
+  "verdict": "major",
+  "summary": { "breaking": 1, "added": 1, "removed": 0, "modified": 1 },
+  "changes": [
+    {
+      "kind": "function",
+      "id": "getUser",
+      "status": "modified",
+      "breaking": true,
+      "reasons": ["input.tenant: required field added"]
+    }
+  ]
+}
+```
+
 ## CI Integration
 
 ```yaml
@@ -159,6 +241,8 @@ jobs:
       - uses: actions/checkout@v4
       - run: npm ci
       - run: npx pikku versions check
+      # Refuse to ship a breaking change to production unintentionally.
+      - run: npx pikku semver --against https://api.acme.com/surface.json --fail-on major
 ```
 
 ## Complete Example

--- a/yarn.lock
+++ b/yarn.lock
@@ -6169,8 +6169,11 @@ __metadata:
   peerDependencies:
     "@pikku/core": ^0.12.83
     "@pikku/playwright": ^0.12.76
+    better-auth: ^1.6.0
   peerDependenciesMeta:
     "@pikku/playwright":
+      optional: true
+    better-auth:
       optional: true
   bin:
     pikku: dist/bin/pikku.js


### PR DESCRIPTION
Closes #1265.

`pikku versions check` already gates contract changes *within* a repo — "you changed this contract without bumping `version:`". Nothing answered the release question: **what does this build owe the clients of the one already deployed?** That needs an external baseline, which is why the answer is always relative to an environment rather than to the previous commit — and pointing `--against` somewhere else is how you ask the same question about staging.

```
$ pikku semver --against https://api.acme.com/surface.json

          Kind      Status    Id               Reason
breaking  function  removed   retiredFunction  function removed
breaking  queue     removed   retired-wiring   queue wiring removed
breaking  function  modified  FabricAdd        input.id: optional field became required

function FabricAdd
   input.id: optional field became required
   output.legacyField: field removed

────────────────────────────────────────
major against https://api.acme.com/surface.json
   3 breaking  0 added  2 removed  1 modified
   written to .pikku/changes.gen.json
```

## The verdict

- **major** — a function or client-facing wiring is gone, or a surviving one tightened its contract
- **minor** — something was added, or a contract loosened compatibly
- **patch** — the surface did not move; the release is internal work, which is the only thing left for it to be

## Decisions worth reviewing

- **Direction decides whether a schema edit is breaking.** You described the field rules symmetrically; I implemented them variance-correct instead, because an input is contravariant (the caller writes it) and an output is covariant (the caller reads it). A newly *required* field breaks callers on an input but nobody on an output; a field that became *optional* breaks consumers on an output but nobody on an input. Removing a field breaks either way, as you said. Enum members move in opposite directions for the same reason. **This is the one place I did not implement the spec literally** — say the word and I'll make it symmetric, but I think a symmetric rule would call safe output additions `major` and miss genuinely breaking output relaxations.
- **The version manifest is consulted, not just the ids.** Published versions are immutable, so a function id that left the source while `versions.pikku.json` still records it is a `@vN` bump, not a removal — that is what holds a deliberate version bump at `minor`. Without the manifest the same disappearance reads `major`, which is the safe reading rather than a wrong one.
- **An uncomparable schema is reported breaking, with the reason stated.** If a named schema's body did not travel with the baseline, it falls back to `contractHash`; if that moved, the change is `breaking` and says *why it could not be classified*. Calling it compatible would be a guess in the unsafe direction — the same rule `pikku audit` follows for a failed run.
- **Only one wiring-level change is classified breaking:** `auth` going from absent/false to true. Every other metadata change is reported compatible, because there is no general way to tell a cosmetic wiring edit from a restricting one. Route/channel *identity* changes are caught for free, since the id is the route.
- **`--against` tells its three input forms apart itself** — a directory is a `.pikku` tree, an `http(s)` URL is a fetched snapshot, any other file is a snapshot — so there is no second flag saying which is which.
- **`semver` and `versions check` share no state.** Different questions, and folding one into the other would remove a build gate that works today.

## Verification

- **46 unit tests**: 19 on the schema differ (both directions × removed/added/required/optional/enum/type, nested paths, array items, local `$ref` resolution, a self-referencing `$ref` that must terminate), 16 on the verdict (including both manifest cases), 11 on snapshot loading (directory, file, URL, 404, non-snapshot JSON, future `schemaVersion`, missing baseline).
- **End-to-end through the built binary**, after a clean `build.sh` (exit 0). Emitted a real snapshot of `packages/cli` (161 functions, 133 schemas), then doctored the baseline to seed four distinct breaks — a removed function, a removed wiring, a required input field, a removed output field — and confirmed all four were found with the right reasons and `major`. Against an undoctored baseline: `patch`. Also verified `--against <dir>`, `--against http://…` (against a real local server), `--json`, `--fail-on major` (exit 1) vs a clean baseline (exit 0), and the error when `--against` is missing.
- prettier, oxlint and `tsc --noEmit` clean.

## Known, for the reviewer

- **PKU463** now names `pikkuSemver.input → 'SemverInput'`, joining 12 commands already on that list. Same generics-vs-zod split as before, non-fatal — the binary runs above are green. `SemverResult` does *not* appear, since it's a union and no schema name is assigned.
- **Plain `--emit` writes to stdout after the CLI banner**, so a bare `> surface.json` captures the banner. `--emit --out <file>` is the clean path and is what the docs recommend; suppressing the banner would mean changing global logger behaviour, which felt out of scope here.
- **Changelog generation is not in this PR**, per the artifact-first split — `.pikku/changes.gen.json` is designed to be what a changelog step reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
