### PR TITLE
fix(kysely-postgres): keep a workflow run's lock off the query pool

### DIFF
--- a/.changeset/workflow-run-lock-pool.md
+++ b/.changeset/workflow-run-lock-pool.md
@@ -14,8 +14,15 @@ production backend down this way, and it only came back on a restart.
 `PgKyselyWorkflowService` now accepts `lockDb`, a second Kysely instance on its
 own pool used only for the run lock. That pool's size becomes the cap on
 concurrent runs per process — run N+1 waits for a lock connection instead of
-starving request serving. `lockTimeoutMs` bounds that wait so a jam surfaces as
-a failed run rather than a process that never finishes one.
+starving request serving. Every worker's `lockDb` has to reach the same database:
+`pg_advisory_xact_lock` is database-scoped, so lock pools pointed at different
+databases never contend and the same run executes twice.
+
+`lockTimeoutMs` bounds how long a run waits for the advisory lock once its
+transaction holds a connection, so a jam surfaces as a failed run rather than a
+process that never finishes one. Waiting for a connection out of a saturated
+`lockDb` stays unbounded — that queue is the backpressure the pool exists to
+apply.
 
 Both default to the previous behaviour: with no `lockDb` the lock is still taken
 on the query pool, and the wait is still unbounded.

--- a/.changeset/workflow-run-lock-pool.md
+++ b/.changeset/workflow-run-lock-pool.md
@@ -1,0 +1,25 @@
+---
+'@pikku/kysely-postgres': patch
+---
+
+Stop a workflow run's lock from starving the query pool.
+
+A Postgres advisory lock lives on a connection and `withRunLock` spans the whole
+workflow body, so every in-flight run held one connection of the pool the rest
+of the app queries through for as long as it ran — external I/O included. At N
+concurrent runs, N being the pool size, every other request queued behind them
+forever: not an error, a hang. Twenty concurrent teardown workflows took a
+production backend down this way, and it only came back on a restart.
+
+`PgKyselyWorkflowService` now accepts `lockDb`, a second Kysely instance on its
+own pool used only for the run lock. That pool's size becomes the cap on
+concurrent runs per process — run N+1 waits for a lock connection instead of
+starving request serving. `lockTimeoutMs` bounds that wait so a jam surfaces as
+a failed run rather than a process that never finishes one.
+
+Both default to the previous behaviour: with no `lockDb` the lock is still taken
+on the query pool, and the wait is still unbounded.
+
+`withStepLock` is unchanged and stays on the query pool — its caller claims the
+step under the lock and runs the step outside it, so it holds a connection for a
+few statements rather than for the step's work.

--- a/packages/services/kysely-postgres/src/index.ts
+++ b/packages/services/kysely-postgres/src/index.ts
@@ -1,4 +1,5 @@
 export { PgKyselyWorkflowService } from './pg-kysely-workflow-service.js'
+export type { PgWorkflowQueueOptions } from './pg-kysely-workflow-service.js'
 export { PgKyselyDeploymentService } from './pg-kysely-deployment-service.js'
 export { PgKyselyAgentStorageService } from './pg-kysely-agent-storage-service.js'
 export { PgKyselyAgentRunService } from './pg-kysely-agent-run-service.js'

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
@@ -349,4 +349,54 @@ describe('advisory locks', () => {
     const result = await service.withStepLock('run-1', 'step-1', async () => 42)
     assert.equal(result, 42)
   })
+
+  /**
+   * The one connection PGlite hands out stands in for a saturated pool: a run
+   * lock taken on the query connection makes every other query wait for the
+   * whole workflow body, which is how concurrent runs wedged a real server.
+   */
+  test('a run lock on the query pool blocks unrelated queries', async () => {
+    let queryFinished = false
+    let releaseBody!: () => void
+    const body = new Promise<void>((resolve) => {
+      releaseBody = resolve
+    })
+
+    const held = service.withRunLock('run-1', () => body)
+    const query = sql`select 1`.execute(db).then(() => {
+      queryFinished = true
+    })
+
+    await new Promise((r) => setTimeout(r, 20))
+    assert.equal(queryFinished, false)
+
+    releaseBody()
+    await Promise.all([held, query])
+    assert.equal(queryFinished, true)
+  })
+
+  test('a run lock on lockDb leaves the query pool free', async () => {
+    const lockDb = createDb()
+    const isolated = new PgKyselyWorkflowService(db, {
+      wireQueues: false,
+      lockDb,
+    } as any)
+    await isolated.init()
+
+    let releaseBody!: () => void
+    const body = new Promise<void>((resolve) => {
+      releaseBody = resolve
+    })
+
+    const held = isolated.withRunLock('run-1', () => body)
+    await new Promise((r) => setTimeout(r, 20))
+
+    const rows = await sql<{
+      one: number
+    }>`select 1 as one`.execute(db)
+    assert.equal(rows.rows[0]!.one, 1)
+
+    releaseBody()
+    await held
+  })
 })

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
@@ -350,11 +350,6 @@ describe('advisory locks', () => {
     assert.equal(result, 42)
   })
 
-  /**
-   * `bodyEntered` is what the lock tests wait on, rather than a delay: it
-   * resolves once the lock is taken and the body is running, which is the state
-   * they assert about.
-   */
   const heldBody = () => {
     let release!: () => void
     let entered!: () => void
@@ -374,11 +369,7 @@ describe('advisory locks', () => {
     }
   }
 
-  /**
-   * The one connection PGlite hands out stands in for a saturated pool: a run
-   * lock taken on the query connection makes every other query wait for the
-   * whole workflow body, which is how concurrent runs wedged a real server.
-   */
+  /** PGlite's single connection stands in for a saturated pool. */
   test('a run lock on the query pool blocks unrelated queries', async () => {
     let queryFinished = false
     const { run, bodyEntered, release } = heldBody()
@@ -398,10 +389,8 @@ describe('advisory locks', () => {
   })
 
   /**
-   * `lockDb` is a second PGlite instance, so this shows the query pool staying
-   * free rather than two workers contending. Contention needs two pools on one
-   * database, which PGlite cannot give: each instance is its own database and
-   * takes a single session.
+   * Each PGlite instance is its own single-session database, so this can only
+   * show the query pool staying free, not two workers contending for the lock.
    */
   test('a run lock on lockDb leaves the query pool free', async () => {
     const lockDb = createDb()

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
@@ -351,30 +351,58 @@ describe('advisory locks', () => {
   })
 
   /**
+   * `bodyEntered` is what the lock tests wait on, rather than a delay: it
+   * resolves once the lock is taken and the body is running, which is the state
+   * they assert about.
+   */
+  const heldBody = () => {
+    let release!: () => void
+    let entered!: () => void
+    const body = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const bodyEntered = new Promise<void>((resolve) => {
+      entered = resolve
+    })
+    return {
+      run: () => {
+        entered()
+        return body
+      },
+      bodyEntered,
+      release,
+    }
+  }
+
+  /**
    * The one connection PGlite hands out stands in for a saturated pool: a run
    * lock taken on the query connection makes every other query wait for the
    * whole workflow body, which is how concurrent runs wedged a real server.
    */
   test('a run lock on the query pool blocks unrelated queries', async () => {
     let queryFinished = false
-    let releaseBody!: () => void
-    const body = new Promise<void>((resolve) => {
-      releaseBody = resolve
-    })
+    const { run, bodyEntered, release } = heldBody()
 
-    const held = service.withRunLock('run-1', () => body)
+    const held = service.withRunLock('run-1', run)
+    await bodyEntered
+
     const query = sql`select 1`.execute(db).then(() => {
       queryFinished = true
     })
-
-    await new Promise((r) => setTimeout(r, 20))
+    await new Promise((r) => setImmediate(r))
     assert.equal(queryFinished, false)
 
-    releaseBody()
+    release()
     await Promise.all([held, query])
     assert.equal(queryFinished, true)
   })
 
+  /**
+   * `lockDb` is a second PGlite instance, so this shows the query pool staying
+   * free rather than two workers contending. Contention needs two pools on one
+   * database, which PGlite cannot give: each instance is its own database and
+   * takes a single session.
+   */
   test('a run lock on lockDb leaves the query pool free', async () => {
     const lockDb = createDb()
     const isolated = new PgKyselyWorkflowService(db, {
@@ -383,20 +411,28 @@ describe('advisory locks', () => {
     } as any)
     await isolated.init()
 
-    let releaseBody!: () => void
-    const body = new Promise<void>((resolve) => {
-      releaseBody = resolve
-    })
+    const { run, bodyEntered, release } = heldBody()
 
-    const held = isolated.withRunLock('run-1', () => body)
-    await new Promise((r) => setTimeout(r, 20))
+    const held = isolated.withRunLock('run-1', run)
+    await bodyEntered
 
     const rows = await sql<{
       one: number
     }>`select 1 as one`.execute(db)
     assert.equal(rows.rows[0]!.one, 1)
 
-    releaseBody()
+    release()
     await held
+  })
+
+  test('a non-finite lock timeout is rejected', () => {
+    assert.throws(
+      () =>
+        new PgKyselyWorkflowService(db, {
+          wireQueues: false,
+          lockTimeoutMs: Number.NaN,
+        } as any),
+      RangeError
+    )
   })
 })

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
@@ -18,13 +18,23 @@ export interface PgWorkflowQueueOptions extends WorkflowQueueOptions {
    * Size it above the deepest chain of runs that start each other inline — a
    * parent holding a lock connection while a child asks for one is a deadlock,
    * not a wait.
+   *
+   * It must connect to the same Postgres database as every other worker's lock
+   * pool. `pg_advisory_xact_lock` is scoped to a database, so two workers whose
+   * lock pools point at different databases never contend and the same run
+   * executes twice.
    */
   lockDb?: Kysely<KyselyPikkuDB>
   /**
-   * Milliseconds to wait for the run lock before giving up, via `lock_timeout`.
-   * `0` (the default) waits forever, which is what a blocked run did before
-   * this option existed. Set it to surface a jam as a failed run rather than a
-   * process that never finishes one.
+   * Milliseconds a run waits for the advisory lock itself, via `lock_timeout`,
+   * once its transaction already holds a connection. `0` (the default) waits
+   * forever, which is what a blocked run did before this option existed. Set it
+   * to surface a jam as a failed run rather than a process that never finishes
+   * one.
+   *
+   * It does not bound checking a connection out of `lockDb`: a saturated lock
+   * pool still queues without a limit, which is the backpressure the pool is
+   * there to apply.
    */
   lockTimeoutMs?: number
 }
@@ -36,7 +46,11 @@ export class PgKyselyWorkflowService extends KyselyWorkflowService {
   constructor(db: Kysely<KyselyPikkuDB>, options: PgWorkflowQueueOptions = {}) {
     super(db, options)
     this.lockDb = options.lockDb ?? db
-    this.lockTimeoutMs = Math.max(0, Math.trunc(options.lockTimeoutMs ?? 0))
+    const lockTimeoutMs = options.lockTimeoutMs ?? 0
+    if (!Number.isFinite(lockTimeoutMs)) {
+      throw new RangeError('lockTimeoutMs must be a finite number of ms')
+    }
+    this.lockTimeoutMs = Math.max(0, Math.trunc(lockTimeoutMs))
   }
 
   /**

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
@@ -4,9 +4,39 @@ import type { WorkflowQueueOptions } from '@pikku/core/workflow'
 import type { Kysely } from 'kysely'
 import { sql } from 'kysely'
 
+export interface PgWorkflowQueueOptions extends WorkflowQueueOptions {
+  /**
+   * A second Kysely instance, on its own connection pool, used only to hold the
+   * run lock. A Postgres advisory lock lives on a connection, and `withRunLock`
+   * spans the whole workflow body — so without this, N concurrent runs occupy N
+   * connections of the pool the rest of the app queries through, and at N =
+   * pool size every other request queues forever behind them. Point this at a
+   * small dedicated pool and that pool's size becomes the cap on concurrent
+   * runs per process: run N+1 waits for a lock connection instead of starving
+   * request serving.
+   *
+   * Size it above the deepest chain of runs that start each other inline — a
+   * parent holding a lock connection while a child asks for one is a deadlock,
+   * not a wait.
+   */
+  lockDb?: Kysely<KyselyPikkuDB>
+  /**
+   * Milliseconds to wait for the run lock before giving up, via `lock_timeout`.
+   * `0` (the default) waits forever, which is what a blocked run did before
+   * this option existed. Set it to surface a jam as a failed run rather than a
+   * process that never finishes one.
+   */
+  lockTimeoutMs?: number
+}
+
 export class PgKyselyWorkflowService extends KyselyWorkflowService {
-  constructor(db: Kysely<KyselyPikkuDB>, options: WorkflowQueueOptions = {}) {
+  private lockDb: Kysely<KyselyPikkuDB>
+  private lockTimeoutMs: number
+
+  constructor(db: Kysely<KyselyPikkuDB>, options: PgWorkflowQueueOptions = {}) {
     super(db, options)
+    this.lockDb = options.lockDb ?? db
+    this.lockTimeoutMs = Math.max(0, Math.trunc(options.lockTimeoutMs ?? 0))
   }
 
   /**
@@ -48,14 +78,27 @@ export class PgKyselyWorkflowService extends KyselyWorkflowService {
     return hash
   }
 
+  /**
+   * Held for the whole workflow body, so it runs on `lockDb` — see the option.
+   */
   async withRunLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
     const lockId = this.hashStringToInt(`run:${id}`)
-    return this.db.transaction().execute(async (trx) => {
+    return this.lockDb.transaction().execute(async (trx) => {
+      if (this.lockTimeoutMs > 0) {
+        await sql
+          .raw(`SET LOCAL lock_timeout = ${this.lockTimeoutMs}`)
+          .execute(trx)
+      }
       await sql`SELECT pg_advisory_xact_lock(${lockId})`.execute(trx)
       return fn()
     })
   }
 
+  /**
+   * Stays on the query pool: the caller only claims the step under this lock
+   * and runs the step itself outside it, so the connection is held for a few
+   * statements rather than for the step's work.
+   */
   async withStepLock<T>(
     runId: string,
     stepName: string,

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
@@ -6,35 +6,18 @@ import { sql } from 'kysely'
 
 export interface PgWorkflowQueueOptions extends WorkflowQueueOptions {
   /**
-   * A second Kysely instance, on its own connection pool, used only to hold the
-   * run lock. A Postgres advisory lock lives on a connection, and `withRunLock`
-   * spans the whole workflow body — so without this, N concurrent runs occupy N
-   * connections of the pool the rest of the app queries through, and at N =
-   * pool size every other request queues forever behind them. Point this at a
-   * small dedicated pool and that pool's size becomes the cap on concurrent
-   * runs per process: run N+1 waits for a lock connection instead of starving
-   * request serving.
-   *
-   * Size it above the deepest chain of runs that start each other inline — a
-   * parent holding a lock connection while a child asks for one is a deadlock,
-   * not a wait.
-   *
-   * It must connect to the same Postgres database as every other worker's lock
-   * pool. `pg_advisory_xact_lock` is scoped to a database, so two workers whose
-   * lock pools point at different databases never contend and the same run
-   * executes twice.
+   * A dedicated pool for the run lock, which is held for the whole workflow
+   * body. Its size caps concurrent runs per process; size it above the deepest
+   * chain of runs that start each other inline, or a parent waiting on a child
+   * deadlocks. Every worker's lock pool must point at the same database —
+   * `pg_advisory_xact_lock` is database-scoped, so pools on different databases
+   * never contend and the same run executes twice. Defaults to `db`.
    */
   lockDb?: Kysely<KyselyPikkuDB>
   /**
-   * Milliseconds a run waits for the advisory lock itself, via `lock_timeout`,
-   * once its transaction already holds a connection. `0` (the default) waits
-   * forever, which is what a blocked run did before this option existed. Set it
-   * to surface a jam as a failed run rather than a process that never finishes
-   * one.
-   *
-   * It does not bound checking a connection out of `lockDb`: a saturated lock
-   * pool still queues without a limit, which is the backpressure the pool is
-   * there to apply.
+   * `lock_timeout` for the advisory lock, so a jam surfaces as a failed run.
+   * `0` (the default) waits forever. Does not bound checking a connection out
+   * of `lockDb` — that queue is the backpressure the pool exists to apply.
    */
   lockTimeoutMs?: number
 }
@@ -92,9 +75,6 @@ export class PgKyselyWorkflowService extends KyselyWorkflowService {
     return hash
   }
 
-  /**
-   * Held for the whole workflow body, so it runs on `lockDb` — see the option.
-   */
   async withRunLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
     const lockId = this.hashStringToInt(`run:${id}`)
     return this.lockDb.transaction().execute(async (trx) => {
@@ -109,9 +89,8 @@ export class PgKyselyWorkflowService extends KyselyWorkflowService {
   }
 
   /**
-   * Stays on the query pool: the caller only claims the step under this lock
-   * and runs the step itself outside it, so the connection is held for a few
-   * statements rather than for the step's work.
+   * Stays on the query pool: the caller claims the step under this lock and
+   * runs it outside, so the connection is held for a few statements.
    */
   async withStepLock<T>(
     runId: string,


### PR DESCRIPTION
## The defect

`withRunLock(runId, …)` at `pikku-workflow-service.ts:1132` wraps `runPikkuFunc('workflow', …)` — the entire workflow body, every `workflow.do(...)` and all of their external calls. The Postgres implementation holds that lock by opening a transaction and taking a blocking `pg_advisory_xact_lock` inside it, so **one executing run pins one pooled connection for its whole wall-clock lifetime**, purely to hold a lock.

Two defaults then draw on a single budget: `queueConcurrency` is 20 (`pikku-workflow-service.ts:166`) and a typical app pool is ~20. A full workflow queue is therefore a fully starved pool, and because a pool wait has no timeout the symptom is a **hang, not an error** — nothing logs "pool exhausted".

Seen in production: 57 teardown workflow runs dispatched inside one minute → exactly 20 connections `idle in transaction` / `wait_event = Client:ClientRead`, holding 20 distinct advisory lock objids, frozen at the same second for ~21 minutes. Every other request, including session lookups, queued behind them. It came back only on a process restart.

`withStepLock` is not affected and is unchanged — its caller claims the step under the lock and runs the step *outside* it (`executeWorkflowStepInner`), so it holds a connection for a few statements rather than for the step's work. This PR documents that on the method.

## What this changes

`PgKyselyWorkflowService` gains two options:

- **`lockDb`** — a second Kysely instance on its own pool, used only for the run lock. That pool's size then becomes the cap on concurrent runs per process: run N+1 waits for a lock connection instead of starving request serving. Sizing guidance is on the option, including the deadlock hazard for runs that start each other inline.
- **`lockTimeoutMs`** — bounds the wait via `lock_timeout`, so a jam surfaces as a failed run rather than a process that never finishes one.

Both default to today's behaviour: with no `lockDb` the lock is still taken on the query pool, and the wait is still unbounded. Nothing changes for existing consumers unless they opt in.

## Scope — this is containment, not the end state

This stops workflow runs from being able to starve request serving. It does **not** remove the underlying design problem: a connection-bound lock held across arbitrary user code. The end state is a lease row with a TTL and a heartbeat, so mutual exclusion survives without pinning a connection at all — that is a larger change to `PikkuWorkflowService`'s contract (a lease needs explicit expiry semantics, where an advisory lock gets release-on-disconnect for free) and is deliberately not in this PR.

## Tests

Two new cases in `pg-kysely-workflow-service.test.ts`, against PGlite whose single session models a saturated pool exactly:

- `a run lock on the query pool blocks unrelated queries` — encodes the bug.
- `a run lock on lockDb leaves the query pool free` — encodes the fix.

17/17 pass; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to isolate workflow run locks on a separate database connection pool.
  * Added configurable timeouts for acquiring workflow locks.
  * Exported workflow queue configuration types for broader integration support.

* **Bug Fixes**
  * Improved console page readiness by allowing up to 60 seconds for startup.
  * Verified that isolated lock connections keep primary database queries available during workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->