### PR TITLE
feat(react,mantine): ship the dev actor switcher instead of copying it per app

### DIFF
--- a/.changeset/dev-actor-switcher-package.md
+++ b/.changeset/dev-actor-switcher-package.md
@@ -1,0 +1,35 @@
+---
+'@pikku/react': minor
+'@pikku/mantine': minor
+'@pikku/cli': patch
+---
+
+feat(react,mantine): ship the dev actor switcher instead of making every app copy it
+
+The dev-only "Sign in as …" control — one click signs in as a declared scenario
+persona, no password — was hand-copied into every app that needed it, because
+`pikku fabric validate` requires any frontend with a login screen to have one.
+The `devActors()` / `signInAsActor()` pair was byte-identical everywhere it
+landed, including the `import.meta.env.DEV` gate that keeps the shared secret out
+of production bundles. That is not a thing each app should be re-deriving from a
+copy-paste.
+
+Split along the dependency line:
+
+- `@pikku/react` gains `useDevActors()`, `signInAsActor()` and `parseDevActors()`.
+  UI-free, so it stays inside the package's react-only dependency budget.
+- `@pikku/mantine/dev` gains `<DevActorSwitcher />`, built on that hook. It is a
+  new entry point rather than part of `/core`, because `/core`'s contract is
+  "drop-in alias for `@mantine/core`" and exporting a component Mantine has no
+  counterpart for would break it.
+
+The component takes `onSignedIn` rather than depending on a router, and the
+actors/secret are passed in rather than read from env — how env is spelled is a
+bundler fact (`import.meta.env.VITE_*` vs `process.env.NEXT_PUBLIC_*`), and a
+package that guesses gets it wrong for half its consumers.
+
+`fabric validate` now also accepts a `useDevActors()` call site as evidence the
+control is wired, so apps that want their own UI on the shared logic pass. The
+hand-rolled shape still passes too — nothing existing breaks. Its fix text no
+longer tells you to hand-write the helper, which would have become wrong advice
+the day this shipped.

--- a/.changeset/dev-actor-switcher-package.md
+++ b/.changeset/dev-actor-switcher-package.md
@@ -2,6 +2,7 @@
 '@pikku/react': minor
 '@pikku/mantine': minor
 '@pikku/cli': patch
+'@pikku/skills': patch
 ---
 
 feat(react,mantine): ship the dev actor switcher instead of making every app copy it
@@ -27,6 +28,12 @@ The component takes `onSignedIn` rather than depending on a router, and the
 actors/secret are passed in rather than read from env — how env is spelled is a
 bundler fact (`import.meta.env.VITE_*` vs `process.env.NEXT_PUBLIC_*`), and a
 package that guesses gets it wrong for half its consumers.
+
+The skills document it in the four places an agent would look: `pikku-better-auth`
+for the `actor` plugin's endpoint (which had only `/dev/quick-login` before, and
+so sent agents to the wrong control), `pikku-scenario` for the actor list being
+the same one a human signs in through, `pikku-react` for the hook, and
+`pikku-fabric` for the validate rule that requires it.
 
 `fabric validate` now also accepts a `useDevActors()` call site as evidence the
 control is wired, so apps that want their own UI on the shared logic pass. The

--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -1428,6 +1428,31 @@ describe('pikku fabric validate', () => {
       }
     })
 
+    test('custom UI built on useDevActors() → no finding', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        await makeFrontend(tmp, {
+          // An app that wants its own control rather than @pikku/mantine/dev's
+          // still satisfies the rule, as long as it drives the shared hook.
+          'src/pages/LoginPage.tsx':
+            "import { useDevActors } from '@pikku/react'\n" +
+            'export const LoginPage = () => {\n' +
+            '  const { actors, signInAs } = useDevActors({ actors: undefined, secret: undefined, apiUrl: "/api" })\n' +
+            '  return <>{actors.map((a) => <button key={a.key} onClick={() => signInAs(a.email)} />)}</>\n}\n',
+        })
+        const result = await runValidate(tmp)
+        assert.ok(
+          !result.findings.some(
+            (f) => f.id === 'app-missing-actor-quick-login-web'
+          ),
+          'useDevActors() is a valid quick-login fingerprint'
+        )
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+
     test('a DevActorSwitcher that is defined but never rendered still errors', async () => {
       const tmp = await makeTmp()
       try {
@@ -2168,4 +2193,3 @@ describe('declared frontends + type-check (live validate.function)', () => {
     }
   })
 })
-

--- a/packages/cli/src/fabric/functions/validate.function.ts
+++ b/packages/cli/src/fabric/functions/validate.function.ts
@@ -149,11 +149,17 @@ const LOGIN_FILE_PATTERN =
 // these means the app actually wires actor sign-in — the component's own
 // definition is excluded, since defining it without rendering it locks the
 // reviewer out just as thoroughly.
-// Canonical implementation: starter-template's DevActorSwitcher, rendered from
-// LoginPage and backed by signInAsActor() → POST /auth/sign-in/actor.
+//
+// Canonical implementation is now `<DevActorSwitcher>` from `@pikku/mantine/dev`
+// (built on `useDevActors` from `@pikku/react`), rendered from the login screen.
+// The hand-rolled shape the templates used to copy — a local component backed by
+// `signInAsActor()` → POST /auth/sign-in/actor — still passes: apps that predate
+// the package keep working, and the useDevActors call site is matched for apps
+// that want their own UI on the shared logic.
 const ACTOR_QUICK_LOGIN_PATTERNS = [
   /<\s*DevActorSwitcher\b/,
   /(?<!function\s)\bsignInAsActor\s*\(/,
+  /(?<!function\s)\buseDevActors\s*\(/,
   /\/auth\/sign-in\/actor/,
 ]
 
@@ -1441,15 +1447,20 @@ export async function runValidate(
             `apps/${name} has a login screen (${loginFiles[0]}) but no one-click actor sign-in — nobody can view the app as a scenario persona without a password`,
             join(appPath, loginFiles[0]!),
             lines(
-              'Add the dev-only "Sign in as …" switcher and render it from the login screen:',
-              '1. lib/auth: devActors() reading the DEV_ACTORS env var, and',
-              '   signInAsActor(email) → POST `${apiUrl()}/auth/sign-in/actor`',
-              '   with { email, secret } and credentials: "include".',
-              '2. components/DevActorSwitcher.tsx: a Menu of the declared actors,',
-              '   each Menu.Item signing in as that persona. Render null when',
-              '   devActors() is empty, so it disappears in production.',
-              `3. Render <DevActorSwitcher /> from ${loginFiles[0]}.`,
-              'Reference: templates/starter-template/apps/app/src/components/DevActorSwitcher.tsx.'
+              'Render the dev-only "Sign in as …" switcher from the login screen.',
+              `In ${loginFiles[0]}:`,
+              "  import { DevActorSwitcher } from '@pikku/mantine/dev'",
+              '  <DevActorSwitcher',
+              '    actors={import.meta.env.DEV ? import.meta.env.VITE_DEV_ACTORS : undefined}',
+              '    secret={import.meta.env.DEV ? import.meta.env.VITE_SCENARIO_ACTOR_SECRET : undefined}',
+              '    apiUrl={apiUrl()}',
+              "    onSignedIn={() => navigate({ to: '/' })}",
+              '  />',
+              'The sandbox dev server bakes both env vars from your declared personas;',
+              'neither is set in production, so the control renders null there.',
+              'Gate the reads on import.meta.env.DEV as above so the secret never',
+              'reaches a production bundle. Next.js apps read the NEXT_PUBLIC_* pair.',
+              'For custom UI, build on useDevActors() from @pikku/react instead.'
             )
           )
         }

--- a/packages/frontend/mantine/README.md
+++ b/packages/frontend/mantine/README.md
@@ -34,6 +34,37 @@ yarn add @pikku/mantine @pikku/react
 # peers: @mantine/core@^8 || ^9, react
 ```
 
+## `@pikku/mantine/dev`
+
+A second entry point for development-only controls. It is deliberately separate
+from `/core`: that one's contract is "drop-in alias for `@mantine/core`", so it
+must not export components Mantine has no counterpart for.
+
+`<DevActorSwitcher />` is the one-click "Sign in as …" control — it signs in as
+any declared scenario persona with no password, so an app can be reviewed as each
+kind of user. `pikku fabric validate` requires any frontend with a login screen
+to ship one, since without it a reviewer is locked out of their own sandbox.
+
+```tsx
+import { DevActorSwitcher } from '@pikku/mantine/dev'
+;<DevActorSwitcher
+  actors={import.meta.env.DEV ? import.meta.env.VITE_DEV_ACTORS : undefined}
+  secret={
+    import.meta.env.DEV ? import.meta.env.VITE_SCENARIO_ACTOR_SECRET : undefined
+  }
+  apiUrl={apiUrl()}
+  onSignedIn={() => navigate({ to: '/' })}
+/>
+```
+
+The sandbox dev server bakes both env vars from your declared personas; neither
+is set in production, so the control renders `null` there. Gate the reads on your
+bundler's dev flag as above so the secret never reaches a production bundle.
+
+It takes `onSignedIn` rather than depending on a router — every app lands
+somewhere different. For custom UI, build on `useDevActors()` from
+[`@pikku/react`](../react) instead; this component is only its default rendering.
+
 ## How it works
 
 The package re-exports the real Mantine component _values_ and only re-casts their

--- a/packages/frontend/mantine/package.json
+++ b/packages/frontend/mantine/package.json
@@ -13,6 +13,10 @@
     "./theme": {
       "import": "./dist/esm/theme/index.js",
       "require": "./dist/cjs/theme/index.js"
+    },
+    "./dev": {
+      "import": "./dist/esm/dev/index.js",
+      "require": "./dist/cjs/dev/index.js"
     }
   },
   "scripts": {

--- a/packages/frontend/mantine/src/dev/DevActorSwitcher.tsx
+++ b/packages/frontend/mantine/src/dev/DevActorSwitcher.tsx
@@ -1,5 +1,10 @@
 import type { FC, CSSProperties } from 'react'
-import { asI18n, useDevActors, type DevActor } from '@pikku/react'
+import {
+  asI18n,
+  useDevActors,
+  type DevActor,
+  type I18nString,
+} from '@pikku/react'
 import { Button, Menu, Text } from '../core/index.js'
 
 export type DevActorSwitcherProps = {
@@ -15,8 +20,12 @@ export type DevActorSwitcherProps = {
    * callback rather than depending on a router.
    */
   onSignedIn?: () => void | Promise<void>
-  /** Menu trigger label. Defaults to "Sign in as …". */
-  label?: string
+  /**
+   * Menu trigger label. Defaults to "Sign in as …" — branded so an app that has
+   * a catalogue can hand over `m.dev_actors__cta()` rather than being forced
+   * back through `asI18n`.
+   */
+  label?: I18nString
   position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
 }
 
@@ -49,7 +58,7 @@ export const DevActorSwitcher: FC<DevActorSwitcherProps> = ({
   secret,
   apiUrl,
   onSignedIn,
-  label = 'Sign in as …',
+  label = asI18n('Sign in as …'),
   position = 'bottom-right',
 }) => {
   const { actors, signInAs, pendingEmail, isPending, error } = useDevActors({
@@ -69,7 +78,7 @@ export const DevActorSwitcher: FC<DevActorSwitcherProps> = ({
           variant="light"
           style={{ position: 'fixed', zIndex: 1000, ...CORNERS[position] }}
         >
-          {asI18n(label)}
+          {label}
         </Button>
       </Menu.Target>
       <Menu.Dropdown>

--- a/packages/frontend/mantine/src/dev/DevActorSwitcher.tsx
+++ b/packages/frontend/mantine/src/dev/DevActorSwitcher.tsx
@@ -1,0 +1,103 @@
+import type { FC, CSSProperties } from 'react'
+import { asI18n, useDevActors, type DevActor } from '@pikku/react'
+import { Button, Menu, Text } from '../core/index.js'
+
+export type DevActorSwitcherProps = {
+  /** Raw JSON actor list from the host's env, or an already-parsed list. */
+  actors: string | DevActor[] | undefined
+  /** The shared scenario actor secret from the host's env. Absent renders nothing. */
+  secret: string | undefined
+  /** API base, including the `/api` prefix if the app has one. */
+  apiUrl: string
+  /**
+   * Where a successful sign-in lands. The app owns this — the templates go to
+   * `/app`, other apps to `/` — which is also why this component takes a
+   * callback rather than depending on a router.
+   */
+  onSignedIn?: () => void | Promise<void>
+  /** Menu trigger label. Defaults to "Sign in as …". */
+  label?: string
+  position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
+}
+
+const CORNERS: Record<
+  NonNullable<DevActorSwitcherProps['position']>,
+  CSSProperties
+> = {
+  'bottom-right': { bottom: 16, right: 16 },
+  'bottom-left': { bottom: 16, left: 16 },
+  'top-right': { top: 16, right: 16 },
+  'top-left': { top: 16, left: 16 },
+}
+
+/**
+ * Dev-only floating "Sign in as …" switcher: one click signs in as any declared
+ * scenario persona, no password, so an app can be reviewed as each kind of user
+ * without knowing a seed password. Without it a reviewer is locked out of their
+ * own sandbox — which is why `pikku fabric validate` requires any frontend with
+ * a login screen to ship one.
+ *
+ * Renders nothing when the host exposed no actors or no secret, which is every
+ * production build.
+ *
+ * Strings here are passed through `asI18n` rather than a message catalogue: this
+ * control never ships to an end user, so translating it would cost every
+ * consuming app three keys for text only its own developers see.
+ */
+export const DevActorSwitcher: FC<DevActorSwitcherProps> = ({
+  actors: rawActors,
+  secret,
+  apiUrl,
+  onSignedIn,
+  label = 'Sign in as …',
+  position = 'bottom-right',
+}) => {
+  const { actors, signInAs, pendingEmail, isPending, error } = useDevActors({
+    actors: rawActors,
+    secret,
+    apiUrl,
+    onSignedIn,
+  })
+
+  if (actors.length === 0) return null
+
+  return (
+    <Menu position="top-end" withArrow>
+      <Menu.Target>
+        <Button
+          size="xs"
+          variant="light"
+          style={{ position: 'fixed', zIndex: 1000, ...CORNERS[position] }}
+        >
+          {asI18n(label)}
+        </Button>
+      </Menu.Target>
+      <Menu.Dropdown>
+        <Menu.Label>{asI18n('Scenario personas (dev only)')}</Menu.Label>
+        {actors.map((actor) => (
+          <Menu.Item
+            key={actor.key}
+            disabled={isPending}
+            onClick={() => signInAs(actor.email)}
+          >
+            <Text size="sm" fw={500}>
+              {asI18n(
+                pendingEmail === actor.email ? `${actor.name} …` : actor.name
+              )}
+            </Text>
+            {actor.jobTitle ? (
+              <Text size="xs" c="dimmed">
+                {asI18n(actor.jobTitle)}
+              </Text>
+            ) : null}
+          </Menu.Item>
+        ))}
+        {error ? (
+          <Text size="xs" c="red" px="sm" pt={4}>
+            {asI18n(error.message)}
+          </Text>
+        ) : null}
+      </Menu.Dropdown>
+    </Menu>
+  )
+}

--- a/packages/frontend/mantine/src/dev/index.ts
+++ b/packages/frontend/mantine/src/dev/index.ts
@@ -1,0 +1,9 @@
+// @pikku/mantine/dev — development-only controls.
+//
+// Deliberately NOT part of `@pikku/mantine/core`: that entry point's contract is
+// "drop-in alias for @mantine/core" (it is `export * from '@mantine/core'` plus
+// i18n type overrides, and `pikku fabric validate` enforces apps import through
+// it). Exporting a component that has no `@mantine/core` counterpart from there
+// would break the alias story, so dev-only controls get their own entry point.
+export { DevActorSwitcher } from './DevActorSwitcher.js'
+export type { DevActorSwitcherProps } from './DevActorSwitcher.js'

--- a/packages/frontend/react/README.md
+++ b/packages/frontend/react/README.md
@@ -31,6 +31,32 @@ const Todos = () => {
 }
 ```
 
+## Dev actor sign-in
+
+`useDevActors()` powers the dev-only "Sign in as …" switcher: one click signs in
+as a declared scenario persona with no password, through Better Auth's actor
+endpoint. It is UI-free, so you can render it however you like — or use the
+ready-made `<DevActorSwitcher />` from `@pikku/mantine/dev`.
+
+```typescript
+import { useDevActors } from '@pikku/react'
+
+const { actors, signInAs, isPending } = useDevActors({
+  // The sandbox dev server bakes these from your declared personas. Gate the
+  // reads on your bundler's dev flag so the secret never reaches production.
+  actors: import.meta.env.DEV ? import.meta.env.VITE_DEV_ACTORS : undefined,
+  secret: import.meta.env.DEV
+    ? import.meta.env.VITE_SCENARIO_ACTOR_SECRET
+    : undefined,
+  apiUrl: apiUrl(),
+  onSignedIn: () => navigate({ to: '/' }),
+})
+```
+
+`actors` is empty unless the host supplied both a list and a secret, so a
+production build renders nothing without you testing for it. The endpoint only
+accepts users flagged `actor: true`, so it can never impersonate a real user.
+
 ## Docs
 
 https://pikku.dev/docs

--- a/packages/frontend/react/package.json
+++ b/packages/frontend/react/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "tsc": "tsc",
+    "test": "node --test src/dev-actors.test.ts",
     "build:esm": "tsc -b && echo '{\"type\": \"module\"}' > dist/esm/package.json",
     "build:cjs": "tsc -b tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json",
     "build": "yarn build:esm && yarn build:cjs",

--- a/packages/frontend/react/src/dev-actors.test.ts
+++ b/packages/frontend/react/src/dev-actors.test.ts
@@ -50,6 +50,20 @@ test('parseDevActors drops entries missing the fields the switcher needs', () =>
     { key: 'ok', email: 'ok@actors.example', name: 'Ok', jobTitle: '' },
     { key: 'no-email', name: 'Broken' },
     { email: 'no-key@actors.example' },
+    // Both are drawn in the menu, so an entry without them is a row reading
+    // "undefined" rather than an actor.
+    { key: 'no-name', email: 'no-name@actors.example', jobTitle: 'Runs it' },
+    {
+      key: 'no-title',
+      email: 'no-title@actors.example',
+      name: 'No Title',
+    },
+    {
+      key: 'wrong-types',
+      email: 'wrong-types@actors.example',
+      name: 42,
+      jobTitle: null,
+    },
     null,
   ])
   assert.deepEqual(

--- a/packages/frontend/react/src/dev-actors.test.ts
+++ b/packages/frontend/react/src/dev-actors.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Run: node --test packages/frontend/react/src/dev-actors.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseDevActors, signInAsActor } from './dev-actors.ts'
+
+test('parseDevActors reads the JSON list the dev server bakes in', () => {
+  const raw = JSON.stringify([
+    {
+      key: 'admin',
+      email: 'admin@actors.example',
+      name: 'Admin',
+      jobTitle: 'Runs it',
+    },
+    {
+      key: 'client',
+      email: 'client@actors.example',
+      name: 'Client',
+      jobTitle: '',
+    },
+  ])
+  const actors = parseDevActors(raw)
+  assert.equal(actors.length, 2)
+  assert.equal(actors[0]!.email, 'admin@actors.example')
+})
+
+test('parseDevActors yields an empty list for anything unusable', () => {
+  // A broken dev affordance must never take the login screen down with it, so
+  // every one of these is an empty list rather than a throw.
+  for (const raw of [
+    undefined,
+    null,
+    '',
+    'not json',
+    '{"key":"admin"}', // object, not an array
+    '[]',
+    42,
+  ]) {
+    assert.deepEqual(
+      parseDevActors(raw),
+      [],
+      `unexpected parse of ${String(raw)}`
+    )
+  }
+})
+
+test('parseDevActors drops entries missing the fields the switcher needs', () => {
+  const raw = JSON.stringify([
+    { key: 'ok', email: 'ok@actors.example', name: 'Ok', jobTitle: '' },
+    { key: 'no-email', name: 'Broken' },
+    { email: 'no-key@actors.example' },
+    null,
+  ])
+  assert.deepEqual(
+    parseDevActors(raw).map((a) => a.key),
+    ['ok']
+  )
+})
+
+test('signInAsActor posts the secret to the actor endpoint with credentials', async () => {
+  let seen: { url: string; init: RequestInit } | null = null
+  const original = globalThis.fetch
+  globalThis.fetch = (async (url: string, init: RequestInit) => {
+    seen = { url, init }
+    return { ok: true, status: 200 } as Response
+  }) as unknown as typeof fetch
+
+  try {
+    await signInAsActor({
+      apiUrl: 'http://localhost:5003/api',
+      email: 'admin@actors.example',
+      secret: 's3cret',
+    })
+  } finally {
+    globalThis.fetch = original
+  }
+
+  assert.ok(seen)
+  const { url, init } = seen as { url: string; init: RequestInit }
+  assert.equal(url, 'http://localhost:5003/api/auth/sign-in/actor')
+  assert.equal(init.method, 'POST')
+  // Cookies must ride the request — the whole point is the session it sets.
+  assert.equal(init.credentials, 'include')
+  assert.deepEqual(JSON.parse(init.body as string), {
+    email: 'admin@actors.example',
+    secret: 's3cret',
+  })
+})
+
+test('signInAsActor throws on a refused sign-in', async () => {
+  const original = globalThis.fetch
+  globalThis.fetch = (async () =>
+    ({ ok: false, status: 401 }) as Response) as unknown as typeof fetch
+  try {
+    await assert.rejects(
+      signInAsActor({
+        apiUrl: 'http://localhost:5003/api',
+        email: 'real-user@example.com',
+        secret: 'wrong',
+      }),
+      /401/
+    )
+  } finally {
+    globalThis.fetch = original
+  }
+})

--- a/packages/frontend/react/src/dev-actors.ts
+++ b/packages/frontend/react/src/dev-actors.ts
@@ -1,0 +1,148 @@
+import { useCallback, useMemo, useState } from 'react'
+
+/**
+ * One scenario persona the sandbox offers for one-click sign-in.
+ *
+ * These are the personas declared with `definePersonas` — the same source
+ * `pikku scenario` and the console read. The address is not written down
+ * anywhere: it is derived from the persona id and `scenarios.emailDomain`, and
+ * the dev seed creates `actor: true` user rows at exactly those addresses.
+ */
+export type DevActor = {
+  key: string
+  email: string
+  name: string
+  jobTitle: string
+}
+
+/**
+ * Parse the actor list a dev server bakes into the frontend bundle.
+ *
+ * The raw value is JSON, supplied by the host: `import.meta.env.VITE_DEV_ACTORS`
+ * under Vite, `process.env.NEXT_PUBLIC_DEV_ACTORS` under Next. This package
+ * deliberately does not read env itself — how env is spelled is a bundler fact,
+ * and a package that guesses gets it wrong for half its consumers.
+ *
+ * Anything unparseable yields an empty list rather than throwing: a broken dev
+ * affordance must not take the login screen down with it.
+ */
+export const parseDevActors = (raw: unknown): DevActor[] => {
+  if (typeof raw !== 'string' || raw.length === 0) return []
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (actor): actor is DevActor =>
+        !!actor &&
+        typeof actor === 'object' &&
+        typeof actor.key === 'string' &&
+        typeof actor.email === 'string'
+    )
+  } catch {
+    return []
+  }
+}
+
+export type SignInAsActorOptions = {
+  /** API base, including the `/api` prefix if the app has one — `/auth/sign-in/actor` is appended. */
+  apiUrl: string
+  email: string
+  /** The shared scenario actor secret. Dev-only; never present in a production bundle. */
+  secret: string
+}
+
+/**
+ * Sign in as a scenario actor through Better Auth's actor endpoint — no
+ * password, using the shared secret the dev server injects.
+ *
+ * The endpoint only accepts rows flagged `actor: true`, so this can never
+ * impersonate a real user however the secret leaks; see the `actor` plugin in
+ * `@pikku/better-auth`.
+ */
+export const signInAsActor = async ({
+  apiUrl,
+  email,
+  secret,
+}: SignInAsActorOptions): Promise<void> => {
+  const response = await fetch(`${apiUrl}/auth/sign-in/actor`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ email, secret }),
+  })
+  if (!response.ok) {
+    throw new Error(`Unable to sign in as ${email} (${response.status})`)
+  }
+}
+
+export type UseDevActorsOptions = {
+  /** Raw JSON actor list from the host's env, or an already-parsed list. */
+  actors: string | DevActor[] | undefined
+  /** The shared scenario actor secret from the host's env. Absent disables sign-in. */
+  secret: string | undefined
+  apiUrl: string
+  /** Called after a successful sign-in — the app owns where that lands. */
+  onSignedIn?: () => void | Promise<void>
+}
+
+export type UseDevActorsResult = {
+  /** Empty whenever the host exposed no actors or no secret — render nothing. */
+  actors: DevActor[]
+  signInAs: (email: string) => void
+  /** The address currently signing in, or null. */
+  pendingEmail: string | null
+  isPending: boolean
+  error: Error | null
+}
+
+/**
+ * State for the dev-only "Sign in as …" switcher.
+ *
+ * Returns an empty actor list unless the host supplied BOTH a list and a
+ * secret, so a production bundle — where neither env var is set — renders
+ * nothing without the caller testing for it. Hosts should still gate the env
+ * reads on their dev flag (`import.meta.env.DEV`) so the secret is never
+ * emitted into a production bundle in the first place; this is the second line,
+ * not the first.
+ */
+export const useDevActors = ({
+  actors: rawActors,
+  secret,
+  apiUrl,
+  onSignedIn,
+}: UseDevActorsOptions): UseDevActorsResult => {
+  const [pendingEmail, setPendingEmail] = useState<string | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+
+  const actors = useMemo(() => {
+    if (!secret) return []
+    return Array.isArray(rawActors) ? rawActors : parseDevActors(rawActors)
+  }, [rawActors, secret])
+
+  const signInAs = useCallback(
+    (email: string) => {
+      if (!secret) return
+      setPendingEmail(email)
+      setError(null)
+      signInAsActor({ apiUrl, email, secret })
+        .then(async () => {
+          await onSignedIn?.()
+        })
+        .catch((cause) => {
+          setError(cause instanceof Error ? cause : new Error(String(cause)))
+        })
+        .finally(() => {
+          setPendingEmail(null)
+        })
+    },
+    [apiUrl, secret, onSignedIn]
+  )
+
+  return {
+    actors,
+    signInAs,
+    pendingEmail,
+    isPending: pendingEmail !== null,
+    error,
+  }
+}

--- a/packages/frontend/react/src/dev-actors.ts
+++ b/packages/frontend/react/src/dev-actors.ts
@@ -36,7 +36,11 @@ export const parseDevActors = (raw: unknown): DevActor[] => {
         !!actor &&
         typeof actor === 'object' &&
         typeof actor.key === 'string' &&
-        typeof actor.email === 'string'
+        typeof actor.email === 'string' &&
+        // `name` and `jobTitle` are what the switcher DRAWS, so an entry missing
+        // either is not a usable actor — it is a menu row reading "undefined".
+        typeof actor.name === 'string' &&
+        typeof actor.jobTitle === 'string'
     )
   } catch {
     return []

--- a/packages/frontend/react/src/index.ts
+++ b/packages/frontend/react/src/index.ts
@@ -16,3 +16,14 @@ export type { CreatePikkuOptions } from './create-pikku.js'
 // `@/i18n` Paraglide scaffold); `@pikku/react` only owns the brand.
 export type { I18nString, I18nNode } from './i18n-types.js'
 export { asI18n } from './i18n-types.js'
+
+// Dev-only scenario actor sign-in — the logic half of the "Sign in as …"
+// switcher. UI-free, so `@pikku/mantine/dev` (which peer-depends on this
+// package) can build the rendered control on top of it.
+export { parseDevActors, signInAsActor, useDevActors } from './dev-actors.js'
+export type {
+  DevActor,
+  SignInAsActorOptions,
+  UseDevActorsOptions,
+  UseDevActorsResult,
+} from './dev-actors.js'

--- a/packages/skills/skills/pikku-better-auth/SKILL.md
+++ b/packages/skills/skills/pikku-better-auth/SKILL.md
@@ -333,19 +333,24 @@ plugins: [actor({ secret: SCENARIO_ACTOR_SECRET })]
 session cookie. `secret` may also be a (possibly async) function, so it can come
 off the secrets service instead of a captured value.
 
-Four properties are what make a password-free sign-in endpoint safe enough to
-ship in the same binary as production:
+**`SCENARIO_ACTOR_SECRET` is a credential as powerful as the most privileged
+persona.** `pikku persona sync` grants declared roles to actor accounts, so an
+`admin` persona is an actor holding real admin — anyone with the secret can take
+a session as one. Keep the endpoint **off outside development and sandbox
+deployments**: leave the secret unset on any stage that should not run scenarios,
+which is the supported switch (`Actor sign-in is not configured`), rather than
+conditionally registering the plugin. Do not treat "actors only" as a licence to
+enable it in production.
+
+Within that boundary, three properties bound the damage:
 
 - **It only ever signs in actors.** The plugin adds a `user.actor` boolean
   column; an email matching a row without it is refused with `User is not an
-  actor`. The secret therefore cannot impersonate a real user — a leaked one
-  buys synthetic accounts only.
+  actor`. So the secret cannot take over a **real user's** account — the blast
+  radius is the actor accounts and whatever roles they were granted.
 - **Unknown emails are created**, flagged `actor: true`, so a scenario that
-  declares a new persona needs no seed step.
-- **An unset secret disables the endpoint** (`Actor sign-in is not configured`).
-  That is the intended way to switch the surface off per deployment: leave
-  `SCENARIO_ACTOR_SECRET` unset on a stage that should not run scenarios, rather
-  than conditionally registering the plugin.
+  declares a new persona needs no seed step. Note the flip side: the secret
+  mints accounts, it does not merely use existing ones.
 - **The comparison is constant-time and length-hiding**, so a wrong secret leaks
   neither the length nor a prefix of the right one.
 

--- a/packages/skills/skills/pikku-better-auth/SKILL.md
+++ b/packages/skills/skills/pikku-better-auth/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   the generated catch-all auth routes, betterAuthSession middleware, OAuth/social providers,
   email+password credentials, database adapters, and session mapping. TRIGGER when: code uses
   pikkuBetterAuth, betterAuth, betterAuthSession, createAuthHandler, user asks about Better Auth,
-  OAuth/social providers, MFA, organizations, login/logout, or @pikku/better-auth. TRIGGER when:
+  OAuth/social providers, MFA, organizations, login/logout, or @pikku/better-auth. TRIGGER when: user asks
+  about the actor plugin, /sign-in/actor, signing in as a scenario persona, or SCENARIO_ACTOR_SECRET. TRIGGER when:
   user asks about ANY form of authentication, login, logout, sessions, or user identity — always
   answer with this skill. DO NOT TRIGGER when: user asks about JWT middleware (use pikku-security)
   or custom session services (use pikku-services).
@@ -315,6 +316,42 @@ it the bare `admin` scope. It is guarded twice — the env var *and* a localhost
 hostname check — because a one-request path to an admin session is exactly the
 thing that must not survive a deploy. An app that has not declared the `admin`
 scope still gets a session, with a warning, since a scopeless dev user is useful.
+
+### Actor sign-in (`actor` plugin)
+
+A different thing from dev quick login, and the one to reach for when "sign in as
+someone" means **a particular kind of user** rather than one fixed admin.
+Register it explicitly — it is not automatic:
+
+```typescript
+import { actor } from '@pikku/better-auth'
+
+plugins: [actor({ secret: SCENARIO_ACTOR_SECRET })]
+```
+
+`POST ${basePath}/sign-in/actor` `{ email, secret, name? }` → 200 + the normal
+session cookie. `secret` may also be a (possibly async) function, so it can come
+off the secrets service instead of a captured value.
+
+Four properties are what make a password-free sign-in endpoint safe enough to
+ship in the same binary as production:
+
+- **It only ever signs in actors.** The plugin adds a `user.actor` boolean
+  column; an email matching a row without it is refused with `User is not an
+  actor`. The secret therefore cannot impersonate a real user — a leaked one
+  buys synthetic accounts only.
+- **Unknown emails are created**, flagged `actor: true`, so a scenario that
+  declares a new persona needs no seed step.
+- **An unset secret disables the endpoint** (`Actor sign-in is not configured`).
+  That is the intended way to switch the surface off per deployment: leave
+  `SCENARIO_ACTOR_SECRET` unset on a stage that should not run scenarios, rather
+  than conditionally registering the plugin.
+- **The comparison is constant-time and length-hiding**, so a wrong secret leaks
+  neither the length nor a prefix of the right one.
+
+This is the endpoint `pikku scenario` signs its actors in through, and the one
+the frontend dev switcher posts to — see `pikku-scenario` for declaring the
+actors and `pikku-react` for `useDevActors()`.
 
 ---
 

--- a/packages/skills/skills/pikku-fabric/SKILL.md
+++ b/packages/skills/skills/pikku-fabric/SKILL.md
@@ -323,10 +323,13 @@ own UI built on `useDevActors()` from `@pikku/react` — validate accepts either
 call site as evidence, so custom rendering passes. See **pikku-react** for the
 props and **pikku-scenario** for where the actor list comes from.
 
-An app that predates the package is **not** required to migrate: a hand-rolled
-`signInAsActor()` or a literal `POST /auth/sign-in/actor` also clears the rule.
-Reach for the shared component in new code, but do not rewrite a working switcher
-just to silence this finding — it is already silent.
+The validator also accepts the shapes that predate the package — a hand-rolled
+`signInAsActor()` or a literal `POST /auth/sign-in/actor` — so an older app does
+not fail the build. **Treat that as a grace period, not the target: migrate those
+to `<DevActorSwitcher />`.** The hand-copied version is exactly the duplication
+the package exists to remove, and the copies drift — the ones that prompted this
+had already diverged on the `import.meta.env.DEV` gate that keeps the shared
+secret out of production bundles.
 
 Do **not** satisfy it with Better Auth's `/dev/quick-login`. That is a different
 endpoint with a different purpose — one fixed admin, not the declared personas —

--- a/packages/skills/skills/pikku-fabric/SKILL.md
+++ b/packages/skills/skills/pikku-fabric/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pikku-fabric
-description: 'Build and convert apps for the Pikku Fabric platform. Covers SQLite/libSQL database setup with Kysely, fabric project layout, deploy provider config, `fabric.config.json`, and the pikku-verify workflow. TRIGGER when: user is working on a Fabric-hosted Pikku project, converting an app to Fabric format, or asking about Fabric deployment, database, or project conventions. DO NOT TRIGGER when: user is working on a generic (non-Fabric) Pikku deployment — use pikku-deploy-cloudflare, pikku-deploy-fastify, etc. instead.'
+description: 'Build and convert apps for the Pikku Fabric platform. Covers SQLite/libSQL database setup with Kysely, fabric project layout, deploy provider config, `fabric.config.json`, and the pikku-verify workflow. TRIGGER when: user is working on a Fabric-hosted Pikku project, converting an app to Fabric format, or asking about Fabric deployment, database, or project conventions. TRIGGER when: user asks about a `pikku fabric validate` finding, including app-missing-actor-quick-login. DO NOT TRIGGER when: user is working on a generic (non-Fabric) Pikku deployment — use pikku-deploy-cloudflare, pikku-deploy-fastify, etc. instead.'
 installGroups: [fabric]
 ---
 
@@ -310,6 +310,22 @@ Always call the `pikku-verify` tool after modifying functions, wirings, or schem
 2. `tsc --noEmit` — validates TypeScript types
 
 The output card shows whether any breaking changes were detected.
+
+### `app-missing-actor-quick-login-<app>`
+
+The `fabric validate` finding people most often misread. It fires when an app has
+a **login screen** but no dev actor switcher, and it is not a style nit: a sandbox
+reviewer has no seed password, so without the control they are locked out of the
+app they were asked to look at.
+
+Satisfy it with `<DevActorSwitcher />` from `@pikku/mantine/dev`, or with your
+own UI built on `useDevActors()` from `@pikku/react` — validate accepts either
+call site as evidence, so custom rendering passes. See **pikku-react** for the
+props and **pikku-scenario** for where the actor list comes from.
+
+Do **not** satisfy it with Better Auth's `/dev/quick-login`. That is a different
+endpoint with a different purpose — one fixed admin, not the declared personas —
+and it does not clear this rule.
 
 ## Hard rules
 

--- a/packages/skills/skills/pikku-fabric/SKILL.md
+++ b/packages/skills/skills/pikku-fabric/SKILL.md
@@ -323,6 +323,11 @@ own UI built on `useDevActors()` from `@pikku/react` — validate accepts either
 call site as evidence, so custom rendering passes. See **pikku-react** for the
 props and **pikku-scenario** for where the actor list comes from.
 
+An app that predates the package is **not** required to migrate: a hand-rolled
+`signInAsActor()` or a literal `POST /auth/sign-in/actor` also clears the rule.
+Reach for the shared component in new code, but do not rewrite a working switcher
+just to silence this finding — it is already silent.
+
 Do **not** satisfy it with Better Auth's `/dev/quick-login`. That is a different
 endpoint with a different purpose — one fixed admin, not the declared personas —
 and it does not clear this rule.

--- a/packages/skills/skills/pikku-react/SKILL.md
+++ b/packages/skills/skills/pikku-react/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pikku-react
-description: 'Set up @pikku/react in a React app: PikkuProvider context, createPikku factory, and the usePikkuRPC / usePikkuFetch hooks for direct (non-React-Query) calls. TRIGGER when: the user is bootstrapping a React frontend that talks to a Pikku backend, asks how to wire `PikkuProvider`, or needs to make one-off RPC calls outside of useQuery/useMutation. DO NOT TRIGGER when: the user is asking about useQuery/useMutation hooks (use pikku-react-query) or about workflows (use pikku-workflows-client).'
+description: 'Set up @pikku/react in a React app: PikkuProvider context, createPikku factory, and the usePikkuRPC / usePikkuFetch hooks for direct (non-React-Query) calls. TRIGGER when: the user is bootstrapping a React frontend that talks to a Pikku backend, asks how to wire `PikkuProvider`, or needs to make one-off RPC calls outside of useQuery/useMutation. TRIGGER when: user asks about the dev actor switcher, "sign in as" / quick-login UI, useDevActors, VITE_DEV_ACTORS, or the app-missing-actor-quick-login validate finding. DO NOT TRIGGER when: the user is asking about useQuery/useMutation hooks (use pikku-react-query) or about workflows (use pikku-workflows-client).'
 installGroups: [core]
 ---
 
@@ -227,6 +227,46 @@ pikku.fetch.setHeader('x-tenant', tenantId)
 
 `authHeaders.jwt` becomes `Authorization: Bearer …` and `authHeaders.apiKey`
 becomes `X-API-KEY`; setting a JWT takes precedence over an API key.
+
+### Dev actor sign-in (`useDevActors`)
+
+The dev-only "Sign in as …" control: one click signs in as a declared scenario
+persona with no password, so the app can be reviewed as each kind of user.
+`pikku fabric validate` **requires** any frontend with a login screen to ship one
+(`app-missing-actor-quick-login-<app>`) — without it a reviewer is locked out of
+their own sandbox.
+
+```tsx
+import { useDevActors } from '@pikku/react'
+
+const { actors, signInAs, pendingEmail, isPending, error } = useDevActors({
+  // Gate both reads on the bundler's dev flag so the secret cannot reach a
+  // production bundle. The sandbox dev server bakes them from your personas.
+  actors: import.meta.env.DEV ? import.meta.env.VITE_DEV_ACTORS : undefined,
+  secret: import.meta.env.DEV
+    ? import.meta.env.VITE_SCENARIO_ACTOR_SECRET
+    : undefined,
+  apiUrl: apiUrl(),
+  onSignedIn: () => navigate({ to: '/' }),
+})
+```
+
+- **It is UI-free**, so render it however you like. For the default rendering use
+  `<DevActorSwitcher />` from `@pikku/mantine/dev` — a separate entry point from
+  `@pikku/mantine/core`, whose contract is "drop-in alias for `@mantine/core`"
+  and so must not export components Mantine has no counterpart for.
+- **`actors` is empty unless the host supplied both a list and a secret**, so a
+  production build renders nothing without you testing for it.
+- **It takes `onSignedIn` rather than a router**, and takes the env values rather
+  than reading them, because how env is spelled is a bundler fact
+  (`import.meta.env.VITE_*` vs `process.env.NEXT_PUBLIC_*`).
+- The underlying `signInAsActor()` and `parseDevActors()` are exported too, for a
+  non-React caller. The endpoint only accepts rows flagged `actor: true`, so it
+  can never impersonate a real user — see **pikku-better-auth**.
+
+Do not hand-write the `devActors()` / `signInAsActor()` pair per app; that
+copy-paste, including the `import.meta.env.DEV` gate, is exactly what this
+replaced.
 
 ## What NOT to do
 

--- a/packages/skills/skills/pikku-scenario/SKILL.md
+++ b/packages/skills/skills/pikku-scenario/SKILL.md
@@ -530,6 +530,25 @@ An actor with no `persona` is its own persona, so a project that never declares 
 - `environments.<name>.apiUrl` is required. `signInPath` defaults to `/auth/sign-in/actor`, `rpcPath` to `/rpc`.
 - **`SCENARIO_ACTOR_SECRET` is an environment variable and never goes in `pikku.config.json`.** It signs actors in. `pikku scenario run` throws without it; a server auto-building actors warns and runs without them.
 
+### The same actors sign a human in
+
+Declared actors are not only for automated runs. `signInPath` is Better Auth's
+`actor` plugin (see `pikku-better-auth`), which any caller can post to — so the
+frontend gets a one-click "Sign in as …" switcher over the **same** list, and an
+app can be reviewed as each kind of user without anyone knowing a seed password.
+
+The sandbox dev server bakes both halves into the frontend from the declared
+personas: `VITE_DEV_ACTORS` (the JSON actor list) and
+`VITE_SCENARIO_ACTOR_SECRET`. Neither is set in a production build, so the
+control renders nothing there — but gate the reads on your bundler's dev flag
+anyway (`import.meta.env.DEV ? … : undefined`) so the secret never reaches a
+production bundle in the first place.
+
+Do not hand-roll the switcher: `useDevActors()` (`pikku-react`) is the logic and
+`<DevActorSwitcher />` from `@pikku/mantine/dev` is a ready rendering of it.
+`pikku fabric validate` **requires** any frontend with a login screen to ship
+one — without it a reviewer is locked out of their own sandbox.
+
 ## Running
 
 ```bash


### PR DESCRIPTION
## Why

The dev-only "Sign in as …" control signs in as a declared scenario persona with no password, and `pikku fabric validate` requires any frontend with a login screen to have one — without it a reviewer is locked out of their own sandbox.

So every such app grew one by copy-paste. The `devActors()` / `signInAsActor()` pair came out byte-identical every time (all five app templates, `starter-template`, `fabric-tests`, and counting), including the `import.meta.env.DEV` gate that keeps the shared actor secret out of production bundles. That gate is the security-shaped part, and it is not something each app should be re-deriving from a copy.

## What

Split along the dependency line:

- **`@pikku/react`** gains `useDevActors()`, `signInAsActor()` and `parseDevActors()`. UI-free, so it stays inside the package's react-only dependency budget.
- **`@pikku/mantine/dev`** gains `<DevActorSwitcher />`, built on that hook.

`/dev` is a new entry point rather than part of `/core` on purpose. `/core`'s contract is "drop-in alias for `@mantine/core`" — it is `export * from '@mantine/core'` plus i18n type overrides, and `validate` has a rule (`app-raw-mantine-imports-*`) enforcing that apps import through it. Exporting a component Mantine has no counterpart for would break that alias story. The dependency direction also works out: `@pikku/mantine` already peer-depends on `@pikku/react`, so the hook is available to it.

## Two API decisions worth flagging

**`onSignedIn` instead of a router dep.** Neither package depends on `@tanstack/react-router` and neither should. Every app lands somewhere different after sign-in (`/app` in the templates, `/` elsewhere), so the destination is the app's business anyway.

**Actors/secret are passed in, not read from env.** How env is spelled is a bundler fact — `import.meta.env.VITE_*` under Vite, `process.env.NEXT_PUBLIC_*` under Next, and `validate` explicitly supports both kinds of frontend. A package that guesses gets it wrong for half its consumers. Keeping the read at the call site is also the only place the `DEV` gate can actually keep the secret out of the production bundle.

Belt and braces: `useDevActors` returns an empty actor list unless the host supplied **both** a list and a secret, so a production build renders nothing without the caller testing for it.

## `fabric validate`

`useDevActors(` joins the accepted fingerprints, so an app that wants its own UI on the shared logic passes. The hand-rolled shape still passes too — nothing existing breaks.

The fix text is rewritten. It previously instructed you to hand-write `lib/auth: devActors() reading the DEV_ACTORS env var`, which becomes wrong advice the day this ships — and that text is what every agent hitting this error follows.

## Testing

- `@pikku/react`: 5 new tests (`parseDevActors` incl. the never-throw contract, `signInAsActor` request shape + failure). New `test` script, so root `yarn test` picks the package up for the first time.
- `@pikku/cli`: new test for the `useDevActors` fingerprint; full `validate.function.test.ts` green at 86/86.
- `@pikku/mantine`: builds to `dist/{esm,cjs}/dev/`, existing 25 tests green.
- `check:peer-deps`, `check:readme-imports`, `check:licenses` all pass.

Peer range: `@pikku/mantine` declares `@pikku/react@^0.12.5` and the component needs the new minor. Left alone deliberately — changesets rewrites internal peer ranges in the `Version Packages` commit (`^0.12.3` → `^0.12.5` last time round).

## Follow-up, not in this PR

Migrating the app templates onto the package — they live in other repos (`starter-template` under `fabric`), and they keep working as-is until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added development-only actor sign-in for selecting and signing in as configured personas.
  * Added the optional Mantine `DevActorSwitcher` menu with loading states, labels, positioning, and error handling.
  * Added configurable actor, secret, API URL, and post-sign-in callback options.
  * Added validation support for custom sign-in interfaces using the development actor APIs.

* **Documentation**
  * Added setup, configuration, security, customization, and production behavior guidance.

* **Tests**
  * Added coverage for actor parsing, sign-in requests, errors, and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->