### PR TITLE
fix(templates): let the #pikku alias resolve a file, not only a directory index

### DIFF
--- a/packages/core/src/template-alias-surface.test.ts
+++ b/packages/core/src/template-alias-surface.test.ts
@@ -148,6 +148,64 @@ describe('templates ship the #pikku alias', () => {
   })
 
   /**
+   * Every `#pikku/…` pattern shares the prefix `#pikku/`, and TypeScript picks
+   * the matching pattern with the longest prefix, ignoring the suffix and
+   * breaking the tie in favour of the first key. So a suffix-specific pattern
+   * such as `#pikku/*.json` only ever wins by being listed before the bare one
+   * — an ordering that does not survive `create-pikku` deep-merging the runtime
+   * template's tsconfig with the functions template's.
+   *
+   * The bare pattern therefore has to resolve a file as well as a directory
+   * index, which a target list does: `#pikku/mcp/mcp.gen.json` misses
+   * `.pikku/mcp/mcp.gen.json/index.ts` and lands on the file behind it.
+   */
+  test('the bare #pikku pattern resolves a file, not only a directory index', () => {
+    const offenders: string[] = []
+
+    for (const template of templateNames()) {
+      const declare = (
+        source: string,
+        targets: string | string[] | undefined
+      ) => {
+        if (targets === undefined) return
+        const list = Array.isArray(targets) ? targets : [targets]
+        // A directory-index target ends in the index file; anything else names
+        // whatever the alias was pointed at, which is what a file needs.
+        if (list.every((target) => /\/index\.[cm]?[jt]s$/.test(target))) {
+          offenders.push(`${source}  ${list.join(', ')}`)
+        }
+      }
+
+      const tsconfigPath = join(templatesDir, template, 'tsconfig.json')
+      if (existsSync(tsconfigPath)) {
+        const tsconfig = JSON.parse(readFileSync(tsconfigPath, 'utf8'))
+        declare(
+          `templates/${template}/tsconfig.json`,
+          tsconfig.compilerOptions?.paths?.['#pikku/*']
+        )
+      }
+
+      const pkg = JSON.parse(
+        readFileSync(join(templatesDir, template, 'package.json'), 'utf8')
+      )
+      declare(
+        `templates/${template}/package.json`,
+        pkg.imports?.['#pikku/*'] as string | string[] | undefined
+      )
+    }
+
+    assert.deepStrictEqual(
+      offenders,
+      [],
+      `The bare '#pikku/*' pattern must list a file target alongside the ` +
+        `directory index, because a suffix-specific pattern like ` +
+        `'#pikku/*.json' loses to it whenever it is not listed first — and ` +
+        `create-pikku's merge decides that order.\n\n` +
+        offenders.join('\n')
+    )
+  })
+
+  /**
    * Node rejects an internal-imports target that is not './'-relative or a
    * bare package specifier, so a '../' target throws ERR_INVALID_PACKAGE_TARGET
    * rather than resolving. A runtime template reaching the functions template

--- a/templates/ai-postgres/tsconfig.json
+++ b/templates/ai-postgres/tsconfig.json
@@ -6,7 +6,7 @@
     "skipLibCheck": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/"],

--- a/templates/aws-lambda-websocket/tsconfig.json
+++ b/templates/aws-lambda-websocket/tsconfig.json
@@ -6,7 +6,7 @@
     "resolveJsonModule": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*"],

--- a/templates/aws-lambda/tsconfig.json
+++ b/templates/aws-lambda/tsconfig.json
@@ -6,7 +6,7 @@
     "skipLibCheck": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*"],

--- a/templates/bullmq/tsconfig.json
+++ b/templates/bullmq/tsconfig.json
@@ -7,7 +7,7 @@
     "resolveJsonModule": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*", "client/queue-worker.ts"],

--- a/templates/cli/tsconfig.json
+++ b/templates/cli/tsconfig.json
@@ -6,7 +6,7 @@
     "resolveJsonModule": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": [".pikku/*"],

--- a/templates/cloudflare-websocket/tsconfig.json
+++ b/templates/cloudflare-websocket/tsconfig.json
@@ -6,7 +6,7 @@
     "resolveJsonModule": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*"],

--- a/templates/cloudflare-workers/tsconfig.json
+++ b/templates/cloudflare-workers/tsconfig.json
@@ -6,7 +6,7 @@
     "skipLibCheck": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*"],

--- a/templates/express-middleware/tsconfig.json
+++ b/templates/express-middleware/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*"],

--- a/templates/express/tsconfig.json
+++ b/templates/express/tsconfig.json
@@ -6,7 +6,7 @@
     "resolveJsonModule": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*"],

--- a/templates/fastify-plugin/tsconfig.json
+++ b/templates/fastify-plugin/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*"],

--- a/templates/fastify/tsconfig.json
+++ b/templates/fastify/tsconfig.json
@@ -6,7 +6,7 @@
     "resolveJsonModule": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*"],

--- a/templates/function-addon/package.json
+++ b/templates/function-addon/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "imports": {
     "#pikku/*.js": "./dist/.pikku/*.js",
-    "#pikku/*": "./dist/.pikku/*/index.js"
+    "#pikku/*": ["./dist/.pikku/*/index.js", "./dist/.pikku/*"]
   },
   "exports": {
     "./types": {

--- a/templates/function-addon/tsconfig.json
+++ b/templates/function-addon/tsconfig.json
@@ -8,7 +8,7 @@
     "resolveJsonModule": true,
     "paths": {
       "#pikku/*.js": ["./.pikku/*.ts"],
-      "#pikku/*": ["./.pikku/*/index.ts"]
+      "#pikku/*": ["./.pikku/*/index.ts", "./.pikku/*"]
     }
   },
   "include": ["src/**/*", "types/**/*", ".pikku/**/*"],

--- a/templates/functions/package.json
+++ b/templates/functions/package.json
@@ -67,6 +67,6 @@
   },
   "imports": {
     "#pikku/*.js": "./.pikku/*.ts",
-    "#pikku/*": "./.pikku/*/index.ts"
+    "#pikku/*": ["./.pikku/*/index.ts", "./.pikku/*"]
   }
 }

--- a/templates/mcp-server/tsconfig.json
+++ b/templates/mcp-server/tsconfig.json
@@ -6,9 +6,8 @@
     "module": "node18",
     "skipLibCheck": true,
     "paths": {
-      "#pikku/*.json": ["../functions/.pikku/*.json"],
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*", "client/mcp.ts", "client/mcp-server.test.ts"],

--- a/templates/pg-boss/tsconfig.json
+++ b/templates/pg-boss/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*", "client/queue-worker.ts"],

--- a/templates/remote-rpc-pg/tsconfig.json
+++ b/templates/remote-rpc-pg/tsconfig.json
@@ -6,7 +6,7 @@
     "resolveJsonModule": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", "client/"],

--- a/templates/remote-rpc-redis/tsconfig.json
+++ b/templates/remote-rpc-redis/tsconfig.json
@@ -6,7 +6,7 @@
     "resolveJsonModule": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", "client/"],

--- a/templates/uws/tsconfig.json
+++ b/templates/uws/tsconfig.json
@@ -6,7 +6,7 @@
     "skipLibCheck": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*"],

--- a/templates/workflows-bullmq/tsconfig.json
+++ b/templates/workflows-bullmq/tsconfig.json
@@ -7,7 +7,7 @@
     "resolveJsonModule": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*", "client/start-workflow.ts"],

--- a/templates/workflows-pg-boss/tsconfig.json
+++ b/templates/workflows-pg-boss/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*", "client/start-workflow.ts"],

--- a/templates/ws/tsconfig.json
+++ b/templates/ws/tsconfig.json
@@ -6,7 +6,7 @@
     "resolveJsonModule": true,
     "paths": {
       "#pikku/*.js": ["../functions/.pikku/*.ts"],
-      "#pikku/*": ["../functions/.pikku/*/index.ts"]
+      "#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
     }
   },
   "include": ["src/", ".pikku/*"],


### PR DESCRIPTION
Fixes #1321.

`Templates (24, mcp-server, yarn)` and `(…, bun)` have been red since #1307:

```
src/start.ts(9,21): error TS2307: Cannot find module '#pikku/mcp/mcp.gen.json' or its corresponding type declarations.
```

## Why

`#pikku/*.json` was added for that import and resolves inside the template only
because it is listed first. TypeScript's `findBestPatternMatch` picks the
matching pattern with the longest **prefix**, ignores the suffix, and breaks the
tie with a strict `>` — so among three patterns that all begin `#pikku/`, the
first matching key wins. `create-pikku` deep-merges the runtime template's
tsconfig with the functions template's, and the merge puts the bare pattern
ahead of the `.json` one:

```json
"#pikku/*.js":   ["./.pikku/*.ts"],
"#pikku/*":      ["./.pikku/*/index.ts"],
"#pikku/*.json": ["./.pikku/*.json"]
```

`#pikku/mcp/mcp.gen.json` then resolves to `./.pikku/mcp/mcp.gen.json/index.ts`,
a directory that was never written.

The runtime half had the same hole from the other direction: the merged
`package.json` `imports` map comes from the functions template, which had no
`.json` pattern at all.

## The change

The bare pattern takes two targets — the directory index first, the file behind
it — which both `paths` and Node's `imports` try in turn. Ordering stops
mattering, `#pikku/*.json` becomes redundant and goes, and a template that later
imports some other generated file needs no new pattern.

```json
"#pikku/*": ["../functions/.pikku/*/index.ts", "../functions/.pikku/*"]
```

## Verification

- New guard in `packages/core/src/template-alias-surface.test.ts` — red on the
  22 templates before the change, green after: a template declaring the alias
  must give the bare pattern a file target, since a suffix-specific pattern only
  wins by an order the merge decides.
- `scripts/test-template.sh mcp-server <branch> yarn` reproduced the failure on
  `main` and passes end to end against this branch — codegen, `tsc`, and both
  test phases, including `start:http`, which exercises the runtime half through
  the `imports` fallback.

No changeset: every file touched is a private template or a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

