### PR TITLE
chore: gate CI on undeclared dependencies with knip (#1263)

### DIFF
--- a/.changeset/knip-undeclared-dependencies.md
+++ b/.changeset/knip-undeclared-dependencies.md
@@ -1,0 +1,32 @@
+---
+'@pikku/openapi-parser': patch
+'@pikku/better-auth': patch
+'@pikku/assistant-ui': patch
+'@pikku/ai-vercel': patch
+'@pikku/console': patch
+'@pikku/next': patch
+'@pikku/kysely': patch
+'@pikku/cli': patch
+---
+
+Declare dependencies that were imported but missing from `package.json`
+
+`@pikku/openapi-parser` and `@pikku/better-auth` imported `zod`, `@pikku/next`
+imported `path-to-regexp`, `@pikku/cli` imported `kysely`, and
+`@pikku/assistant-ui` imported `rxjs`, none of which were declared. Each
+resolved through Yarn hoisting inside the monorepo and would fail for anyone
+installing the package on its own.
+
+`rxjs`, `kysely` and `path-to-regexp` reach consumers through public
+signatures — `Observable<BaseEvent>` is the return type of a published method,
+and `createCoercionPlugin` returns a `KyselyPlugin` — so they are runtime
+dependencies rather than build-only ones.
+
+`@pikku/assistant-ui` pins `rxjs` to the exact `7.8.1` that `@ag-ui/client`
+pins, rather than a caret range. The two packages exchange `Observable`s, so a
+range that floats to a second copy gives them two incompatible `Observable`
+types.
+
+`@pikku/kysely` also drops `SqliteSerializePlugin`, an alias of
+`SerializePlugin` that has been marked `@deprecated` in favour of it. Use
+`SerializePlugin`.

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -34,7 +34,7 @@ jobs:
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -46,6 +46,11 @@ jobs:
         run: yarn lint
       - name: Check no runtime i18n key resolvers
         run: node scripts/check-no-i18n-key-resolver.mjs
+      # Imports that are not declared resolve through Yarn hoisting in this
+      # repo and fail for anyone installing the package on its own, so they
+      # stay invisible until a release. See knip.jsonc for what is checked.
+      - name: Check for undeclared dependencies
+        run: yarn knip
 
   build:
     name: Build

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://unpkg.com/knip@5/schema.json",
+
+  // Only the rules that are true-positive dense on this repo.
+  //
+  // `files` and `dependencies` are deliberately absent: pikku functions are
+  // discovered by codegen rather than imported, so every `*.function.ts` and
+  // the CLI's own `cli.wiring.ts` read as orphaned to an import-graph tool,
+  // and e2e's addons and drivers are wired at runtime. Turning those on
+  // reports ~1100 findings of which almost none are real. `exports` and
+  // `types` are covered by the surface scan behind #1233, which can see the
+  // two things knip cannot: the fabric repo as a downstream consumer, and
+  // specifiers the CLI emits inside template literals.
+  "include": ["unlisted", "binaries", "duplicates"],
+
+  "ignoreDependencies": [
+    // `cloudflare:workers` is the Workers built-in module scheme, not the
+    // `cloudflare` npm package. Installing that package would be wrong.
+    "cloudflare",
+    // Lives at `verifiers/db-schema/addon` and is deliberately outside the
+    // workspace globs — that verifier exists to prove an addon resolves when
+    // it is not a workspace, so declaring it as one would defeat the test.
+    "@pikku/verifier-db-addon",
+  ],
+
+  "ignoreBinaries": [
+    // A c8 subcommand (`npx c8 report`), not a binary on PATH.
+    "report",
+    // A workspace script (`packages/console`), invoked from the repo root.
+    "generate",
+    // `@pikku/cli`'s own bin, run through npx from a workspace that is being
+    // generated rather than one that depends on the CLI.
+    "pikku",
+  ],
+
+  // Build output and generated sources are not hand-authored, and their
+  // imports are already accounted for by the source they are generated from.
+  "ignore": ["**/dist/**", "**/.pikku/**", "**/*.gen.ts", "**/*.gen.d.ts"],
+}

--- a/package.json
+++ b/package.json
@@ -69,20 +69,32 @@
     "benchmark:baseline:fastify": "tsx benchmarks/bench-baseline-fastify.ts",
     "benchmark:baseline:uws": "tsx benchmarks/bench-baseline-uws.ts",
     "benchmark:flame": "npx 0x -- npx tsx benchmarks/bench-express.ts --flame",
-    "benchmark:workflow": "tsx benchmarks/bench-workflow.ts"
+    "benchmark:workflow": "tsx benchmarks/bench-workflow.ts",
+    "knip": "knip"
   },
   "packageManager": "yarn@4.10.3",
   "devDependencies": {
     "0x": "^6.0.0",
+    "@pikku/core": "workspace:*",
+    "@pikku/express-middleware": "workspace:*",
+    "@pikku/fastify-plugin": "workspace:*",
+    "@pikku/uws-handler": "workspace:*",
     "@types/autocannon": "^7.12.7",
     "@types/node": "^25.6.0",
     "autocannon": "^8.0.0",
+    "esbuild": "^0.27.2",
+    "express": "^5",
+    "fastify": "^5.8.2",
     "husky": "^9.1.7",
+    "knip": "^5.64.4",
     "lint-staged": "^16.4.0",
+    "npm-check-updates": "^17.1.18",
     "oxlint": "^1.60.0",
+    "pinst": "^3.0.0",
     "prettier": "3.8.3",
     "tsx": "^4.21.0",
-    "typedoc": "^0.28.19"
+    "typedoc": "^0.28.19",
+    "uWebSockets.js": "uNetworking/uWebSockets.js#v20.68.0"
   },
   "dependencies": {
     "@changesets/cli": "^2.31.0",

--- a/packages/assistant-ui/package.json
+++ b/packages/assistant-ui/package.json
@@ -25,7 +25,8 @@
     "@assistant-ui/react": "^0.14.24",
     "@assistant-ui/react-ag-ui": "^0.0.43",
     "@pikku/voice-agents": "^0.0.4",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "rxjs": "7.8.1"
   },
   "peerDependencies": {
     "react": "^18 || ^19",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
     "chokidar": "^4.0.3",
     "esbuild": "~0.27.0",
     "istanbul-lib-instrument": "^6.0.3",
+    "kysely": "^0.29.0",
     "open": "^10.2.0",
     "openapi-types": "^12.1.3",
     "path-to-regexp": "^8.3.0",

--- a/packages/console/next-env.d.ts
+++ b/packages/console/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -33,8 +33,10 @@
     "prepublishOnly": "echo 'Source-only package — no build needed'"
   },
   "dependencies": {
+    "@assistant-ui/react": "^0.14.24",
     "@codemirror/lang-html": "^6.4.11",
     "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/language": "^6.12.3",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.41.0",
     "@emotion/react": "^11.14.0",
@@ -96,6 +98,7 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6",
     "postcss": "^8",
+    "postcss-load-config": "^6.0.1",
     "postcss-preset-mantine": "^1.18.0",
     "postcss-simple-vars": "^7",
     "react-router": "^7",

--- a/packages/console/src/components/project/panels/FunctionDetailsForm.tsx
+++ b/packages/console/src/components/project/panels/FunctionDetailsForm.tsx
@@ -19,12 +19,15 @@ import { FunctionSquare, Pencil } from 'lucide-react'
 import { useFunctionMeta, useSchema } from '../../../hooks/useWirings'
 import { SchemaViewer } from '../../ui/SchemaViewer'
 import { PikkuBadge } from '../../ui/PikkuBadge'
-import { SidePanel, SidePanelContent, SidePanelHeader } from '../../panel/SidePanel'
+import {
+  SidePanel,
+  SidePanelContent,
+  SidePanelHeader,
+} from '../../panel/SidePanel'
 import { usePanelContext } from '../../../context/PanelContext'
 import { funcWrapperDefs } from '../../ui/badge-defs'
 import { CommonDetails } from './shared/CommonDetails'
 import { FunctionEditor } from './FunctionEditor'
-
 
 interface FunctionDetailsFormProps {
   functionName: string
@@ -146,7 +149,10 @@ export const FunctionTabbedPanel: React.FC<FunctionDetailsFormProps> = ({
               onClose={() => setEditing(false)}
             />
           ) : (
-            <FunctionConfiguration functionName={functionName} metadata={passedMetadata} />
+            <FunctionConfiguration
+              functionName={functionName}
+              metadata={passedMetadata}
+            />
           )}
         </Box>
       </SidePanelContent>
@@ -190,11 +196,19 @@ export const FunctionInput: React.FC<FunctionDetailsFormProps> = ({
   }
 
   if (error) {
-    return <Text c="red">{m.functions_schema_load_error({ message: error.message })}</Text>
+    return (
+      <Text c="red">
+        {m.functions_schema_load_error({ message: error.message })}
+      </Text>
+    )
   }
 
   if (!schema) {
-    return <Text c="dimmed">{m.functions_schema_not_found({ name: inputSchemaName })}</Text>
+    return (
+      <Text c="dimmed">
+        {m.functions_schema_not_found({ name: inputSchemaName })}
+      </Text>
+    )
   }
 
   return <SchemaViewer schema={schema} />
@@ -223,14 +237,20 @@ export const FunctionOutput: React.FC<FunctionDetailsFormProps> = ({
   }
 
   if (error) {
-    return <Text c="red">{m.functions_schema_load_error({ message: error.message })}</Text>
+    return (
+      <Text c="red">
+        {m.functions_schema_load_error({ message: error.message })}
+      </Text>
+    )
   }
 
   if (!schema) {
-    return <Text c="dimmed">{m.functions_schema_not_found({ name: outputSchemaName })}</Text>
+    return (
+      <Text c="dimmed">
+        {m.functions_schema_not_found({ name: outputSchemaName })}
+      </Text>
+    )
   }
 
   return <SchemaViewer schema={schema} />
 }
-
-export const FunctionDetailsForm = FunctionConfiguration

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -18,7 +18,8 @@
     ".": "./dist/index.js"
   },
   "dependencies": {
-    "yaml": "^2.7.1"
+    "yaml": "^2.7.1",
+    "zod": "^4"
   },
   "devDependencies": {
     "typescript": "^6.0.3"

--- a/packages/runtimes/next/package.json
+++ b/packages/runtimes/next/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "cookie": "^1.1.1",
-    "eventemitter3": "^5.0.4"
+    "eventemitter3": "^5.0.4",
+    "path-to-regexp": "^8.3.0"
   },
   "devDependencies": {
     "@pikku/better-auth": "^0.12.17",

--- a/packages/services/ai-vercel/package.json
+++ b/packages/services/ai-vercel/package.json
@@ -24,6 +24,7 @@
     "ai": "^6.0.0"
   },
   "devDependencies": {
+    "@ai-sdk/provider": "^3.0.0",
     "ai": "^6.0.105",
     "typescript": "^6.0.3",
     "zod": "^4.3.6"

--- a/packages/services/better-auth/package.json
+++ b/packages/services/better-auth/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@pikku/core": "^0.12.82",
-    "better-auth": "^1.6.0"
+    "better-auth": "^1.6.0",
+    "zod": "^4"
   },
   "devDependencies": {
     "@better-auth/api-key": "^1.6.19",

--- a/packages/services/kysely/src/index.ts
+++ b/packages/services/kysely/src/index.ts
@@ -21,7 +21,6 @@ export { KyselyVirtualUserRunStore } from './kysely-virtual-user-run-store.js'
 
 export {
   SerializePlugin,
-  SqliteSerializePlugin,
   BaseSerializePlugin,
   type Serializer,
   type Deserializer,

--- a/packages/services/kysely/src/serialize-plugin.ts
+++ b/packages/services/kysely/src/serialize-plugin.ts
@@ -231,8 +231,3 @@ export class SerializePlugin extends BaseSerializePlugin {
     super(serializer, deserializer, skipNodeKind)
   }
 }
-
-/**
- * @deprecated use {@link SerializePlugin} instead
- */
-export const SqliteSerializePlugin = SerializePlugin

--- a/templates/mcp-server/package.json
+++ b/templates/mcp-server/package.json
@@ -22,6 +22,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@pikku/core": "^0.12.83",
     "@pikku/modelcontextprotocol": "^0.12.8"
   }

--- a/verifiers/addon-registry/source/package.json
+++ b/verifiers/addon-registry/source/package.json
@@ -32,5 +32,8 @@
     "@pikku/core": "*",
     "typescript": "^6.0.3",
     "zod": "^4"
+  },
+  "dependencies": {
+    "@pikku/core": "workspace:*"
   }
 }

--- a/verifiers/classification/package.json
+++ b/verifiers/classification/package.json
@@ -8,6 +8,7 @@
     "@pikku/core": "workspace:*",
     "@pikku/inspector": "workspace:*",
     "@types/node": "^24",
+    "pg": "^8.21.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3"
   },

--- a/verifiers/workflows/package.json
+++ b/verifiers/workflows/package.json
@@ -8,11 +8,13 @@
   },
   "dependencies": {
     "@pikku/core": "workspace:*",
+    "@pikku/jose": "workspace:*",
     "@pikku/kysely": "workspace:*",
     "@pikku/kysely-postgres": "workspace:*",
     "@pikku/queue-bullmq": "workspace:*",
     "@pikku/queue-pg-boss": "workspace:*",
     "@pikku/redis": "workspace:*",
+    "@pikku/schema-cfworker": "workspace:*",
     "kysely": "^0.29.0",
     "kysely-postgres-js": "^3.0.0",
     "postgres": "^3.4.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3151,6 +3151,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@codemirror/language@npm:^6.12.3":
+  version: 6.12.4
+  resolution: "@codemirror/language@npm:6.12.4"
+  dependencies:
+    "@codemirror/state": "npm:^6.0.0"
+    "@codemirror/view": "npm:^6.23.0"
+    "@lezer/common": "npm:^1.5.0"
+    "@lezer/highlight": "npm:^1.0.0"
+    "@lezer/lr": "npm:^1.0.0"
+    style-mod: "npm:^4.0.0"
+  checksum: 10/6a9af11337d15036761ad959dceba4cfd054cdfae84afa4d54534927d277591a57c2b581f66df4428510dd06c641151aa699ab1dc7c338d923ac06a219d83bc6
+  languageName: node
+  linkType: hard
+
 "@codemirror/lint@npm:^6.0.0":
   version: 6.9.5
   resolution: "@codemirror/lint@npm:6.9.5"
@@ -3303,12 +3317,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.11.2":
+  version: 1.11.2
+  resolution: "@emnapi/core@npm:1.11.2"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.2"
+    tslib: "npm:^2.4.0"
+  checksum: 10/b3e9693f79ca1d8bb90cb8a950150c7738f54eca0ae1849d3d5103a87ce4e388c2669fb253cc123d3449ad2ae12583435455dbdc0270b1e9efb0cfd502c952b4
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/runtime@npm:1.10.0"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10/d21083d07fa0c2da171c142e78ef986b66b07d45b06accc0bcaf49fcc61bb4dbc10e1c1760813070165b9f49b054376a931045347f21c0f42ff1eb2d2040faac
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.11.2":
+  version: 1.11.2
+  resolution: "@emnapi/runtime@npm:1.11.2"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/280a219d3bf302615dabaaa248223b0e5fe9c49bacf0987dd958ca37ab425b62cf05287053cb188e711681418aaa5e447eaed6b62a0848c0a1303b2707864600
   languageName: node
   linkType: hard
 
@@ -3327,6 +3360,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10/57cd4292be81c05d26aa886d68a9e4c449ff666e8503fed6463dfc6b64a4e4213f03c152d53296b7cda32840271e38cd33347332070658f01befeb9bf4e59f36
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@emnapi/wasi-threads@npm:1.2.2"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/297fb6b1d89744bd0b41d5fec32bade05dc8dcf1f70eba86527226609fb3f6ad3fa96b3b2377b7449709715b3bd1569654c9def1dbbc85fb6b9cb0cff5bc5ebf
   languageName: node
   linkType: hard
 
@@ -5050,7 +5092,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@modelcontextprotocol/sdk@npm:1.30.0":
+"@modelcontextprotocol/sdk@npm:1.30.0, @modelcontextprotocol/sdk@npm:^1.30.0":
   version: 1.30.0
   resolution: "@modelcontextprotocol/sdk@npm:1.30.0"
   dependencies:
@@ -5143,6 +5185,18 @@ __metadata:
     "@emnapi/core": ^1.7.1
     "@emnapi/runtime": ^1.7.1
   checksum: 10/57a4b68f05f15b79bf45240ac173d3eaf72620d1b73261e7db407aa7ba8eb68e670fb1612d2ceef6b8cc500970a5ed6995c71c77661027971012ed2459ce307f
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:^1.1.6":
+  version: 1.2.3
+  resolution: "@napi-rs/wasm-runtime@npm:1.2.3"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.3"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1 || ^2.0.0-alpha.4
+    "@emnapi/runtime": ^1.7.1 || ^2.0.0-alpha.4
+  checksum: 10/86f7f092309eb005ff9e456c12a9f81ae06ff823602740a8c9c54b2dfc17620d9b4d88c4cd179541c794aed521ac57c7e37457a00e87a624867d78f6bbce0d7c
   languageName: node
   linkType: hard
 
@@ -5350,6 +5404,143 @@ __metadata:
   version: 0.133.0
   resolution: "@oxc-project/types@npm:0.133.0"
   checksum: 10/de44f653a9e0c0267309122f1f184120c6869af4382218a6bf4a320c5150743eb00b5e8641b04917666281995ed0fe6381561922a48a28082a75bb122acf3ac6
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-android-arm-eabi@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-android-arm-eabi@npm:11.24.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-android-arm64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-android-arm64@npm:11.24.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-darwin-arm64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-darwin-arm64@npm:11.24.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-darwin-x64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-darwin-x64@npm:11.24.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-freebsd-x64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-freebsd-x64@npm:11.24.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.24.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm-musleabihf@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-arm-musleabihf@npm:11.24.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm64-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-arm64-gnu@npm:11.24.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm64-musl@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-arm64-musl@npm:11.24.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-ppc64-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-ppc64-gnu@npm:11.24.2"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-riscv64-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-riscv64-gnu@npm:11.24.2"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-riscv64-musl@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-riscv64-musl@npm:11.24.2"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-s390x-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-s390x-gnu@npm:11.24.2"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-x64-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-x64-gnu@npm:11.24.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-x64-musl@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-x64-musl@npm:11.24.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-openharmony-arm64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-openharmony-arm64@npm:11.24.2"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-wasm32-wasi@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-wasm32-wasi@npm:11.24.2"
+  dependencies:
+    "@emnapi/core": "npm:1.11.2"
+    "@emnapi/runtime": "npm:1.11.2"
+    "@napi-rs/wasm-runtime": "npm:^1.1.6"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-win32-arm64-msvc@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-win32-arm64-msvc@npm:11.24.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-win32-x64-msvc@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-win32-x64-msvc@npm:11.24.2"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -5786,6 +5977,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/ai-vercel@workspace:packages/services/ai-vercel"
   dependencies:
+    "@ai-sdk/provider": "npm:^3.0.0"
     ai: "npm:^6.0.105"
     typescript: "npm:^6.0.3"
     zod: "npm:^4.3.6"
@@ -5818,6 +6010,7 @@ __metadata:
     react: "npm:^19"
     react-dom: "npm:^19"
     react-markdown: "npm:^10.1.0"
+    rxjs: "npm:7.8.1"
     typescript: "npm:^6.0.3"
   peerDependencies:
     react: ^18 || ^19
@@ -5886,6 +6079,7 @@ __metadata:
   peerDependencies:
     "@pikku/core": ^0.12.82
     better-auth: ^1.6.0
+    zod: ^4
   languageName: unknown
   linkType: soft
 
@@ -5955,6 +6149,7 @@ __metadata:
     chokidar: "npm:^4.0.3"
     esbuild: "npm:~0.27.0"
     istanbul-lib-instrument: "npm:^6.0.3"
+    kysely: "npm:^0.29.0"
     open: "npm:^10.2.0"
     openapi-types: "npm:^12.1.3"
     path-to-regexp: "npm:^8.3.0"
@@ -6003,8 +6198,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/console@workspace:packages/console"
   dependencies:
+    "@assistant-ui/react": "npm:^0.14.24"
     "@codemirror/lang-html": "npm:^6.4.11"
     "@codemirror/lang-javascript": "npm:^6.2.5"
+    "@codemirror/language": "npm:^6.12.3"
     "@codemirror/theme-one-dark": "npm:^6.1.3"
     "@codemirror/view": "npm:^6.41.0"
     "@emotion/react": "npm:^11.14.0"
@@ -6052,6 +6249,7 @@ __metadata:
     mantine-datatable: "npm:^8.3.8"
     mermaid: "npm:^11.16.0"
     postcss: "npm:^8"
+    postcss-load-config: "npm:^6.0.1"
     postcss-preset-mantine: "npm:^1.18.0"
     postcss-simple-vars: "npm:^7"
     react: "npm:^19"
@@ -6191,7 +6389,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pikku/express-middleware@npm:^0.12.5, @pikku/express-middleware@npm:^0.12.6, @pikku/express-middleware@workspace:packages/runtimes/express-middleware":
+"@pikku/express-middleware@npm:^0.12.5, @pikku/express-middleware@npm:^0.12.6, @pikku/express-middleware@workspace:*, @pikku/express-middleware@workspace:packages/runtimes/express-middleware":
   version: 0.0.0-use.local
   resolution: "@pikku/express-middleware@workspace:packages/runtimes/express-middleware"
   dependencies:
@@ -6230,7 +6428,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pikku/fastify-plugin@npm:^0.12.4, @pikku/fastify-plugin@npm:^0.12.6, @pikku/fastify-plugin@workspace:packages/runtimes/fastify-plugin":
+"@pikku/fastify-plugin@npm:^0.12.4, @pikku/fastify-plugin@npm:^0.12.6, @pikku/fastify-plugin@workspace:*, @pikku/fastify-plugin@workspace:packages/runtimes/fastify-plugin":
   version: 0.0.0-use.local
   resolution: "@pikku/fastify-plugin@workspace:packages/runtimes/fastify-plugin"
   dependencies:
@@ -6473,16 +6671,27 @@ __metadata:
   dependencies:
     0x: "npm:^6.0.0"
     "@changesets/cli": "npm:^2.31.0"
+    "@pikku/core": "workspace:*"
+    "@pikku/express-middleware": "workspace:*"
+    "@pikku/fastify-plugin": "workspace:*"
+    "@pikku/uws-handler": "workspace:*"
     "@types/autocannon": "npm:^7.12.7"
     "@types/node": "npm:^25.6.0"
     autocannon: "npm:^8.0.0"
+    esbuild: "npm:^0.27.2"
+    express: "npm:^5"
+    fastify: "npm:^5.8.2"
     husky: "npm:^9.1.7"
+    knip: "npm:^5.64.4"
     lint-staged: "npm:^16.4.0"
+    npm-check-updates: "npm:^17.1.18"
     oxlint: "npm:^1.60.0"
+    pinst: "npm:^3.0.0"
     prettier: "npm:3.8.3"
     tsx: "npm:^4.21.0"
     typedoc: "npm:^0.28.19"
     typescript: "npm:^6.0.3"
+    uWebSockets.js: "uNetworking/uWebSockets.js#v20.68.0"
   languageName: unknown
   linkType: soft
 
@@ -6508,6 +6717,7 @@ __metadata:
     cookie: "npm:^1.1.1"
     eventemitter3: "npm:^5.0.4"
     next: "npm:15.5.12"
+    path-to-regexp: "npm:^8.3.0"
     react: "npm:^19"
     react-dom: "npm:^19"
     typescript: "npm:^6.0.3"
@@ -6542,6 +6752,7 @@ __metadata:
   dependencies:
     typescript: "npm:^6.0.3"
     yaml: "npm:^2.7.1"
+    zod: "npm:^4"
   languageName: unknown
   linkType: soft
 
@@ -6979,6 +7190,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/templates-mcp-server@workspace:templates/mcp-server"
   dependencies:
+    "@modelcontextprotocol/sdk": "npm:^1.30.0"
     "@pikku/cli": "npm:^0.12.104"
     "@pikku/core": "npm:^0.12.83"
     "@pikku/modelcontextprotocol": "npm:^0.12.8"
@@ -7135,7 +7347,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pikku/uws-handler@npm:^0.12.5, @pikku/uws-handler@workspace:packages/runtimes/uws-handler":
+"@pikku/uws-handler@npm:^0.12.5, @pikku/uws-handler@workspace:*, @pikku/uws-handler@workspace:packages/runtimes/uws-handler":
   version: 0.0.0-use.local
   resolution: "@pikku/uws-handler@workspace:packages/runtimes/uws-handler"
   dependencies:
@@ -7257,6 +7469,7 @@ __metadata:
     "@pikku/core": "workspace:*"
     "@pikku/inspector": "workspace:*"
     "@types/node": "npm:^24"
+    pg: "npm:^8.21.0"
     tsx: "npm:^4.21.0"
     typescript: "npm:^6.0.3"
   languageName: unknown
@@ -7541,11 +7754,13 @@ __metadata:
     "@pikku/cli": "workspace:*"
     "@pikku/core": "workspace:*"
     "@pikku/inspector": "workspace:*"
+    "@pikku/jose": "workspace:*"
     "@pikku/kysely": "workspace:*"
     "@pikku/kysely-postgres": "workspace:*"
     "@pikku/queue-bullmq": "workspace:*"
     "@pikku/queue-pg-boss": "workspace:*"
     "@pikku/redis": "workspace:*"
+    "@pikku/schema-cfworker": "workspace:*"
     "@types/node": "npm:^24"
     kysely: "npm:^0.29.0"
     kysely-postgres-js: "npm:^3.0.0"
@@ -11724,6 +11939,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10/d12f1dafe12d7a573c406b35ffef0038042b9cc9fbcc74d657267eb635499b956276afc05eebdbd81bea582e1c4c921421a1dd7243a93daaa8c8216b19395c23
+  languageName: node
+  linkType: hard
+
+"@tybys/wasm-util@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "@tybys/wasm-util@npm:0.10.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/6cf39f7a2926b1c8bc6fe3f9f03318a33dd6dae81bdbd059983f9c6ee22d10a827f12564d648c05a2d4926e03c86cbe2799fb20609ee65e9efc39603039b4765
   languageName: node
   linkType: hard
 
@@ -16774,7 +16998,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.9":
+"fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -16924,6 +17148,15 @@ __metadata:
   dependencies:
     reusify: "npm:^1.0.4"
   checksum: 10/ab2fe3a7a108112e7752cfe7fc11683c21e595913a6a593ad0b4415f31dddbfc283775ab66f2c8ccea6ab7cfc116157cbddcfae9798d9de98d08fe0a2c3e97b2
+  languageName: node
+  linkType: hard
+
+"fd-package-json@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fd-package-json@npm:2.0.0"
+  dependencies:
+    walk-up-path: "npm:^4.0.0"
+  checksum: 10/e595a1a23f8e208815cdcf26c92218240da00acce80468324408dc4a5cb6c26b6efb5076f0458a02f044562a1e60253731187a627d5416b4961468ddfc0ae426
   languageName: node
   linkType: hard
 
@@ -17141,6 +17374,17 @@ __metadata:
     hasown: "npm:^2.0.2"
     mime-types: "npm:^2.1.12"
   checksum: 10/52ecd6e927c8c4e215e68a7ad5e0f7c1031397439672fd9741654b4a94722c4182e74cc815b225dcb5be3f4180f36428f67c6dd39eaa98af0dcfdd26c00c19cd
+  languageName: node
+  linkType: hard
+
+"formatly@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "formatly@npm:0.3.0"
+  dependencies:
+    fd-package-json: "npm:^2.0.0"
+  bin:
+    formatly: bin/index.mjs
+  checksum: 10/0e5a9cbb826d93171b00c283e20e6a564a16e7bc3839e695790347a1f23e3536a88d613f5cabd07403d60b7bdffe179987c88b1fc2900a9be49eea01ffbe4244
   languageName: node
   linkType: hard
 
@@ -18512,7 +18756,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^2.7.0":
+"jiti@npm:^2.6.0, jiti@npm:^2.7.0":
   version: 2.7.0
   resolution: "jiti@npm:2.7.0"
   bin:
@@ -18781,6 +19025,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"knip@npm:^5.64.4":
+  version: 5.88.1
+  resolution: "knip@npm:5.88.1"
+  dependencies:
+    "@nodelib/fs.walk": "npm:^1.2.3"
+    fast-glob: "npm:^3.3.3"
+    formatly: "npm:^0.3.0"
+    jiti: "npm:^2.6.0"
+    minimist: "npm:^1.2.8"
+    oxc-resolver: "npm:^11.19.1"
+    picocolors: "npm:^1.1.1"
+    picomatch: "npm:^4.0.1"
+    smol-toml: "npm:^1.5.2"
+    strip-json-comments: "npm:5.0.3"
+    unbash: "npm:^2.2.0"
+    yaml: "npm:^2.8.2"
+    zod: "npm:^4.1.11"
+  peerDependencies:
+    "@types/node": ">=18"
+    typescript: ">=5.0.4 <7"
+  bin:
+    knip: bin/knip.js
+    knip-bun: bin/knip-bun.js
+  checksum: 10/2356c5725bdf2cc90b51cc39563812db0f23aa45857c64992bbe9b13705a6b4a8a50eb28713795ffc212713d2e9ccc7ef6d5c80fd387a118b717b13e036b8de3
+  languageName: node
+  linkType: hard
+
 "kysely-codegen@npm:^0.20.0":
   version: 0.20.0
   resolution: "kysely-codegen@npm:0.20.0"
@@ -19038,6 +19309,13 @@ __metadata:
     lightningcss-win32-x64-msvc:
       optional: true
   checksum: 10/098e61007f0d0ec8b5c50884e33b543b551d1ff21bc7b062434b6638fd0b8596858f823b60dfc2a4aa756f3cb120ad79f2b7f4a55b1bda2c0269ab8cf476f114
+  languageName: node
+  linkType: hard
+
+"lilconfig@npm:^3.1.1":
+  version: 3.1.3
+  resolution: "lilconfig@npm:3.1.3"
+  checksum: 10/b932ce1af94985f0efbe8896e57b1f814a48c8dbd7fc0ef8469785c6303ed29d0090af3ccad7e36b626bfca3a4dc56cc262697e9a8dd867623cf09a39d54e4c3
   languageName: node
   linkType: hard
 
@@ -21041,6 +21319,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-check-updates@npm:^17.1.18":
+  version: 17.1.18
+  resolution: "npm-check-updates@npm:17.1.18"
+  bin:
+    ncu: build/cli.js
+    npm-check-updates: build/cli.js
+  checksum: 10/4a124bd8e18c990329177d2fd0a7c85c7c015e46ec8c8d3d553b2d9218a895250138d8c716f5e412a232af9fdc6194d1434f4349b10c5dff0d7e638034cc79ee
+  languageName: node
+  linkType: hard
+
 "npm-run-path@npm:^4.0.1":
   version: 4.0.1
   resolution: "npm-run-path@npm:4.0.1"
@@ -21258,6 +21546,72 @@ __metadata:
   version: 0.5.0
   resolution: "outdent@npm:0.5.0"
   checksum: 10/7d94a7d93883afa32c99d84f33248b221f4eeeedbb571921fe0e5cf0bee32e64746c587e9606d98ec22762870c782d21dd4bc3a0edf442d347cb54aa107b198d
+  languageName: node
+  linkType: hard
+
+"oxc-resolver@npm:^11.19.1":
+  version: 11.24.2
+  resolution: "oxc-resolver@npm:11.24.2"
+  dependencies:
+    "@oxc-resolver/binding-android-arm-eabi": "npm:11.24.2"
+    "@oxc-resolver/binding-android-arm64": "npm:11.24.2"
+    "@oxc-resolver/binding-darwin-arm64": "npm:11.24.2"
+    "@oxc-resolver/binding-darwin-x64": "npm:11.24.2"
+    "@oxc-resolver/binding-freebsd-x64": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-arm-gnueabihf": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-arm-musleabihf": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-arm64-gnu": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-arm64-musl": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-ppc64-gnu": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-riscv64-gnu": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-riscv64-musl": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-s390x-gnu": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-x64-gnu": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-x64-musl": "npm:11.24.2"
+    "@oxc-resolver/binding-openharmony-arm64": "npm:11.24.2"
+    "@oxc-resolver/binding-wasm32-wasi": "npm:11.24.2"
+    "@oxc-resolver/binding-win32-arm64-msvc": "npm:11.24.2"
+    "@oxc-resolver/binding-win32-x64-msvc": "npm:11.24.2"
+  dependenciesMeta:
+    "@oxc-resolver/binding-android-arm-eabi":
+      optional: true
+    "@oxc-resolver/binding-android-arm64":
+      optional: true
+    "@oxc-resolver/binding-darwin-arm64":
+      optional: true
+    "@oxc-resolver/binding-darwin-x64":
+      optional: true
+    "@oxc-resolver/binding-freebsd-x64":
+      optional: true
+    "@oxc-resolver/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxc-resolver/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxc-resolver/binding-linux-arm64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-arm64-musl":
+      optional: true
+    "@oxc-resolver/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-riscv64-musl":
+      optional: true
+    "@oxc-resolver/binding-linux-s390x-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-x64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-x64-musl":
+      optional: true
+    "@oxc-resolver/binding-openharmony-arm64":
+      optional: true
+    "@oxc-resolver/binding-wasm32-wasi":
+      optional: true
+    "@oxc-resolver/binding-win32-arm64-msvc":
+      optional: true
+    "@oxc-resolver/binding-win32-x64-msvc":
+      optional: true
+  checksum: 10/42e10840125f4b942a7cbcad757f1d882eb737cd6c96c13128eade6613c56a24727075e069b3dff145b3cd36e21fe5e4a1de19b5da09466864fa63d35aae71f3
   languageName: node
   linkType: hard
 
@@ -21773,6 +22127,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pg-connection-string@npm:^2.14.0":
+  version: 2.14.0
+  resolution: "pg-connection-string@npm:2.14.0"
+  checksum: 10/9434e5fbb918b9224a18ad8b739c3da83940ec95c113a0e38371dbd3e8f84c6e3cbaf4dbfaf36d02a1281b0e844af290a1bc240b8d865a98cae6864d89ee11a0
+  languageName: node
+  linkType: hard
+
 "pg-int8@npm:1.0.1":
   version: 1.0.1
   resolution: "pg-int8@npm:1.0.1"
@@ -21809,6 +22170,13 @@ __metadata:
   version: 1.12.0
   resolution: "pg-protocol@npm:1.12.0"
   checksum: 10/0f5d8a5dbef39ef4d06686910ad61599b8d26c4505e76af2f6da3a1a1028c312f61678fae5e5012d477fe318b5ebc8507a828c087973b22e5fd4ec1e7394101a
+  languageName: node
+  linkType: hard
+
+"pg-protocol@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "pg-protocol@npm:1.16.0"
+  checksum: 10/fe826fccf317460d5f23b289e2d44a00c5fd46765e52c9eb14e3bda6ab44aef8a8906f7e2f07a2a3a9cc6087ebf9fbf2f430ee6bfdd1d24f870a17aa722e53eb
   languageName: node
   linkType: hard
 
@@ -21869,6 +22237,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pg@npm:^8.21.0":
+  version: 8.23.0
+  resolution: "pg@npm:8.23.0"
+  dependencies:
+    pg-cloudflare: "npm:^1.4.0"
+    pg-connection-string: "npm:^2.14.0"
+    pg-pool: "npm:^3.14.0"
+    pg-protocol: "npm:^1.16.0"
+    pg-types: "npm:2.2.0"
+    pgpass: "npm:1.0.5"
+  peerDependencies:
+    pg-native: ">=3.0.1"
+  dependenciesMeta:
+    pg-cloudflare:
+      optional: true
+  peerDependenciesMeta:
+    pg-native:
+      optional: true
+  checksum: 10/eb9be4e664638331cc12bdf5f4d78d94f0ec052a13a609f3c48007905ac9da5c1987affa745225f37f34759c982860b25fcc1477c04d07a099d06b345d455f72
+  languageName: node
+  linkType: hard
+
 "pgpass@npm:1.0.5":
   version: 1.0.5
   resolution: "pgpass@npm:1.0.5"
@@ -21889,6 +22279,13 @@ __metadata:
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10/60c2595003b05e4535394d1da94850f5372c9427ca4413b71210f437f7b2ca091dbd611c45e8b37d10036fa8eade25c1b8951654f9d3973bfa66a2ff4d3b08bc
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.1":
+  version: 4.0.5
+  resolution: "picomatch@npm:4.0.5"
+  checksum: 10/8bad770af9dcdb7f94ad1a893adcbe08a97d75a18872f8fed37161d3124217471c402b3929f051532f795f4ff2e53dcebb1644df4c1a5f3a9c476fef3b9f8c51
   languageName: node
   linkType: hard
 
@@ -21991,6 +22388,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pinst@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pinst@npm:3.0.0"
+  bin:
+    pinst: bin.js
+  checksum: 10/a75e4f7b5eeb9c76e7fd1b2d9854fcd38c304a3b1f9b563946a0f4357772c742222094e851f4c23d0bbdc4151af2d7875bb919c9ef8a9c4af77a02a73e8f72f0
+  languageName: node
+  linkType: hard
+
 "pkce-challenge@npm:^5.0.0":
   version: 5.0.1
   resolution: "pkce-challenge@npm:5.0.1"
@@ -22088,6 +22494,29 @@ __metadata:
   peerDependencies:
     postcss: ^8.4.21
   checksum: 10/32f5422478e60086e5d70b4ea6f4bcdb15baae16e9e311497fbbf5e6d07dfb5916e7fd61957e8664b923c8c68a5bd364cb0517d8e263cfd12cc601a1c1ab9ad2
+  languageName: node
+  linkType: hard
+
+"postcss-load-config@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "postcss-load-config@npm:6.0.1"
+  dependencies:
+    lilconfig: "npm:^3.1.1"
+  peerDependencies:
+    jiti: ">=1.21.0"
+    postcss: ">=8.0.9"
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  peerDependenciesMeta:
+    jiti:
+      optional: true
+    postcss:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  checksum: 10/1691cfc94948a9373d4f7b3b7a8500cfaf8cb2dcc2107c14f90f2a711a9892a362b0866894ac5bb723455fa685a15116d9ed3252188689c4502b137c19d6bdc4
   languageName: node
   linkType: hard
 
@@ -24136,6 +24565,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"smol-toml@npm:^1.5.2":
+  version: 1.8.0
+  resolution: "smol-toml@npm:1.8.0"
+  checksum: 10/eb8aeeebd1c3e5de6069922c9a44bb40b9b3c534e685ccd0aa299b4d7307f1ec49471da57812bdbf1d21a0c09f1dd47eb0e814d0d34c892142187ccce2487ea9
+  languageName: node
+  linkType: hard
+
 "socks-proxy-agent@npm:^8.0.3, socks-proxy-agent@npm:^8.0.5":
   version: 8.0.5
   resolution: "socks-proxy-agent@npm:8.0.5"
@@ -24516,7 +24952,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-json-comments@npm:^5.0.2":
+"strip-json-comments@npm:5.0.3, strip-json-comments@npm:^5.0.2":
   version: 5.0.3
   resolution: "strip-json-comments@npm:5.0.3"
   checksum: 10/3ccbf26f278220f785e4b71f8a719a6a063d72558cc63cb450924254af258a4f4c008b8c9b055373a680dc7bd525be9e543ad742c177f8a7667e0b726258e0e4
@@ -25309,6 +25745,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unbash@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "unbash@npm:2.2.0"
+  checksum: 10/dc169c6cacff0364c3d46dbe3f08f4c812cee63359f94ebace483b1a382585d5a1bf4007c12ed3c73671a0256d0026efc23e4732583ae76b42d8570fc4680667
+  languageName: node
+  linkType: hard
+
 "unbzip2-stream@npm:^1.4.3":
   version: 1.4.3
   resolution: "unbzip2-stream@npm:1.4.3"
@@ -26048,6 +26491,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"walk-up-path@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "walk-up-path@npm:4.0.0"
+  checksum: 10/6a230b20e5de296895116dc12b09dafaec1f72b8060c089533d296e241aff059dfaebe0d015c77467f857e4b40c78e08f7481add76f340233a1f34fa8af9ed63
+  languageName: node
+  linkType: hard
+
 "web-streams-polyfill@npm:^3.0.3":
   version: 3.3.3
   resolution: "web-streams-polyfill@npm:3.3.3"
@@ -26613,7 +27063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4.1.13, zod@npm:^4.4.3":
+"zod@npm:^4.1.11, zod@npm:^4.1.13, zod@npm:^4.4.3":
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10/804b9a42aa8f35f2b3c5a8dff906291cb749115f83ee2afe3576d70b5b5c53c965365c7f4967690647a9c54af9838ff232a85ff9577a0a36c44b68bc6cdefe36


### PR DESCRIPTION
Closes #1263.

## The bug this catches

An import that is never declared in its package's `package.json` resolves
fine in this repo — Yarn hoists it from the root — and fails only for
someone installing that package on its own. It stays invisible right up
until a release. The existing "Validate Package Deps" job does not see it.

## What runs

`yarn knip` in the lint job, scoped to the three rules that are
true-positive dense here:

| rule | why |
|---|---|
| `unlisted` | the bug above |
| `binaries` | same, for `bin` entries |
| `duplicates` | two exported names for one thing |

`files`, `dependencies`, `exports` and `types` are deliberately **off**.
Pikku functions are discovered by codegen rather than imported, so an
import-graph tool reads every `*.function.ts` and the CLI's own
`cli.wiring.ts` as orphaned — turning those on reports ~1100 findings of
which almost none are real. `exports`/`types` are covered by the surface
scan behind #1233, which can see the two things knip cannot: the fabric
repo as a downstream consumer, and specifiers the CLI emits inside
template literals.

Locally: `yarn knip`.

## What it found

All fixed in this PR, so the gate is green on the commit that adds it.

**Published packages** (changeset included):
- `zod` — `@pikku/openapi-parser`, `@pikku/better-auth`
- `path-to-regexp` — `@pikku/next`
- `kysely` — `@pikku/cli`
- `rxjs` — `@pikku/assistant-ui`
- `@assistant-ui/react`, `@codemirror/language`, `postcss-load-config` — `@pikku/console`
- `@ai-sdk/provider` — `@pikku/ai-vercel` (type-only, so devDependency)

`rxjs`, `kysely` and `path-to-regexp` reach consumers through public
signatures — `Observable<BaseEvent>` is a published return type, and
`createCoercionPlugin` returns a `KyselyPlugin` — so they are runtime
dependencies rather than build-only.

`@pikku/assistant-ui` pins `rxjs` to the exact `7.8.1` that
`@ag-ui/client` pins rather than a caret range. The two exchange
`Observable`s; a range floats to 7.8.2 and gives them two incompatible
`Observable` types (this actually broke the build until pinned, and the
pin also removes a duplicate rxjs install).

**Non-published:** `@modelcontextprotocol/sdk` in the mcp-server
template, plus the benchmark and verifier manifests.

**Duplicates:** `SqliteSerializePlugin` (a long-`@deprecated` alias of
`SerializePlugin`) and a `FunctionDetailsForm` alias of
`FunctionConfiguration`. Also drops `packages/console/next-env.d.ts`, a
Next.js leftover in what is now a Vite app.

## Ignores

Three entries, each commented in `knip.jsonc` — `cloudflare` (the
`cloudflare:workers` built-in module scheme, not the npm package),
`@pikku/verifier-db-addon` (deliberately outside the workspace globs so
the verifier can prove non-workspace addon resolution), and three
binaries that are subcommands or workspace scripts rather than PATH
binaries.

## Verification

`yarn build`, `yarn test` (28/28) and `yarn test:verifiers` all exit 0,
and `packages/console` type-checks clean without `next-env.d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected runtime and peer dependency declarations across packages and templates, improving installation and execution reliability.
  * Pinned the assistant UI’s RxJS version for consistent behavior.
* **Breaking Changes**
  * Removed the deprecated `SqliteSerializePlugin` alias. Use `SerializePlugin` instead.
* **Chores**
  * Added dependency validation and benchmark workflow tooling.
  * Updated development tooling and package configuration.
* **Maintenance**
  * Improved package metadata and streamlined console type configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->