### PR TITLE
fix(cli): fail deploy plan and apply when the build pipeline fails

### DIFF
--- a/.changeset/deploy-fails-on-build-failure.md
+++ b/.changeset/deploy-fails-on-build-failure.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+`pikku deploy plan` and `pikku deploy apply` now fail with a non-zero exit code when the build pipeline reports a failure, instead of continuing on to plan or deploy against a stale bundle.

--- a/packages/cli/src/deploy/build-pipeline.ts
+++ b/packages/cli/src/deploy/build-pipeline.ts
@@ -9,6 +9,7 @@ import { join } from 'node:path'
 import { existsSync } from 'node:fs'
 import { mkdir, writeFile, copyFile } from 'node:fs/promises'
 import type { InspectorState } from '@pikku/inspector'
+import { PikkuError } from '@pikku/core/errors'
 
 import { analyzeDeployment } from './analyzer/index.js'
 import { withoutScenarios } from '../functions/wirings/scenarios/scenario-partition.js'
@@ -38,6 +39,30 @@ export interface BuildPipelineResult {
   bundled: BundleResult[]
   bundleErrors: Array<{ unitName: string; error: string }>
   codegenErrors: Array<{ unitName: string; error: string }>
+}
+
+/**
+ * A unit that failed codegen or bundling is an expected build outcome (the
+ * gate did its job) — a PikkuError makes the runner log the message alone,
+ * without a stack trace.
+ */
+export class PikkuDeployBuildFailedError extends PikkuError {}
+
+/**
+ * The message for a build that produced an incomplete artifact, or `null`
+ * when every unit was generated and bundled.
+ */
+export function describeBuildFailure(
+  result: Pick<BuildPipelineResult, 'bundleErrors' | 'codegenErrors'>
+): string | null {
+  const failures = [
+    ...result.codegenErrors.map((e) => `codegen ${e.unitName}: ${e.error}`),
+    ...result.bundleErrors.map((e) => `bundle ${e.unitName}: ${e.error}`),
+  ]
+  if (failures.length === 0) {
+    return null
+  }
+  return `Deploy build failed — ${failures.length} unit(s) did not build:\n  ${failures.join('\n  ')}`
 }
 
 const MERGED_SERVER_UNIT_NAME = 'pikku-server-container'

--- a/packages/cli/src/functions/commands/deploy-apply.ts
+++ b/packages/cli/src/functions/commands/deploy-apply.ts
@@ -9,7 +9,11 @@ import type {
 } from '../../deploy/provider-adapter.js'
 import type { InspectorState } from '@pikku/inspector'
 import type { Logger } from '@pikku/core/services'
-import { runBuildPipeline } from '../../deploy/build-pipeline.js'
+import {
+  runBuildPipeline,
+  describeBuildFailure,
+  PikkuDeployBuildFailedError,
+} from '../../deploy/build-pipeline.js'
 
 function toRelativeImport(fromDir: string, toFile: string): string {
   let rel = relative(fromDir, toFile).replace(/\\/g, '/')
@@ -328,6 +332,19 @@ export const deployApply = pikkuSessionlessFunc<
         errors: [],
       })
       return
+    }
+
+    const buildFailure = describeBuildFailure(buildResult)
+    if (buildFailure) {
+      await writeResultFile(resultFile, {
+        success: false,
+        errors: buildResult.bundleErrors.map((e) => ({
+          step: 'bundle',
+          error: `${e.unitName}: ${e.error}`,
+        })),
+        codegenErrors: buildResult.codegenErrors,
+      })
+      throw new PikkuDeployBuildFailedError(buildFailure)
     }
 
     const { providerDir, bundled } = buildResult

--- a/packages/cli/src/functions/commands/deploy-build-failure.test.ts
+++ b/packages/cli/src/functions/commands/deploy-build-failure.test.ts
@@ -1,0 +1,213 @@
+import { test, describe, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { InspectorState } from '@pikku/inspector'
+
+import { deployPlan } from './deploy-plan.js'
+import { deployApply } from './deploy-apply.js'
+import type { Bundler } from '../../deploy/bundler/bundler.interface.js'
+import type { BundleError } from '../../deploy/bundler/types.js'
+
+/**
+ * A single-unit provider loaded straight from a data: URL, so the deploy
+ * commands run their real resolveProvider path without a provider package
+ * being installed. `deployed` records whether apply reached the deploy step.
+ */
+const deployed: string[] = []
+
+const providerModule = (): string =>
+  `data:text/javascript,${encodeURIComponent(`
+    export const createAdapter = () => ({
+      name: 'fake',
+      deployDirName: 'fake',
+      singleUnit: true,
+      generateEntrySource: () => 'export default {}',
+      generateUnitConfigs: () => new Map(),
+      generateInfraManifest: () => null,
+      deploy: async () => {
+        globalThis.__pikkuFakeProviderDeployed.push('deploy')
+        return { success: true, workersDeployed: [], resourcesCreated: [], errors: [] }
+      },
+    })
+  `)}`
+
+let root: string
+let logs: string[]
+
+const logger = {
+  info: (msg: string) => logs.push(String(msg)),
+  warn: (msg: string) => logs.push(String(msg)),
+  error: (msg: string) => logs.push(String(msg)),
+  debug: () => {},
+}
+
+const config = () => ({
+  rootDir: root,
+  outDir: join(root, '.pikku'),
+  deploy: {
+    providers: { fake: providerModule() },
+    defaultProvider: 'fake',
+  },
+})
+
+const inspectorState = (): InspectorState =>
+  ({
+    rootDir: root,
+    functions: {
+      meta: { createTodo: { pikkuFuncId: 'createTodo', name: 'createTodo' } },
+    },
+    http: {
+      meta: {
+        post: {
+          '/todo': {
+            pikkuFuncId: 'createTodo',
+            method: 'post',
+            route: '/todo',
+          },
+        },
+      },
+    },
+    agents: { agentsMeta: {} },
+    mcpEndpoints: { toolsMeta: {}, resourcesMeta: {}, promptsMeta: {} },
+    channels: { meta: {} },
+    queueWorkers: { meta: {} },
+    scheduledTasks: { meta: {} },
+    workflows: { graphMeta: {} },
+    secrets: { definitions: [], usage: [] },
+    variables: { definitions: [] },
+    filesAndMethods: {
+      pikkuConfigFactory: {
+        file: join(root, 'src', 'config.ts'),
+        variable: 'createConfig',
+      },
+      singletonServicesFactory: {
+        file: join(root, 'src', 'services.ts'),
+        variable: 'createSingletonServices',
+      },
+    },
+  }) as unknown as InspectorState
+
+const bundlerWith = (errors: BundleError[]): Bundler => ({
+  bundleUnits: async () => ({
+    results: errors.length
+      ? []
+      : [
+          {
+            unitName: 'unit',
+            bundlePath: join(root, 'bundle.js'),
+            packageJsonPath: join(root, 'package.json'),
+            exactDependenciesPath: join(root, 'exact.json'),
+            metafilePath: join(root, 'metafile.json'),
+            bundleSizeBytes: 10,
+            bundleHash: 'hash',
+            exactDependenciesHash: 'dephash',
+            exactDependencies: {},
+            exactOptionalDependencies: {},
+          },
+        ],
+    errors,
+  }),
+})
+
+const RESOLVE_FAILURE: BundleError = {
+  unitName: 'todo-unit',
+  error: 'Could not resolve "./missing-service.js"',
+}
+
+const run = async (
+  command: typeof deployPlan | typeof deployApply,
+  errors: BundleError[],
+  data: Record<string, unknown> = {}
+) =>
+  command.func(
+    {
+      logger,
+      config: config(),
+      getInspectorState: async () => inspectorState(),
+      bundler: bundlerWith(errors),
+    } as never,
+    data as never,
+    {} as never
+  )
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'pikku-deploy-build-'))
+  logs = []
+  deployed.length = 0
+  ;(globalThis as Record<string, unknown>).__pikkuFakeProviderDeployed =
+    deployed
+  mkdirSync(join(root, 'src'), { recursive: true })
+  mkdirSync(join(root, '.pikku'), { recursive: true })
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'todo-app' }),
+    'utf-8'
+  )
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+  delete (globalThis as Record<string, unknown>).__pikkuFakeProviderDeployed
+})
+
+describe('deploy plan bundle failures', () => {
+  test('throws when a unit failed to bundle', async () => {
+    await assert.rejects(
+      () => run(deployPlan, [RESOLVE_FAILURE]),
+      (error: Error) => {
+        assert.match(error.message, /todo-unit/)
+        assert.match(error.message, /missing-service/)
+        return true
+      }
+    )
+  })
+
+  test('still writes the result file before failing', async () => {
+    const resultFile = join(root, 'result.json')
+    await assert.rejects(() =>
+      run(deployPlan, [RESOLVE_FAILURE], { resultFile })
+    )
+    const result = JSON.parse(readFileSync(resultFile, 'utf-8'))
+    assert.equal(result.success, false)
+    assert.deepEqual(result.errors, [RESOLVE_FAILURE])
+  })
+
+  test('resolves when every unit bundled', async () => {
+    await run(deployPlan, [])
+  })
+})
+
+describe('deploy apply bundle failures', () => {
+  test('throws and never deploys when a unit failed to bundle', async () => {
+    await assert.rejects(
+      () => run(deployApply, [RESOLVE_FAILURE]),
+      (error: Error) => {
+        assert.match(error.message, /todo-unit/)
+        return true
+      }
+    )
+    assert.deepEqual(deployed, [])
+  })
+
+  test('writes a failing result file before failing', async () => {
+    const resultFile = join(root, 'result.json')
+    await assert.rejects(() =>
+      run(deployApply, [RESOLVE_FAILURE], { resultFile })
+    )
+    const result = JSON.parse(readFileSync(resultFile, 'utf-8'))
+    assert.equal(result.success, false)
+  })
+
+  test('deploys when every unit bundled', async () => {
+    await run(deployApply, [])
+    assert.deepEqual(deployed, ['deploy'])
+  })
+})

--- a/packages/cli/src/functions/commands/deploy-plan.ts
+++ b/packages/cli/src/functions/commands/deploy-plan.ts
@@ -4,7 +4,11 @@ import { readFile } from 'node:fs/promises'
 import { pikkuSessionlessFunc } from '#pikku/function'
 import { generatePlan } from '../../deploy/plan/index.js'
 import { formatPlan } from '../../deploy/plan/formatter.js'
-import { runBuildPipeline } from '../../deploy/build-pipeline.js'
+import {
+  runBuildPipeline,
+  describeBuildFailure,
+  PikkuDeployBuildFailedError,
+} from '../../deploy/build-pipeline.js'
 import type { DeployProvider } from '../../deploy/plan/provider.js'
 import { resolveProvider, getEntryContext } from './deploy-apply.js'
 
@@ -143,6 +147,11 @@ export const deployPlan = pikkuSessionlessFunc<
         ),
         'utf-8'
       )
+    }
+
+    const buildFailure = describeBuildFailure(result)
+    if (buildFailure) {
+      throw new PikkuDeployBuildFailedError(buildFailure)
     }
   },
 })


### PR DESCRIPTION
Closes #560

## Problem

`runBuildPipeline` records failures in its result, but neither `deploy plan` nor `deploy apply` looked at them:

- `deploy plan` went on to diff against a stale bundle
- `deploy apply` went on to hand that stale bundle to `provider.deploy`

Both exited `0`, so CI reported a green deploy of a build that never succeeded.

## Change

- New `PikkuDeployBuildFailedError` plus `describeBuildFailure(result)` in `packages/cli/src/deploy/build-pipeline.ts`.
- `deploy-plan.ts` and `deploy-apply.ts` gate on the pipeline result. In `deploy apply` the gate sits **before** `provider.deploy`, so a failed build can never reach a provider.
- No `process.exit` — the error rides the existing `PikkuError` → `CLIError(1)` path, so the process exits `1` and the message is formatted like every other CLI error.

## Tests

New `packages/cli/src/functions/commands/deploy-build-failure.test.ts` — 6 tests, 4 of which are red before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)