### PR TITLE
fix(cli): fail validate on a workspace subpath exports cannot resolve

### DIFF
--- a/.changeset/validate-workspace-subpath-exports.md
+++ b/.changeset/validate-workspace-subpath-exports.md
@@ -1,0 +1,20 @@
+---
+'@pikku/cli': patch
+---
+
+Fail validate when a workspace subpath import cannot resolve through the owning package's exports.
+
+`exports` does not probe file extensions the way a bundler alias does, so a map
+like `"./pikku/*": "./src/pikku/*"` resolves `pkg/pikku/client.gen` to a file
+that was never written — the real one is `client.gen.ts`. Nothing surfaces it
+while the consumer carries a `resolve.alias` for the same specifier: the alias
+wins wherever that config is loaded, and the broken map only bites somewhere
+else — another app in the repo, a different bundler, plain node, or a generated
+vite config that never merged the app's own.
+
+The new check pairs every workspace-internal subpath import with the owning
+package's `exports` and reports the ones that resolve to nothing, matching
+Node's pattern precedence (longest literal prefix, then longest suffix) and
+following fallback arrays so a declaration-only subpath still counts as
+resolvable. It runs once at the workspace root, where both halves are in view,
+and reports each broken subpath once rather than once per importer.

--- a/packages/cli/src/functions/validate/validate-registry.ts
+++ b/packages/cli/src/functions/validate/validate-registry.ts
@@ -7,6 +7,7 @@ import {
 } from './addon-package-checks.js'
 import { runSharedProjectChecks } from './shared-checks.js'
 import { runTypeIdentityChecks } from './type-identity-checks.js'
+import { runWorkspaceExportsChecks } from './workspace-exports-checks.js'
 import type { ValidateFinding as Finding } from './persona-checks.js'
 
 export type ValidateTarget = {
@@ -114,6 +115,15 @@ export const CHECKS: ValidateCheck[] = [
     applies: async ({ dir, label }) =>
       label === '.' && existsSync(join(dir, 'node_modules')),
     run: async ({ dir }) => runTypeIdentityChecks(dir),
+  },
+  {
+    id: 'workspace-exports',
+    subject: 'workspace subpath imports',
+    // Root only: the check pairs an import in one package with the exports map
+    // of another, so it needs the whole tree in view. Per-package it would see
+    // the consumer without the producer and report nothing.
+    applies: async ({ label }) => label === '.',
+    run: async ({ dir }) => runWorkspaceExportsChecks(dir),
   },
 ]
 

--- a/packages/cli/src/functions/validate/workspace-exports-checks.test.ts
+++ b/packages/cli/src/functions/validate/workspace-exports-checks.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, test } from 'node:test'
+import { runWorkspaceExportsChecks } from './workspace-exports-checks.js'
+import { planValidation } from './validate-registry.js'
+
+const makeTmp = () => mkdtemp(join(tmpdir(), 'pikku-workspace-exports-'))
+
+const writeJson = async (path: string, value: unknown) => {
+  await mkdir(join(path, '..'), { recursive: true })
+  await writeFile(path, JSON.stringify(value, null, 2))
+}
+
+/**
+ * The shape that motivated the check: a generated client whose files are
+ * `*.gen.ts` on disk, imported extensionless, behind an exports map that
+ * substitutes no extension.
+ */
+const makeSdkWorkspace = async (root: string, exportsField: unknown) => {
+  await writeJson(join(root, 'package.json'), {
+    name: 'root',
+    workspaces: ['apps/*', 'packages/*'],
+  })
+
+  await writeJson(join(root, 'packages', 'sdk', 'package.json'), {
+    name: '@acme/sdk',
+    exports: exportsField,
+  })
+  await mkdir(join(root, 'packages', 'sdk', 'src', 'pikku'), {
+    recursive: true,
+  })
+  await writeFile(
+    join(root, 'packages', 'sdk', 'src', 'pikku', 'client.gen.ts'),
+    'export const client = 1\n'
+  )
+  await writeFile(
+    join(root, 'packages', 'sdk', 'src', 'pikku', 'rpc-map.gen.d.ts'),
+    'export type Map = never\n'
+  )
+
+  await writeJson(join(root, 'apps', 'console', 'package.json'), {
+    name: '@acme/console',
+    dependencies: { '@acme/sdk': 'workspace:*' },
+  })
+  await mkdir(join(root, 'apps', 'console', 'src'), { recursive: true })
+}
+
+const writeConsumer = (root: string, body: string) =>
+  writeFile(join(root, 'apps', 'console', 'src', 'main.ts'), body)
+
+describe('workspace exports checks', () => {
+  test('flags an extensionless subpath the exports map cannot resolve', async () => {
+    const root = await makeTmp()
+    await makeSdkWorkspace(root, { './pikku/*': './src/pikku/*' })
+    await writeConsumer(
+      root,
+      "import { client } from '@acme/sdk/pikku/client.gen'\n"
+    )
+
+    const findings = await runWorkspaceExportsChecks(root)
+    assert.equal(findings.length, 1)
+    assert.equal(findings[0]!.id, 'workspace-subpath-not-exported')
+    assert.equal(findings[0]!.severity, 'error')
+    assert.match(findings[0]!.message, /client\.gen/)
+  })
+
+  test('accepts a map that substitutes the real extension', async () => {
+    const root = await makeTmp()
+    await makeSdkWorkspace(root, { './pikku/*': './src/pikku/*.ts' })
+    await writeConsumer(
+      root,
+      "import { client } from '@acme/sdk/pikku/client.gen'\n"
+    )
+
+    assert.deepEqual(await runWorkspaceExportsChecks(root), [])
+  })
+
+  test('resolves a declaration-only subpath through a fallback array', async () => {
+    const root = await makeTmp()
+    await makeSdkWorkspace(root, {
+      './pikku/*': ['./src/pikku/*.ts', './src/pikku/*.d.ts'],
+    })
+    await writeConsumer(
+      root,
+      [
+        "import { client } from '@acme/sdk/pikku/client.gen'",
+        "import type { Map } from '@acme/sdk/pikku/rpc-map.gen'",
+      ].join('\n')
+    )
+
+    assert.deepEqual(await runWorkspaceExportsChecks(root), [])
+  })
+
+  test('prefers the longer pattern so a .js specifier maps to source', async () => {
+    const root = await makeTmp()
+    await makeSdkWorkspace(root, {
+      './pikku/*.js': './src/pikku/*.ts',
+      './pikku/*': ['./src/pikku/*.ts', './src/pikku/*.d.ts'],
+    })
+    await writeConsumer(
+      root,
+      "import { client } from '@acme/sdk/pikku/client.gen.js'\n"
+    )
+
+    assert.deepEqual(await runWorkspaceExportsChecks(root), [])
+  })
+
+  test('ignores a package that publishes no exports field', async () => {
+    const root = await makeTmp()
+    await makeSdkWorkspace(root, undefined)
+    await writeConsumer(
+      root,
+      "import { client } from '@acme/sdk/pikku/client.gen'\n"
+    )
+
+    assert.deepEqual(await runWorkspaceExportsChecks(root), [])
+  })
+
+  test('ignores third-party and relative specifiers', async () => {
+    const root = await makeTmp()
+    await makeSdkWorkspace(root, { './pikku/*': './src/pikku/*' })
+    await writeConsumer(
+      root,
+      [
+        "import react from 'react/jsx-runtime'",
+        "import './local/thing.js'",
+      ].join('\n')
+    )
+
+    assert.deepEqual(await runWorkspaceExportsChecks(root), [])
+  })
+
+  test('reports each broken subpath once, not once per importer', async () => {
+    const root = await makeTmp()
+    await makeSdkWorkspace(root, { './pikku/*': './src/pikku/*' })
+    await writeConsumer(
+      root,
+      "import { client } from '@acme/sdk/pikku/client.gen'\n"
+    )
+    await writeFile(
+      join(root, 'apps', 'console', 'src', 'other.ts'),
+      "import { client } from '@acme/sdk/pikku/client.gen'\n"
+    )
+
+    const findings = await runWorkspaceExportsChecks(root)
+    assert.equal(findings.length, 1)
+  })
+
+  test('is planned at the workspace root only', async () => {
+    const root = await makeTmp()
+    await makeSdkWorkspace(root, { './pikku/*': './src/pikku/*' })
+
+    const plan = await planValidation(root)
+    const targets = plan
+      .filter(({ check }) => check.id === 'workspace-exports')
+      .map(({ target }) => target.label)
+    assert.deepEqual(targets, ['.'])
+  })
+})

--- a/packages/cli/src/functions/validate/workspace-exports-checks.ts
+++ b/packages/cli/src/functions/validate/workspace-exports-checks.ts
@@ -1,0 +1,228 @@
+import { existsSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import { join, relative } from 'node:path'
+import { readJsonSafe } from './shared-checks.js'
+import type { ValidateFinding } from './persona-checks.js'
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  '.pikku',
+  '.pikku-runtime',
+  'coverage',
+  '.next',
+  '.yarn',
+])
+
+const SOURCE_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.mts',
+  '.cts',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+])
+
+const IMPORT_PATTERN =
+  /(?:import|export)\s[^'"]*?from\s*['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)/g
+
+type WorkspacePackage = {
+  name: string
+  dir: string
+  exports: unknown
+}
+
+/**
+ * Every target a single `exports` value can resolve to, in the order Node tries
+ * them. Conditions collapse to their targets because a subpath that only
+ * resolves under one condition still has to resolve under that condition.
+ */
+function targetsOf(value: unknown): string[] {
+  if (typeof value === 'string') return [value]
+  if (Array.isArray(value)) return value.flatMap(targetsOf)
+  if (value && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).flatMap(targetsOf)
+  }
+  return []
+}
+
+/**
+ * Node picks the pattern with the longest literal prefix, then the longest
+ * suffix — so `./pikku/*.js` wins over `./pikku/*` for a `.js` specifier.
+ */
+function patternRank(key: string): [number, number] {
+  const star = key.indexOf('*')
+  if (star === -1) return [key.length, 0]
+  return [star, key.length - star - 1]
+}
+
+function matchSubpath(
+  exportsField: unknown,
+  subpath: string
+): { targets: string[]; key: string } | null {
+  if (!exportsField || typeof exportsField !== 'object') return null
+  const entries = Object.entries(exportsField as Record<string, unknown>)
+  if (!entries.some(([key]) => key.startsWith('.'))) return null
+
+  const exact = entries.find(([key]) => key === subpath)
+  if (exact) return { targets: targetsOf(exact[1]), key: exact[0] }
+
+  const candidates = entries
+    .filter(([key]) => key.includes('*'))
+    .map(([key, value]) => {
+      const star = key.indexOf('*')
+      const prefix = key.slice(0, star)
+      const suffix = key.slice(star + 1)
+      if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) return null
+      if (subpath.length < prefix.length + suffix.length) return null
+      const wildcard = subpath.slice(prefix.length, subpath.length - suffix.length)
+      return { key, value, wildcard }
+    })
+    .filter((c): c is NonNullable<typeof c> => c !== null)
+    .sort((a, b) => {
+      const [ap, as] = patternRank(a.key)
+      const [bp, bs] = patternRank(b.key)
+      return bp - ap || bs - as
+    })
+
+  const best = candidates[0]
+  if (!best) return null
+  return {
+    targets: targetsOf(best.value).map((t) => t.replaceAll('*', best.wildcard)),
+    key: best.key,
+  }
+}
+
+async function collectWorkspacePackages(
+  root: string,
+  maxDepth = 5
+): Promise<Map<string, WorkspacePackage>> {
+  const packages = new Map<string, WorkspacePackage>()
+
+  const visit = async (dir: string, depth: number): Promise<void> => {
+    const pkg = await readJsonSafe<{ name?: string; exports?: unknown }>(
+      join(dir, 'package.json')
+    )
+    if (pkg?.name) {
+      packages.set(pkg.name, { name: pkg.name, dir, exports: pkg.exports })
+    }
+    if (depth >= maxDepth) return
+    const entries = await readdir(dir, { withFileTypes: true }).catch(() => [])
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      if (entry.name.startsWith('.') || SKIP_DIRS.has(entry.name)) continue
+      await visit(join(dir, entry.name), depth + 1)
+    }
+  }
+
+  await visit(root, 0)
+  return packages
+}
+
+async function* sourceFiles(
+  dir: string,
+  depth = 0
+): AsyncGenerator<string> {
+  if (depth > 8) return
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name.startsWith('.') || SKIP_DIRS.has(entry.name)) continue
+      yield* sourceFiles(full, depth + 1)
+      continue
+    }
+    if (!entry.isFile()) continue
+    const dot = entry.name.lastIndexOf('.')
+    if (dot === -1) continue
+    if (entry.name.includes('.gen.')) continue
+    if (!SOURCE_EXTENSIONS.has(entry.name.slice(dot))) continue
+    yield full
+  }
+}
+
+function splitSpecifier(
+  specifier: string,
+  packages: Map<string, WorkspacePackage>
+): { pkg: WorkspacePackage; subpath: string } | null {
+  if (specifier.startsWith('.') || specifier.startsWith('/')) return null
+  const parts = specifier.split('/')
+  const name = specifier.startsWith('@')
+    ? parts.slice(0, 2).join('/')
+    : parts[0]!
+  const pkg = packages.get(name)
+  if (!pkg) return null
+  const rest = specifier.slice(name.length)
+  if (rest === '') return null
+  return { pkg, subpath: `.${rest}` }
+}
+
+/**
+ * Every workspace-internal subpath import must resolve through the owning
+ * package's own `exports`.
+ *
+ * `exports` does not probe extensions the way a bundler alias does, so a map
+ * like `"./pikku/*": "./src/pikku/*"` resolves `pkg/pikku/client.gen` to a file
+ * called `client.gen` that was never written — the real file is `client.gen.ts`.
+ * Nothing catches it while a `resolve.alias` in the consumer's own vite config
+ * covers the same specifier: the alias wins locally, and the broken map only
+ * surfaces where that config is not in play (a sandbox scaffold config, a
+ * different bundler, plain node, another app in the same repo).
+ */
+export async function runWorkspaceExportsChecks(
+  root: string
+): Promise<ValidateFinding[]> {
+  const packages = await collectWorkspacePackages(root)
+  if (packages.size === 0) return []
+
+  const findings: ValidateFinding[] = []
+  const seen = new Set<string>()
+
+  for await (const file of sourceFiles(root)) {
+    let source: string
+    try {
+      source = await readFile(file, 'utf8')
+    } catch {
+      continue
+    }
+    if (!source.includes('from') && !source.includes('import(')) continue
+
+    for (const match of source.matchAll(IMPORT_PATTERN)) {
+      const specifier = match[1] ?? match[2]
+      if (!specifier) continue
+      const split = splitSpecifier(specifier, packages)
+      if (!split) continue
+      const { pkg, subpath } = split
+      if (!pkg.exports) continue
+
+      const resolved = matchSubpath(pkg.exports, subpath)
+      const targets = resolved?.targets ?? []
+      if (targets.some((t) => existsSync(join(pkg.dir, t)))) continue
+
+      const key = `${pkg.name}${subpath.slice(1)}`
+      if (seen.has(key)) continue
+      seen.add(key)
+
+      findings.push({
+        id: 'workspace-subpath-not-exported',
+        severity: 'error',
+        message: resolved
+          ? `"${specifier}" matches "${resolved.key}" in ${pkg.name}'s exports, but every target it maps to is missing: ${targets.join(', ')}.`
+          : `"${specifier}" is not covered by any subpath in ${pkg.name}'s exports.`,
+        path: relative(root, file) || file,
+        fixHint: [
+          `Make ${pkg.name} resolvable on its own — exports does not add file extensions,`,
+          `so a target must name a file that exists (e.g. "./src/pikku/*.ts", or a`,
+          `fallback array ["./src/pikku/*.ts", "./src/pikku/*.d.ts"]).`,
+          `A resolve.alias in one consumer hides this everywhere else.`,
+        ].join('\n'),
+      })
+    }
+  }
+
+  return findings
+}


### PR DESCRIPTION
## The failure this catches

`exports` does not probe file extensions the way a bundler alias does. So a map like:

```json
"exports": { "./pikku/*": "./src/pikku/*" }
```

resolves `pkg/pikku/client.gen` to a file called `client.gen` that was never written — the real one is `client.gen.ts`. Node agrees:

```
pkg/pikku/client.gen     -> FAIL MODULE_NOT_FOUND
pkg/pikku/client.gen.ts  -> packages/sdk/src/pikku/client.gen.ts
```

What makes it survive review is that it usually *works*. The consumer carries a `resolve.alias` for the same specifier, the alias wins wherever that config is loaded, and the broken map only bites somewhere else — another app in the repo, a different bundler, plain node, or a generated vite config that never merged the app's own.

That last one is how it surfaced: a sandbox served an app through a scaffold vite config, the alias wasn't in play, and every generated-client import died at once with `Failed to resolve import … Does the file exist?` — pointing at a file that does exist, under a name nothing asked for. The same repo turned out to have a second instance in its project template, on a subpath that had fallen through a catch-all pattern.

## The check

Pairs every workspace-internal subpath import with the owning package's `exports` and reports the ones that resolve to nothing.

- Follows Node's pattern precedence — longest literal prefix, then longest suffix — so `./pikku/*.js` correctly beats `./pikku/*` for a `.js` specifier.
- Follows fallback arrays and collapses conditions, so a declaration-only subpath resolved via `["./src/pikku/*.ts", "./src/pikku/*.d.ts"]` still counts as resolvable.
- Skips packages with no `exports` field — legacy resolution is not this check's business.
- Runs once at the workspace root, where both the importer and the producer are in view, and reports each broken subpath once rather than once per importer.

## Verification

8 unit tests covering the broken map, the fixed map, the declaration-only fallback, pattern precedence, no-`exports` packages, third-party/relative specifiers, dedup across importers, and root-only planning.

Run against the real monorepo that motivated it: 1 finding before the fixes, 0 after, no false positives across ~40 workspace packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace validation for internal package subpath imports.
  * Detects unresolved or broken package export paths, including pattern-based and fallback exports.
  * Reports each validation issue once and ignores external, relative, generated, and dependency files.
* **Bug Fixes**
  * Prevents missing workspace exports from going undetected during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->