### PR TITLE
fix(console): contain addon package names to node_modules, and report the wired namespace

### DIFF
--- a/packages/addon/pikku-console/src/functions/addon-readiness.function.ts
+++ b/packages/addon/pikku-console/src/functions/addon-readiness.function.ts
@@ -5,6 +5,7 @@ import { BadRequestError, LocalEnvironmentOnlyError } from '@pikku/core/errors'
 import { pikkuFunc } from '#pikku'
 import { findProjectRoot } from '../lib/find-project-root.js'
 import { readWiringOverrides } from '../lib/addon-readiness.js'
+import { assertAddonPackageName } from '../lib/derive-instance-overrides.js'
 
 export const addonReadiness = pikkuFunc<
   { packageName: string; namespace: string },
@@ -20,6 +21,7 @@ export const addonReadiness = pikkuFunc<
     { metaService, addonReadinessService },
     { packageName, namespace }
   ) => {
+    assertAddonPackageName(packageName)
     if (!/^[a-z0-9-]+$/.test(namespace)) {
       throw new BadRequestError(`Invalid namespace: ${namespace}`)
     }

--- a/packages/addon/pikku-console/src/functions/install-addon.function.ts
+++ b/packages/addon/pikku-console/src/functions/install-addon.function.ts
@@ -6,6 +6,7 @@ import {
 import { pikkuFunc } from '#pikku'
 import { findProjectRoot } from '../lib/find-project-root.js'
 import {
+  assertAddonPackageName,
   deriveInstanceOverrides,
   readAddonDeclaredNames,
   type InstanceOverrides,
@@ -28,6 +29,7 @@ export const installAddon = pikkuFunc<
     ready: boolean
     missingSecrets: string[]
     missingVariables: string[]
+    namespace: string
   }
 >({
   title: 'Install Addon',
@@ -44,10 +46,7 @@ export const installAddon = pikkuFunc<
       await import('node:fs/promises')
     const { join, dirname } = await import('node:path')
     const { existsSync } = await import('node:fs')
-    const validPkg = /^(@[a-z0-9-]+\/)?[a-z0-9._-]+$/
-    if (!validPkg.test(packageName)) {
-      throw new BadRequestError(`Invalid package name: ${packageName}`)
-    }
+    assertAddonPackageName(packageName)
     if (!/^[a-z0-9-]+$/.test(namespace)) {
       throw new BadRequestError(`Invalid namespace: ${namespace}`)
     }
@@ -132,6 +131,7 @@ wireAddon(${serializeWireAddon(namespace, packageName, overrides)})
       ready,
       missingSecrets,
       missingVariables,
+      namespace,
       message: ready
         ? `Installed ${packageName} and created ${wiringFile}. Restart the server to activate it.`
         : `Installed ${packageName} and created ${wiringFile}, but it cannot start until ${missing.join(', ')} ${missing.length === 1 ? 'is' : 'are'} set. Configure ${missing.length === 1 ? 'it' : 'them'}, then restart the server.`,

--- a/packages/addon/pikku-console/src/lib/derive-instance-overrides.test.ts
+++ b/packages/addon/pikku-console/src/lib/derive-instance-overrides.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'assert'
 import { describe, test } from 'node:test'
 import {
+  assertAddonPackageName,
   deriveInstanceOverrides,
   packageBase,
 } from './derive-instance-overrides.js'
@@ -68,4 +69,32 @@ describe('deriveInstanceOverrides', () => {
     assert.equal(packageBase('addon-slack'), 'slack')
     assert.equal(packageBase('mypkg'), 'mypkg')
   })
+})
+
+describe('assertAddonPackageName', () => {
+  for (const name of [
+    '@pikku/addon-mandrill',
+    'addon-slack',
+    'my.pkg',
+    'a-b_c',
+  ]) {
+    test(`accepts ${name}`, () => {
+      assert.doesNotThrow(() => assertAddonPackageName(name))
+    })
+  }
+
+  for (const name of [
+    '.',
+    '..',
+    '../../etc',
+    '@pikku/../evil',
+    '_private',
+    'UPPER',
+    'has space',
+    '',
+  ]) {
+    test(`rejects ${JSON.stringify(name)}`, () => {
+      assert.throws(() => assertAddonPackageName(name), /Invalid package name/)
+    })
+  }
 })

--- a/packages/addon/pikku-console/src/lib/derive-instance-overrides.ts
+++ b/packages/addon/pikku-console/src/lib/derive-instance-overrides.ts
@@ -3,14 +3,8 @@ import { existsSync } from 'node:fs'
 import { join, resolve, sep } from 'node:path'
 import { BadRequestError } from '@pikku/core/errors'
 
-/**
- * A package name reaches this module from the console as request input and is
- * joined onto `node_modules`, so it is a path segment before it is a name.
- *
- * npm forbids a leading `.` or `_`, and anchoring the first character on that
- * rule is what excludes `.` and `..` — a trailing `[a-z0-9._-]+` alone matches
- * both, so a shape check that looks right still walks out of the tree.
- */
+/** Anchoring the first character on npm's no-leading-dot rule is what excludes
+ *  `.` and `..`; a trailing `[a-z0-9._-]+` alone matches both. */
 const VALID_PACKAGE_NAME = /^(@[a-z0-9-]+\/)?[a-z0-9-][a-z0-9._-]*$/
 
 export function assertAddonPackageName(packageName: string): void {

--- a/packages/addon/pikku-console/src/lib/derive-instance-overrides.ts
+++ b/packages/addon/pikku-console/src/lib/derive-instance-overrides.ts
@@ -1,6 +1,23 @@
 import { readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, resolve, sep } from 'node:path'
+import { BadRequestError } from '@pikku/core/errors'
+
+/**
+ * A package name reaches this module from the console as request input and is
+ * joined onto `node_modules`, so it is a path segment before it is a name.
+ *
+ * npm forbids a leading `.` or `_`, and anchoring the first character on that
+ * rule is what excludes `.` and `..` — a trailing `[a-z0-9._-]+` alone matches
+ * both, so a shape check that looks right still walks out of the tree.
+ */
+const VALID_PACKAGE_NAME = /^(@[a-z0-9-]+\/)?[a-z0-9-][a-z0-9._-]*$/
+
+export function assertAddonPackageName(packageName: string): void {
+  if (!VALID_PACKAGE_NAME.test(packageName)) {
+    throw new BadRequestError(`Invalid package name: ${packageName}`)
+  }
+}
 
 /**
  * Per-instance override derivation for a second-or-later `wireAddon` of the
@@ -96,7 +113,12 @@ export function addonPikkuDir(
   rootDir: string,
   packageName: string
 ): string | null {
-  const pkgDir = join(rootDir, 'node_modules', packageName)
+  assertAddonPackageName(packageName)
+  const modulesDir = resolve(rootDir, 'node_modules')
+  const pkgDir = resolve(modulesDir, packageName)
+  if (!pkgDir.startsWith(modulesDir + sep)) {
+    throw new BadRequestError(`Invalid package name: ${packageName}`)
+  }
   for (const candidate of [
     join(pkgDir, '.pikku'),
     join(pkgDir, 'dist', '.pikku'),

--- a/packages/cli/src/functions/validate/validate-registry.test.ts
+++ b/packages/cli/src/functions/validate/validate-registry.test.ts
@@ -50,12 +50,6 @@ describe('target discovery', () => {
   })
 })
 
-/**
- * `workspace-exports` is planned at the root of every target — its precondition
- * is the root, not a kind — so it rides along in each of these expectations. It
- * is the plan that is asserted here; whether the check finds anything is
- * workspace-exports-checks.test.ts.
- */
 describe('validation planning', () => {
   test('an addon gets the addon check and not the app checks', async () => {
     const tmp = await makeTmp()

--- a/packages/console/src/components/packages/installResult.ts
+++ b/packages/console/src/components/packages/installResult.ts
@@ -14,6 +14,12 @@ export interface AddonInstallResult {
   ready: boolean
   missingSecrets: string[]
   missingVariables: string[]
+  /**
+   * The name the addon was actually wired under. Carried back because the
+   * console cannot read it from anywhere else until the server re-inspects,
+   * and the package id is a different thing that only coincides sometimes.
+   */
+  namespace: string
 }
 
 export const installResultKey = (packageName: string) => [

--- a/packages/console/src/components/packages/installResult.ts
+++ b/packages/console/src/components/packages/installResult.ts
@@ -14,11 +14,6 @@ export interface AddonInstallResult {
   ready: boolean
   missingSecrets: string[]
   missingVariables: string[]
-  /**
-   * The name the addon was actually wired under. Carried back because the
-   * console cannot read it from anywhere else until the server re-inspects,
-   * and the package id is a different thing that only coincides sometimes.
-   */
   namespace: string
 }
 

--- a/packages/console/src/pages/PackageDetailPage.tsx
+++ b/packages/console/src/pages/PackageDetailPage.tsx
@@ -732,7 +732,7 @@ export const PackageDetailPage: React.FC<{
         <Box p="xl">
           {installResult ? (
             <AddonInstallOutcome
-              namespace={activeInstance?.namespace ?? id}
+              namespace={activeInstance?.namespace ?? installResult.namespace}
               result={installResult}
             />
           ) : (


### PR DESCRIPTION
Follow-up to #1258, which merged before these two review findings were addressed.

**Path containment.** `addonReadiness` passed `packageName` straight into a path join with no validation at all, and `installAddon`'s own shape check accepted `.` and `..` — `[a-z0-9._-]+` matches both — so reusing it would not have helped. Anchoring the first character on npm's own rule (no leading `.` or `_`) is what excludes the dot segments. `addonPikkuDir` now also asserts the resolved path stays under `node_modules`, since every caller reaches the filesystem through it.

**The wired namespace.** The install response omitted the name the addon was actually wired under, so the console fell back to the package id — a different thing that only coincides sometimes — whenever the server had not re-inspected yet. It is now carried back on the result and read by `AddonInstallOutcome`.

No changeset: `.changeset/addon-install-reports-readiness.md` is still pending and already covers `@pikku/addon-console` and `@pikku/console` at patch, and the feature these fixes touch is unreleased, so they ship under that bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation results now display the installed add-on’s namespace.
  * Package details show the active instance namespace when available.

* **Bug Fixes**
  * Improved validation for add-on package names.
  * Prevented invalid package paths from being used during installation.

* **Tests**
  * Removed outdated registry validation coverage and related documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->