### PR TITLE
feat(console): export the nav dock's preferences

### DIFF
--- a/.changeset/export-dock-prefs.md
+++ b/.changeset/export-dock-prefs.md
@@ -1,0 +1,19 @@
+---
+'@pikku/console': patch
+---
+
+feat(console): export the nav dock's preferences so an embedding app can move it
+
+`<NavDock>` is presentational and already reads `useDockPrefs()` itself — the
+side it sits on and whether it is held open (and so reserves its edge) come from
+localStorage rather than props, precisely so the dock and the menu that moves it
+can never disagree. But the only menu offering those controls lives inside
+`ConsoleNavDock`, which an app embedding the dock replaces wholesale: it builds
+its own zones from its own routes, and hands the dock its own account tile.
+
+So an embedding app could mount the dock but never offer "put it on the left" or
+"keep it visible", and its only route to the prefs was to restate the two storage
+keys and hope they stay put. Fabric had exactly that copy.
+
+`useDockPrefs`, `DOCK_SIDES`, `isVerticalDock` and `DockSide` are now part of the
+package's surface. Nothing changes for the console itself.

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -75,6 +75,16 @@ export { NavDock } from './components/nav-dock/NavDock'
 export type { NavDockProps } from './components/nav-dock/NavDock'
 export { ConsoleNavDock } from './components/nav-dock/ConsoleNavDock'
 export { DockFlyout } from './components/nav-dock/DockFlyout'
+// The dock's own preferences, so an embedding app can offer the menu that moves
+// it from ITS account tile — the console's lives inside `ConsoleNavDock`, which
+// such an app replaces wholesale. Without this the app's only way to reach them
+// is to restate the storage keys and hope they never change.
+export {
+  DOCK_SIDES,
+  isVerticalDock,
+  useDockPrefs,
+} from './components/nav-dock/useDockPrefs'
+export type { DockSide } from './components/nav-dock/useDockPrefs'
 export { isSep } from './components/nav-dock/model'
 export type {
   DockBadge,


### PR DESCRIPTION
`<NavDock>` is presentational, but the two things that decide its geometry — which edge it sits on, and whether it is held open (and so reserves that edge) — are not props. It reads them from `useDockPrefs()` itself, on purpose: the menu that changes them is a tile inside the dock, so an app threading them through would only get a chance to disagree with the dock about where it is.

The catch is that the only menu offering those controls lives inside `ConsoleNavDock`, which an app embedding the dock replaces wholesale — it builds its own zones from its own routes and hands the dock its own account tile. So an embedding app could mount the dock but never offer "put it on the left" or "keep it visible", and its only route to the prefs was to restate the two localStorage keys and hope they never move. Fabric had exactly that copy, which is what prompted this.

`useDockPrefs`, `DOCK_SIDES`, `isVerticalDock` and `DockSide` are now exported from the package index. Pure surface addition — no behaviour change for the console itself.

Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)