### PR TITLE
fix(core,cli): bind the generated CredentialsMap to wire.getCredential

### DIFF
--- a/.changeset/typed-wire-get-credential.md
+++ b/.changeset/typed-wire-get-credential.md
@@ -1,0 +1,12 @@
+---
+'@pikku/core': patch
+'@pikku/cli': patch
+---
+
+fix: type `wire.getCredential` from the generated `CredentialsMap`
+
+`wire.getCredential('slack')` now resolves its value type from the project's
+credentials codegen, the way `services.credentials.get('slack')` already did.
+`PikkuWire` takes a `TypedCredentials` parameter and the generated function
+types bind `CredentialsMap` into it; a name the map does not know stays callable
+with an explicit type argument.

--- a/packages/cli/src/functions/wirings/functions/pikku-command-function-types-split.ts
+++ b/packages/cli/src/functions/wirings/functions/pikku-command-function-types-split.ts
@@ -21,6 +21,7 @@ export const pikkuFunctionTypesSplit = pikkuSessionlessFunc<
       packageMappings,
       rpcInternalMapDeclarationFile,
       servicesFile,
+      credentialsFile,
     } = config
 
     // Check for required types
@@ -41,6 +42,14 @@ export const pikkuFunctionTypesSplit = pikkuSessionlessFunc<
       throw new Error('Required types not found')
     }
 
+    // The credentials leaf is only written when the project declares at least
+    // one credential, so importing from it unconditionally would emit a broken
+    // import for every project that declares none.
+    const credentialsTypeImport =
+      credentialsFile && visitState.credentials?.definitions.length
+        ? `import type { CredentialsMap } from '${getFileImportRelativePath(functionTypesFile, credentialsFile, packageMappings)}'`
+        : undefined
+
     const configTypeImport = pikkuConfigType
       ? `import type { ${pikkuConfigType.type} } from '${getFileImportRelativePath(functionTypesFile, pikkuConfigType.typePath, packageMappings)}'`
       : '// Config type not found, will use fallback'
@@ -58,7 +67,8 @@ export const pikkuFunctionTypesSplit = pikkuSessionlessFunc<
       config.addonName,
       undefined,
       typeof config.addon === 'object' ? config.addon?.categories : undefined,
-      `import type { ScopeId } from '${getFileImportRelativePath(functionTypesFile, config.scopesFile, packageMappings)}'`
+      `import type { ScopeId } from '${getFileImportRelativePath(functionTypesFile, config.scopesFile, packageMappings)}'`,
+      credentialsTypeImport
     )
 
     const addonRefs = serializeAddonRefs({

--- a/packages/cli/src/functions/wirings/functions/serialize-function-types.test.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-function-types.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert'
 import { describe, test } from 'node:test'
 import { serializeFunctionTypes } from './serialize-function-types.js'
 
-const emit = (nodeCategories?: string[]) =>
+const emit = (nodeCategories?: string[], credentialsTypeImport?: string) =>
   serializeFunctionTypes(
     "import type { Session } from './session.js'",
     'Session',
@@ -15,7 +15,9 @@ const emit = (nodeCategories?: string[]) =>
     "import type { Config } from './config.js'",
     undefined,
     undefined,
-    nodeCategories
+    nodeCategories,
+    undefined,
+    credentialsTypeImport
   )
 
 describe('serializeFunctionTypes', () => {
@@ -83,6 +85,40 @@ describe('serializeFunctionTypes', () => {
         content,
         /type PikkuMiddlewareConfig<[^]*?priority\?: MiddlewarePriority/
       )
+    })
+  })
+
+  // `wire.getCredential('slack')` is only as typed as the map bound to the wire,
+  // so the generated wire type has to pass `CredentialsMap` into `PikkuWire`.
+  describe('credentials', () => {
+    test('binds the generated CredentialsMap to every function wire', () => {
+      const content = emit(
+        undefined,
+        "import type { CredentialsMap } from './credentials.js'"
+      )
+
+      assert.match(
+        content,
+        /import type \{ CredentialsMap \} from '\.\/credentials\.js'/
+      )
+      assert.doesNotMatch(
+        content,
+        /type CredentialsMap = Record<string, unknown>/
+      )
+      for (const wire of [
+        /PikkuWire<In, Out, false, Session,.*TypedScenario<ScenarioOut>, TypedPersonas, CredentialsMap>/,
+        /PikkuWire<In, Out, true, Session,.*TypedScenario, TypedPersonas, CredentialsMap>/,
+      ]) {
+        assert.match(content, wire)
+      }
+    })
+
+    test('falls back to an untyped map when the project declares none', () => {
+      const content = emit()
+
+      assert.match(content, /type CredentialsMap = Record<string, unknown>/)
+      assert.doesNotMatch(content, /import type \{ CredentialsMap \}/)
+      assert.match(content, /TypedPersonas, CredentialsMap>/)
     })
   })
 

--- a/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
@@ -14,7 +14,8 @@ export const serializeFunctionTypes = (
   packageName?: string,
   workflowTypesImport?: string,
   nodeCategories?: string[],
-  scopesTypeImport?: string
+  scopesTypeImport?: string,
+  credentialsTypeImport?: string
 ) => {
   const packageNameValue = packageName ? `'${packageName}'` : 'null'
   const nodeCategoryType = nodeCategories?.length
@@ -27,6 +28,11 @@ import type { TypedScenario, TypedPersonas } from '../scenarios/pikku-scenario-t
   // Falls back to `string` when a project has no scopes codegen, so that
   // `scopes` stays usable rather than resolving to an unbound type name.
   const scopesImport = scopesTypeImport || `type ScopeId = string`
+  // Same fallback reasoning as scopes: a project that declares no credentials
+  // never has a credentials leaf to import from, and `wire.getCredential` stays
+  // callable with an explicit type argument.
+  const credentialsImport =
+    credentialsTypeImport || `type CredentialsMap = Record<string, unknown>`
 
   return `/**
  * Core function, middleware, and permission types for all wirings
@@ -54,6 +60,7 @@ import { pikkuState as __pikkuState } from '@pikku/core/state'
 import { CreateWireServices } from '@pikku/core/types'
 import type { NodeType } from '@pikku/core/node'
 ${scopesImport}
+${credentialsImport}
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 import {
   CorePikkuFunction,
@@ -343,7 +350,7 @@ export type PikkuFunctionSessionless<
     Out,
     RequiredServices,
     Session,
-    PickRequired<PikkuWire<In, Out, false, Session, TypedPikkuRPC, null, any, TypedWorkflow, unknown, TypedScenario<ScenarioOut>, TypedPersonas>, RequiredWires>
+    PickRequired<PikkuWire<In, Out, false, Session, TypedPikkuRPC, null, any, TypedWorkflow, unknown, TypedScenario<ScenarioOut>, TypedPersonas, CredentialsMap>, RequiredWires>
   >
 
 /**
@@ -364,7 +371,7 @@ export type PikkuFunction<
     Out,
     RequiredServices,
     Session,
-    PickRequired<PikkuWire<In, Out, true, Session, TypedPikkuRPC, null, any, TypedWorkflow, unknown, TypedScenario, TypedPersonas>, RequiredWires>
+    PickRequired<PikkuWire<In, Out, true, Session, TypedPikkuRPC, null, any, TypedWorkflow, unknown, TypedScenario, TypedPersonas, CredentialsMap>, RequiredWires>
   >
 
 /**

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,7 +5,7 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2690 observable things**: 857 exported names, plus
+**2691 observable things**: 858 exported names, plus
 1833 members on the classes and interfaces among them, reachable
 through 52 entry points.
 
@@ -20,7 +20,7 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | `./virtual-user` | 34 | 34 | 115 |
 | `./agent` | 49 | 47 | 81 |
 | `./channel` | 32 | 32 | 84 |
-| `./types` | 25 | 22 | 74 |
+| `./types` | 26 | 23 | 74 |
 | `./queue` | 22 | 22 | 71 |
 | `./http` | 25 | 25 | 49 |
 | `./errors` | 49 | 49 | 20 |
@@ -105,6 +105,7 @@ export type PikkuWire<
   TriggerOutput = unknown,
   TypedScenario extends PikkuScenarioWire<any> | never = PikkuScenarioWire<any>,
   TypedActors extends ScenarioPersonas = ScenarioPersonas,
+  TypedCredentials = Record<string, unknown>,
 > = {
   rpc: TypedRPC
 } & Partial<{
@@ -141,7 +142,7 @@ export type PikkuWire<
   hasSessionChanged: () => boolean
   pikkuUserId: string
   setCredential: (name: string, value: unknown) => void
-  getCredential: <T = unknown>(name: string) => T | null | Promise<T | null>
+  getCredential: GetCredential<TypedCredentials>
   getCredentials: () =>
     Record<string, unknown> | Promise<Record<string, unknown>>
   audit: {
@@ -250,6 +251,12 @@ export type CreateWireServices<
   services: SingletonServices,
   wire: PikkuRawWire
 ) => Promise<WireServices<Services, SingletonServices>>
+export type GetCredential<TCredentials = Record<string, unknown>> = {
+  <K extends keyof TCredentials & string>(
+    name: K
+  ): TCredentials[K] | null | Promise<TCredentials[K] | null>
+  <T = unknown>(name: string): T | null | Promise<T | null>
+}
 export interface PikkuPackageState {
   function: { meta: FunctionsMeta; functions: Map<string, CorePikkuFunctionConfig<any, any>> }
   rpc: { meta: Record<string, string>; files: Map< string, { exportedName: string; path: string } > }
@@ -283,6 +290,7 @@ export type PikkuWire<
   TriggerOutput = unknown,
   TypedScenario extends PikkuScenarioWire<any> | never = PikkuScenarioWire<any>,
   TypedActors extends ScenarioPersonas = ScenarioPersonas,
+  TypedCredentials = Record<string, unknown>,
 > = {
   rpc: TypedRPC
 } & Partial<{
@@ -319,7 +327,7 @@ export type PikkuWire<
   hasSessionChanged: () => boolean
   pikkuUserId: string
   setCredential: (name: string, value: unknown) => void
-  getCredential: <T = unknown>(name: string) => T | null | Promise<T | null>
+  getCredential: GetCredential<TypedCredentials>
   getCredentials: () =>
     Record<string, unknown> | Promise<Record<string, unknown>>
   audit: {
@@ -3421,7 +3429,7 @@ resumeAgentSync: (runId: string, approvals: { toolCallId: string; approved: bool
 runAgent: (agentName: string, input: AgentInput, params: RunAgentParams, agentSessionMap?: Map<string, string> | undefined) => Promise<AgentOutput>
 export type RunAgentParams = {
   sessionService?: SessionService<CoreUserSession>
-  getCredential?: <T = unknown>(name: string) => T | null | Promise<T | null>
+  getCredential?: GetCredential
   anonymousOwnerResourceId?: string
 }
 signalRunInterrupt: (runId: string, interruption?: AgentInterruption) => boolean

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -197,6 +197,22 @@ export interface CoreSingletonServices<Config extends CoreConfig = CoreConfig> {
   auth?: () => Promise<AuthInstance>
 }
 
+/**
+ * Reads a single credential. The first signature resolves the value type from
+ * the project's generated `CredentialsMap`; the second keeps a name the map
+ * does not know callable with an explicit type.
+ *
+ * `TCredentials` is unconstrained because the generated map is an interface,
+ * which has no implicit index signature and so cannot satisfy
+ * `Record<string, unknown>`.
+ */
+export type GetCredential<TCredentials = Record<string, unknown>> = {
+  <K extends keyof TCredentials & string>(
+    name: K
+  ): TCredentials[K] | null | Promise<TCredentials[K] | null>
+  <T = unknown>(name: string): T | null | Promise<T | null>
+}
+
 export type PikkuWire<
   In = unknown,
   Out = unknown,
@@ -212,6 +228,7 @@ export type PikkuWire<
   // `ScenarioContext`.
   TypedScenario extends PikkuScenarioWire<any> | never = PikkuScenarioWire<any>,
   TypedActors extends ScenarioPersonas = ScenarioPersonas,
+  TypedCredentials = Record<string, unknown>,
 > = {
   /** Always present — lazily initialised on first access for every function invocation */
   rpc: TypedRPC
@@ -271,7 +288,7 @@ export type PikkuWire<
   /** Set a credential value (available in middleware) */
   setCredential: (name: string, value: unknown) => void
   /** Get a single credential by name — lazy-loads from CredentialService on first call, sync thereafter */
-  getCredential: <T = unknown>(name: string) => T | null | Promise<T | null>
+  getCredential: GetCredential<TypedCredentials>
   /** Get all resolved credentials — lazy-loads from CredentialService on first call, sync thereafter */
   getCredentials: () =>
     Record<string, unknown> | Promise<Record<string, unknown>>

--- a/packages/core/src/types/typed-credentials.test.ts
+++ b/packages/core/src/types/typed-credentials.test.ts
@@ -1,0 +1,72 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import type { CoreUserSession, GetCredential, PikkuWire } from './core.types.js'
+import type { PikkuRPC } from '../wirings/rpc/rpc-types.js'
+import type { PikkuWorkflowWire } from '../wirings/workflow/workflow.types.js'
+import type { PikkuScenarioWire } from '../wirings/workflow/scenario.types.js'
+import type { ScenarioPersonas } from '../services/personas-service.js'
+
+interface CredentialsMap {
+  slack: { token: string }
+  stripe: { apiKey: string; accountId: string }
+}
+
+type TypedWire = PikkuWire<
+  unknown,
+  unknown,
+  false,
+  CoreUserSession,
+  PikkuRPC,
+  null,
+  never,
+  PikkuWorkflowWire,
+  unknown,
+  PikkuScenarioWire<any>,
+  ScenarioPersonas,
+  CredentialsMap
+>
+
+const VALUES: Record<string, unknown> = {
+  slack: { token: 'xoxb-1' },
+  stripe: { apiKey: 'sk-1', accountId: 'acct-1' },
+  'not-in-the-map': { anything: true },
+}
+
+// Mirrors `createWireServicesCredentialWireProps`, so this also pins that a
+// generic single-signature implementation still satisfies the overload pair.
+const getCredential: NonNullable<TypedWire['getCredential']> = <T = unknown>(
+  name: string
+) => (VALUES[name] ?? null) as T | null
+
+describe('wire.getCredential is typed by the generated CredentialsMap', () => {
+  test('resolves a mapped name without an explicit type argument', async () => {
+    const slack: { token: string } | null | Promise<{ token: string } | null> =
+      getCredential('slack')
+    assert.deepEqual(await slack, { token: 'xoxb-1' })
+
+    const stripe = await getCredential('stripe')
+    assert.equal(stripe?.accountId, 'acct-1')
+  })
+
+  test('rejects the wrong type for a mapped name', () => {
+    // @ts-expect-error 'slack' resolves to { token: string }, not a string
+    const wrong: string | null | Promise<string | null> = getCredential('slack')
+    assert.ok(wrong)
+  })
+
+  test('keeps an unmapped name callable with an explicit type argument', async () => {
+    const other = await getCredential<{ anything: boolean }>('not-in-the-map')
+    assert.equal(other?.anything, true)
+  })
+
+  test('falls back to unknown when no map is bound', async () => {
+    const untyped: GetCredential = <T = unknown>(name: string) =>
+      (VALUES[name] ?? null) as T | null
+    // @ts-expect-error no map is bound, so the value is unknown
+    const wrong: { token: string } | null = await untyped('slack')
+    assert.deepEqual(wrong, { token: 'xoxb-1' })
+    assert.deepEqual(await untyped<{ token: string }>('slack'), {
+      token: 'xoxb-1',
+    })
+  })
+})

--- a/packages/core/src/wirings/agent/agent-prepare.ts
+++ b/packages/core/src/wirings/agent/agent-prepare.ts
@@ -1,4 +1,8 @@
-import type { PikkuRawWire, CoreUserSession } from '../../types/core.types.js'
+import type {
+  PikkuRawWire,
+  CoreUserSession,
+  GetCredential,
+} from '../../types/core.types.js'
 import type {
   CoreAgent,
   AgentInput,
@@ -42,7 +46,7 @@ import { resolveModelConfig } from './agent-model-config.js'
 export type RunAgentParams = {
   sessionService?: SessionService<CoreUserSession>
   /** Credential accessor for the current request — used to read per-user overrides (e.g. AI_API_KEY). */
-  getCredential?: <T = unknown>(name: string) => T | null | Promise<T | null>
+  getCredential?: GetCredential
   /** Ephemeral owner identity minted for a sessionless request; never client-supplied, never reused across requests. */
   anonymousOwnerResourceId?: string
 }

--- a/packages/core/tsconfig.type-tests.json
+++ b/packages/core/tsconfig.type-tests.json
@@ -6,5 +6,8 @@
     "declaration": false,
     "declarationMap": false
   },
-  "files": ["src/classification/secret-value.test.ts"]
+  "files": [
+    "src/classification/secret-value.test.ts",
+    "src/types/typed-credentials.test.ts"
+  ]
 }


### PR DESCRIPTION
Closes #420

## Problem

`services.credentials.get()` has been typed against the generated `CredentialsMap` since `TypedCredentialService` landed — but the wire accessor never was:

```ts
getCredential: <T = unknown>(name: string) => T | null | Promise<T | null>
```

Every `wire.getCredential(...)` call site had to hand-pass a generic, and a typo in the credential name was not a compile error.

## Change

- `PikkuWire` gains a `TypedCredentials` type parameter, threaded exactly the way `TypedPikkuRPC`, `TypedWorkflow`, `TypedScenario` and `TypedPersonas` already are.
- New exported `GetCredential<TCredentials>` overload type in `@pikku/core`.
- The CLI emits the `CredentialsMap` import and binds it into the wire type. Projects that declare no credentials fall back to `type CredentialsMap = Record<string, unknown>`, mirroring the existing `scopesTypeImport` fallback — so nothing regresses for projects without credentials.

## Tests

New `packages/core/src/types/typed-credentials.test.ts` type tests (registered in `tsconfig.type-tests.json`) — red before the change, green after. Core suite 2221 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)