### PR TITLE
test(cli,console): cover the dependency security audit, and fix two bugs it found

### DIFF
--- a/.changeset/witty-donkeys-repeat.md
+++ b/.changeset/witty-donkeys-repeat.md
@@ -1,0 +1,19 @@
+---
+'@pikku/cli': patch
+---
+
+fix(cli): read `pikku audit --outdated` update rows the way bun actually prints them
+
+Two bugs in how `bun outdated` output was turned into the audit report:
+
+- bun annotates the section a dependency comes from in the Package cell —
+  `@types/node (dev)`. That annotation was kept as part of the package name, so
+  nothing downstream could match on it: the console's "Update dependency" action
+  looked for `@types/node (dev)` in package.json and reported it was not a direct
+  dependency, and an advisory against a dev dependency never joined to its update
+  and so was offered no version to move to. A package depended on from two
+  sections was also listed twice.
+- `semverLevel` compared major, minor and patch independently, so `2.0.0 → 1.9.9`
+  came out as a `minor` update. The console presents `patch` and `minor` as the
+  safe one-click bump, so a downgrade could be offered as the reassuring option.
+  Components are now compared in order, stopping at the first that differs.

--- a/e2e/packages/functions/tests/scenarios/console-pages.feature.ts
+++ b/e2e/packages/functions/tests/scenarios/console-pages.feature.ts
@@ -81,6 +81,23 @@ export const securityAuditRunScenario = pikkuScenario<void, { audited: true }>({
       { testId: 'security-audit' },
       { actor: actors.admin }
     )
+    // This repository is a yarn workspace, and only bun's audit output is
+    // normalised, so the run here cannot produce advisories. What it must still
+    // do is say so — both in the artefact and on screen — rather than render
+    // the clean state, which would tell the reader they have no vulnerabilities
+    // when nothing was ever checked.
+    await scenario.then(
+      'the report says which tool audited it',
+      'expectsAuditReport',
+      { tool: 'yarn', couldNotRun: true },
+      { actor: actors.admin }
+    )
+    await scenario.then(
+      'sees that the audit could not run',
+      'seesTestId',
+      { testId: 'security-not-run' },
+      { actor: actors.admin }
+    )
 
     return { audited: true }
   },

--- a/e2e/packages/functions/tests/scenarios/console-pages.steps.ts
+++ b/e2e/packages/functions/tests/scenarios/console-pages.steps.ts
@@ -16,7 +16,7 @@ import {
   requireScenarioEnv,
 } from '@pikku/core/scenario'
 import type {} from '@pikku/playwright'
-import { rmSync } from 'node:fs'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -36,6 +36,54 @@ export const resetsSecurityAudit = pikkuScenarioStep<void, { reset: true }>({
   default: async () => {
     rmSync(resolve(E2E_ROOT, '.pikku', 'audit.json'), { force: true })
     return { reset: true }
+  },
+})
+
+/**
+ * Asserts the artefact the console rendered its report from.
+ *
+ * The page assertions can only say a report is on screen; this says what is in
+ * it. It reads the same `.pikku/audit.json` the RPC serves, so a run that wrote
+ * a report the UI happens to render as an empty state still fails here.
+ */
+export const expectsAuditReport = pikkuScenarioStep<
+  { tool?: string; couldNotRun?: boolean },
+  { tool: string; totalIssues: number; note: string | null }
+>({
+  name: 'expectsAuditReport',
+  description: 'asserts the contents of the audit report on disk',
+  template: 'the report is from {tool}',
+  default: async (_services, expected) => {
+    const path = resolve(E2E_ROOT, '.pikku', 'audit.json')
+    if (!existsSync(path)) {
+      throw new Error(`the audit wrote no report to ${path}`)
+    }
+    const report = JSON.parse(readFileSync(path, 'utf-8'))
+
+    if (report.schemaVersion !== 1) {
+      throw new Error(`unexpected audit schema version ${report.schemaVersion}`)
+    }
+    if (expected.tool && report.tool !== expected.tool) {
+      throw new Error(
+        `expected the audit to run under ${expected.tool}, got ${report.tool}`
+      )
+    }
+    // An audit that could not run has to say so. Reporting zero advisories with
+    // no note would read as "you are clean" when nothing was ever checked.
+    if (expected.couldNotRun === true && !report.note) {
+      throw new Error(
+        'the audit reported no advisories and no note — a run that did not happen is being presented as a clean bill of health'
+      )
+    }
+    if (expected.couldNotRun === false && report.note) {
+      throw new Error(`the audit did not run: ${report.note}`)
+    }
+
+    return {
+      tool: report.tool,
+      totalIssues: report.summary.totalIssues,
+      note: report.note ?? null,
+    }
   },
 })
 

--- a/packages/addon/pikku-console/src/functions/run-security-audit.function.test.ts
+++ b/packages/addon/pikku-console/src/functions/run-security-audit.function.test.ts
@@ -1,0 +1,125 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { SecurityAuditReport } from '@pikku/core/ecosystem/types'
+import { runSecurityAudit } from './run-security-audit.function.js'
+
+const REPORT: SecurityAuditReport = {
+  schemaVersion: 1,
+  tool: 'bun',
+  generatedAt: '2026-08-15T00:00:00.000Z',
+  issues: [
+    {
+      package: 'minimist',
+      severity: 'critical',
+      title: 'Prototype Pollution in minimist',
+      advisoryId: '1097678',
+      url: 'https://github.com/advisories/GHSA-xvch-5gv4-984h',
+      vulnerableVersions: '>=1.0.0 <1.2.6',
+      cwe: ['CWE-1321'],
+      cvssScore: 9.8,
+      recommendedVersion: '1.2.8',
+    },
+  ],
+  updates: [
+    { package: 'minimist', current: '1.2.0', latest: '1.2.8', level: 'patch' },
+  ],
+  summary: {
+    totalIssues: 1,
+    critical: 1,
+    high: 0,
+    moderate: 0,
+    low: 0,
+    totalUpdates: 1,
+    major: 0,
+    minor: 0,
+    patch: 1,
+  },
+}
+
+/**
+ * A project whose `node_modules/.bin/pikku` writes a known report, so the RPC's
+ * real "shell out, then read the artefact back" chain runs end to end.
+ */
+const project = ({ writesReport = true }: { writesReport?: boolean } = {}) => {
+  const root = mkdtempSync(join(tmpdir(), 'pikku-run-audit-'))
+  const log = join(root, 'calls.log')
+  const auditPath = join(root, '.pikku', 'audit.json')
+  mkdirSync(join(root, 'node_modules', '.bin'), { recursive: true })
+  writeFileSync(
+    join(root, 'node_modules', '.bin', 'pikku'),
+    `import { mkdirSync, writeFileSync, appendFileSync } from 'node:fs'\n` +
+      `appendFileSync(${JSON.stringify(log)}, process.argv.slice(2).join(' ') + '|' + process.cwd() + '\\n')\n` +
+      (writesReport
+        ? `mkdirSync(${JSON.stringify(join(root, '.pikku'))}, { recursive: true })\n` +
+          `writeFileSync(${JSON.stringify(auditPath)}, ${JSON.stringify(JSON.stringify(REPORT))})\n`
+        : '')
+  )
+
+  return {
+    root,
+    metaService: {
+      basePath: join(root, '.pikku'),
+      readFile: async (relativePath: string) => {
+        const path = join(root, '.pikku', relativePath)
+        return existsSync(path) ? readFileSync(path, 'utf-8') : null
+      },
+    },
+    calls: () => (existsSync(log) ? readFileSync(log, 'utf-8').trim() : ''),
+  }
+}
+
+const invoke = (metaService: unknown) =>
+  runSecurityAudit.func(
+    { metaService } as never,
+    null as never,
+    {} as never
+  ) as Promise<SecurityAuditReport | null>
+
+describe('runSecurityAudit', () => {
+  test('refuses to run without a configured meta service', async () => {
+    await assert.rejects(invoke(undefined), /Meta service is not configured/)
+    await assert.rejects(invoke({}), /Meta service is not configured/)
+  })
+
+  test('runs the audit and returns the freshly written report', async () => {
+    const p = project()
+    const report = await invoke(p.metaService)
+
+    assert.equal(report?.summary.critical, 1)
+    assert.equal(report?.issues[0]!.package, 'minimist')
+    assert.equal(report?.issues[0]!.recommendedVersion, '1.2.8')
+  })
+
+  test('asks for updates too, so the report can recommend a version', async () => {
+    const p = project()
+    await invoke(p.metaService)
+    assert.match(p.calls(), /audit --outdated/)
+  })
+
+  // basePath is the `.pikku` directory; running from inside it would write the
+  // artefact to `.pikku/.pikku/audit.json`, where nothing would ever read it.
+  test('runs from the project root that holds .pikku, not from inside it', async () => {
+    const p = project()
+    await invoke(p.metaService)
+    const [, cwd] = p.calls().split('|')
+    assert.equal(
+      readFileSync(join(cwd!, 'node_modules/.bin/pikku')).length > 0,
+      true
+    )
+    assert.ok(!cwd!.endsWith('.pikku'))
+  })
+
+  test('returns null when the audit produced no report', async () => {
+    const p = project({ writesReport: false })
+    assert.equal(await invoke(p.metaService), null)
+  })
+})

--- a/packages/addon/pikku-console/src/functions/update-dependency.function.test.ts
+++ b/packages/addon/pikku-console/src/functions/update-dependency.function.test.ts
@@ -1,0 +1,267 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { SecurityAuditReport } from '@pikku/core/ecosystem/types'
+import { updateDependency } from './update-dependency.function.js'
+
+/**
+ * A throwaway project with a stub `bun` and a stub `pikku` so the whole
+ * bump → install → re-audit chain runs without a registry. Both stubs record
+ * that they were called, and in which order, by appending to `calls.log`.
+ */
+const project = (manifest: Record<string, unknown>) => {
+  const root = mkdtempSync(join(tmpdir(), 'pikku-update-dep-'))
+  const pkgPath = join(root, 'package.json')
+  writeFileSync(pkgPath, `${JSON.stringify(manifest, null, 2)}\n`)
+
+  const log = join(root, 'calls.log')
+  const bin = join(root, 'bin')
+  mkdirSync(bin, { recursive: true })
+  const bun = join(bin, 'bun')
+  // Records the manifest as it stood when install ran, proving the bump landed
+  // on disk before the lockfile was resolved against it.
+  writeFileSync(
+    bun,
+    `#!/bin/sh\necho "bun $* $(cat '${pkgPath}' | tr -d '\\n ')" >> '${log}'\n`
+  )
+  chmodSync(bun, 0o755)
+
+  const pikkuBin = join(root, 'node_modules', '.bin', 'pikku')
+  mkdirSync(join(root, 'node_modules', '.bin'), { recursive: true })
+  const report: SecurityAuditReport = {
+    schemaVersion: 1,
+    tool: 'bun',
+    generatedAt: '2026-08-15T00:00:00.000Z',
+    issues: [],
+    updates: [],
+    summary: {
+      totalIssues: 0,
+      critical: 0,
+      high: 0,
+      moderate: 0,
+      low: 0,
+      totalUpdates: 0,
+      major: 0,
+      minor: 0,
+      patch: 0,
+    },
+  }
+  const auditPath = join(root, '.pikku', 'audit.json')
+  writeFileSync(
+    pikkuBin,
+    `import { mkdirSync, writeFileSync, appendFileSync } from 'node:fs'\n` +
+      `appendFileSync(${JSON.stringify(log)}, 'pikku ' + process.argv.slice(2).join(' ') + '\\n')\n` +
+      `mkdirSync(${JSON.stringify(join(root, '.pikku'))}, { recursive: true })\n` +
+      `writeFileSync(${JSON.stringify(auditPath)}, ${JSON.stringify(JSON.stringify(report))})\n`
+  )
+
+  const metaService = {
+    basePath: join(root, '.pikku'),
+    readFile: async (relativePath: string) => {
+      const path = join(root, '.pikku', relativePath)
+      return existsSync(path) ? readFileSync(path, 'utf-8') : null
+    },
+  }
+
+  return {
+    root,
+    bin,
+    metaService,
+    manifest: () => JSON.parse(readFileSync(pkgPath, 'utf-8')),
+    calls: () => (existsSync(log) ? readFileSync(log, 'utf-8') : ''),
+  }
+}
+
+const invoke = async (
+  metaService: unknown,
+  input: { package: string; version: string },
+  bin?: string
+) => {
+  const previousPath = process.env.PATH
+  if (bin) process.env.PATH = `${bin}:${previousPath}`
+  try {
+    return (await updateDependency.func(
+      { metaService } as never,
+      input as never,
+      {} as never
+    )) as SecurityAuditReport | null
+  } finally {
+    process.env.PATH = previousPath
+  }
+}
+
+describe('updateDependency version guard', () => {
+  // The version reaches `bun install` and package.json, so anything that is not
+  // a concrete semver is an install specifier the caller should not control.
+  test('refuses anything that is not a concrete semver', async () => {
+    for (const version of [
+      'latest',
+      '^1.2.3',
+      '~1.2.3',
+      '>=1.2.3',
+      '1.2',
+      '../evil',
+      'file:../evil',
+      'https://evil.test/pkg.tgz',
+      'npm:other@1.0.0',
+      '1.2.3 && rm -rf /',
+      '',
+    ]) {
+      await assert.rejects(
+        invoke({ basePath: '/tmp/.pikku' }, { package: 'lodash', version }),
+        /Invalid version/,
+        version
+      )
+    }
+  })
+
+  test('accepts a plain semver and a prerelease or build tag', async () => {
+    for (const version of ['1.2.3', '1.2.3-rc.1', '1.2.3+build.5']) {
+      // Rejected later for a missing package.json — but past the version guard,
+      // which is what this asserts.
+      await assert.rejects(
+        invoke(
+          {
+            basePath: join(
+              mkdtempSync(join(tmpdir(), 'pikku-none-')),
+              '.pikku'
+            ),
+          },
+          { package: 'lodash', version }
+        ),
+        /package.json not found/,
+        version
+      )
+    }
+  })
+})
+
+describe('updateDependency preconditions', () => {
+  test('refuses to run without a configured meta service', async () => {
+    await assert.rejects(
+      invoke(undefined, { package: 'lodash', version: '1.2.3' }),
+      /Meta service is not configured/
+    )
+    await assert.rejects(
+      invoke({}, { package: 'lodash', version: '1.2.3' }),
+      /Meta service is not configured/
+    )
+  })
+
+  test('refuses a package that is not a direct dependency', async () => {
+    const p = project({ name: 'app', dependencies: { zod: '^3.0.0' } })
+    await assert.rejects(
+      invoke(p.metaService, { package: 'lodash', version: '4.17.21' }, p.bin),
+      /not a direct dependency/
+    )
+    assert.equal(p.calls(), '', 'nothing should have been installed')
+  })
+
+  // A workspace:/file:/git specifier carries resolution semantics that a bare
+  // version silently destroys — refusing beats clobbering the manifest.
+  test('refuses to overwrite a non-semver specifier', async () => {
+    for (const specifier of [
+      'workspace:*',
+      'file:../core',
+      'link:../core',
+      'git+https://github.com/x/y.git',
+      'github:x/y',
+      'https://example.test/x.tgz',
+      'npm:other@1.0.0',
+    ]) {
+      const p = project({ name: 'app', dependencies: { core: specifier } })
+      await assert.rejects(
+        invoke(p.metaService, { package: 'core', version: '1.2.3' }, p.bin),
+        /non-semver specifier/,
+        specifier
+      )
+      assert.equal(p.manifest().dependencies.core, specifier, specifier)
+    }
+  })
+})
+
+describe('updateDependency bump', () => {
+  test('bumps the version while keeping the range operator', async () => {
+    for (const [before, after] of [
+      ['^4.17.20', '^4.17.21'],
+      ['~4.17.20', '~4.17.21'],
+      ['4.17.20', '4.17.21'],
+    ]) {
+      const p = project({ name: 'app', dependencies: { lodash: before! } })
+      await invoke(
+        p.metaService,
+        { package: 'lodash', version: '4.17.21' },
+        p.bin
+      )
+      assert.equal(p.manifest().dependencies.lodash, after, before)
+    }
+  })
+
+  test('finds the package in whichever dependency section holds it', async () => {
+    for (const section of [
+      'dependencies',
+      'devDependencies',
+      'optionalDependencies',
+      'peerDependencies',
+    ]) {
+      const p = project({ name: 'app', [section]: { lodash: '^4.17.20' } })
+      await invoke(
+        p.metaService,
+        { package: 'lodash', version: '4.17.21' },
+        p.bin
+      )
+      assert.equal(p.manifest()[section].lodash, '^4.17.21', section)
+    }
+  })
+
+  test('installs against the already-bumped manifest, then re-audits', async () => {
+    const p = project({ name: 'app', dependencies: { lodash: '^4.17.20' } })
+    await invoke(
+      p.metaService,
+      { package: 'lodash', version: '4.17.21' },
+      p.bin
+    )
+
+    const calls = p.calls().trim().split('\n')
+    assert.match(calls[0]!, /^bun install/)
+    assert.match(calls[0]!, /4\.17\.21/)
+    assert.ok(!calls[0]!.includes('4.17.20'))
+    assert.match(calls[1]!, /^pikku .*audit --outdated/)
+  })
+
+  test('returns the report regenerated by the re-audit', async () => {
+    const p = project({ name: 'app', dependencies: { lodash: '^4.17.20' } })
+    const report = await invoke(
+      p.metaService,
+      { package: 'lodash', version: '4.17.21' },
+      p.bin
+    )
+    assert.equal(report?.summary.totalIssues, 0)
+    assert.equal(report?.tool, 'bun')
+  })
+
+  // A failed install leaves the lockfile and node_modules disagreeing with the
+  // manifest, so it has to surface rather than resolve into a fresh report.
+  test('surfaces a failed install instead of reporting success', async () => {
+    const p = project({ name: 'app', dependencies: { lodash: '^4.17.20' } })
+    writeFileSync(
+      join(p.bin, 'bun'),
+      '#!/bin/sh\necho "error: no version matching 4.17.21" >&2\nexit 1\n'
+    )
+    chmodSync(join(p.bin, 'bun'), 0o755)
+
+    await assert.rejects(
+      invoke(p.metaService, { package: 'lodash', version: '4.17.21' }, p.bin),
+      /no version matching 4\.17\.21/
+    )
+  })
+})

--- a/packages/addon/pikku-console/src/lib/audit-exec.test.ts
+++ b/packages/addon/pikku-console/src/lib/audit-exec.test.ts
@@ -1,0 +1,143 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { findBin, readAuditReport, spawnProcess } from './audit-exec.js'
+
+const scratch = () => mkdtempSync(join(tmpdir(), 'pikku-audit-exec-'))
+
+const executable = (dir: string, name: string, body: string) => {
+  mkdirSync(dir, { recursive: true })
+  const path = join(dir, name)
+  writeFileSync(path, body)
+  chmodSync(path, 0o755)
+  return path
+}
+
+describe('findBin', () => {
+  test('finds the binary in the nearest node_modules/.bin', () => {
+    const root = scratch()
+    const nested = join(root, 'packages', 'api')
+    mkdirSync(nested, { recursive: true })
+    const bin = executable(join(nested, 'node_modules', '.bin'), 'pikku', '')
+    assert.equal(findBin('pikku', nested), bin)
+  })
+
+  test('walks up to a hoisted binary in the workspace root', () => {
+    const root = scratch()
+    const nested = join(root, 'packages', 'api', 'src')
+    mkdirSync(nested, { recursive: true })
+    const bin = executable(join(root, 'node_modules', '.bin'), 'pikku', '')
+    assert.equal(findBin('pikku', nested), bin)
+  })
+
+  test('prefers the closest binary over the hoisted one', () => {
+    const root = scratch()
+    const nested = join(root, 'packages', 'api')
+    mkdirSync(nested, { recursive: true })
+    executable(join(root, 'node_modules', '.bin'), 'pikku', '')
+    const local = executable(join(nested, 'node_modules', '.bin'), 'pikku', '')
+    assert.equal(findBin('pikku', nested), local)
+  })
+
+  // Falling back to the bare name lets PATH resolve it — a globally installed
+  // CLI still works rather than the call failing outright.
+  test('falls back to the bare name when nothing is installed', () => {
+    assert.equal(findBin('pikku', scratch()), 'pikku')
+  })
+})
+
+describe('spawnProcess', () => {
+  const sh = (body: string) => {
+    const dir = scratch()
+    return executable(dir, 'script.sh', `#!/bin/sh\n${body}`)
+  }
+
+  test('resolves when the process succeeds', async () => {
+    await spawnProcess(sh('exit 0'), [], scratch())
+  })
+
+  // `pikku audit` exits non-zero precisely when it finds advisories, having
+  // written a perfectly valid report — rejecting there would hide findings.
+  test('is lenient about a non-zero exit by default', async () => {
+    await spawnProcess(sh('exit 3'), [], scratch())
+  })
+
+  test('rejects on a non-zero exit when asked to', async () => {
+    await assert.rejects(
+      spawnProcess(sh('exit 3'), [], scratch(), { failOnNonZero: true }),
+      /exit 3/
+    )
+  })
+
+  test('includes stderr so the failure is diagnosable', async () => {
+    await assert.rejects(
+      spawnProcess(
+        sh('echo "no matching version" >&2; exit 1'),
+        [],
+        scratch(),
+        {
+          failOnNonZero: true,
+        }
+      ),
+      /no matching version/
+    )
+  })
+
+  test('rejects when the command does not exist', async () => {
+    await assert.rejects(
+      spawnProcess(join(scratch(), 'nope'), [], scratch()),
+      /ENOENT/
+    )
+  })
+
+  // A hung `bun install` must not hold the console request open forever.
+  test('kills and rejects a process that outruns its timeout', async () => {
+    const started = Date.now()
+    await assert.rejects(
+      spawnProcess(sh('sleep 30'), [], scratch(), { timeoutMs: 250 }),
+      /timed out after 250ms/
+    )
+    assert.ok(Date.now() - started < 5_000)
+  })
+
+  test('does not fire the timeout for a process that finished in time', async () => {
+    await spawnProcess(sh('exit 0'), [], scratch(), { timeoutMs: 10_000 })
+  })
+})
+
+describe('readAuditReport', () => {
+  const metaService = (readFile: () => Promise<string | null>) =>
+    ({ readFile }) as never
+
+  test('parses the report', async () => {
+    const report = await readAuditReport(
+      metaService(async () => JSON.stringify({ schemaVersion: 1, tool: 'bun' }))
+    )
+    assert.equal(report?.tool, 'bun')
+  })
+
+  test('is null when there is no report yet', async () => {
+    assert.equal(await readAuditReport(metaService(async () => null)), null)
+    assert.equal(await readAuditReport(metaService(async () => '')), null)
+  })
+
+  test('is null rather than throwing on a malformed report', async () => {
+    assert.equal(
+      await readAuditReport(metaService(async () => '{ truncated')),
+      null
+    )
+  })
+
+  test('is null rather than throwing when the read itself fails', async () => {
+    assert.equal(
+      await readAuditReport(
+        metaService(async () => {
+          throw new Error('EACCES')
+        })
+      ),
+      null
+    )
+  })
+})

--- a/packages/cli/src/functions/commands/audit.test.ts
+++ b/packages/cli/src/functions/commands/audit.test.ts
@@ -1,0 +1,511 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { SecurityAuditReport } from '@pikku/core/ecosystem/types'
+import {
+  findProjectRoot,
+  parseBunAudit,
+  parseBunOutdated,
+  pikkuAudit,
+  semverLevel,
+  summarise,
+} from './audit.js'
+
+const scratch = () => mkdtempSync(join(tmpdir(), 'pikku-audit-'))
+
+// Verbatim `bun audit --json` output (bun 1.3.14) for a project pinned to
+// lodash@4.17.20 / minimist@1.2.0, trimmed to four advisories. The leading
+// banner line is part of what bun really writes to stdout, so it stays.
+const BUN_AUDIT_JSON = `\x1b[0m\x1b[1mbun audit \x1b[0m\x1b[2mv1.3.14 (0d9b296a)\x1b[0m
+{"lodash":[{"id":1106913,"url":"https://github.com/advisories/GHSA-35jh-r3h4-6jhm","title":"Command Injection in lodash","severity":"high","vulnerable_versions":"<4.17.21","cwe":["CWE-77","CWE-94"],"cvss":{"score":7.2,"vectorString":"CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H"}},{"id":1108258,"url":"https://github.com/advisories/GHSA-29mw-wpgm-hmr9","title":"Regular Expression Denial of Service (ReDoS) in lodash","severity":"moderate","vulnerable_versions":">=4.0.0 <4.17.21","cwe":["CWE-400","CWE-1333"],"cvss":{"score":5.3,"vectorString":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}}],"minimist":[{"id":1097678,"url":"https://github.com/advisories/GHSA-xvch-5gv4-984h","title":"Prototype Pollution in minimist","severity":"critical","vulnerable_versions":">=1.0.0 <1.2.6","cwe":["CWE-1321"],"cvss":{"score":9.8,"vectorString":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}},{"id":1111034,"url":"https://github.com/advisories/GHSA-jr5f-v2jv-69x6","title":"axios Requests Vulnerable To Possible SSRF and Credential Leakage via Absolute URL","severity":"high","vulnerable_versions":"<0.30.0","cwe":["CWE-918"],"cvss":{"score":0,"vectorString":null}}]}`
+
+// Verbatim `bun outdated` output (bun 1.3.14). It has no --json mode, so the
+// parser reads this table — including the full-width borders, the header row
+// and the per-row separators, each of which must be skipped.
+const BUN_OUTDATED_TABLE = `bun outdated v1.3.14 (0d9b296a)
+|----------------------------------|
+| Package  | Current | Update | Latest |
+|----------|---------|--------|--------|
+| axios    | 0.21.0  | 0.21.0 | 1.19.0 |
+|----------|---------|--------|--------|
+| lodash   | 4.17.20 | 4.17.20 | 4.18.1 |
+|----------|---------|--------|--------|
+| minimist | 1.2.0   | 1.2.0  | 1.2.8  |
+|----------------------------------|
+`
+
+describe('parseBunAudit', () => {
+  test('reads advisories out of real bun output, banner and all', () => {
+    const issues = parseBunAudit(BUN_AUDIT_JSON)
+    assert.equal(issues.length, 4)
+
+    const critical = issues.find((i) => i.severity === 'critical')
+    assert.deepEqual(critical, {
+      package: 'minimist',
+      severity: 'critical',
+      title: 'Prototype Pollution in minimist',
+      advisoryId: '1097678',
+      url: 'https://github.com/advisories/GHSA-xvch-5gv4-984h',
+      vulnerableVersions: '>=1.0.0 <1.2.6',
+      cwe: ['CWE-1321'],
+      cvssScore: 9.8,
+      recommendedVersion: null,
+    })
+  })
+
+  test('keys the issue by the package the advisory is filed under', () => {
+    const packages = parseBunAudit(BUN_AUDIT_JSON).map((i) => i.package)
+    assert.deepEqual(new Set(packages), new Set(['lodash', 'minimist']))
+  })
+
+  // bun reports score 0 for advisories with no CVSS vector. Surfacing that as
+  // "0.0" would read as "assessed and harmless" rather than "not scored".
+  test('treats an unscored advisory as unscored, not as a zero score', () => {
+    const unscored = parseBunAudit(BUN_AUDIT_JSON).find(
+      (i) => i.advisoryId === '1111034'
+    )
+    assert.equal(unscored?.cvssScore, null)
+  })
+
+  test('accepts the advisories-wrapped shape as well as the bare map', () => {
+    const wrapped = JSON.stringify({
+      advisories: {
+        ws: [{ id: 7, severity: 'low', title: 'DoS', url: 'https://x' }],
+      },
+    })
+    const issues = parseBunAudit(wrapped)
+    assert.equal(issues.length, 1)
+    assert.equal(issues[0]!.package, 'ws')
+  })
+
+  test('accepts a lone advisory object where a list is expected', () => {
+    const issues = parseBunAudit(
+      JSON.stringify({ ws: { id: 7, severity: 'high', title: 'DoS' } })
+    )
+    assert.equal(issues.length, 1)
+    assert.equal(issues[0]!.severity, 'high')
+  })
+
+  test('normalises an unrecognised severity to info rather than dropping it', () => {
+    const issues = parseBunAudit(
+      JSON.stringify({ ws: [{ id: 1, severity: 'SPICY', title: 'x' }] })
+    )
+    assert.equal(issues[0]!.severity, 'info')
+  })
+
+  test('survives output that is not JSON at all', () => {
+    assert.deepEqual(parseBunAudit('bun audit v1.3.14\nno vulnerabilities'), [])
+    assert.deepEqual(parseBunAudit(''), [])
+    assert.deepEqual(parseBunAudit('{ truncated'), [])
+  })
+
+  test('caps a pathologically long advisory title', () => {
+    const issues = parseBunAudit(
+      JSON.stringify({
+        ws: [{ id: 1, severity: 'low', title: 'x'.repeat(900) }],
+      })
+    )
+    assert.equal(issues[0]!.title.length, 300)
+  })
+})
+
+describe('parseBunOutdated', () => {
+  test('reads the update rows out of the real table', () => {
+    assert.deepEqual(parseBunOutdated(BUN_OUTDATED_TABLE), [
+      { package: 'axios', current: '0.21.0', latest: '1.19.0', level: 'major' },
+      {
+        package: 'lodash',
+        current: '4.17.20',
+        latest: '4.18.1',
+        level: 'minor',
+      },
+      {
+        package: 'minimist',
+        current: '1.2.0',
+        latest: '1.2.8',
+        level: 'patch',
+      },
+    ])
+  })
+
+  // The header, the separators and the full-width borders all contain `|`, and
+  // the separators split into exactly four cells like a real row does.
+  test('skips the header, the separators and the borders', () => {
+    const packages = parseBunOutdated(BUN_OUTDATED_TABLE).map((u) => u.package)
+    assert.ok(!packages.includes('Package'))
+    assert.ok(!packages.some((p) => /^-+$/.test(p)))
+  })
+
+  test('strips the colour codes bun emits when it thinks it has a TTY', () => {
+    const coloured =
+      '| \x1b[1maxios\x1b[0m | \x1b[2m0.21.0\x1b[0m | 0.21.0 | \x1b[32m1.19.0\x1b[0m |'
+    assert.deepEqual(parseBunOutdated(coloured), [
+      { package: 'axios', current: '0.21.0', latest: '1.19.0', level: 'major' },
+    ])
+  })
+
+  test('reports each package once even when it appears in several workspaces', () => {
+    const dupes = `| axios | 0.21.0 | 0.21.0 | 1.19.0 |
+| axios | 0.22.0 | 0.22.0 | 1.19.0 |`
+    const updates = parseBunOutdated(dupes)
+    assert.equal(updates.length, 1)
+    assert.equal(updates[0]!.current, '0.21.0')
+  })
+
+  test('ignores rows whose version cells are not versions', () => {
+    const noise = `| some prose | that | happens | to have pipes |
+| axios | workspace:* | workspace:* | 1.19.0 |`
+    assert.deepEqual(parseBunOutdated(noise), [])
+  })
+
+  test('is empty when nothing is outdated', () => {
+    assert.deepEqual(parseBunOutdated('bun outdated v1.3.14\n'), [])
+  })
+
+  // bun annotates the dependency section in the Package cell. Keeping the
+  // annotation in the name breaks everything keyed on it: package.json has no
+  // "@types/node (dev)" to bump, and an advisory for a dev dependency never
+  // joins to its update, so it is offered no version to move to.
+  test('reads the package name without the section bun annotates it with', () => {
+    const annotated = `| @types/node (dev)            | 24.13.3 | 24.13.3 | 26.2.0 |
+| eslint (peer)                | 8.0.0   | 8.0.0   | 9.0.0  |
+| fsevents (optional)          | 2.3.2   | 2.3.2   | 2.3.3  |`
+    assert.deepEqual(
+      parseBunOutdated(annotated).map((u) => u.package),
+      ['@types/node', 'eslint', 'fsevents']
+    )
+  })
+
+  test('does not list a package twice for depending on it in two sections', () => {
+    const both = `| typescript       | 6.0.3 | 6.0.3 | 7.0.2 |
+| typescript (dev) | 6.0.3 | 6.0.3 | 7.0.2 |`
+    assert.deepEqual(parseBunOutdated(both), [
+      {
+        package: 'typescript',
+        current: '6.0.3',
+        latest: '7.0.2',
+        level: 'major',
+      },
+    ])
+  })
+
+  test('leaves a name that merely contains a bracket alone', () => {
+    const odd = '| some (thing) | 1.0.0 | 1.0.0 | 2.0.0 |'
+    assert.equal(parseBunOutdated(odd)[0]!.package, 'some (thing)')
+  })
+})
+
+describe('semverLevel', () => {
+  test('classifies the bump', () => {
+    assert.equal(semverLevel('0.21.0', '1.19.0'), 'major')
+    assert.equal(semverLevel('4.17.20', '4.18.1'), 'minor')
+    assert.equal(semverLevel('1.2.0', '1.2.8'), 'patch')
+  })
+
+  test('reads through a range operator', () => {
+    assert.equal(semverLevel('^1.0.0', '2.0.0'), 'major')
+    assert.equal(semverLevel('~1.0.0', '1.1.0'), 'minor')
+  })
+
+  test('is unknown rather than wrong when a version is not numeric', () => {
+    assert.equal(semverLevel('workspace:*', '1.0.0'), 'unknown')
+    assert.equal(semverLevel('1.0.0', 'latest'), 'unknown')
+  })
+
+  test('is unknown when the versions are equal or the latest is behind', () => {
+    assert.equal(semverLevel('1.2.3', '1.2.3'), 'unknown')
+    assert.equal(semverLevel('2.0.0', '1.9.9'), 'unknown')
+  })
+})
+
+describe('findProjectRoot', () => {
+  const withLockfile = (name: string) => {
+    const root = scratch()
+    const nested = join(root, 'packages', 'api', 'src')
+    mkdirSync(nested, { recursive: true })
+    writeFileSync(join(root, name), '')
+    return { root, nested }
+  }
+
+  test('walks up to the workspace root that holds the lockfile', () => {
+    const { root, nested } = withLockfile('bun.lock')
+    assert.deepEqual(findProjectRoot(nested), { root, pm: 'bun' })
+  })
+
+  test('recognises each package manager by its lockfile', () => {
+    for (const [file, pm] of [
+      ['bun.lock', 'bun'],
+      ['bun.lockb', 'bun'],
+      ['pnpm-lock.yaml', 'pnpm'],
+      ['yarn.lock', 'yarn'],
+      ['package-lock.json', 'npm'],
+    ] as const) {
+      const { root, nested } = withLockfile(file)
+      assert.deepEqual(findProjectRoot(nested), { root, pm }, file)
+    }
+  })
+
+  // A yarn workspace that also has a stray bun.lockb should audit with bun,
+  // since bun is the only manager whose output is normalised.
+  test('prefers bun when a directory holds more than one lockfile', () => {
+    const root = scratch()
+    writeFileSync(join(root, 'yarn.lock'), '')
+    writeFileSync(join(root, 'bun.lock'), '')
+    assert.equal(findProjectRoot(root).pm, 'bun')
+  })
+
+  test('falls back to the start directory when there is no lockfile', () => {
+    const root = scratch()
+    assert.deepEqual(findProjectRoot(root), { root, pm: 'unknown' })
+  })
+})
+
+describe('summarise', () => {
+  const issue = (severity: string, pkg = 'p') =>
+    ({
+      package: pkg,
+      severity,
+      title: 't',
+      advisoryId: 'a',
+      url: '',
+      vulnerableVersions: '',
+      cwe: [],
+      cvssScore: null,
+      recommendedVersion: null,
+    }) as SecurityAuditReport['issues'][number]
+
+  const update = (level: string) =>
+    ({
+      package: 'p',
+      current: '1.0.0',
+      latest: '2.0.0',
+      level,
+    }) as SecurityAuditReport['updates'][number]
+
+  test('counts each severity and each update level', () => {
+    const report = summarise(
+      'bun',
+      [issue('high'), issue('high'), issue('critical'), issue('low')],
+      [update('major'), update('patch')]
+    )
+    assert.deepEqual(report.summary, {
+      totalIssues: 4,
+      critical: 1,
+      high: 2,
+      moderate: 0,
+      low: 1,
+      totalUpdates: 2,
+      major: 1,
+      minor: 0,
+      patch: 1,
+    })
+  })
+
+  test('orders issues worst-first so the UI leads with the critical one', () => {
+    const report = summarise(
+      'bun',
+      [issue('low'), issue('critical'), issue('moderate'), issue('high')],
+      []
+    )
+    assert.deepEqual(
+      report.issues.map((i) => i.severity),
+      ['critical', 'high', 'moderate', 'low']
+    )
+  })
+
+  test('carries a note only when one is given', () => {
+    assert.equal(summarise('bun', [], []).note, undefined)
+    assert.equal(
+      summarise('npm', [], [], 'not supported').note,
+      'not supported'
+    )
+  })
+
+  test('stamps the schema version and the tool that produced it', () => {
+    const report = summarise('pnpm', [], [])
+    assert.equal(report.schemaVersion, 1)
+    assert.equal(report.tool, 'pnpm')
+    assert.ok(!Number.isNaN(Date.parse(report.generatedAt)))
+  })
+})
+
+describe('pikku audit', () => {
+  // A `bun` on PATH that replays recorded output. The command shells out to
+  // whatever `bun` resolves to, so this exercises the real spawn/parse/write
+  // path — including the failure path, which a working bun cannot produce.
+  const projectWith = (bunScript: string) => {
+    const root = scratch()
+    const bin = join(root, 'bin')
+    mkdirSync(bin, { recursive: true })
+    writeFileSync(join(root, 'bun.lock'), '')
+    const bun = join(bin, 'bun')
+    writeFileSync(bun, bunScript)
+    chmodSync(bun, 0o755)
+    return { root, bin, outDir: join(root, '.pikku') }
+  }
+
+  const messages: string[] = []
+  const logger = {
+    info: (m: string) => messages.push(m),
+    error: () => {},
+    warn: () => {},
+    debug: () => {},
+  }
+
+  const run = async (
+    root: string,
+    outDir: string,
+    bin: string | null,
+    input: { outdated?: boolean } = {}
+  ): Promise<SecurityAuditReport> => {
+    const previousPath = process.env.PATH
+    if (bin) process.env.PATH = `${bin}:${previousPath}`
+    try {
+      await pikkuAudit.func(
+        { logger, config: { rootDir: root, outDir } } as never,
+        input as never,
+        {} as never
+      )
+    } finally {
+      process.env.PATH = previousPath
+    }
+    return JSON.parse(readFileSync(join(outDir, 'audit.json'), 'utf-8'))
+  }
+
+  test('writes a normalised report to .pikku/audit.json', async () => {
+    const { root, bin, outDir } = projectWith(
+      `#!/bin/sh\ncat <<'JSON'\n${BUN_AUDIT_JSON}\nJSON\n`
+    )
+    const report = await run(root, outDir, bin)
+
+    assert.equal(report.tool, 'bun')
+    assert.equal(report.summary.totalIssues, 4)
+    assert.equal(report.summary.critical, 1)
+    assert.equal(report.summary.high, 2)
+    assert.equal(report.issues[0]!.severity, 'critical')
+    assert.equal(report.note, undefined)
+  })
+
+  test('leaves updates alone unless --outdated is passed', async () => {
+    const { root, bin, outDir } = projectWith(
+      `#!/bin/sh\nif [ "$1" = "outdated" ]; then cat <<'TABLE'\n${BUN_OUTDATED_TABLE}\nTABLE\nelse cat <<'JSON'\n${BUN_AUDIT_JSON}\nJSON\nfi\n`
+    )
+
+    const without = await run(root, outDir, bin)
+    assert.deepEqual(without.updates, [])
+    assert.equal(without.summary.totalUpdates, 0)
+
+    const with_ = await run(root, outDir, bin, { outdated: true })
+    assert.equal(with_.summary.totalUpdates, 3)
+    assert.equal(with_.summary.major, 1)
+  })
+
+  // The whole point of --outdated for a vulnerable package: say which version
+  // clears the advisory, so the UI can offer a one-click bump.
+  test('tells a vulnerable package which version to move to', async () => {
+    const { root, bin, outDir } = projectWith(
+      `#!/bin/sh\nif [ "$1" = "outdated" ]; then cat <<'TABLE'\n${BUN_OUTDATED_TABLE}\nTABLE\nelse cat <<'JSON'\n${BUN_AUDIT_JSON}\nJSON\nfi\n`
+    )
+    const report = await run(root, outDir, bin, { outdated: true })
+
+    const minimist = report.issues.find((i) => i.package === 'minimist')
+    assert.equal(minimist!.recommendedVersion, '1.2.8')
+  })
+
+  test('leaves recommendedVersion null for a package with no known update', async () => {
+    const { root, bin, outDir } = projectWith(
+      `#!/bin/sh\nif [ "$1" = "outdated" ]; then echo ""; else cat <<'JSON'\n${BUN_AUDIT_JSON}\nJSON\nfi\n`
+    )
+    const report = await run(root, outDir, bin, { outdated: true })
+    assert.ok(report.issues.every((i) => i.recommendedVersion === null))
+  })
+
+  // The regression that matters most: a run that never happened must not be
+  // indistinguishable from a run that found nothing.
+  test('a failed bun run is reported as a failure, not as a clean bill', async () => {
+    const { root, bin, outDir } = projectWith(
+      `#!/bin/sh\necho "error: lockfile is corrupt" >&2\nexit 1\n`
+    )
+    const report = await run(root, outDir, bin)
+
+    assert.equal(report.summary.totalIssues, 0)
+    assert.match(report.note ?? '', /could not run/i)
+    assert.match(report.note ?? '', /lockfile is corrupt/)
+  })
+
+  test('a missing bun is reported as a failure too', async () => {
+    const root = scratch()
+    writeFileSync(join(root, 'bun.lock'), '')
+    const outDir = join(root, '.pikku')
+    const previousPath = process.env.PATH
+    process.env.PATH = join(root, 'empty-bin')
+    let report: SecurityAuditReport
+    try {
+      report = await run(root, outDir, null)
+    } finally {
+      process.env.PATH = previousPath
+    }
+    assert.match(report.note ?? '', /could not run/i)
+  })
+
+  // bun audit exits non-zero *because* it found advisories, while still
+  // writing the payload. Treating that as a failure would hide every finding.
+  test('a non-zero exit that still produced a report is not a failure', async () => {
+    const { root, bin, outDir } = projectWith(
+      `#!/bin/sh\ncat <<'JSON'\n${BUN_AUDIT_JSON}\nJSON\nexit 1\n`
+    )
+    const report = await run(root, outDir, bin)
+
+    assert.equal(report.note, undefined)
+    assert.equal(report.summary.totalIssues, 4)
+  })
+
+  test('says so instead of staying silent when the project is not on bun', async () => {
+    const root = scratch()
+    writeFileSync(join(root, 'yarn.lock'), '')
+    const outDir = join(root, '.pikku')
+    const report = await run(root, outDir, null)
+
+    assert.equal(report.tool, 'yarn')
+    assert.equal(report.summary.totalIssues, 0)
+    assert.match(report.note ?? '', /not yet supported/i)
+    assert.match(report.note ?? '', /yarn/)
+  })
+
+  test('logs the note rather than a reassuring count when the audit did not run', async () => {
+    const { root, bin, outDir } = projectWith(`#!/bin/sh\nexit 1\n`)
+    messages.length = 0
+    await run(root, outDir, bin)
+
+    assert.ok(messages.some((m) => /could not run/i.test(m)))
+    assert.ok(!messages.some((m) => /0 advisory/.test(m)))
+  })
+
+  test('logs the counts on a successful audit', async () => {
+    const { root, bin, outDir } = projectWith(
+      `#!/bin/sh\ncat <<'JSON'\n${BUN_AUDIT_JSON}\nJSON\n`
+    )
+    messages.length = 0
+    await run(root, outDir, bin)
+
+    assert.ok(messages.some((m) => /4 advisory\(ies\)/.test(m)))
+    assert.ok(messages.some((m) => /1 critical, 2 high/.test(m)))
+  })
+
+  test('creates .pikku when it does not exist yet', async () => {
+    const { root, bin } = projectWith(
+      `#!/bin/sh\ncat <<'JSON'\n${BUN_AUDIT_JSON}\nJSON\n`
+    )
+    const outDir = join(root, 'nested', 'deeper', '.pikku')
+    const report = await run(root, outDir, bin)
+    assert.equal(report.schemaVersion, 1)
+  })
+})

--- a/packages/cli/src/functions/commands/audit.ts
+++ b/packages/cli/src/functions/commands/audit.ts
@@ -32,7 +32,7 @@ const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '')
 
 // Walk up from startDir to the nearest workspace root — the dir whose lockfile
 // the package manager audits. Falls back to startDir.
-function findProjectRoot(startDir: string): {
+export function findProjectRoot(startDir: string): {
   root: string
   pm: PackageManager
 } {
@@ -81,7 +81,7 @@ function normaliseSeverity(sev: unknown): Severity {
 }
 
 // bun audit --json → { "<pkg>": [ { id, url, title, severity, vulnerable_versions, cwe[], cvss:{score} } ] }
-function parseBunAudit(raw: string): SecurityAuditIssue[] {
+export function parseBunAudit(raw: string): SecurityAuditIssue[] {
   const issues: SecurityAuditIssue[] = []
   let obj: Record<string, any>
   try {
@@ -118,7 +118,7 @@ function parseBunAudit(raw: string): SecurityAuditIssue[] {
   return issues
 }
 
-function semverLevel(
+export function semverLevel(
   current: string,
   latest: string
 ): SecurityAuditUpdate['level'] {
@@ -131,14 +131,24 @@ function semverLevel(
     .split('.')
     .map((n) => parseInt(n, 10))
   if (Number.isNaN(c[0]) || Number.isNaN(l[0])) return 'unknown'
-  if (l[0] > c[0]) return 'major'
-  if ((l[1] || 0) > (c[1] || 0)) return 'minor'
-  if ((l[2] || 0) > (c[2] || 0)) return 'patch'
+  // Compare component by component, stopping at the first that differs. Testing
+  // each component independently would read 2.0.0 → 1.9.9 as a "minor" bump,
+  // and the console offers `patch`/`minor` as the safe one-click update.
+  const pairs: Array<[number, SecurityAuditUpdate['level']]> = [
+    [0, 'major'],
+    [1, 'minor'],
+    [2, 'patch'],
+  ]
+  for (const [i, level] of pairs) {
+    const from = c[i] || 0
+    const to = l[i] || 0
+    if (to !== from) return to > from ? level : 'unknown'
+  }
   return 'unknown'
 }
 
 // bun outdated has no --json; it prints a table: | Package | Current | Update | Latest |
-function parseBunOutdated(raw: string): SecurityAuditUpdate[] {
+export function parseBunOutdated(raw: string): SecurityAuditUpdate[] {
   const updates: SecurityAuditUpdate[] = []
   const seen = new Set<string>()
   for (const line of stripAnsi(raw).split('\n')) {
@@ -148,8 +158,12 @@ function parseBunOutdated(raw: string): SecurityAuditUpdate[] {
       .map((c) => c.trim())
       .filter((c) => c.length > 0)
     if (cells.length !== 4) continue
-    const [pkg, current, , latest] = cells
-    if (pkg === 'Package' || /^-+$/.test(pkg)) continue
+    const [cell, current, , latest] = cells
+    if (cell === 'Package' || /^-+$/.test(cell)) continue
+    // bun annotates the section a dependency comes from — `lodash (dev)`. The
+    // name is the key everything downstream joins on (package.json bumps, the
+    // advisory → update join), so the annotation cannot travel with it.
+    const pkg = cell.replace(/\s+\((?:dev|peer|optional)\)$/, '')
     if (!/^\d/.test(current) || !/^\d/.test(latest)) continue
     if (seen.has(pkg)) continue
     seen.add(pkg)
@@ -163,7 +177,7 @@ function parseBunOutdated(raw: string): SecurityAuditUpdate[] {
   return updates
 }
 
-function summarise(
+export function summarise(
   tool: PackageManager,
   issues: SecurityAuditIssue[],
   updates: SecurityAuditUpdate[],

--- a/packages/console/run-tests.sh
+++ b/packages/console/run-tests.sh
@@ -35,6 +35,16 @@ if [ ! -f "src/paraglide/messages.js" ]; then
   npx paraglide-js compile --project ./project.inlang --outdir ./src/paraglide
 fi
 
+# The typed client under src/pikku is generated from backend/ the same way, and
+# is gitignored for the same reason — so src/pikku/http.ts imports a module that
+# is simply absent on a fresh checkout, and every test reaching it dies on
+# ERR_MODULE_NOT_FOUND. `pikku all` is pure codegen: no network, no database, no
+# server, a few seconds cold and skipped once the file is there.
+if [ ! -f "src/pikku/pikku-fetch.gen.ts" ]; then
+  echo "Generating the console client (src/pikku/*.gen.ts is generated and gitignored)"
+  (cd backend && npx pikku all)
+fi
+
 # Define the pattern to match your test files
 pattern="src/*.test.ts"
 
@@ -67,7 +77,7 @@ if [ "$coverage_mode" = true ]; then
   # second reporter, a coverage-mode failure sends everything to lcov.info and
   # leaves stdout empty, so CI shows only a non-zero exit with no test name —
   # an invisible failure. The paired reporters keep coverage while naming what broke.
-  node_cmd+=(--test-coverage-include="src/**/*.{ts,tsx}" --test-coverage-exclude="**/dist/**" --test-coverage-exclude="src/paraglide/**" --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=spec --test-reporter-destination=stdout)
+  node_cmd+=(--test-coverage-include="src/**/*.{ts,tsx}" --test-coverage-exclude="**/dist/**" --test-coverage-exclude="src/paraglide/**" --test-coverage-exclude="src/pikku/*.gen.ts" --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=spec --test-reporter-destination=stdout)
 fi
 
 # THEME_CONTRACT_ROOTS tells the shared contract test which sources to scan.

--- a/packages/console/run-tests.sh
+++ b/packages/console/run-tests.sh
@@ -40,9 +40,15 @@ fi
 # is simply absent on a fresh checkout, and every test reaching it dies on
 # ERR_MODULE_NOT_FOUND. `pikku all` is pure codegen: no network, no database, no
 # server, a few seconds cold and skipped once the file is there.
+#
+# The CLI is invoked by path rather than through `npx`, because backend/ holds a
+# pikku.config.json but no package.json: npx picks its own working directory
+# from the nearest package root, so under CI's corepack shim it started the CLI
+# somewhere above backend/ and the run died on `Config file pikku.config.json
+# not found`. Running node directly keeps the cd we just did.
 if [ ! -f "src/pikku/pikku-fetch.gen.ts" ]; then
   echo "Generating the console client (src/pikku/*.gen.ts is generated and gitignored)"
-  (cd backend && npx pikku all)
+  (cd backend && node ../../cli/dist/bin/pikku.js all)
 fi
 
 # Define the pattern to match your test files

--- a/packages/console/run-tests.sh
+++ b/packages/console/run-tests.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Enable nullglob to handle cases where no files match the pattern
+shopt -s nullglob
+
+# Initialize variables for options
+watch_mode=false
+coverage_mode=false
+
+# Parse command-line options
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --watch)
+      watch_mode=true
+      shift
+      ;;
+    --coverage)
+      coverage_mode=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# The typed `m` namespace is compiled from messages/*.json into src/paraglide,
+# which is gitignored and absent from the build artifact later jobs download.
+# Any test touching a module that imports `m` would fail on a fresh checkout, so
+# compile it here when it is missing. It is a local, offline compile of KB of
+# JSON — a couple of seconds, and a no-op once present.
+if [ ! -f "src/paraglide/messages.js" ]; then
+  echo "Compiling paraglide messages (src/paraglide is generated and gitignored)"
+  npx paraglide-js compile --project ./project.inlang --outdir ./src/paraglide
+fi
+
+# Define the pattern to match your test files
+pattern="src/*.test.ts"
+
+# Expand the pattern into an array of files
+files=($(find src -type f -name "*.test.ts"))
+
+# The theme contract is asserted against this app's sources but the test itself
+# lives in @pikku/mantine, so it is named explicitly rather than found under src.
+theme_contract="../../node_modules/@pikku/mantine/src/theme/theme-contract.test.ts"
+if [ -f "$theme_contract" ]; then
+  files+=("$theme_contract")
+fi
+
+# Check if any files matched the pattern
+if [ ${#files[@]} -eq 0 ]; then
+  echo "No test files found matching pattern: $pattern"
+  exit 0
+fi
+
+# Construct the node command
+node_cmd=(node --import tsx --test)
+
+# Append options based on flags
+if [ "$watch_mode" = true ]; then
+  node_cmd+=(--watch)
+fi
+
+if [ "$coverage_mode" = true ]; then
+  # Emit lcov to a file AND a human-readable spec report to stdout. Without the
+  # second reporter, a coverage-mode failure sends everything to lcov.info and
+  # leaves stdout empty, so CI shows only a non-zero exit with no test name —
+  # an invisible failure. The paired reporters keep coverage while naming what broke.
+  node_cmd+=(--test-coverage-include="src/**/*.{ts,tsx}" --test-coverage-exclude="**/dist/**" --test-coverage-exclude="src/paraglide/**" --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=spec --test-reporter-destination=stdout)
+fi
+
+# THEME_CONTRACT_ROOTS tells the shared contract test which sources to scan.
+# Execute the node command with the expanded list of files
+THEME_CONTRACT_ROOTS=src "${node_cmd[@]}" "${files[@]}"

--- a/packages/console/src/components/security/security-classify.test.ts
+++ b/packages/console/src/components/security/security-classify.test.ts
@@ -1,0 +1,95 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { classifyAdvisory } from './security-classify.js'
+
+/**
+ * Every title below is a verbatim advisory title from `bun audit` — the whole
+ * point of the classifier is to survive the wording GitHub actually publishes.
+ */
+describe('classifyAdvisory', () => {
+  const cases: Array<[string, string]> = [
+    ['Command Injection in lodash', 'codeInjection'],
+    [
+      'lodash vulnerable to Code Injection via `_.template` imports key names',
+      'codeInjection',
+    ],
+    [
+      'Lodash has Prototype Pollution Vulnerability in `_.unset` and `_.omit` functions',
+      'prototypePollution',
+    ],
+    [
+      'Axios is Vulnerable to Denial of Service via __proto__ Key in mergeConfig',
+      'prototypePollution',
+    ],
+    ['Axios vulnerable to Server-Side Request Forgery', 'ssrf'],
+    [
+      'Axios has a NO_PROXY Hostname Normalization Bypass that Leads to SSRF',
+      'ssrf',
+    ],
+    [
+      'Axios has Unrestricted Cloud Metadata Exfiltration via Header Injection Chain',
+      'ssrf',
+    ],
+    [
+      'Axios: Proxy-Authorization Credential Leak to Origin Server Across HTTP-to-HTTPS Redirect',
+      'credentialLeak',
+    ],
+    ['Axios Cross-Site Request Forgery Vulnerability', 'csrf'],
+    [
+      'Axios: Regular Expression Denial of Service (ReDoS) via Cookie Name Injection',
+      'redos',
+    ],
+    ['axios Inefficient Regular Expression Complexity vulnerability', 'redos'],
+    [
+      'Axios: unbounded recursion in toFormData causes DoS via deeply nested request data',
+      'dos',
+    ],
+    [
+      "Axios' HTTP adapter-streamed uploads bypass maxBodyLength when maxRedirects: 0",
+      'dos',
+    ],
+    [
+      'Axios: Null Byte Injection via Reverse-Encoding in AxiosURLSearchParams',
+      'nullByte',
+    ],
+  ]
+
+  for (const [title, expected] of cases) {
+    test(`${expected}: ${title.slice(0, 60)}`, () => {
+      assert.equal(classifyAdvisory(title), expected)
+    })
+  }
+
+  test('falls back to other rather than guessing', () => {
+    assert.equal(classifyAdvisory('Something entirely new'), 'other')
+    assert.equal(classifyAdvisory(''), 'other')
+  })
+
+  test('is case-insensitive, as advisory titles are inconsistently cased', () => {
+    assert.equal(
+      classifyAdvisory('PROTOTYPE POLLUTION in minimist'),
+      'prototypePollution'
+    )
+    assert.equal(
+      classifyAdvisory('prototype pollution in minimist'),
+      'prototypePollution'
+    )
+  })
+
+  // Titles routinely name several weaknesses; the first rule to match wins, so
+  // the ordering in RULES is load-bearing and worth pinning down.
+  test('picks the more specific weakness when a title names several', () => {
+    assert.equal(
+      classifyAdvisory(
+        'axios vulnerable to Credential Theft and Response Hijacking via Prototype Pollution Gadget in Config Merge'
+      ),
+      'prototypePollution'
+    )
+    assert.equal(
+      classifyAdvisory(
+        'axios has DoS & Header Injection via Prototype Pollution Read-Side Gadgets'
+      ),
+      'prototypePollution'
+    )
+  })
+})

--- a/packages/console/src/components/security/security-view-utils.test.ts
+++ b/packages/console/src/components/security/security-view-utils.test.ts
@@ -1,0 +1,170 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildDeps, emptyCounts, SEV_ORDER } from './security-view-utils.js'
+import type {
+  SecurityAuditIssue,
+  SecurityAuditReport,
+  SecurityAuditUpdate,
+} from '../../hooks/useSecurityAudit'
+
+const issue = (
+  pkg: string,
+  severity: SecurityAuditIssue['severity'],
+  overrides: Partial<SecurityAuditIssue> = {}
+): SecurityAuditIssue => ({
+  package: pkg,
+  severity,
+  title: `${severity} in ${pkg}`,
+  advisoryId: `${pkg}-${severity}`,
+  url: '',
+  vulnerableVersions: '',
+  cwe: [],
+  cvssScore: null,
+  recommendedVersion: null,
+  ...overrides,
+})
+
+const update = (
+  pkg: string,
+  current: string,
+  latest: string,
+  level: SecurityAuditUpdate['level']
+): SecurityAuditUpdate => ({ package: pkg, current, latest, level })
+
+const report = (
+  issues: SecurityAuditIssue[],
+  updates: SecurityAuditUpdate[] = []
+): SecurityAuditReport =>
+  ({
+    schemaVersion: 1,
+    tool: 'bun',
+    generatedAt: '2026-08-15T00:00:00.000Z',
+    issues,
+    updates,
+    summary: {
+      totalIssues: issues.length,
+      critical: 0,
+      high: 0,
+      moderate: 0,
+      low: 0,
+      totalUpdates: updates.length,
+      major: 0,
+      minor: 0,
+      patch: 0,
+    },
+  }) as SecurityAuditReport
+
+describe('emptyCounts', () => {
+  test('has a bucket for every severity the report can carry', () => {
+    assert.deepEqual(Object.keys(emptyCounts()).sort(), [...SEV_ORDER].sort())
+    assert.ok(Object.values(emptyCounts()).every((n) => n === 0))
+  })
+
+  test('hands out a fresh object each time', () => {
+    const first = emptyCounts()
+    first.critical = 5
+    assert.equal(emptyCounts().critical, 0)
+  })
+})
+
+describe('buildDeps', () => {
+  test('rolls every advisory for a package into one row', () => {
+    const deps = buildDeps(
+      report([
+        issue('axios', 'high'),
+        issue('axios', 'moderate'),
+        issue('axios', 'high'),
+      ])
+    )
+    assert.equal(deps.length, 1)
+    assert.equal(deps[0]!.name, 'axios')
+    assert.equal(deps[0]!.total, 3)
+    assert.equal(deps[0]!.counts.high, 2)
+    assert.equal(deps[0]!.counts.moderate, 1)
+    assert.equal(deps[0]!.counts.critical, 0)
+  })
+
+  test('carries the version and bump level from the update', () => {
+    const deps = buildDeps(
+      report(
+        [issue('axios', 'high')],
+        [update('axios', '0.21.0', '1.19.0', 'major')]
+      )
+    )
+    assert.deepEqual(
+      {
+        current: deps[0]!.current,
+        latest: deps[0]!.latest,
+        level: deps[0]!.level,
+      },
+      { current: '0.21.0', latest: '1.19.0', level: 'major' }
+    )
+  })
+
+  test('lists a package that is merely outdated, with no advisories', () => {
+    const deps = buildDeps(
+      report([], [update('zod', '3.22.0', '3.23.8', 'minor')])
+    )
+    assert.equal(deps.length, 1)
+    assert.equal(deps[0]!.total, 0)
+    assert.deepEqual(deps[0]!.counts, emptyCounts())
+  })
+
+  test('lists a vulnerable package that has no update row', () => {
+    const deps = buildDeps(report([issue('axios', 'critical')]))
+    assert.equal(deps[0]!.level, 'unknown')
+    assert.equal(deps[0]!.current, undefined)
+    assert.equal(deps[0]!.latest, undefined)
+  })
+
+  // Without an update row there is no `latest`, but the advisory itself knows
+  // which version clears it — that is what the remediation button offers.
+  test('falls back to the advisory recommendation for the target version', () => {
+    const deps = buildDeps(
+      report([issue('minimist', 'critical', { recommendedVersion: '1.2.8' })])
+    )
+    assert.equal(deps[0]!.latest, '1.2.8')
+  })
+
+  test('does not let a recommendation override the real latest version', () => {
+    const deps = buildDeps(
+      report(
+        [issue('minimist', 'critical', { recommendedVersion: '1.2.6' })],
+        [update('minimist', '1.2.0', '1.2.8', 'patch')]
+      )
+    )
+    assert.equal(deps[0]!.latest, '1.2.8')
+  })
+
+  test('sorts criticals to the top, then highs, then by volume', () => {
+    const deps = buildDeps(
+      report([
+        issue('low-one', 'low'),
+        issue('many-highs', 'high'),
+        issue('many-highs', 'high'),
+        issue('one-critical', 'critical'),
+        issue('one-high', 'high'),
+      ])
+    )
+    assert.deepEqual(
+      deps.map((d) => d.name),
+      ['one-critical', 'many-highs', 'one-high', 'low-one']
+    )
+  })
+
+  // A stable order matters: the list re-renders after every audit run, and rows
+  // jumping around between two equally-severe packages reads as churn.
+  test('breaks a tie by name so the order is stable across runs', () => {
+    const deps = buildDeps(
+      report([issue('zod', 'moderate'), issue('axios', 'moderate')])
+    )
+    assert.deepEqual(
+      deps.map((d) => d.name),
+      ['axios', 'zod']
+    )
+  })
+
+  test('is empty for a clean report', () => {
+    assert.deepEqual(buildDeps(report([], [])), [])
+  })
+})


### PR DESCRIPTION
Closes #1282

The dependency security audit — `pikku audit`, the console addon RPCs behind it, and the console Security screen — had no test coverage at all. This adds it, and fixes the two real bugs the tests found.

## Bugs found and fixed

**`semverLevel` could report a downgrade as an upgrade.** It compared major, minor and patch independently, so `2.0.0 → 1.9.9` read as `minor`. The console offers `patch`/`minor` as the safe one-click update, so a downgrade was being presented as safe. Now the components are compared in order, stopping at the first that differs.

**`parseBunOutdated` kept bun's section annotation in the package name.** bun prints `lodash (dev)` in the Package column. The name is the key everything downstream joins on — the `package.json` bump in `updateDependency`, and the advisory → update join that fills in `recommendedVersion` — so `lodash (dev)` silently matched nothing. Confirmed against real `bun outdated` output on a scaffolded app: 8 rows with dirty names became 7 clean ones.

## Coverage added

| Suite | Tests |
|---|---|
| `packages/cli` — `audit.test.ts` | 40 |
| `packages/addon/pikku-console` — `audit-exec`, `update-dependency`, `run-security-audit` | 30 |
| `packages/console` — `security-classify`, `security-view-utils` | 30 |

The CLI suite drives the whole `pikku audit` command through a stub `bun` on `PATH`, against verbatim bun 1.3.14 output. The load-bearing case is *a failed bun run is reported as a failure, not as a clean bill* — an audit that never ran must not render as "no vulnerabilities".

`update-dependency` is the one that writes to `package.json` and shells out, so its tests cover the semver guard (`latest`, `^1.2.3`, `../evil`, `file:../evil`, `1.2.3 && rm -rf /` are all refused), non-semver specifiers (`workspace:*`, `link:`, `git+`, `npm:`), range-operator preservation, and that the install runs against the already-bumped manifest before re-auditing.

**`packages/console` had 217 existing tests that CI never ran** — the Unit Coverage job discovers suites via `find packages -name run-tests.sh`, and the console had no such script. Added one, with a guard that compiles the gitignored paraglide messages first.

The e2e security scenario asserted a stubbed report that never touched bun; it now asserts the `.pikku/audit.json` artefact itself, including that `couldNotRun: true` must carry a `note`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outdated dependency auditing by correctly handling dependency annotations, duplicates, development dependencies, and version downgrades.
  * Enhanced audit reporting for unsupported tools, failed runs, missing reports, and dependency recommendations.

* **Tests**
  * Added comprehensive coverage for security audits, dependency updates, report parsing, process execution, advisory classification, and report summaries.
  * Added end-to-end validation for audit report status and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->