### PR TITLE
fix(skills): address review feedback on the build-mode skills

### DIFF
--- a/packages/skills/skills/pikku-build-app/SKILL.md
+++ b/packages/skills/skills/pikku-build-app/SKILL.md
@@ -39,7 +39,9 @@ project shaped so `pikku fabric init` later adopts it with zero rework.
 
 ## 0. Bootstrap, before anything else
 
-    bunx --bun pikku bootstrap
+```sh
+bunx --bun pikku bootstrap
+```
 
 One command, run once, now — not later when you start building. It wires the
 `#pikku` import alias the generated code depends on. On a fresh scaffold `.pikku/`
@@ -131,8 +133,10 @@ and none is discoverable from code:
 
 Then keep it honest — both must pass, and `validate` is a real gate:
 
-    bunx --bun pikku knowledge index
-    bunx --bun pikku knowledge validate
+```sh
+bunx --bun pikku knowledge index
+bunx --bun pikku knowledge validate
+```
 
 ---
 
@@ -316,8 +320,13 @@ or not the note says `built`.
 1. **Migration.** SQL in `db/sqlite/` at the project root, numbered on from the
    ones already there. Apply with `bunx --bun pikku db migrate`, which also
    regenerates the Kysely types your functions import.
-2. **Seed.** Demo rows in `db/sqlite-dev-seed.sql`, applied with
-   `bunx --bun pikku db seed`, `ON CONFLICT DO NOTHING` so it stays idempotent.
+2. **Seed.** Demo rows in `db/sqlite-dev-seed.sql`. **There is no seed command** —
+   `bunx --bun pikku db reset` is the only thing that applies the file, and it
+   wipes, migrates and seeds in one go (`--no-seed` stops after the migration,
+   for working on an empty state the test data would hide). Because reset always
+   arrives at a database it just wiped, **the seed file is plain `INSERT`s** — no
+   `ON CONFLICT DO NOTHING`, no `INSERT OR IGNORE`. Nothing ever applies it
+   twice, so it never has to defend itself.
    Do this generously and do it now: an empty app demos badly and critiques
    badly, and you cannot judge a screen's hierarchy, overflow, or truncation
    against zero rows. Seed rows each persona sees differently — with an ownership
@@ -378,7 +387,9 @@ Rules that are not optional:
 
 Then run it:
 
-    bun run prebuild && bun run dev
+```sh
+bun run prebuild && bun run dev
+```
 
 That starts the API on :3000 and every frontend in `pikkufabric.config.json`. A
 frontend running against a dead API looks exactly like an app bug, so if every
@@ -453,9 +464,11 @@ export const tenantReportsAFaultScenario = pikkuScenario<void, { id: string }>({
 
 Run them:
 
-    bunx --bun pikku scenario run local --spawn                       # server-side, the fast path
-    bunx --bun pikku scenario run local --spawn --run browser         # the same journeys, driven as a human
-    bunx --bun pikku scenario run local-admin --spawn --run browser   # the second app
+```sh
+bunx --bun pikku scenario run local --spawn                       # server-side, the fast path
+bunx --bun pikku scenario run local --spawn --run browser         # the same journeys, driven as a human
+bunx --bun pikku scenario run local-admin --spawn --run browser   # the second app
+```
 
 `--spawn` starts and stops the server for the run; drop it if `bun run dev` is
 already up. The browser pass needs the environment's `appUrl` and a browser
@@ -467,8 +480,10 @@ Green scenarios tell you the journeys you wrote still work. They say nothing
 about the code you never wrote a journey for, and that gap is invisible without
 measuring it:
 
-    bunx --bun pikku dev --coverage                        # server, instrumented
-    bunx --bun pikku scenario run local --coverage         # against that server
+```sh
+bunx --bun pikku dev --coverage                        # server, instrumented
+bunx --bun pikku scenario run local --coverage         # against that server
+```
 
 That writes `coverage/scenario-coverage.json` — which functions each journey
 exercised. **A function no scenario touches has never been run by anything but
@@ -553,7 +568,9 @@ llms.txt and use the real component.
 
 Then critique it. Free, and works across coding agents:
 
-    npx impeccable install     # needs Node 22.12+
+```sh
+npx impeccable install     # current releases need Node 22.18+
+```
 
 Impeccable scores a screen against interaction heuristics and names what is
 wrong: hierarchy, spacing, type registers, states you forgot. Run it on **every**

--- a/packages/skills/skills/pikku-build-app/references/multi-app.md
+++ b/packages/skills/skills/pikku-build-app/references/multi-app.md
@@ -25,9 +25,12 @@ Then, in order:
 - `name` → `@project/admin`
 - `dev` and `preview` ports → `7105`. Every frontend needs its own, or the second
   one fails to bind and the dev runner looks like it hung.
-- `tsBuildInfoFile` → `admin-tsc.tsbuildinfo`. Left alone, the two apps fight
-  over one incremental cache and you get type errors that vanish on a clean
-  build — an hour of debugging for a one-word edit.
+- the `--tsBuildInfoFile` path inside the **`tsc` script** → `admin-tsc.tsbuildinfo`.
+  In this template it is a CLI flag on that script (`tsc --noEmit --incremental
+  --tsBuildInfoFile node_modules/.cache/app-tsc.tsbuildinfo`), not a
+  `compilerOptions` entry — `tsconfig.json` needs no change. Left alone, the two
+  apps fight over one incremental cache and you get type errors that vanish on a
+  clean build: an hour of debugging for a one-word edit.
 
 ### 2. `pikkufabric.config.json`
 

--- a/packages/skills/skills/pikku-build-app/references/ship.md
+++ b/packages/skills/skills/pikku-build-app/references/ship.md
@@ -7,8 +7,10 @@ the last phase, and nothing in it is needed before then.
 
 `pikku deploy` builds and ships without any hosted service:
 
-    bunx --bun pikku deploy plan  --provider standalone --runtime bun
-    bunx --bun pikku deploy apply --provider standalone --runtime bun
+```sh
+bunx --bun pikku deploy plan  --provider standalone --runtime bun
+bunx --bun pikku deploy apply --provider standalone --runtime bun
+```
 
 `standalone` comes from the installed `@pikku/deploy-standalone` adapter: it
 bundles the project into a single unit and emits either a `bundle.js` you run
@@ -29,15 +31,35 @@ this wrong and sign-in fails on one app only, which is a miserable thing to debu
 
 Before shipping, run the full gate:
 
-    bunx --bun pikku all --tsc-summary --fail-on-warn
-    bunx --bun pikku validate
-    bunx --bun pikku knowledge validate
-    bunx --bun pikku scenario run local --spawn --coverage
+```sh
+bunx --bun pikku all --tsc-summary --fail-on-warn
+bunx --bun pikku validate
+bunx --bun pikku knowledge validate
+bunx --bun pikku scenario run local --spawn --coverage
+bunx --bun pikku scenario run local --spawn --run browser
+bun run build                     # every frontend workspace, type-checked
+```
 
 Keep `--coverage` on the release run even though you have been reading it per
 milestone (§7a). Each of those readings only covered the functions that
 milestone added; this is the first time the whole surface is measured at once,
 and it is where a function orphaned by a later refactor shows up.
+
+**The last two lines are not optional, and one of them is easy to talk yourself
+out of.** The server-side pass proves the functions; it renders nothing. The
+pages are client-rendered, so a component that throws still returns HTTP 200
+with an empty shell — the same trap §6 warns about, and the release gate is
+exactly where it gets shipped past. Run the browser pass, and run it **for every
+environment in `pikkufabric.config.json`**, not just the first:
+
+```sh
+bunx --bun pikku scenario run local-admin --spawn --run browser
+```
+
+`bun run build` is what type-checks each frontend (each app's `tsc` script runs
+`--noEmit`). `pikku all --tsc-summary` covers the functions package; it does not
+reach into the apps, so a broken screen passes every pikku command and fails on
+the deploy.
 
 `pikku all --security --fail-on-error` additionally runs the data-classification
 lint over function return types, catching a `Pii`/`Secret` field that leaks

--- a/packages/skills/skills/pikku-build-platform/SKILL.md
+++ b/packages/skills/skills/pikku-build-platform/SKILL.md
@@ -36,22 +36,36 @@ half-wired workflow engine is worse than no workflow engine.
 ## Choosing surfaces — during `pikku-build-app` §5 (planning)
 
 When you plan milestones, each surface below becomes its own milestone note in
-`knowledge/milestones/`, ordered after the spine it depends on. Pick the ones the
-domain actually motivates, and write the motivation into the note. If you cannot
-name what a surface is *for* in this app, drop it and say why in
-`knowledge/decisions/` — a documented omission is a stronger showcase than a
+`knowledge/milestones/`, ordered after the spine it depends on.
+
+**Five are required, and if the domain does not motivate them you chose the
+wrong domain:** workflows, schedules, queues, an AI agent, and realtime. They are
+what "platform" means here, and a showcase missing one of them is a showcase of
+something else. Pick a domain that needs all five — that choice is yours to make
+at §1, and it is much cheaper than contriving a use later.
+
+The rest — MCP, triggers and webhooks, extra locales, contract versioning,
+addons — are chosen on merit. Write the motivation into the note. If you cannot
+name what one of *those* is for in this app, drop it and say why in
+`knowledge/decisions/`: a documented omission is a stronger showcase than a
 contrived inclusion.
+
+What is never acceptable is a required surface present as a stub. A cron job
+that logs `tick` does not become a schedule by existing, and it is worse than
+the documented omission because it claims to be finished.
 
 Most surfaces are switched on by the CLI rather than hand-wired:
 
-    bunx --bun pikku enable workflow      # workflow workers
-    bunx --bun pikku enable agent         # public agent endpoints
-    bunx --bun pikku enable events        # realtime events channel + SSE stream
-    bunx --bun pikku enable remote-rpc    # internal RPC queue worker + HTTP endpoint
-    bunx --bun pikku enable webhook       # outgoing webhook delivery queue worker
-    bunx --bun pikku enable scenarios     # scenario instrumentation
-    bunx --bun pikku enable console       # console functions
-    bunx --bun pikku enable rpc           # public RPC endpoint
+```sh
+bunx --bun pikku enable workflow      # workflow workers
+bunx --bun pikku enable agent         # public agent endpoints
+bunx --bun pikku enable events        # realtime events channel + SSE stream
+bunx --bun pikku enable remote-rpc    # internal RPC queue worker + HTTP endpoint
+bunx --bun pikku enable webhook       # outgoing webhook delivery queue worker
+bunx --bun pikku enable scenarios     # scenario instrumentation
+bunx --bun pikku enable console       # console functions
+bunx --bun pikku enable rpc           # public RPC endpoint
+```
 
 Each scaffolds a `*.gen.ts` and wires it. Run the enable, then `pikku all`, then
 write the function — not the other way round.
@@ -150,7 +164,9 @@ schedule or queue rather than a request, because that is the interesting path.
 
 ### Contract versioning — `pikku-versioning`
 
-    bunx --bun pikku versions init
+```sh
+bunx --bun pikku versions init
+```
 
 The CLI suggests this on every run of a project without it. Versioning a function
 contract, then changing it, is a short milestone that shows something no
@@ -186,13 +202,15 @@ Two things change in a showcase:
 Everything in `pikku-build-app` §9, plus the checks a showcase should be able to
 survive:
 
-    bunx --bun pikku all --tsc-summary --fail-on-warn --strict-meta
-    bunx --bun pikku all --security --fail-on-error
-    bunx --bun pikku validate
-    bunx --bun pikku knowledge validate
-    bunx --bun pikku audit
-    bunx --bun pikku scenario run local --spawn --coverage
-    bunx --bun pikku scenario run local --spawn --run browser
+```sh
+bunx --bun pikku all --tsc-summary --fail-on-warn --strict-meta
+bunx --bun pikku all --security --fail-on-error
+bunx --bun pikku validate
+bunx --bun pikku knowledge validate
+bunx --bun pikku audit
+bunx --bun pikku scenario run local --spawn --coverage
+bunx --bun pikku scenario run local --spawn --run browser
+```
 
 - `--strict-meta` fails an agent tool with no description.
 - `--security` runs the data-classification lint over function return types,
@@ -214,7 +232,8 @@ built.
 
 - Base workflow: `pikku-build-app` — read it first, follow it in full
 - Per-surface skills: `pikku-workflow`, `pikku-schedule`, `pikku-cron`,
-  `pikku-queue`, `pikku-agent`, `pikku-realtime`, `pikku-websocket`, `pikku-mcp`,
-  `pikku-trigger`, `pikku-i18n`, `pikku-rtl`, `pikku-emails`, `pikku-versioning`,
-  `pikku-addon`, `pikku-security`, `pikku-audit`
+  `pikku-queue`, `pikku-agent`, `pikku-ai-vercel`, `pikku-realtime`,
+  `pikku-websocket`, `pikku-mcp`, `pikku-trigger`, `pikku-i18n`, `pikku-rtl`,
+  `pikku-emails`, `pikku-versioning`, `pikku-addon`, `pikku-security`,
+  `pikku-audit`
 - Every feature, end to end: https://pikkufabric.com/llm-all-features.txt

--- a/packages/skills/skills/pikku-build-quick/SKILL.md
+++ b/packages/skills/skills/pikku-build-quick/SKILL.md
@@ -59,20 +59,41 @@ defaults are the point.
 kind of person, plus **a second one of the primary kind** — that is what makes
 "you see yours, not theirs" observable when you click around.
 
+**One kind of person** — no `defineSystemRole` at all. Ownership is the only
+rule, and it lives in each function's `permissions`, not in a role:
+
+```typescript
+import { definePersonas } from '#pikku/scopes/pikku-personas.gen.js'
+
+definePersonas({
+  visitor: { name: 'Visitor', jobTitle: 'Synthetic health-check user', account: {} },
+  amina: { name: 'Amina', jobTitle: 'Gardener', account: {} },
+  bilal: { name: 'Bilal', jobTitle: 'Gardener', account: {} },
+})
+```
+
+**Several kinds** — one role each, and only for the kinds the user actually
+named:
+
 ```typescript
 import { definePersonas } from '#pikku/scopes/pikku-personas.gen.js'
 import { defineSystemRole } from '#pikku'
 
 defineSystemRole({
   owner: { displayName: 'Owner', description: 'Sees only their own rows', scopes: [] },
+  tenant: { displayName: 'Tenant', description: 'Sees only their own tenancy', scopes: [] },
 })
 
 definePersonas({
   visitor: { name: 'Visitor', jobTitle: 'Synthetic health-check user', account: {} },
   amina: { name: 'Amina', jobTitle: 'Owner', roles: ['owner'], account: {} },
   bilal: { name: 'Bilal', jobTitle: 'Owner', roles: ['owner'], account: {} },
+  chidi: { name: 'Chidi', jobTitle: 'Tenant', roles: ['tenant'], account: {} },
 })
 ```
+
+Two owners in both examples, deliberately: one owner cannot demonstrate that
+owners are separated from each other.
 
 - **Keep `visitor`.** The shipped scenarios name `actors.visitor`; removing it
   fails `pikku all` and nothing you write after that registers.
@@ -92,10 +113,12 @@ Then, in this order — it is the order codegen depends on:
 
 1. **Migration** — SQL in `db/sqlite/`, numbered on from what is there. Apply
    with `bunx --bun pikku db migrate`, which regenerates the Kysely types.
-2. **Seed** — rows in `db/sqlite-dev-seed.sql`, `ON CONFLICT DO NOTHING`, applied
-   with `bunx --bun pikku db seed`. **Be generous, and seed rows for both
-   personas.** An empty app demos badly, and you cannot see a layout break
-   against zero rows.
+2. **Seed** — rows in `db/sqlite-dev-seed.sql`. There is no seed command:
+   `bunx --bun pikku db reset` wipes, migrates and seeds in one go, and is the
+   only thing that applies the file. It always starts from a wiped database, so
+   the file is plain `INSERT`s — no `ON CONFLICT DO NOTHING`. **Be generous, and
+   seed rows for both personas.** An empty app demos badly, and you cannot see a
+   layout break against zero rows.
 3. **Functions** — one `pikkuFunc` per `*.function.ts`, `expose: true`. Pikku
    generates the typed RPC client and React Query hooks; you do NOT write HTTP
    routes. `wireHTTP` only for a real REST shape (a third-party webhook).
@@ -134,7 +157,9 @@ than they save:
 
 Then run it:
 
-    bun run prebuild && bun run dev
+```sh
+bun run prebuild && bun run dev
+```
 
 API on :3000, app on the port vite prints. A frontend against a dead API looks
 exactly like an app bug, so if every request fails, check both came up.
@@ -150,7 +175,7 @@ headlessly and assert on rendered text.
 phone — an overflowing table, a row of buttons wrapped into a pile, a modal
 taller than the viewport. It is the most likely width your demo gets opened at.
 
-If you have five spare minutes, `npx impeccable install` (Node 22.12+) scores
+If you have five spare minutes, `npx impeccable install` (Node 22.18+) scores
 each screen against interaction heuristics and names what is wrong. Feed it
 screenshots, not source. It will polish the default look; it will not give the
 app a look — that is `pikku-build-app` §8a.
@@ -186,7 +211,9 @@ export const ownerCreatesAndSeesItScenario = pikkuScenario<void, { id: string }>
 
 Keep the three shipped scenarios in `packages/functions/test/scenarios/` green.
 
-    bunx --bun pikku scenario run local --spawn
+```sh
+bunx --bun pikku scenario run local --spawn
+```
 
 ## 6. Hand it over honestly
 


### PR DESCRIPTION
Follow-up to #1309, addressing the CodeRabbit review that landed after the merge.

## Fixed

| # | Finding | Change |
|---|---|---|
| 1 | **`pikku db seed` does not exist** | `pikku-build-app` §6.2 and `pikku-build-quick` §3.2 both told agents to run it. `pikku db reset` is the only command that applies `db/sqlite-dev-seed.sql` (wipe → migrate → seed; `--no-seed` stops after the migration). The prescribed `ON CONFLICT DO NOTHING` also contradicted `pikku-fabric`'s own rule — reset always arrives at a wiped database, so the seed file is plain `INSERT`s. This was the serious one: agents following either skill hit an unknown-command error at the first seeding step. |
| 2 | Release gate was server-side only | `references/ship.md` now runs `scenario run --run browser` **per environment** plus `bun run build`. The server-side pass renders nothing, so a client-rendered page whose component throws still returns 200 and passes every `pikku` command. |
| 3 | Platform surfaces all left "to merit" | `pikku-build-platform` now names five required surfaces — workflows, schedules, queues, an AI agent, realtime — and leaves MCP, triggers, extra locales, versioning and addons to merit. A showcase missing one of the five is a showcase of something else. |
| 4 | `pikku-ai-vercel` missing from platform's reference list | Added. |
| 5 | Persona example implied roles are always needed | `pikku-build-quick` §2 split into a one-kind variant (no `defineSystemRole` at all) and a several-kinds variant. |
| 6 | impeccable Node requirement | 22.18+, not 22.12+ (3.6.0 raised it). Fixed in both skills. |
| 7 | `tsBuildInfoFile` guidance ambiguous | In this template it is a CLI flag on the `tsc` script, not a `compilerOptions` entry — `tsconfig.json` needs no change. Reworded so it cannot be read as "edit tsconfig". |
| 8 | MD046 — indented code blocks | Fenced them. 50 of the 65 corpus skills already used fenced blocks; these three were the outliers. |

## Not changed, with reasoning

- **Three `yarn` → `bun` comments** (`pikku-build-app:42`, `pikku-build-platform:57`, `pikku-build-quick:102`). These lines describe commands run inside a **bun-scaffolded generated project**, not this monorepo. `bunx --bun` is load-bearing: the `pikku` CLI has a `#!/usr/bin/env node` shebang and fails under Node < 24 with `ERR_UNKNOWN_BUILTIN_MODULE: No such built-in module: node:sqlite`. Swapping in the monorepo's package manager would break the instruction. (`references/multi-app.md` already tells the reader to *correct* a shipped `["yarn", "dev"]` entry for exactly this reason.)
- The `tsBuildInfoFile` comment as literally written was wrong for this template — verified against `apps/app/package.json` (flag present on the `tsc` script) and `apps/app/tsconfig.json` (no `tsBuildInfoFile`). Reworded rather than applied.

## Verification

- `node scripts/embed.mjs` → 88 files / 65 skills / 773 KB
- Every `corpus.test.ts` assertion replicated and passing: frontmatter parses, names match directories and are unique, descriptions within bounds, `installGroups` valid, fabric group unchanged at the pinned 6, every backticked `references/` path resolves on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)