### PR TITLE
feat(cli): emit the gateway surface into #pikku/gateway

### DIFF
--- a/.changeset/gateway-pikku-barrel.md
+++ b/.changeset/gateway-pikku-barrel.md
@@ -1,0 +1,14 @@
+---
+'@pikku/cli': patch
+---
+
+Emit the gateway surface into `#pikku/gateway`
+
+`wireGateway` had meta codegen but no types codegen, so the only way to wire a
+gateway was to import `@pikku/core/gateway` directly. It now generates
+`#pikku/gateway`, carrying a project-typed `wireGateway`, `GatewayWiring`, a
+`PikkuGatewayAdapterFactory` that receives the project's own `SingletonServices`,
+and the adapter/message types an implementation needs.
+
+It gets its own barrel rather than joining the `pikku-types.gen.ts` hub, so the
+generated surface does not repeat the root-barrel duplication it replaces.

--- a/packages/cli/src/functions/commands/bootstrap.ts
+++ b/packages/cli/src/functions/commands/bootstrap.ts
@@ -21,6 +21,7 @@ export const bootstrap = pikkuVoidFunc({
     await rpc.invoke('pikkuQueueTypes')
     await rpc.invoke('pikkuWorkflow', { bootstrap: true })
     await rpc.invoke('pikkuTriggerTypes', { bootstrap: true })
+    await rpc.invoke('pikkuGatewayTypes', { bootstrap: true })
     await rpc.invoke('pikkuMCPTypes')
     await rpc.invoke('pikkuAgentTypes')
     await rpc.invoke('pikkuNodeTypes')

--- a/packages/cli/src/functions/wirings/gateway/pikku-command-gateway-types.ts
+++ b/packages/cli/src/functions/wirings/gateway/pikku-command-gateway-types.ts
@@ -1,0 +1,35 @@
+import { pikkuSessionlessFunc } from '#pikku'
+import { writeFileInDir } from '../../../utils/file-writer.js'
+import { getFileImportRelativePath } from '../../../utils/file-import-path.js'
+import { logCommandInfoAndTime } from '../../../middleware/log-command-info-and-time.js'
+import { serializeGatewayTypes } from './serialize-gateway-types.js'
+
+export const pikkuGatewayTypes = pikkuSessionlessFunc<
+  { bootstrap?: boolean },
+  void
+>({
+  func: async ({ logger, config, getInspectorState }, data) => {
+    const { gatewaysTypesFile, packageMappings } = config
+    const visitState = await getInspectorState(false, true, data?.bootstrap ?? false)
+
+    const { singletonServicesType } = visitState.filesAndMethods
+
+    if (!singletonServicesType) {
+      throw new Error('SingletonServices type not found')
+    }
+
+    const singletonServicesTypeImport = `import type { ${singletonServicesType.type} } from '${getFileImportRelativePath(gatewaysTypesFile, singletonServicesType.typePath, packageMappings)}'`
+
+    const content = serializeGatewayTypes(
+      singletonServicesTypeImport,
+      singletonServicesType.type
+    )
+    await writeFileInDir(logger, gatewaysTypesFile, content)
+  },
+  middleware: [
+    logCommandInfoAndTime({
+      commandStart: 'Creating gateway types',
+      commandEnd: 'Created gateway types',
+    }),
+  ],
+})

--- a/packages/cli/src/functions/wirings/gateway/serialize-gateway-types.ts
+++ b/packages/cli/src/functions/wirings/gateway/serialize-gateway-types.ts
@@ -1,0 +1,56 @@
+/**
+ * Generates type definitions for gateway wirings
+ */
+export const serializeGatewayTypes = (
+  singletonServicesTypeImport: string,
+  singletonServicesTypeName: string
+) => {
+  return `/**
+ * Gateway-specific type definitions for tree-shaking optimization
+ */
+
+import { wireGateway as wireGatewayCore } from '@pikku/core/gateway'
+import type { CoreGateway, GatewayAdapter, GatewayInboundMessage, GatewayOutboundMessage, GatewayTransportType, WebhookVerificationResult } from '@pikku/core/gateway'
+${singletonServicesTypeImport}
+
+${singletonServicesTypeName !== 'SingletonServices' ? `type SingletonServices = ${singletonServicesTypeName}` : ''}
+
+export type { GatewayAdapter, GatewayInboundMessage, GatewayOutboundMessage, GatewayTransportType, WebhookVerificationResult }
+
+/**
+ * Builds a {@link GatewayAdapter} from your application's services.
+ * The core factory type is handed \`CoreSingletonServices\`; this one receives
+ * the services your project actually registered.
+ */
+export type PikkuGatewayAdapterFactory = (
+  services: SingletonServices
+) => GatewayAdapter | Promise<GatewayAdapter>
+
+/**
+ * Type definition for gateway wirings.
+ * Declares a gateway name, its transport and its target pikku function.
+ */
+export type GatewayWiring = CoreGateway
+
+/**
+ * Registers a gateway with the Pikku framework.
+ * Runs everywhere — inspector extracts at build time.
+ *
+ * @param gateway - Gateway definition with name, transport type and function
+ *
+ * @example
+ * \`\`\`typescript
+ * wireGateway({
+ *   name: 'stripe',
+ *   type: 'webhook',
+ *   func: handleStripeEvent
+ * })
+ * \`\`\`
+ */
+export const wireGateway = (
+  gateway: GatewayWiring
+) => {
+  wireGatewayCore(gateway as any)
+}
+`
+}

--- a/packages/cli/src/functions/workflows/all.workflow.ts
+++ b/packages/cli/src/functions/workflows/all.workflow.ts
@@ -134,6 +134,9 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
         workflow.do('Bootstrap Trigger types', 'pikkuTriggerTypes', {
           bootstrap: true,
         }),
+        workflow.do('Bootstrap gateway types', 'pikkuGatewayTypes', {
+          bootstrap: true,
+        }),
         workflow.do('Bootstrap MCP types', 'pikkuMCPTypes', null),
         workflow.do('Bootstrap AI agent types', 'pikkuAgentTypes', null),
       ])
@@ -187,6 +190,7 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
       typeGenerators.push(
         workflow.do('HTTP types', 'pikkuHTTPTypes', null),
         workflow.do('Channel types', 'pikkuChannelTypes', null),
+        workflow.do('Gateway types', 'pikkuGatewayTypes', {}),
         workflow.do('Scheduler types', 'pikkuSchedulerTypes', null),
         workflow.do('Queue types', 'pikkuQueueTypes', null),
         workflow.do('MCP types', 'pikkuMCPTypes', null)

--- a/packages/cli/src/utils/pikku-cli-config.ts
+++ b/packages/cli/src/utils/pikku-cli-config.ts
@@ -241,6 +241,9 @@ const _getPikkuCLIConfig = async (
 
     // Gateways
     const gatewayDir = join(result.outDir, 'gateway')
+    if (!result.gatewaysTypesFile) {
+      result.gatewaysTypesFile = join(gatewayDir, 'pikku-gateway-types.gen.ts')
+    }
     if (!result.gatewaysWiringFile) {
       result.gatewaysWiringFile = join(
         gatewayDir,

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -111,6 +111,7 @@ export interface PikkuCLICoreOutputFiles {
   eventsSchemasFile?: string
 
   // Triggers
+  gatewaysTypesFile: string
   triggersTypesFile: string
   triggersWiringFile: string
   triggersWiringMetaFile: string

--- a/verifiers/gateway/package.json
+++ b/verifiers/gateway/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "imports": {
     "#pikku": "./.pikku/pikku-types.gen.ts",
+    "#pikku/gateway": "./.pikku/gateway/pikku-gateway-types.gen.ts",
     "#pikku/*": "./.pikku/*"
   },
   "scripts": {

--- a/verifiers/gateway/src/mock-adapter.ts
+++ b/verifiers/gateway/src/mock-adapter.ts
@@ -3,7 +3,7 @@ import type {
   GatewayInboundMessage,
   GatewayOutboundMessage,
   WebhookVerificationResult,
-} from '@pikku/core/gateway'
+} from '#pikku/gateway'
 
 /**
  * Mock gateway adapter for testing all three transport types.

--- a/verifiers/gateway/src/start.ts
+++ b/verifiers/gateway/src/start.ts
@@ -1,7 +1,7 @@
 import { createConfig, createSingletonServices } from './services.js'
 import '../.pikku/pikku-bootstrap.gen.js'
 
-import { wireGateway } from '@pikku/core/gateway'
+import { wireGateway } from '#pikku/gateway'
 import { fetch } from '@pikku/core'
 import { LocalGatewayService } from '@pikku/core/services'
 import { runLocalChannel } from '@pikku/core/channel/local'


### PR DESCRIPTION
Closes #1283. Step 3 of #1279.

`wireGateway` had meta codegen but no types codegen, so the only way to wire a gateway was to import `@pikku/core/gateway` directly. Gateway is app surface, so it belongs behind the generated alias like every other wiring.

**Emitted into `#pikku/gateway`:**
- `wireGateway` — project-typed wrapper over the core call
- `GatewayWiring`
- `PikkuGatewayAdapterFactory` — receives the project's own `SingletonServices`, not `CoreSingletonServices`
- re-exported for implementors: `GatewayAdapter`, `GatewayInboundMessage`, `GatewayOutboundMessage`, `GatewayTransportType`, `WebhookVerificationResult`

`createListenerMessageHandler` and `resolveGatewayAdapter` stay behind — gateway-runner internals, not app surface. They're candidates for #1233.

### Its own barrel, not the root hub

`pikku-types.gen.ts` re-exports every wiring type into one namespace. That is the same shape that left `@pikku/core`'s root barrel with 119 of 206 names duplicating a dedicated subpath — repeating it in generated output would trade one barrel for another. Gateway is reached as `#pikku/gateway`, matching how workflow types are already consumed.

That needs an explicit `imports` entry, because `"#pikku/*": "./.pikku/*"` cannot resolve a bare directory at runtime:

```json
"#pikku/gateway": "./.pikku/gateway/pikku-gateway-types.gen.ts"
```

Scaffolding should write that entry — left as follow-up, since it generalises to every per-wiring barrel in step 4 of #1279.

### Verification

The gateway verifier now imports `wireGateway` and the adapter types through `#pikku/gateway` in both `start.ts` and `mock-adapter.ts`, so the suite exercises type resolution and runtime resolution together. **11/11 passing.** `packages/cli` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)