### PR TITLE
fix(cli): stop exporting overload-parameter shapes from generated types

### DIFF
--- a/.changeset/unexport-generated-overload-shapes.md
+++ b/.changeset/unexport-generated-overload-shapes.md
@@ -1,0 +1,15 @@
+---
+'@pikku/cli': patch
+---
+
+Stop exporting overload-parameter shapes from generated types
+
+Types such as `PikkuFunctionConfigWithSchema`, `PikkuAuthConfig` and
+`TriggerWiring` exist only to name the `config` argument inside an overload
+signature. Exporting them made them part of what an app can import from
+`#pikku` — a compatibility promise with no consumer.
+
+The channel, cli, http, mcp, queue and scheduler templates already kept theirs
+internal; the function, trigger and workflow templates now do the same.
+`pikkuVoidFunc` gains the explicit `PikkuFunctionConfig` return type its
+sibling factories already declare, so its inferred type stays nameable.

--- a/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
@@ -101,7 +101,7 @@ export type PikkuMiddleware<RequiredServices extends SingletonServices = WiredSi
 /**
  * Configuration object for creating a permission with metadata
  */
-export type PikkuPermissionConfig<In = unknown, RequiredServices extends SecretlessServices<Services> = WiredServices> = {
+type PikkuPermissionConfig<In = unknown, RequiredServices extends SecretlessServices<Services> = WiredServices> = {
   /** The permission function */
   func: PikkuPermission<In, RequiredServices>
   /** Optional human-readable name for the permission */
@@ -151,7 +151,7 @@ export type PikkuAuth<RequiredServices extends SecretlessServices<SingletonServi
 /**
  * Configuration object for creating an auth permission with metadata
  */
-export type PikkuAuthConfig<RequiredServices extends SecretlessServices<SingletonServices> = WiredAuthServices> = CorePikkuAuthConfig<RequiredServices, Session>
+type PikkuAuthConfig<RequiredServices extends SecretlessServices<SingletonServices> = WiredAuthServices> = CorePikkuAuthConfig<RequiredServices, Session>
 
 /**
  * Factory function for creating auth-only permissions with tree-shaking support.
@@ -182,7 +182,7 @@ export const pikkuAuth = <RequiredServices extends SecretlessServices<SingletonS
 /**
  * Configuration object for creating middleware with metadata
  */
-export type PikkuMiddlewareConfig<RequiredServices extends SingletonServices = WiredSingletonServices> = {
+type PikkuMiddlewareConfig<RequiredServices extends SingletonServices = WiredSingletonServices> = {
   /** The middleware function */
   func: PikkuMiddleware<RequiredServices>
   /** Optional human-readable name for the middleware */
@@ -374,7 +374,7 @@ export type PikkuFunctionConfig<
  * {@link PikkuFunctionConfig} for a function that runs without a session.
  * Has no \`scopes\`: an anonymous caller holds none, so none can ever be met.
  */
-export type PikkuFunctionSessionlessConfig<
+type PikkuFunctionSessionlessConfig<
   In = unknown,
   Out = unknown,
   RequiredWires extends keyof PikkuWire = never,
@@ -396,7 +396,7 @@ type SchemaInferred<S, Fallback = unknown> = S extends StandardSchemaV1
  * Schema-overload variant for pikkuFunc. Derived from CorePikkuFunctionConfig
  * so adding a field on the core type automatically propagates here.
  */
-export type PikkuFunctionConfigWithSchema<
+type PikkuFunctionConfigWithSchema<
   InputSchema extends StandardSchemaV1 | undefined = undefined,
   OutputSchema extends StandardSchemaV1 | undefined = undefined,
   RequiredWires extends keyof PikkuWire = never,
@@ -501,7 +501,7 @@ export const pikkuListFunc = <
  * CorePikkuSessionlessFunctionConfig to stay in sync with the generic-typed
  * config — so it has no \`scopes\` either.
  */
-export type PikkuFunctionSessionlessConfigWithSchema<
+type PikkuFunctionSessionlessConfigWithSchema<
   InputSchema extends StandardSchemaV1 | undefined = undefined,
   OutputSchema extends StandardSchemaV1 | undefined = undefined,
   RequiredWires extends keyof PikkuWire = never,
@@ -588,7 +588,7 @@ export const pikkuVoidFunc = (
   func:
     | PikkuFunctionSessionless<void, void, 'session' | 'rpc'>
     | PikkuFunctionSessionlessConfig<void, void, 'session' | 'rpc'>
-) => {
+): PikkuFunctionConfig<void, void, 'session' | 'rpc'> => {
   return typeof func === 'function' ? { func } : func
 }
 

--- a/packages/cli/src/functions/wirings/triggers/serialize-trigger-types.ts
+++ b/packages/cli/src/functions/wirings/triggers/serialize-trigger-types.ts
@@ -32,7 +32,7 @@ export type PikkuTriggerFunction<
 /**
  * Configuration object for creating a trigger function with metadata
  */
-export type PikkuTriggerFunctionConfig<
+type PikkuTriggerFunctionConfig<
   TInput = unknown,
   TOutput = unknown,
   InputSchema extends StandardSchemaV1 | undefined = undefined,
@@ -49,7 +49,7 @@ type InferSchemaOutput<T> = T extends StandardSchemaV1<any, infer Output> ? Outp
  * Use this when you want to define input/output schemas using Zod.
  * Types are automatically inferred from the schemas.
  */
-export type PikkuTriggerFunctionConfigWithSchema<
+type PikkuTriggerFunctionConfigWithSchema<
   InputSchema extends StandardSchemaV1,
   OutputSchema extends StandardSchemaV1 | undefined = undefined
 > = {
@@ -69,7 +69,7 @@ export type PikkuTriggerFunctionConfigWithSchema<
  * Type definition for trigger wirings.
  * Declares a trigger name and its target pikku function.
  */
-export type TriggerWiring = CoreTrigger
+type TriggerWiring = CoreTrigger
 
 /**
  * A trigger source with the subscription function, using project-specific services.

--- a/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.ts
+++ b/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.ts
@@ -104,7 +104,7 @@ export type PikkuFunctionScenario<
   Ctx = Out
 > = PikkuFunctionSessionless<In, Out, 'scenario' | 'actors', WiredServices, Ctx>
 
-export type PikkuWorkflowConfigWithSchema<
+type PikkuWorkflowConfigWithSchema<
   InputSchema extends StandardSchemaV1 | undefined = undefined,
   OutputSchema extends StandardSchemaV1 | undefined = undefined
 > = {
@@ -169,7 +169,7 @@ export function pikkuWorkflowComplexFunc(func: any) {
   return typeof func === 'function' ? { func } : func
 }
 
-export type PikkuScenarioConfigWithSchema<
+type PikkuScenarioConfigWithSchema<
   InputSchema extends StandardSchemaV1 | undefined = undefined,
   OutputSchema extends StandardSchemaV1 | undefined = undefined
 > = Omit<PikkuWorkflowConfigWithSchema<InputSchema, OutputSchema>, 'func' | 'auth' | 'scopes' | 'permissions'> & {
@@ -274,7 +274,7 @@ export type PikkuFeatureEntry<Entry> = Entry extends {
     ? Entry
     : never
 
-export type PikkuFeatureConfig<Scenarios extends readonly unknown[]> = {
+type PikkuFeatureConfig<Scenarios extends readonly unknown[]> = {
   /** Human-readable name. The export identifier is the id. */
   name: string
   description?: string
@@ -336,7 +336,7 @@ export type PikkuFunctionScenarioStep<
   Surface extends 'default' ? 'scenarioStep' : 'scenarioStep' | Surface
 >
 
-export type PikkuScenarioStepConfigWithSchema<
+type PikkuScenarioStepConfigWithSchema<
   InputSchema extends StandardSchemaV1 | undefined = undefined,
   OutputSchema extends StandardSchemaV1 | undefined = undefined
 > = {
@@ -397,7 +397,7 @@ export type PikkuScenarioStepConfigWithSchema<
   >
 }
 
-export type PikkuScenarioStepConfig<In, Out> =
+type PikkuScenarioStepConfig<In, Out> =
   Omit<PikkuScenarioStepConfigWithSchema<undefined, undefined>, 'browser' | 'cli' | 'default' | 'input' | 'output'> & {
     browser?: PikkuFunctionScenarioStep<In, Out, 'browser'>
     cli?: PikkuFunctionScenarioStep<In, Out, 'cli'>
@@ -457,7 +457,7 @@ export function pikkuScenarioStep(config: any) {
  * rule coherent — an assertion runs every witness it has and fails if they
  * disagree, and this has exactly one by construction.
  */
-export type PikkuSubjectScenarioStepConfigWithSchema<
+type PikkuSubjectScenarioStepConfigWithSchema<
   InputSchema extends StandardSchemaV1 | undefined = undefined,
   OutputSchema extends StandardSchemaV1 | undefined = undefined
 > = Omit<
@@ -471,7 +471,7 @@ export type PikkuSubjectScenarioStepConfigWithSchema<
   >
 }
 
-export type PikkuSubjectScenarioStepConfig<In, Out> =
+type PikkuSubjectScenarioStepConfig<In, Out> =
   Omit<PikkuScenarioStepConfig<In, Out>, 'browser' | 'cli' | 'default'> & {
     func: PikkuFunctionScenarioStep<In, Out, 'default'>
   }

--- a/verifiers/types/type-tests/function/overload-shapes-are-private.ts
+++ b/verifiers/types/type-tests/function/overload-shapes-are-private.ts
@@ -1,0 +1,86 @@
+/**
+ * Type constraint: overload-parameter shapes stay out of the generated surface
+ *
+ * Types such as `PikkuFunctionConfigWithSchema` exist only to name the `config`
+ * argument inside an overload signature. Exporting them makes them part of what
+ * an app can import from `#pikku`, which is a compatibility promise nobody asked
+ * for. The channel, cli, http, mcp, queue and scheduler templates already keep
+ * theirs internal; these assert the function, trigger and workflow templates do
+ * the same.
+ *
+ * Each name is re-exported below so `noUnusedLocals` cannot hand the directive
+ * an error of its own — the only error left for it to consume is the missing
+ * member, so re-exporting any of these names fails the suite as an unused
+ * `@ts-expect-error`.
+ */
+
+// @ts-expect-error - PikkuPermissionConfig is an overload parameter, not API
+import type { PikkuPermissionConfig } from '#pikku'
+// @ts-expect-error - PikkuAuthConfig is an overload parameter, not API
+import type { PikkuAuthConfig } from '#pikku'
+// @ts-expect-error - PikkuMiddlewareConfig is an overload parameter, not API
+import type { PikkuMiddlewareConfig } from '#pikku'
+// @ts-expect-error - PikkuFunctionSessionlessConfig is an overload parameter, not API
+import type { PikkuFunctionSessionlessConfig } from '#pikku'
+// @ts-expect-error - PikkuFunctionConfigWithSchema is an overload parameter, not API
+import type { PikkuFunctionConfigWithSchema } from '#pikku'
+// @ts-expect-error - PikkuFunctionSessionlessConfigWithSchema is an overload parameter, not API
+import type { PikkuFunctionSessionlessConfigWithSchema } from '#pikku'
+// @ts-expect-error - PikkuTriggerFunctionConfig is an overload parameter, not API
+import type { PikkuTriggerFunctionConfig } from '#pikku'
+// @ts-expect-error - PikkuTriggerFunctionConfigWithSchema is an overload parameter, not API
+import type { PikkuTriggerFunctionConfigWithSchema } from '#pikku'
+// @ts-expect-error - TriggerWiring is an overload parameter, not API
+import type { TriggerWiring } from '#pikku'
+
+// @ts-expect-error - PikkuWorkflowConfigWithSchema is an overload parameter, not API
+import type { PikkuWorkflowConfigWithSchema } from '#pikku/workflow/pikku-workflow-types.gen.js'
+// @ts-expect-error - PikkuScenarioConfigWithSchema is an overload parameter, not API
+import type { PikkuScenarioConfigWithSchema } from '#pikku/workflow/pikku-workflow-types.gen.js'
+// @ts-expect-error - PikkuFeatureConfig is an overload parameter, not API
+import type { PikkuFeatureConfig } from '#pikku/workflow/pikku-workflow-types.gen.js'
+// @ts-expect-error - PikkuScenarioStepConfig is an overload parameter, not API
+import type { PikkuScenarioStepConfig } from '#pikku/workflow/pikku-workflow-types.gen.js'
+// @ts-expect-error - PikkuScenarioStepConfigWithSchema is an overload parameter, not API
+import type { PikkuScenarioStepConfigWithSchema } from '#pikku/workflow/pikku-workflow-types.gen.js'
+// @ts-expect-error - PikkuSubjectScenarioStepConfig is an overload parameter, not API
+import type { PikkuSubjectScenarioStepConfig } from '#pikku/workflow/pikku-workflow-types.gen.js'
+// @ts-expect-error - PikkuSubjectScenarioStepConfigWithSchema is an overload parameter, not API
+import type { PikkuSubjectScenarioStepConfigWithSchema } from '#pikku/workflow/pikku-workflow-types.gen.js'
+
+export type _PermissionConfig = PikkuPermissionConfig
+export type _AuthConfig = PikkuAuthConfig
+export type _MiddlewareConfig = PikkuMiddlewareConfig
+export type _SessionlessConfig = PikkuFunctionSessionlessConfig
+export type _FunctionConfigWithSchema = PikkuFunctionConfigWithSchema
+export type _SessionlessConfigWithSchema = PikkuFunctionSessionlessConfigWithSchema
+export type _TriggerFunctionConfig = PikkuTriggerFunctionConfig
+export type _TriggerFunctionConfigWithSchema = PikkuTriggerFunctionConfigWithSchema
+export type _TriggerWiring = TriggerWiring
+export type _WorkflowConfigWithSchema = PikkuWorkflowConfigWithSchema
+export type _ScenarioConfigWithSchema = PikkuScenarioConfigWithSchema
+export type _FeatureConfig = PikkuFeatureConfig
+export type _ScenarioStepConfig = PikkuScenarioStepConfig
+export type _ScenarioStepConfigWithSchema = PikkuScenarioStepConfigWithSchema
+export type _SubjectScenarioStepConfig = PikkuSubjectScenarioStepConfig
+export type _SubjectScenarioStepConfigWithSchema = PikkuSubjectScenarioStepConfigWithSchema
+
+/**
+ * The factories the shapes belong to stay exported — this is about the argument
+ * type being unnameable, not about the API being gone.
+ */
+import {
+  pikkuFunc,
+  pikkuSessionlessFunc,
+  pikkuVoidFunc,
+  pikkuPermission,
+  pikkuMiddleware,
+  pikkuTriggerFunc,
+} from '#pikku'
+
+void pikkuFunc
+void pikkuSessionlessFunc
+void pikkuVoidFunc
+void pikkuPermission
+void pikkuMiddleware
+void pikkuTriggerFunc


### PR DESCRIPTION
Closes step 1 of #1279.

Types such as `PikkuFunctionConfigWithSchema`, `PikkuAuthConfig` and `TriggerWiring` name the `config` argument inside an overload signature and nothing else. Exporting them put them in `#pikku`, where an app could import them — a compatibility promise nobody asked for.

The generator already disagreed with itself: of 19 such helpers, 8 were exported and 11 were not. `channel`, `cli`, `http`, `mcp`, `queue` and `scheduler` kept theirs internal while `function`, `trigger` and `workflow` leaked them. Template drift, not a decision. This brings the three into line — 16 names lose their `export`.

A repo-wide scan confirms no consumer exists for any of the 16, in hand-written or generated code.

### One real dependency the reference count missed

`pikkuVoidFunc` was the only factory without an explicit return type, so its *inferred* return named `PikkuFunctionSessionlessConfig`. Once that type went private, `export const all = pikkuVoidFunc({…})` in another module could no longer name its own type (TS2883). It now annotates `PikkuFunctionConfig` the way `pikkuFunc` and `pikkuSessionlessFunc` already do.

### Verification

`verifiers/types/type-tests/function/overload-shapes-are-private.ts` asserts each name is unimportable. The aliases are re-exported so `noUnusedLocals` cannot hand the directive an error of its own — the only error left to consume is the missing member, so re-exporting any of these names fails the suite as an unused `@ts-expect-error`.

Confirmed red-then-green on this branch: re-exporting `PikkuFunctionConfigWithSchema` and `TriggerWiring` fails exactly those two assertions and no others; reverting returns the suite to green. `packages/cli` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)