### PR TITLE
feat(cli,core): every definer reaches the app through its #pikku leaf, and middleware keeps its priority

### DIFF
--- a/.changeset/lucky-pears-shave.md
+++ b/.changeset/lucky-pears-shave.md
@@ -1,0 +1,22 @@
+---
+'@pikku/cli': patch
+'@pikku/core': patch
+---
+
+Every definer an app calls is now reachable through its `#pikku` leaf.
+
+`defineCredential` had no generated door, so a credential file had to name
+`@pikku/core/credential` directly — the one import in an otherwise
+`#pikku`-only wiring that reached past the leaf. It is now generated into the
+project's own `.pikku` alongside `defineSecret`, `defineVariable` and
+`defineScope`, and `cors` joins the names the `#pikku/http` leaf carries.
+
+A leaf index re-exports every entry file the leaf has rather than only the
+first, so the definer and the typed service map are both reachable through
+`#pikku/<leaf>` instead of one of them being left behind a relative path into
+`.pikku`.
+
+The definition types are also generated before the leaf indexes are written,
+not after. They read only `config`, so nothing held them back to the inspected
+pass, and running them there left the first codegen after an upgrade with a
+`#pikku/credentials` that resolved but was missing `defineCredential`.

--- a/e2e/packages/emails/src/emails-credentials.secret.ts
+++ b/e2e/packages/emails/src/emails-credentials.secret.ts
@@ -1,4 +1,4 @@
-import { defineSecret } from '@pikku/core/secret'
+import { defineSecret } from '#pikku/secrets'
 import { z } from 'zod'
 
 export const EmailsCredentialsSchema = z.string()

--- a/e2e/packages/fake-crm/src/fake-crm-key.secret.ts
+++ b/e2e/packages/fake-crm/src/fake-crm-key.secret.ts
@@ -1,4 +1,4 @@
-import { defineSecret } from '@pikku/core/secret'
+import { defineSecret } from '#pikku/secrets'
 import { z } from 'zod'
 
 export const FakeCrmApiKeySchema = z.string()

--- a/e2e/packages/fake-crm/src/fake-crm.credential.ts
+++ b/e2e/packages/fake-crm/src/fake-crm.credential.ts
@@ -1,4 +1,4 @@
-import { defineCredential } from '@pikku/core/credential'
+import { defineCredential } from '#pikku/credentials'
 import { z } from 'zod'
 
 export const FakeCrmSchema = z.object({

--- a/e2e/packages/functions/src/addons/emails-promo.secret.ts
+++ b/e2e/packages/functions/src/addons/emails-promo.secret.ts
@@ -1,4 +1,4 @@
-import { defineSecret } from '@pikku/core/secret'
+import { defineSecret } from '#pikku/secrets'
 import { z } from 'zod'
 
 export const EmailsPromoCredentialsSchema = z.string()

--- a/e2e/packages/hmac-signer/src/hmac-key.credential.ts
+++ b/e2e/packages/hmac-signer/src/hmac-key.credential.ts
@@ -1,4 +1,4 @@
-import { defineCredential } from '@pikku/core/credential'
+import { defineCredential } from '#pikku/credentials'
 import { z } from 'zod'
 
 export const HmacKeySchema = z.object({ secretKey: z.string() })

--- a/e2e/packages/oauth-api/src/user-oauth.credential.ts
+++ b/e2e/packages/oauth-api/src/user-oauth.credential.ts
@@ -1,4 +1,4 @@
-import { defineCredential } from '@pikku/core/credential'
+import { defineCredential } from '#pikku/credentials'
 import { z } from 'zod'
 
 export const UserOAuthSchema = z.object({

--- a/e2e/src/credentials.ts
+++ b/e2e/src/credentials.ts
@@ -1,4 +1,4 @@
-import { defineCredential } from '@pikku/core/credential'
+import { defineCredential } from '#pikku/credentials'
 import { z } from 'zod'
 
 defineCredential({

--- a/e2e/src/middleware.ts
+++ b/e2e/src/middleware.ts
@@ -1,5 +1,4 @@
-import { cors } from '@pikku/core/middleware'
-import { addHTTPMiddleware } from '@pikku/core/http'
+import { addHTTPMiddleware, cors } from '#pikku/http'
 import { pikkuMiddleware } from '@pikku/core/middleware'
 import type { CoreSingletonServices } from '@pikku/core/types'
 import type { CorePikkuMiddleware } from '@pikku/core/middleware'

--- a/packages/cli/src/functions/commands/bootstrap.ts
+++ b/packages/cli/src/functions/commands/bootstrap.ts
@@ -24,6 +24,8 @@ export const bootstrap = pikkuVoidFunc({
     await rpc.invoke('pikkuMCPTypes')
     await rpc.invoke('pikkuAgentTypes')
     await rpc.invoke('pikkuSecretDefinitionTypes')
+    await rpc.invoke('pikkuCredentialDefinitionTypes')
+    await rpc.invoke('pikkuVariableDefinitionTypes')
     await rpc.invoke('pikkuScopeDefinitionTypes')
     await rpc.invoke('pikkuCLITypes', { bootstrap: true })
     await rpc.invoke('pikkuLeafIndexes')

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -635,7 +635,7 @@ export interface Services extends CoreServices<SingletonServices> {}
   // Conditional: credential / secret file
   if (flags.credential === 'apikey') {
     files[`src/${name}.credential.ts`] = `import { z } from 'zod'
-import { defineCredential } from '@pikku/core/credential'
+import { defineCredential } from '#pikku/credentials'
 
 export const ${camelName}CredentialSchema = z.object({
   apiKey: z.string().describe(${literal(`${displayName} API key`)}),
@@ -656,7 +656,7 @@ defineCredential({
   tenantId: z.string().optional().describe('Upstream tenant id'),`
       : `  token: z.string().describe(${literal(`${displayName} bearer token`)}),`
     files[`src/${name}.credential.ts`] = `import { z } from 'zod'
-import { defineCredential } from '@pikku/core/credential'
+import { defineCredential } from '#pikku/credentials'
 
 export const ${camelName}CredentialSchema = z.object({
 ${credentialFields}
@@ -672,8 +672,8 @@ defineCredential({
 `
   } else if (flags.oauth || flags.credential === 'oauth2') {
     files[`src/${name}.credential.ts`] = `import { z } from 'zod'
-import { defineCredential } from '@pikku/core/credential'
-import { defineSecret } from '@pikku/core/secret'
+import { defineCredential } from '#pikku/credentials'
+import { defineSecret } from '#pikku/secrets'
 
 export const ${camelName}TokenSchema = z.object({
   accessToken: z.string(),
@@ -704,7 +704,7 @@ defineSecret({
 `
   } else if (flags.secret) {
     files[`src/${name}.secret.ts`] = `import { z } from 'zod'
-import { defineSecret } from '@pikku/core/secret'
+import { defineSecret } from '#pikku/secrets'
 
 export const ${camelName}SecretsSchema = z.object({
   apiKey: z.string().describe(${literal(`${displayName} API key`)}),
@@ -726,7 +726,7 @@ defineSecret({
   // Conditional: variable file
   if (flags.variable) {
     files[`src/${name}.variable.ts`] = `import { z } from 'zod'
-import { defineVariable } from '@pikku/core/variable'
+import { defineVariable } from '#pikku/variables'
 
 export const ${camelName}VariableSchema = z.string().optional().describe('TODO: describe this variable')
 

--- a/packages/cli/src/functions/wirings/functions/pikku-command-leaf-indexes.ts
+++ b/packages/cli/src/functions/wirings/functions/pikku-command-leaf-indexes.ts
@@ -7,48 +7,58 @@ import { logCommandInfoAndTime } from '../../../middleware/log-command-info-and-
 import { serializeLeafIndex } from './serialize-leaf-index.js'
 
 /**
- * The leaf name a wiring's entry file is reached by. An addon never generates
+ * The entry files a wiring's leaf is reached by. An addon never generates
  * the wiring leaves, so those indexes are simply absent and `#pikku/http`
  * fails to resolve rather than resolving to a module missing the export.
+ *
+ * Most leaves have a single entry. The three package-tier leaves split their
+ * definer from their typed-service map across two generated files, and an app
+ * imports from both — so each is listed and the index re-exports all of them.
  */
 const leafEntries = [
-  ['function', 'functionTypesFile'],
-  ['error', 'errorTypesFile'],
-  ['http', 'httpTypesFile'],
-  ['channel', 'channelsTypesFile'],
-  ['gateway', 'gatewaysTypesFile'],
-  ['trigger', 'triggersTypesFile'],
-  ['scheduler', 'schedulersTypesFile'],
-  ['queue', 'queueTypesFile'],
-  ['workflow', 'workflowTypesFile'],
-  ['scenarios', 'scenarioTypesFile'],
-  ['mcp', 'mcpTypesFile'],
-  ['agent', 'agentTypesFile'],
-  ['cli', 'cliTypesFile'],
-  ['addon', 'addonTypesFile'],
-  ['secrets', 'secretTypesFile'],
-  ['credentials', 'credentialsFile'],
-  ['scopes', 'scopeTypesFile'],
-  ['variables', 'variableTypesFile'],
-  ['auth', 'authTypesFile'],
+  ['function', ['functionTypesFile']],
+  ['error', ['errorTypesFile']],
+  ['http', ['httpTypesFile']],
+  ['channel', ['channelsTypesFile']],
+  ['gateway', ['gatewaysTypesFile']],
+  ['trigger', ['triggersTypesFile']],
+  ['scheduler', ['schedulersTypesFile']],
+  ['queue', ['queueTypesFile']],
+  ['workflow', ['workflowTypesFile']],
+  ['scenarios', ['scenarioTypesFile']],
+  ['mcp', ['mcpTypesFile']],
+  ['agent', ['agentTypesFile']],
+  ['cli', ['cliTypesFile']],
+  ['addon', ['addonTypesFile']],
+  ['secrets', ['secretTypesFile', 'secretsFile']],
+  ['credentials', ['credentialTypesFile', 'credentialsFile']],
+  ['scopes', ['scopeTypesFile']],
+  ['variables', ['variableTypesFile', 'variablesFile']],
+  ['auth', ['authTypesFile']],
 ] as const
 
 export const pikkuLeafIndexes = pikkuSessionlessFunc<void, void>({
   func: async ({ logger, config }) => {
     const written = new Set<string>()
 
-    for (const [leaf, key] of leafEntries) {
-      const entryFile = config[key]
-      if (!entryFile || !existsSync(entryFile)) continue
+    for (const [leaf, keys] of leafEntries) {
+      const entryFiles = keys
+        .map((key) => config[key])
+        .filter((entryFile): entryFile is string =>
+          Boolean(entryFile && existsSync(entryFile))
+        )
+      if (entryFiles.length === 0) continue
 
-      const indexFile = join(dirname(entryFile), 'index.ts')
-      if (indexFile === entryFile) continue
+      const indexFile = join(dirname(entryFiles[0]!), 'index.ts')
+      const entryImportPaths = entryFiles
+        .filter((entryFile) => entryFile !== indexFile)
+        .map((entryFile) => `./${basename(entryFile).replace(/\.ts$/, '.js')}`)
+      if (entryImportPaths.length === 0) continue
 
-      const entryImportPath = `./${basename(entryFile).replace(/\.ts$/, '.js')}`
       await writeFileInDir(
         logger,
         indexFile,
-        serializeLeafIndex(leaf, entryImportPath)
+        serializeLeafIndex(leaf, entryImportPaths)
       )
       written.add(indexFile)
     }

--- a/packages/cli/src/functions/wirings/functions/serialize-function-types.test.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-function-types.test.ts
@@ -52,6 +52,40 @@ describe('serializeFunctionTypes', () => {
     }
   })
 
+  // Re-implementing a core factory means the generated copy drifts from it. The
+  // `__priority` stamp the middleware runner orders by is applied by core's
+  // `pikkuMiddleware` alone, so a generated one that rebuilds the body instead
+  // of calling it silently drops every priority an app declares.
+  describe('pikkuMiddleware', () => {
+    test('delegates to core rather than re-implementing it', () => {
+      const content = emit()
+
+      assert.match(
+        content,
+        /import \{[^}]*pikkuMiddleware as pikkuMiddlewareCore[^}]*\} from '@pikku\/core\/middleware'/s
+      )
+      assert.match(content, /pikkuMiddlewareCore\(middleware\)/)
+      assert.doesNotMatch(
+        content,
+        /typeof middleware === 'function' \? middleware : middleware\.func/
+      )
+    })
+
+    test('accepts and emits the priority the runtime orders by', () => {
+      const content = emit()
+
+      assert.match(
+        content,
+        /import type \{[^}]*MiddlewarePriority[^}]*\} from '@pikku\/core\/middleware'/s
+      )
+      assert.match(content, /export type \{ MiddlewarePriority \}/)
+      assert.match(
+        content,
+        /type PikkuMiddlewareConfig<[^]*?priority\?: MiddlewarePriority/
+      )
+    })
+  })
+
   describe('node config', () => {
     test('narrows category to the addon categories the project declared', () => {
       assert.match(

--- a/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
@@ -33,6 +33,7 @@ import type { TypedScenario, TypedPersonas } from '../scenarios/pikku-scenario-t
  */
 
 import type { CorePikkuMiddleware } from '@pikku/core/middleware'
+import type { MiddlewarePriority } from '@pikku/core/middleware'
 import type { PickRequired } from '@pikku/core/utils'
 import type { ListInput, ListOutput } from '@pikku/core/function'
 import type { CorePermissionGroup } from '@pikku/core/function'
@@ -45,7 +46,7 @@ import type {
   CorePikkuPermission,
 } from '@pikku/core/function'
 import { pikkuAuth as pikkuAuthCore } from '@pikku/core/function'
-import { addTagMiddleware as addTagMiddlewareCore, addGlobalMiddleware as addGlobalMiddlewareCore } from '@pikku/core/middleware'
+import { addTagMiddleware as addTagMiddlewareCore, addGlobalMiddleware as addGlobalMiddlewareCore, pikkuMiddleware as pikkuMiddlewareCore } from '@pikku/core/middleware'
 import {
   addGlobalPermission as addGlobalPermissionCore,
 } from '@pikku/core/middleware'
@@ -204,7 +205,11 @@ type PikkuMiddlewareConfig<RequiredServices extends SingletonServices = WiredSin
   name?: string
   /** Optional description of what the middleware does */
   description?: string
+  /** Execution priority. \`highest\` runs first (outermost). Defaults to 'medium'. */
+  priority?: MiddlewarePriority
 }
+
+export type { MiddlewarePriority }
 
 /**
  * Factory function for creating middleware with tree-shaking support.
@@ -222,6 +227,7 @@ type PikkuMiddlewareConfig<RequiredServices extends SingletonServices = WiredSin
  * const logMiddleware = pikkuMiddleware({
  *   name: 'Request Logger',
  *   description: 'Logs all incoming requests',
+ *   priority: 'high',
  *   func: async ({ logger }, wires, next) => {
  *     logger.info('Request started')
  *     await next()
@@ -232,7 +238,7 @@ type PikkuMiddlewareConfig<RequiredServices extends SingletonServices = WiredSin
 export const pikkuMiddleware = <RequiredServices extends SingletonServices = WiredSingletonServices>(
   middleware: PikkuMiddleware<RequiredServices> | PikkuMiddlewareConfig<RequiredServices>
 ): PikkuMiddleware<RequiredServices> => {
-  return typeof middleware === 'function' ? middleware : middleware.func
+  return pikkuMiddlewareCore(middleware)
 }
 
 /**

--- a/packages/cli/src/functions/wirings/functions/serialize-leaf-index.test.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-leaf-index.test.ts
@@ -1,0 +1,30 @@
+import { test, describe } from 'node:test'
+import * as assert from 'assert'
+import { serializeLeafIndex } from './serialize-leaf-index.js'
+
+describe('serializeLeafIndex', () => {
+  test('re-exports a single entry', () => {
+    const index = serializeLeafIndex('http', ['./pikku-http-types.gen.js'])
+    assert.match(index, /export \* from '\.\/pikku-http-types\.gen\.js'/)
+  })
+
+  test('names the leaf it is the entry for', () => {
+    const index = serializeLeafIndex('http', ['./pikku-http-types.gen.js'])
+    assert.match(index, /`?#pikku\/http`? resolves here/)
+  })
+
+  /**
+   * The definer and the typed-service map are generated into separate files.
+   * An index that re-exported only one of them would leave the other reachable
+   * solely by a relative path into `.pikku`, which is the import the leaves
+   * exist to replace.
+   */
+  test('re-exports every entry a leaf has', () => {
+    const index = serializeLeafIndex('credentials', [
+      './pikku-credential-types.gen.js',
+      './pikku-credentials.gen.js',
+    ])
+    assert.match(index, /export \* from '\.\/pikku-credential-types\.gen\.js'/)
+    assert.match(index, /export \* from '\.\/pikku-credentials\.gen\.js'/)
+  })
+})

--- a/packages/cli/src/functions/wirings/functions/serialize-leaf-index.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-leaf-index.ts
@@ -6,12 +6,25 @@
  * overridable in `pikku.config.json`, so no single `#pikku/*` pattern can reach
  * them by name. One generated re-export per leaf gives every wiring a stable
  * specifier while leaving the entry file wherever the project put it.
+ *
+ * A leaf may have more than one entry. `credentials` splits its definer
+ * (`defineCredential`) from its map (`CredentialsMap`, `TypedCredentialService`)
+ * across two generated files, as `secrets` and `variables` do, and both halves
+ * are the app's to import — so the index re-exports each of them rather than
+ * picking one and leaving the other reachable only by a relative path into
+ * `.pikku`.
  */
-export const serializeLeafIndex = (leaf: string, entryImportPath: string) => {
+export const serializeLeafIndex = (
+  leaf: string,
+  entryImportPaths: string[]
+) => {
+  const exports = entryImportPaths
+    .map((path) => `export * from '${path}'`)
+    .join('\n')
   return `/**
  * Subpath entry — \`#pikku/${leaf}\` resolves here.
  */
 
-export * from '${entryImportPath}'
+${exports}
 `
 }

--- a/packages/cli/src/functions/wirings/http/serialize-http-types.test.ts
+++ b/packages/cli/src/functions/wirings/http/serialize-http-types.test.ts
@@ -1,0 +1,25 @@
+import { test, describe } from 'node:test'
+import * as assert from 'assert'
+import { serializeHTTPTypes } from './serialize-http-types.js'
+
+describe('serializeHTTPTypes', () => {
+  /**
+   * `cors` is middleware an app wires like any other, and every other name it
+   * wires HTTP with is already on this leaf. Leaving it on
+   * `@pikku/core/middleware` made it the one import in a wiring file that
+   * reached past `#pikku`.
+   */
+  test('the http leaf carries cors', () => {
+    assert.match(
+      serializeHTTPTypes('./pikku-types.gen.js'),
+      /export \{ cors \} from '@pikku\/core\/middleware'/
+    )
+  })
+
+  test('the http leaf still carries addHTTPMiddleware', () => {
+    assert.match(
+      serializeHTTPTypes('./pikku-types.gen.js'),
+      /export const addHTTPMiddleware/
+    )
+  })
+})

--- a/packages/cli/src/functions/wirings/http/serialize-http-types.ts
+++ b/packages/cli/src/functions/wirings/http/serialize-http-types.ts
@@ -8,6 +8,7 @@ export const serializeHTTPTypes = (functionTypesImportPath: string) => {
 
 import { wireHTTP as wireHTTPCore, addHTTPMiddleware as addHTTPMiddlewareCore, wireHTTPRoutes as wireHTTPRoutesCore, defineHTTPRoutes as defineHTTPRoutesCore } from '@pikku/core/http'
 import { AssertHTTPWiringParams } from '@pikku/core/http'
+export { cors } from '@pikku/core/middleware'
 import type { PikkuFunction, PikkuFunctionSessionless, PikkuPermission, PikkuMiddleware, PikkuFunctionConfig } from '${functionTypesImportPath}'
 import type {
   CoreHTTPFunctionWiring,

--- a/packages/cli/src/functions/wirings/package/pikku-command-package-types.ts
+++ b/packages/cli/src/functions/wirings/package/pikku-command-package-types.ts
@@ -2,6 +2,7 @@ import { pikkuVoidFunc } from '#pikku/function'
 import { writeFileInDir } from '../../../utils/file-writer.js'
 import { logCommandInfoAndTime } from '../../../middleware/log-command-info-and-time.js'
 import {
+  serializeCredentialDefinitionTypes,
   serializeScopeDefinitionTypes,
   serializeSecretDefinitionTypes,
   serializeVariableDefinitionTypes,
@@ -17,6 +18,20 @@ export const pikkuSecretDefinitionTypes = pikkuVoidFunc({
     logCommandInfoAndTime({
       commandStart: 'Creating Secret definition types',
       commandEnd: 'Created Secret definition types',
+    }),
+  ],
+})
+
+export const pikkuCredentialDefinitionTypes = pikkuVoidFunc({
+  func: async ({ logger, config }) => {
+    const { credentialTypesFile } = config
+    const content = serializeCredentialDefinitionTypes()
+    await writeFileInDir(logger, credentialTypesFile, content)
+  },
+  middleware: [
+    logCommandInfoAndTime({
+      commandStart: 'Creating Credential definition types',
+      commandEnd: 'Created Credential definition types',
     }),
   ],
 })

--- a/packages/cli/src/functions/wirings/package/serialize-package-types.test.ts
+++ b/packages/cli/src/functions/wirings/package/serialize-package-types.test.ts
@@ -1,0 +1,45 @@
+import { test, describe } from 'node:test'
+import * as assert from 'assert'
+import {
+  serializeCredentialDefinitionTypes,
+  serializeScopeDefinitionTypes,
+  serializeSecretDefinitionTypes,
+  serializeVariableDefinitionTypes,
+} from './serialize-package-types.js'
+
+/**
+ * Each definer is generated into the project's own `.pikku` so an app reaches
+ * it through `#pikku/<leaf>` rather than naming `@pikku/core` for something the
+ * generator already puts in front of it.
+ */
+describe('definition types', () => {
+  test('the credentials leaf carries defineCredential', () => {
+    assert.match(
+      serializeCredentialDefinitionTypes(),
+      /export \{ defineCredential \} from '@pikku\/core\/credential'/
+    )
+  })
+
+  test('the secrets leaf carries defineSecret', () => {
+    assert.match(
+      serializeSecretDefinitionTypes(),
+      /export \{ defineSecret \} from '@pikku\/core\/secret'/
+    )
+  })
+
+  test('the variables leaf carries defineVariable', () => {
+    assert.match(
+      serializeVariableDefinitionTypes(),
+      /export \{ defineVariable \} from '@pikku\/core\/variable'/
+    )
+  })
+
+  test('the scopes leaf carries defineScope and defineSystemRole', () => {
+    const scopes = serializeScopeDefinitionTypes()
+    assert.match(scopes, /export \{ defineScope \} from '@pikku\/core\/scope'/)
+    assert.match(
+      scopes,
+      /export \{ defineSystemRole \} from '@pikku\/core\/role'/
+    )
+  })
+})

--- a/packages/cli/src/functions/wirings/package/serialize-package-types.ts
+++ b/packages/cli/src/functions/wirings/package/serialize-package-types.ts
@@ -3,6 +3,11 @@ export const serializeSecretDefinitionTypes = () => {
 `
 }
 
+export const serializeCredentialDefinitionTypes = () => {
+  return `export { defineCredential } from '@pikku/core/credential'
+`
+}
+
 export const serializeScopeDefinitionTypes = () => {
   return `export { defineScope } from '@pikku/core/scope'
 export { defineSystemRole } from '@pikku/core/role'

--- a/packages/cli/src/functions/workflows/all.workflow.ts
+++ b/packages/cli/src/functions/workflows/all.workflow.ts
@@ -143,6 +143,16 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
         'pikkuSecretDefinitionTypes',
         null
       )
+      await workflow.do(
+        'Bootstrap Credential definition types',
+        'pikkuCredentialDefinitionTypes',
+        null
+      )
+      await workflow.do(
+        'Bootstrap Variable definition types',
+        'pikkuVariableDefinitionTypes',
+        null
+      )
       if (!config.addon) {
         await workflow.do('Bootstrap CLI types', 'pikkuCLITypes', {
           bootstrap: true,
@@ -174,6 +184,30 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
         await workflow.do(`Scaffold ${generator}`, generator, null)
       }
     }
+
+    // Before the leaf indexes, because an index only re-exports entry files that
+    // exist when it is written. These four are pure — they read `config` and
+    // nothing else — so nothing holds them back to the inspected pass below, and
+    // running them there would leave the first run after an upgrade with a
+    // `#pikku/credentials` that resolves but is missing `defineCredential`.
+    await Promise.all([
+      workflow.do(
+        'Secret definition types',
+        'pikkuSecretDefinitionTypes',
+        null
+      ),
+      workflow.do(
+        'Credential definition types',
+        'pikkuCredentialDefinitionTypes',
+        null
+      ),
+      workflow.do('Scope definition types', 'pikkuScopeDefinitionTypes', null),
+      workflow.do(
+        'Variable definition types',
+        'pikkuVariableDefinitionTypes',
+        null
+      ),
+    ])
 
     await workflow.do('Function types split', 'pikkuFunctionTypesSplit', {})
     await workflow.do('Leaf subpath entries', 'pikkuLeafIndexes', null)
@@ -258,23 +292,12 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
       workflow.do('Events scaffold', 'pikkuEventsScaffold', null),
       workflow.do('Emails', 'pikkuEmails', null),
       workflow.do('Error types', 'pikkuErrorTypes', null),
-      workflow.do(
-        'Secret definition types',
-        'pikkuSecretDefinitionTypes',
-        null
-      ),
       workflow.do('Auth', 'pikkuAuth', {}),
       workflow.do('Secrets', 'pikkuSecrets', null),
       workflow.do('Credentials', 'pikkuCredentials', null),
-      workflow.do('Scope definition types', 'pikkuScopeDefinitionTypes', null),
       workflow.do('Scopes', 'pikkuScopes', {}),
       workflow.do('Roles', 'pikkuRoles', {}),
       workflow.do('Personas', 'pikkuPersonas', {}),
-      workflow.do(
-        'Variable definition types',
-        'pikkuVariableDefinitionTypes',
-        null
-      ),
       workflow.do('Variables', 'pikkuVariables', null),
       workflow.do('Addon types', 'pikkuAddonTypes', null),
     ])

--- a/packages/cli/src/utils/pikku-cli-config.ts
+++ b/packages/cli/src/utils/pikku-cli-config.ts
@@ -914,6 +914,12 @@ const _getPikkuCLIConfig = async (
 
     // Credentials (typed wrapper for CredentialService)
     const credentialsDir = join(result.outDir, 'credentials')
+    if (!result.credentialTypesFile) {
+      result.credentialTypesFile = join(
+        credentialsDir,
+        'pikku-credential-types.gen.ts'
+      )
+    }
     if (!result.credentialsFile) {
       result.credentialsFile = join(credentialsDir, 'pikku-credentials.gen.ts')
     }

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -223,6 +223,9 @@ export interface PikkuCLICoreOutputFiles {
   // Secrets metadata JSON
   secretsMetaJsonFile: string
 
+  // Credentials
+  credentialTypesFile: string
+
   // Credentials (typed wrapper for CredentialService)
   credentialsFile: string
 

--- a/packages/core/src/app-leaf-surface.test.ts
+++ b/packages/core/src/app-leaf-surface.test.ts
@@ -116,7 +116,81 @@ const barrelSpecifiers = (file: string) => {
   return found
 }
 
+/**
+ * Names a leaf carries, mapped to the leaf that carries them. An app reaching
+ * `@pikku/core` for one of these is the smell that says the generator is not
+ * emitting something it should — the definer is already generated into the
+ * project's own `.pikku`, so naming core instead couples the app to a package
+ * it otherwise never imports.
+ */
+const namesOwnedByALeaf = new Map<string, string>([
+  ['defineCredential', '#pikku/credentials'],
+  ['defineSecret', '#pikku/secrets'],
+  ['defineVariable', '#pikku/variables'],
+  ['defineScope', '#pikku/scopes'],
+  ['defineSystemRole', '#pikku/scopes'],
+  ['cors', '#pikku/http'],
+  ['InvalidOriginError', '#pikku/error'],
+])
+
+const coreNamesThatHaveALeaf = (file: string) => {
+  const source = ts.createSourceFile(
+    file,
+    readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true
+  )
+  const found: { name: string; leaf: string; line: number }[] = []
+  for (const statement of source.statements) {
+    if (!ts.isImportDeclaration(statement)) continue
+    const moduleSpecifier = statement.moduleSpecifier
+    if (!ts.isStringLiteral(moduleSpecifier)) continue
+    if (!/^@pikku\/core(\/|$)/.test(moduleSpecifier.text)) continue
+
+    const bindings = statement.importClause?.namedBindings
+    if (!bindings || !ts.isNamedImports(bindings)) continue
+    for (const element of bindings.elements) {
+      const name = (element.propertyName ?? element.name).text
+      const leaf = namesOwnedByALeaf.get(name)
+      if (!leaf) continue
+      const { line } = source.getLineAndCharacterOfPosition(
+        element.getStart(source)
+      )
+      found.push({ name, leaf, line: line + 1 })
+    }
+  }
+  return found
+}
+
 describe('app leaf surface', () => {
+  test('no Pikku project reaches past a leaf for a name the leaf carries', () => {
+    const projects = findProjects(repoRoot)
+    assert.ok(projects.length > 0, 'expected to discover Pikku projects')
+
+    // A project nested inside another (an addon under `e2e/packages`) is
+    // discovered on its own account and again as its parent's source, so the
+    // same offence is reached twice.
+    const offenders = new Set<string>()
+    for (const project of projects) {
+      for (const file of projectSourceFiles(project)) {
+        for (const { name, leaf, line } of coreNamesThatHaveALeaf(file)) {
+          offenders.add(
+            `${relative(repoRoot, file)}:${line}  ${name} — import it from '${leaf}'`
+          )
+        }
+      }
+    }
+
+    assert.deepStrictEqual(
+      [...offenders].sort(),
+      [],
+      `An app developer imports from '#pikku/<leaf>'. Reaching past it to ` +
+        `'@pikku/core' for a name the leaf already carries is the smell that ` +
+        `says the generator is not emitting something it should.\n\n` +
+        [...offenders].sort().join('\n')
+    )
+  })
+
   test('no Pikku project reaches the app tier through a barrel', () => {
     const projects = findProjects(repoRoot)
     assert.ok(projects.length > 0, 'expected to discover Pikku projects')

--- a/verifiers/secrets/src/credentials.ts
+++ b/verifiers/secrets/src/credentials.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
-import { defineSecret } from '@pikku/core/secret'
-import { defineCredential } from '@pikku/core/credential'
+import { defineSecret } from '#pikku/secrets'
+import { defineCredential } from '#pikku/credentials'
 
 /**
  * Example API credentials using defineSecret with Zod schema.

--- a/verifiers/variables/src/variables.ts
+++ b/verifiers/variables/src/variables.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { defineVariable } from '@pikku/core/variable'
+import { defineVariable } from '#pikku/variables'
 
 export const serverConfigSchema = z.object({
   host: z.string().describe('Server hostname'),


### PR DESCRIPTION
Replaces #1300, which was built on the `#pikku` types hub and the `@pikku/core/ecosystem` tier — both deleted by #1311. Roughly 60% of that PR was absorbed there; this is what was actually left, reimplemented on the leaf model.

## The generated `pikkuMiddleware` was dropping `priority`

A live bug on `main`. The generated factory re-implemented core's rather than delegating to it — `typeof middleware === 'function' ? middleware : middleware.func` — and dropped `priority` twice over: `PikkuMiddlewareConfig` had no such field, and a middleware passing one anyway never received the `__priority` stamp that `middleware-runner.ts` sorts on. Ordering silently fell back to declaration order.

It now delegates to `@pikku/core/middleware`, and `MiddlewarePriority` is emitted alongside it.

## Every definer reaches the app through its leaf

An app developer imports from `#pikku/<leaf>`; reaching past it to `@pikku/core` is the smell that says the generator is not emitting something it should. #1311 already routed `defineSecret`, `defineScope` and `defineVariable`. Still missing:

- **`defineCredential` had no door at all** — generated into the project's `.pikku` via a new `credentialTypesFile` config key.
- **`cors`** joins `#pikku/http`, next to the `addHTTPMiddleware` it is wired with.
- **Leaf indexes were single-entry.** `credentials`, `secrets` and `variables` each have two entries (the definer and the typed service map); only the first was re-exported, so the second was reachable only through a raw relative path into `.pikku` — which is what apps were doing. `serializeLeafIndex` now re-exports every entry a leaf has.
- **10 call sites** migrated across `e2e` and `verifiers`.

## Generation order, not a second bootstrap trigger

The definition-type generators ran *after* the leaf-index step. A leaf index only re-exports entry files that exist when it is written, so on an upgrade — `.pikku` present, definer file not yet generated, so the `!existsSync(outDir)` bootstrap gate does not fire — the run produced a `#pikku/credentials` that resolved but was missing `defineCredential`. Every inspection between those two points saw it, which leaves an unresolved factory's input silently `any`. A trailing index refresh papered over the file but not the inspections.

The four generators are hoisted ahead of `pikkuLeafIndexes` and dropped from the inspected pass. They read only `config`, so nothing held them there — one ordering change fixes the cold and warm paths.

## Guard

`packages/core/src/app-leaf-surface.test.ts` discovers every directory with a `pikku.config.json` and fails on any project naming `@pikku/core` for a name its leaf carries. Red baseline: 16 offenders across 11 distinct names.

## Verification

- `app-leaf-surface.test.ts` — 16 offenders → 2/2 green; re-confirmed red by reverting a single migrated call site
- `packages/cli` — 1107 pass, 0 fail
- `packages/core` — 2197 pass, 0 fail, 10 skipped
- `verifiers/secrets` cold codegen + `tsc` — exit 0
- `verifiers/secrets` warm upgrade path (definer + index deleted) — index correct in the same run, `tsc` exit 0
- `changeset status` — exit 0

## Left out

- **`templates/uws` `cors`** — runtime templates are not on the `#pikku` alias on `main`; that is #1307's territory.
- **`InvalidOriginError` on the http leaf** — `#pikku/error` already carries it, and a second door breaks one-door-per-name.
- **13 `e2e` tsc errors are pre-existing** — `emailStore`/`hmacSigner`/`oauthApiClient`/`todoStore` missing on `WiredServices`, in addon files this branch never touches. Its only `e2e` changes are eight import lines. Each addon's own `tsc` passes; it is the e2e root tsconfig pulling addon sources against e2e's `.pikku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)