### PR TITLE
fix(ci): stop bun template installs compiling a dev-only native module

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -251,8 +251,14 @@ Object.entries(all)
         fi
     done
 
+    # --ignore-scripts: the @pikku/* packages go in as `file:` deps above, and a
+    # file: dependency brings its devDependencies with it — so @pikku/kysely's
+    # dev-only better-sqlite3 lands in the test app and gets compiled from source
+    # through a `bunx node-gyp@latest` whose extraction races itself, failing on a
+    # different half-written file every run. No template imports better-sqlite3,
+    # none of them declare a postinstall, and codegen is re-run explicitly below.
     log_info "Installing dependencies..."
-    if ! "$PACKAGE_MANAGER" install; then
+    if ! "$PACKAGE_MANAGER" install --ignore-scripts; then
         log_error "Failed to install dependencies"
         exit 1
     fi


### PR DESCRIPTION
Closes #1303.

Every PR has been losing 2–3 random `Templates (24, *, bun)` shards to the same failure, with a different half-written file named each time:

```
gyp ERR! stack Error: Cannot find module '<varies each run>'
gyp ERR! cwd .../test-app/node_modules/kysely/node_modules/better-sqlite3
error: install script from "better-sqlite3" exited with 1
```

`scripts/test-template.sh` patches the `@pikku/*` packages into the test app as `file:` deps for the non-yarn path, and a `file:` dependency brings its **devDependencies** along — so `@pikku/kysely`'s dev-only `better-sqlite3` gets installed and compiled from source through a `bunx node-gyp@latest` extraction that races itself.

Installing with `--ignore-scripts` drops that build. Nothing real is lost: no template imports `better-sqlite3`, no template declares a `postinstall`, and the script already re-runs `pikku` codegen explicitly after the install.

The Templates matrix on this PR is the verification — it exercises every shard under both package managers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)