### PR TITLE
feat(core,cli,inspector): add forEach fan-out to declarative graph nodes

### DIFF
--- a/.changeset/graph-foreach-fanout.md
+++ b/.changeset/graph-foreach-fanout.md
@@ -1,0 +1,26 @@
+---
+'@pikku/core': patch
+'@pikku/inspector': patch
+'@pikku/cli': patch
+---
+
+feat(graph): per-item `forEach` fanout for declarative workflow graphs
+
+A graph node can now run once per element of an upstream array:
+
+```ts
+postVideo: {
+  forEach: 'getMyVideo',              // or (ref) => ref('getMyVideo', 'rows')
+  mode: 'sequential',                 // optional, defaults to 'parallel'
+  input: (ref, template, $item) => ({ url: $item('URL VIDEO') }),
+}
+```
+
+Each element runs as its own step instance (`postVideo[0]`, `postVideo[1]`, …)
+and the node's result is the ordered array of per-item results, so a fanned node
+chains straight into another `forEach`. Downstream nodes wait for every item. A
+non-array source fails the run loudly instead of coercing.
+
+The change is additive: `forEach` and `mode` are new optional node fields, and
+`$item` is appended after `template` so existing `input: (ref) => …` and
+`input: (ref, template) => …` nodes are unchanged.

--- a/packages/cli/src/functions/wirings/workflow/graph-foreach.compile.test.ts
+++ b/packages/cli/src/functions/wirings/workflow/graph-foreach.compile.test.ts
@@ -6,10 +6,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 /**
- * The graph type machinery emitted by serializeWorkflowTypes, paired with stub
- * RPC / workflow / agent maps. Kept in lockstep with the emitter — the sibling
- * serialize-workflow-types.test.ts pins that the emitter still produces these
- * exact constructs, while this file proves they compile and enforce the union.
+ * The same emitted graph machinery as agent-graph-node.compile.test.ts, used
+ * here to prove the forEach fanout surface is purely additive: the existing
+ * `(ref) => ...` and `(ref, template) => ...` input shapes must still compile
+ * unchanged alongside the appended `$item` parameter.
  */
 const MACHINERY = `
 type FlattenedRPCMap = {
@@ -83,7 +83,7 @@ declare function pikkuWorkflowGraph<
 `
 
 const typeErrors = (consumer: string): string[] => {
-  const dir = mkdtempSync(join(tmpdir(), 'pikku-agent-graph-'))
+  const dir = mkdtempSync(join(tmpdir(), 'pikku-graph-foreach-'))
   try {
     const file = join(dir, 'fixture.ts')
     writeFileSync(file, `${MACHINERY}\n${consumer}\n`)
@@ -104,18 +104,18 @@ const typeErrors = (consumer: string): string[] => {
   }
 }
 
-describe('pikkuWorkflowGraph agent-name nodes', () => {
-  test('an agent-name node compiles and a downstream node refs its output', () => {
+describe('pikkuWorkflowGraph forEach fanout', () => {
+  test('a forEach node id with $item() input compiles', () => {
     const errors = typeErrors(`
 export const g = pikkuWorkflowGraph({
-  nodes: { entry: 'userCreate', classify: 'summarize', notify: 'emailSend' },
+  nodes: { entry: 'userCreate', notify: 'emailSend' },
   config: {
-    entry: { next: 'classify' },
-    classify: { next: 'notify', input: (ref) => ({ message: ref('entry', 'email') }) },
+    entry: { next: 'notify' },
     notify: {
-      input: (ref) => ({
-        to: ref('entry', 'email'),
-        subject: ref('classify', 'summary'),
+      forEach: 'entry',
+      input: (ref, template, $item) => ({
+        to: $item('email'),
+        subject: $item(),
         body: 'hi',
       }),
     },
@@ -125,35 +125,77 @@ export const g = pikkuWorkflowGraph({
     assert.deepEqual(errors, [])
   })
 
-  test('a sub-workflow name is also accepted as a node func', () => {
-    const errors = typeErrors(
-      `export const g = pikkuWorkflowGraph({ nodes: { a: 'onboardWorkflow' } })`
-    )
+  test('forEach also accepts a (ref) callback, with a sequential mode', () => {
+    const errors = typeErrors(`
+export const g = pikkuWorkflowGraph({
+  nodes: { entry: 'userCreate', notify: 'emailSend' },
+  config: {
+    entry: { next: 'notify' },
+    notify: {
+      forEach: (ref) => ref('entry', 'email'),
+      mode: 'sequential',
+      input: (ref, template, $item) => ({ to: $item(), subject: 's', body: 'b' }),
+    },
+  },
+})
+`)
     assert.deepEqual(errors, [])
   })
 
-  test('an unknown node func name (not an rpc, workflow, or agent) is rejected', () => {
-    const errors = typeErrors(
-      `export const g = pikkuWorkflowGraph({ nodes: { x: 'notARealThing' } })`
-    )
-    assert.ok(
-      errors.some((e) => e.includes('notARealThing')),
-      `expected a rejection mentioning notARealThing, got ${JSON.stringify(errors)}`
-    )
-  })
-
-  test('ref() against a non-existent agent output key is rejected', () => {
+  test('forEach rejects a node id that is not in the graph', () => {
     const errors = typeErrors(`
 export const g = pikkuWorkflowGraph({
-  nodes: { classify: 'summarize', notify: 'emailSend' },
-  config: {
-    notify: { input: (ref) => ({ to: ref('classify', 'nope'), subject: 's', body: 'b' }) },
-  },
+  nodes: { entry: 'userCreate', notify: 'emailSend' },
+  config: { notify: { forEach: 'nope' } },
 })
 `)
     assert.ok(
       errors.length > 0,
-      'expected ref() to reject an unknown agent output key'
+      'expected forEach to reject an unknown node id'
     )
+  })
+
+  test('mode rejects an unknown value', () => {
+    const errors = typeErrors(`
+export const g = pikkuWorkflowGraph({
+  nodes: { entry: 'userCreate', notify: 'emailSend' },
+  config: { notify: { forEach: 'entry', mode: 'batched' } },
+})
+`)
+    assert.ok(errors.length > 0, 'expected mode to reject an unknown value')
+  })
+
+  test('an existing single-param (ref) => ... node still compiles untouched', () => {
+    const errors = typeErrors(`
+export const g = pikkuWorkflowGraph({
+  nodes: { entry: 'userCreate', notify: 'emailSend' },
+  config: {
+    entry: { next: 'notify' },
+    notify: {
+      input: (ref) => ({ to: ref('entry', 'email'), subject: 's', body: 'b' }),
+    },
+  },
+})
+`)
+    assert.deepEqual(errors, [])
+  })
+
+  test('an existing (ref, template) => ... node still compiles untouched', () => {
+    const errors = typeErrors(`
+export const g = pikkuWorkflowGraph({
+  nodes: { entry: 'userCreate', notify: 'emailSend' },
+  config: {
+    entry: { next: 'notify' },
+    notify: {
+      input: (ref, template) => ({
+        to: ref('entry', 'email'),
+        subject: template('hi $0', [ref('entry', 'id')]),
+        body: 'b',
+      }),
+    },
+  },
+})
+`)
+    assert.deepEqual(errors, [])
   })
 })

--- a/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.test.ts
+++ b/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.test.ts
@@ -29,6 +29,20 @@ describe('serializeWorkflowTypes', () => {
     assert.match(result, /keyof FlattenedAgentMap & string/)
   })
 
+  test('a graph node can declare a forEach source and a fanout mode', () => {
+    const result = emit()
+    assert.match(result, /forEach\?: ForEachConfig<FuncMap>/)
+    assert.match(result, /mode\?: 'parallel' \| 'sequential'/)
+  })
+
+  test("$item is appended after template so neither existing input shape shifts", () => {
+    const result = emit()
+    assert.match(
+      result,
+      /\(ref: RefFunction<FuncMap>, template: TemplateFunction, \$item: ItemFunction\)/
+    )
+  })
+
   test('ref() resolves output keys for an agent-name node', () => {
     const result = emit()
     assert.match(

--- a/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.ts
+++ b/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.ts
@@ -151,13 +151,23 @@ type RefFunction<FuncMap extends Record<string, string>> = {
 
 type TemplateFunction = (templateStr: string, refs: TypedRef<unknown>[]) => TemplateString
 
+type ItemFunction = (path?: string) => TypedRef<unknown>
+
+type ForEachConfig<FuncMap extends Record<string, string>> =
+  | Extract<keyof FuncMap, string>
+  | ((ref: RefFunction<FuncMap>) => TypedRef<unknown>)
+
 type GraphNodeConfigMap<FuncMap extends Record<string, string>> = {
   [K in Extract<keyof FuncMap, string>]?: {
     next?: NextConfig<Extract<keyof FuncMap, string>>
+    /** Run this node once per element of an upstream array. Its result becomes the ordered array of per-item results. */
+    forEach?: ForEachConfig<FuncMap>
+    /** How the per-item instances of a forEach node run. Defaults to 'parallel'. */
+    mode?: 'parallel' | 'sequential'
     input?:
       | NodeInputType<FuncMap, K>
       | (() => NodeInputType<FuncMap, K>)
-      | ((ref: RefFunction<FuncMap>, template: TemplateFunction) => NodeInputType<FuncMap, K>)
+      | ((ref: RefFunction<FuncMap>, template: TemplateFunction, $item: ItemFunction) => NodeInputType<FuncMap, K>)
     onError?: Extract<keyof FuncMap, string> | Extract<keyof FuncMap, string>[]
     /** Free-text node documentation. Non-semantic — excluded from graphHash. */
     notes?: string

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,8 +5,8 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2691 observable things**: 858 exported names, plus
-1833 members on the classes and interfaces among them, reachable
+**2697 observable things**: 862 exported names, plus
+1835 members on the classes and interfaces among them, reachable
 through 53 entry points.
 
 An entry point whose exports are mostly *exclusive* is a self-contained
@@ -16,7 +16,7 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | --- | ---: | ---: | ---: |
 | `./services` | 135 | 110 | 396 |
 | `./scenario` | 52 | 52 | 141 |
-| `./workflow` | 78 | 29 | 131 |
+| `./workflow` | 82 | 33 | 133 |
 | `./virtual-user` | 34 | 34 | 115 |
 | `./agent` | 49 | 47 | 81 |
 | `./channel` | 32 | 32 | 84 |
@@ -1041,9 +1041,16 @@ export interface FilterStepMeta {
   condition: Condition
   outputVar?: string
 }
+export type ForEachConfig<NodeIds extends string = string> =
+  | NodeIds
+  | RefValue
+  | ((ref: RefFn<NodeIds>) => RefValue)
+export type ForEachMode = 'parallel' | 'sequential'
 export interface GraphNodeConfig<NodeIds extends string = string> {
   func: string
-  input?: (ref: RefFn<NodeIds>) => Record<string, unknown>
+  forEach?: ForEachConfig<NodeIds>
+  mode?: ForEachMode
+  input?: (ref: RefFn<NodeIds>, template: TemplateFn, $item: ItemFn) => Record<string, unknown>
   next?: NextConfig<NodeIds>
   onError?: NodeIds | NodeIds[]
   retries?: number
@@ -1063,6 +1070,7 @@ export type InputSource =
   | { from: 'literal'; value: unknown }
   | { from: 'template'; parts: string[]; expressions: InputSource[] }
 isRef: (value: unknown) => value is RefValue
+export type ItemFn = (path?: string) => RefValue
 export type OutputBinding =
   | { from: 'outputVar'; name: string; path?: string }
   | { from: 'stateVar'; name: string; path?: string }
@@ -1273,6 +1281,10 @@ export interface SwitchStepMeta {
   defaultSteps?: WorkflowStepMeta[]
 }
 template: (templateStr: string, refs: { $ref: string; path?: string | undefined; }[]) => TemplateString
+export type TemplateFn = (
+  templateStr: string,
+  refs: Array<{ $ref: string; path?: string }>
+) => TemplateString
 export type TemplateString = {
   $template: {
     parts: string[]

--- a/packages/core/src/wirings/workflow/graph/graph-foreach-queued.test.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-foreach-queued.test.ts
@@ -1,0 +1,569 @@
+/**
+ * forEach fan-out over the durable (queued) path.
+ *
+ * `graph-foreach.test.ts` drives the inline runner, which plans and executes in
+ * one process. Production runs instead go out to a queue: entry nodes are
+ * queued by `runWorkflowGraph`, each step comes back through
+ * `executeWorkflowStep` (which has to map `node[i]` back to `node` before it
+ * can find the RPC), and every completion re-enters `continueGraph` through the
+ * orchestrator. These tests exercise that loop.
+ */
+
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../../services/in-memory-workflow-service.js'
+import { runWorkflowGraph } from './graph-runner.js'
+import { pikkuState } from '../../../pikku-state.js'
+
+const silentLogger = { error() {}, info() {}, warn() {}, debug() {} }
+
+interface QueuedJob {
+  queueName: string
+  data: any
+}
+
+type RpcImpl = (rpcName: string, data: any) => Promise<any>
+
+interface Harness {
+  ws: InMemoryWorkflowService
+  rpc: any
+  jobs: QueuedJob[]
+  onEnqueue: (fn: (job: QueuedJob) => void | Promise<void>) => void
+  drain: (max?: number) => Promise<void>
+}
+
+const isOrchestratorJob = (queueName: string) =>
+  queueName.includes('orchestrator')
+
+function harness(rpcImpl: RpcImpl): Harness {
+  const jobs: QueuedJob[] = []
+  let enqueueHook: ((job: QueuedJob) => void | Promise<void>) | undefined
+
+  pikkuState(null, 'package', 'singletonServices', {
+    logger: silentLogger,
+    queueService: {
+      add: async (queueName: string, data: any) => {
+        const job = { queueName, data }
+        jobs.push(job)
+        await enqueueHook?.(job)
+        return 'job-1'
+      },
+    },
+  } as any)
+
+  const ws = new InMemoryWorkflowService()
+  const rpc = { rpcWithWire: rpcImpl } as any
+
+  const drain = async (max = 200) => {
+    let processed = 0
+    while (jobs.length) {
+      if (++processed > max) {
+        throw new Error('the queue never settled — the fan-out is looping')
+      }
+      const job = jobs.shift()!
+      if (isOrchestratorJob(job.queueName)) {
+        await ws.orchestrateWorkflow(job.data.runId, rpc)
+      } else {
+        await ws.executeWorkflowStep(
+          job.data.runId,
+          job.data.stepName,
+          job.data.rpcName,
+          job.data.data,
+          rpc
+        )
+      }
+    }
+  }
+
+  return {
+    ws,
+    rpc,
+    jobs,
+    onEnqueue: (fn) => {
+      enqueueHook = fn
+    },
+    drain,
+  }
+}
+
+function seedMeta(name: string, nodes: Record<string, any>, entry: string[]) {
+  const metaState = pikkuState(null, 'workflows', 'meta')
+  metaState[name] = {
+    name,
+    pikkuFuncId: name,
+    source: 'graph',
+    entryNodeIds: entry,
+    graphHash: `${name}-hash`,
+    nodes,
+  }
+  return () => {
+    delete metaState[name]
+  }
+}
+
+const stepNames = async (ws: InMemoryWorkflowService, runId: string) =>
+  (await ws.getStepInstances(runId)).map((i) => i.stepName).sort()
+
+describe('graph forEach fanout — durable queued path', () => {
+  test('every item gets its own queued step, and each one resolves $item', async () => {
+    const seen: any[] = []
+    const h = harness(async (rpcName, data) => {
+      if (rpcName === 'listRows')
+        return { rows: [{ n: 1 }, { n: 2 }, { n: 3 }] }
+      if (rpcName === 'handleRow') {
+        seen.push(data)
+        return { doubled: data.value * 2 }
+      }
+      return {}
+    })
+    const cleanup = seedMeta(
+      'queuedFanout',
+      {
+        list: { nodeId: 'list', rpcName: 'listRows', next: 'handle' },
+        handle: {
+          nodeId: 'handle',
+          rpcName: 'handleRow',
+          forEach: { $ref: 'list', path: 'rows' },
+          input: { value: { $ref: '$item', path: 'n' } },
+        },
+      },
+      ['list']
+    )
+
+    const { runId } = await runWorkflowGraph(
+      h.ws,
+      'queuedFanout',
+      {},
+      h.rpc,
+      false
+    )
+    await h.drain()
+
+    assert.equal((await h.ws.getRun(runId))?.status, 'completed')
+    assert.deepEqual(await stepNames(h.ws, runId), [
+      'handle[0]',
+      'handle[1]',
+      'handle[2]',
+      'list',
+    ])
+    assert.deepEqual(
+      seen.map((d) => d.value).sort(),
+      [1, 2, 3],
+      `each queued instance should carry its own item, got ${JSON.stringify(seen)}`
+    )
+
+    cleanup()
+  })
+
+  test('a parallel fanout queues every item in one orchestrator pass', async () => {
+    const h = harness(async (rpcName) => {
+      if (rpcName === 'listRows') return [1, 2, 3]
+      return { ok: true }
+    })
+    const cleanup = seedMeta(
+      'queuedFanoutBurst',
+      {
+        list: { nodeId: 'list', rpcName: 'listRows', next: 'handle' },
+        handle: {
+          nodeId: 'handle',
+          rpcName: 'handleRow',
+          forEach: { $ref: 'list' },
+          input: { value: { $ref: '$item' } },
+        },
+      },
+      ['list']
+    )
+
+    await runWorkflowGraph(h.ws, 'queuedFanoutBurst', {}, h.rpc, false)
+
+    // list, then the orchestrator pass that fans handle out.
+    while (h.jobs.length) {
+      const job = h.jobs.shift()!
+      if (isOrchestratorJob(job.queueName)) {
+        await h.ws.orchestrateWorkflow(job.data.runId, h.rpc)
+        break
+      }
+      await h.ws.executeWorkflowStep(
+        job.data.runId,
+        job.data.stepName,
+        job.data.rpcName,
+        job.data.data,
+        h.rpc
+      )
+    }
+
+    const queuedSteps = h.jobs
+      .filter((j) => !isOrchestratorJob(j.queueName))
+      .map((j) => j.data.stepName)
+    assert.deepEqual(
+      queuedSteps,
+      ['handle[0]', 'handle[1]', 'handle[2]'],
+      'a parallel fanout should have all of its items in flight at once'
+    )
+
+    cleanup()
+  })
+
+  test("mode: 'sequential' never has two items queued at once", async () => {
+    const executed: string[] = []
+    const h = harness(async (rpcName, data) => {
+      if (rpcName === 'listRows') return ['a', 'b', 'c']
+      executed.push(data.value)
+      return { value: data.value }
+    })
+    const cleanup = seedMeta(
+      'queuedFanoutSequential',
+      {
+        list: { nodeId: 'list', rpcName: 'listRows', next: 'handle' },
+        handle: {
+          nodeId: 'handle',
+          rpcName: 'handleRow',
+          mode: 'sequential',
+          forEach: { $ref: 'list' },
+          input: { value: { $ref: '$item' } },
+        },
+      },
+      ['list']
+    )
+
+    const { runId } = await runWorkflowGraph(
+      h.ws,
+      'queuedFanoutSequential',
+      {},
+      h.rpc,
+      false
+    )
+
+    h.onEnqueue(async (job) => {
+      if (isOrchestratorJob(job.queueName)) return
+      if (!job.data.stepName.startsWith('handle[')) return
+      const unfinished = (await h.ws.getStepInstances(job.data.runId)).filter(
+        (i) =>
+          i.stepName.startsWith('handle[') &&
+          i.stepName !== job.data.stepName &&
+          i.status !== 'succeeded'
+      )
+      assert.deepEqual(
+        unfinished.map((i) => i.stepName),
+        [],
+        `${job.data.stepName} was queued while earlier items were still unfinished`
+      )
+    })
+
+    await h.drain()
+
+    assert.equal((await h.ws.getRun(runId))?.status, 'completed')
+    assert.deepEqual(
+      executed,
+      ['a', 'b', 'c'],
+      'sequential items should run in source order'
+    )
+
+    cleanup()
+  })
+
+  test('a downstream node fires once, after every item, with the ordered results', async () => {
+    const downstreamCalls: any[] = []
+    const h = harness(async (rpcName, data) => {
+      if (rpcName === 'listRows') return [1, 2, 3]
+      if (rpcName === 'handleRow') return { squared: data.value * data.value }
+      if (rpcName === 'summarise') {
+        downstreamCalls.push(data)
+        return { ok: true }
+      }
+      return {}
+    })
+    const cleanup = seedMeta(
+      'queuedFanoutAggregate',
+      {
+        list: { nodeId: 'list', rpcName: 'listRows', next: 'handle' },
+        handle: {
+          nodeId: 'handle',
+          rpcName: 'handleRow',
+          forEach: { $ref: 'list' },
+          input: { value: { $ref: '$item' } },
+          next: 'summary',
+        },
+        summary: {
+          nodeId: 'summary',
+          rpcName: 'summarise',
+          input: { results: { $ref: 'handle' } },
+        },
+      },
+      ['list']
+    )
+
+    const { runId } = await runWorkflowGraph(
+      h.ws,
+      'queuedFanoutAggregate',
+      {},
+      h.rpc,
+      false
+    )
+    await h.drain()
+
+    assert.equal((await h.ws.getRun(runId))?.status, 'completed')
+    assert.equal(
+      downstreamCalls.length,
+      1,
+      `the downstream node should run once, not once per item (ran ${downstreamCalls.length}x)`
+    )
+    assert.deepEqual(downstreamCalls[0], {
+      results: [{ squared: 1 }, { squared: 4 }, { squared: 9 }],
+    })
+
+    cleanup()
+  })
+
+  test('a downstream node stays put while sibling items are still in flight', async () => {
+    // The orchestrator job for item 0 lands while items 1 and 2 are still
+    // sitting on the step queue — only a completion count that ignores the
+    // unfinished siblings would release the downstream node here.
+    const downstreamCalls: any[] = []
+    const h = harness(async (rpcName, data) => {
+      if (rpcName === 'listRows') return [1, 2, 3]
+      if (rpcName === 'handleRow') return { squared: data.value * data.value }
+      if (rpcName === 'summarise') {
+        downstreamCalls.push(data)
+        return { ok: true }
+      }
+      return {}
+    })
+    const cleanup = seedMeta(
+      'queuedFanoutEagerOrchestrator',
+      {
+        list: { nodeId: 'list', rpcName: 'listRows', next: 'handle' },
+        handle: {
+          nodeId: 'handle',
+          rpcName: 'handleRow',
+          forEach: { $ref: 'list' },
+          input: { value: { $ref: '$item' } },
+          next: 'summary',
+        },
+        summary: {
+          nodeId: 'summary',
+          rpcName: 'summarise',
+          input: { results: { $ref: 'handle' } },
+        },
+      },
+      ['list']
+    )
+
+    const { runId } = await runWorkflowGraph(
+      h.ws,
+      'queuedFanoutEagerOrchestrator',
+      {},
+      h.rpc,
+      false
+    )
+
+    // An orchestrator job runs as soon as it exists, rather than behind the
+    // items its siblings are still waiting on.
+    let processed = 0
+    while (h.jobs.length) {
+      if (++processed > 200) throw new Error('the queue never settled')
+      const index = h.jobs.findIndex((j) => isOrchestratorJob(j.queueName))
+      const job = h.jobs.splice(index === -1 ? 0 : index, 1)[0]!
+      if (isOrchestratorJob(job.queueName)) {
+        const unfinishedItems = (await h.ws.getStepInstances(runId)).filter(
+          (i) => i.stepName.startsWith('handle[') && i.status !== 'succeeded'
+        )
+        await h.ws.orchestrateWorkflow(job.data.runId, h.rpc)
+        if (unfinishedItems.length > 0) {
+          assert.deepEqual(
+            downstreamCalls,
+            [],
+            `the downstream node ran while ${unfinishedItems.length} item(s) were unfinished`
+          )
+        }
+      } else {
+        await h.ws.executeWorkflowStep(
+          job.data.runId,
+          job.data.stepName,
+          job.data.rpcName,
+          job.data.data,
+          h.rpc
+        )
+      }
+    }
+
+    assert.equal((await h.ws.getRun(runId))?.status, 'completed')
+    assert.deepEqual(downstreamCalls, [
+      { results: [{ squared: 1 }, { squared: 4 }, { squared: 9 }] },
+    ])
+
+    cleanup()
+  })
+
+  test('an entry node fans out over the trigger input', async () => {
+    const seen: any[] = []
+    const h = harness(async (_rpcName, data) => {
+      seen.push(data)
+      return { ok: true }
+    })
+    const cleanup = seedMeta(
+      'queuedEntryFanout',
+      {
+        handle: {
+          nodeId: 'handle',
+          rpcName: 'handleRow',
+          forEach: { $ref: 'trigger', path: 'ids' },
+          input: { id: { $ref: '$item' } },
+        },
+      },
+      ['handle']
+    )
+
+    const { runId } = await runWorkflowGraph(
+      h.ws,
+      'queuedEntryFanout',
+      { ids: ['x', 'y'] },
+      h.rpc,
+      false
+    )
+    await h.drain()
+
+    assert.equal((await h.ws.getRun(runId))?.status, 'completed')
+    assert.deepEqual(await stepNames(h.ws, runId), ['handle[0]', 'handle[1]'])
+    assert.deepEqual(seen.map((d) => d.id).sort(), ['x', 'y'])
+
+    cleanup()
+  })
+
+  test('a sequential entry fanout still runs every item', async () => {
+    const executed: string[] = []
+    const h = harness(async (_rpcName, data) => {
+      executed.push(data.id)
+      return { ok: true }
+    })
+    const cleanup = seedMeta(
+      'queuedEntryFanoutSequential',
+      {
+        handle: {
+          nodeId: 'handle',
+          rpcName: 'handleRow',
+          mode: 'sequential',
+          forEach: { $ref: 'trigger', path: 'ids' },
+          input: { id: { $ref: '$item' } },
+        },
+      },
+      ['handle']
+    )
+
+    const { runId } = await runWorkflowGraph(
+      h.ws,
+      'queuedEntryFanoutSequential',
+      { ids: ['x', 'y', 'z'] },
+      h.rpc,
+      false
+    )
+    await h.drain()
+
+    assert.equal(
+      (await h.ws.getRun(runId))?.status,
+      'completed',
+      'an entry fanout that starts one item at a time must still reach the rest'
+    )
+    assert.deepEqual(executed, ['x', 'y', 'z'])
+
+    cleanup()
+  })
+
+  test('a failing item fails the run instead of stalling it', async () => {
+    const h = harness(async (rpcName, data) => {
+      if (rpcName === 'listRows') return [1, 2, 3]
+      if (data.value === 2) throw new Error('item 2 exploded')
+      return { ok: true }
+    })
+    const cleanup = seedMeta(
+      'queuedFanoutFailure',
+      {
+        list: { nodeId: 'list', rpcName: 'listRows', next: 'handle' },
+        handle: {
+          nodeId: 'handle',
+          rpcName: 'handleRow',
+          forEach: { $ref: 'list' },
+          retries: 0,
+          input: { value: { $ref: '$item' } },
+          next: 'summary',
+        },
+        summary: { nodeId: 'summary', rpcName: 'summarise' },
+      },
+      ['list']
+    )
+
+    const { runId } = await runWorkflowGraph(
+      h.ws,
+      'queuedFanoutFailure',
+      {},
+      h.rpc,
+      false
+    )
+    await h.drain().catch(() => {})
+
+    const run = await h.ws.getRun(runId)
+    assert.notEqual(
+      run?.status,
+      'completed',
+      'a run with a failed item must never report success'
+    )
+    const instances = await h.ws.getStepInstances(runId)
+    assert.equal(
+      instances.some((i) => i.stepName === 'summary'),
+      false,
+      'the downstream node must not run when an item failed'
+    )
+
+    cleanup()
+  })
+
+  test('re-orchestrating a settled fanout does not re-queue its items', async () => {
+    const calls: any[] = []
+    const h = harness(async (rpcName, data) => {
+      if (rpcName === 'listRows') return [1, 2]
+      calls.push(data)
+      return { ok: true }
+    })
+    const cleanup = seedMeta(
+      'queuedFanoutIdempotent',
+      {
+        list: { nodeId: 'list', rpcName: 'listRows', next: 'handle' },
+        handle: {
+          nodeId: 'handle',
+          rpcName: 'handleRow',
+          forEach: { $ref: 'list' },
+          input: { value: { $ref: '$item' } },
+        },
+      },
+      ['list']
+    )
+
+    const { runId } = await runWorkflowGraph(
+      h.ws,
+      'queuedFanoutIdempotent',
+      {},
+      h.rpc,
+      false
+    )
+    await h.drain()
+    assert.equal(calls.length, 2)
+
+    // A duplicated orchestrator job — queues redeliver.
+    await h.ws.orchestrateWorkflow(runId, h.rpc)
+    await h.drain()
+
+    assert.equal(
+      calls.length,
+      2,
+      `a redelivered orchestrator job re-ran the fanout (${calls.length} calls)`
+    )
+    assert.deepEqual(await stepNames(h.ws, runId), [
+      'handle[0]',
+      'handle[1]',
+      'list',
+    ])
+
+    cleanup()
+  })
+})

--- a/packages/core/src/wirings/workflow/graph/graph-foreach.test.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-foreach.test.ts
@@ -1,0 +1,626 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../../services/in-memory-workflow-service.js'
+import { runWorkflowGraph } from './graph-runner.js'
+import { pikkuState } from '../../../pikku-state.js'
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('graph forEach fanout', () => {
+  test('parallel forEach runs one instance per element and threads $item', async () => {
+    const ws = new InMemoryWorkflowService()
+    const seen: any[] = []
+
+    const mockRpcService = {
+      rpcWithWire: async (rpcName: string, data: any) => {
+        if (rpcName === 'listRows') {
+          return { rows: [{ n: 1 }, { n: 2 }, { n: 3 }] }
+        }
+        if (rpcName === 'handleRow') {
+          seen.push(data)
+          return { doubled: data.value * 2 }
+        }
+        return {}
+      },
+    }
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['fanoutParallel'] = {
+      name: 'fanoutParallel',
+      pikkuFuncId: 'fanoutParallel',
+      source: 'graph',
+      entryNodeIds: ['list'],
+      graphHash: 'fanout-parallel-hash',
+      nodes: {
+        list: { nodeId: 'list', rpcName: 'listRows', next: 'handle' },
+        handle: {
+          nodeId: 'handle',
+          rpcName: 'handleRow',
+          forEach: { $ref: 'list', path: 'rows' },
+          input: { value: { $ref: '$item', path: 'n' } },
+        },
+      },
+    }
+
+    const { runId } = await runWorkflowGraph(
+      ws,
+      'fanoutParallel',
+      {},
+      mockRpcService,
+      true
+    )
+
+    const run = await ws.getRun(runId)
+    assert.equal(run?.status, 'completed')
+
+    const instances = await ws.getStepInstances(runId)
+    const names = instances.map((i) => i.stepName).sort()
+    assert.deepEqual(names, ['handle[0]', 'handle[1]', 'handle[2]', 'list'])
+
+    assert.deepEqual(
+      seen.map((d) => d.value).sort(),
+      [1, 2, 3],
+      `each element should be threaded through $item, got ${JSON.stringify(seen)}`
+    )
+
+    delete metaState['fanoutParallel']
+  })
+
+  test('$item with no path binds the whole element', async () => {
+    const ws = new InMemoryWorkflowService()
+    const seen: any[] = []
+
+    const mockRpcService = {
+      rpcWithWire: async (rpcName: string, data: any) => {
+        if (rpcName === 'listWhole') return ['a', 'b']
+        if (rpcName === 'takeWhole') {
+          seen.push(data)
+          return { ok: true }
+        }
+        return {}
+      },
+    }
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['fanoutWholeItem'] = {
+      name: 'fanoutWholeItem',
+      pikkuFuncId: 'fanoutWholeItem',
+      source: 'graph',
+      entryNodeIds: ['list'],
+      graphHash: 'fanout-whole-hash',
+      nodes: {
+        list: { nodeId: 'list', rpcName: 'listWhole', next: 'take' },
+        take: {
+          nodeId: 'take',
+          rpcName: 'takeWhole',
+          forEach: { $ref: 'list' },
+          input: { letter: { $ref: '$item' } },
+        },
+      },
+    }
+
+    const { runId } = await runWorkflowGraph(
+      ws,
+      'fanoutWholeItem',
+      {},
+      mockRpcService,
+      true
+    )
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    assert.deepEqual(
+      seen.map((d) => d.letter).sort(),
+      ['a', 'b'],
+      `$item() with no path should bind the element itself, got ${JSON.stringify(seen)}`
+    )
+
+    delete metaState['fanoutWholeItem']
+  })
+
+  test('a fanned node aggregates its per-item results in source order', async () => {
+    const ws = new InMemoryWorkflowService()
+    let downstreamInput: any
+
+    const mockRpcService = {
+      rpcWithWire: async (rpcName: string, data: any) => {
+        if (rpcName === 'listOrdered') return [10, 20, 30]
+        if (rpcName === 'slowSquare') {
+          // The first element resolves last, so an unordered aggregation
+          // would visibly reorder the results.
+          await delay(data.value === 10 ? 30 : data.value === 20 ? 15 : 1)
+          return { squared: data.value * data.value }
+        }
+        if (rpcName === 'collect') {
+          downstreamInput = data
+          return { ok: true }
+        }
+        return {}
+      },
+    }
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['fanoutOrdered'] = {
+      name: 'fanoutOrdered',
+      pikkuFuncId: 'fanoutOrdered',
+      source: 'graph',
+      entryNodeIds: ['list'],
+      graphHash: 'fanout-ordered-hash',
+      nodes: {
+        list: { nodeId: 'list', rpcName: 'listOrdered', next: 'square' },
+        square: {
+          nodeId: 'square',
+          rpcName: 'slowSquare',
+          forEach: { $ref: 'list' },
+          input: { value: { $ref: '$item' } },
+          next: 'collect',
+        },
+        collect: {
+          nodeId: 'collect',
+          rpcName: 'collect',
+          input: { results: { $ref: 'square' } },
+        },
+      },
+    }
+
+    const { runId } = await runWorkflowGraph(
+      ws,
+      'fanoutOrdered',
+      {},
+      mockRpcService,
+      true
+    )
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    assert.deepEqual(downstreamInput, {
+      results: [{ squared: 100 }, { squared: 400 }, { squared: 900 }],
+    })
+
+    delete metaState['fanoutOrdered']
+  })
+
+  test('a downstream node waits for every item of the fanned node', async () => {
+    const ws = new InMemoryWorkflowService()
+    let collectCalls = 0
+    let inFlight = 0
+    let sawCollectWhileItemsInFlight = false
+
+    const mockRpcService = {
+      rpcWithWire: async (rpcName: string, data: any) => {
+        if (rpcName === 'listWait') return [1, 2, 3]
+        if (rpcName === 'slowItem') {
+          inFlight++
+          await delay(data.value * 10)
+          inFlight--
+          return data.value
+        }
+        if (rpcName === 'afterAll') {
+          collectCalls++
+          if (inFlight > 0) sawCollectWhileItemsInFlight = true
+          return { ok: true }
+        }
+        return {}
+      },
+    }
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['fanoutJoin'] = {
+      name: 'fanoutJoin',
+      pikkuFuncId: 'fanoutJoin',
+      source: 'graph',
+      entryNodeIds: ['list'],
+      graphHash: 'fanout-join-hash',
+      nodes: {
+        list: { nodeId: 'list', rpcName: 'listWait', next: 'each' },
+        each: {
+          nodeId: 'each',
+          rpcName: 'slowItem',
+          forEach: { $ref: 'list' },
+          input: { value: { $ref: '$item' } },
+          next: 'after',
+        },
+        after: { nodeId: 'after', rpcName: 'afterAll' },
+      },
+    }
+
+    const { runId } = await runWorkflowGraph(
+      ws,
+      'fanoutJoin',
+      {},
+      mockRpcService,
+      true
+    )
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    assert.equal(collectCalls, 1, 'downstream node should run exactly once')
+    assert.equal(
+      sawCollectWhileItemsInFlight,
+      false,
+      'downstream node must not run while fanned items are still in flight'
+    )
+
+    delete metaState['fanoutJoin']
+  })
+
+  test("mode: 'sequential' runs one item at a time in order", async () => {
+    const ws = new InMemoryWorkflowService()
+    const events: string[] = []
+    let concurrent = 0
+    let maxConcurrent = 0
+
+    const mockRpcService = {
+      rpcWithWire: async (rpcName: string, data: any) => {
+        if (rpcName === 'listSeq') return ['a', 'b', 'c']
+        if (rpcName === 'seqStep') {
+          concurrent++
+          maxConcurrent = Math.max(maxConcurrent, concurrent)
+          events.push(`start:${data.value}`)
+          await delay(5)
+          events.push(`end:${data.value}`)
+          concurrent--
+          return data.value.toUpperCase()
+        }
+        return {}
+      },
+    }
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['fanoutSequential'] = {
+      name: 'fanoutSequential',
+      pikkuFuncId: 'fanoutSequential',
+      source: 'graph',
+      entryNodeIds: ['list'],
+      graphHash: 'fanout-seq-hash',
+      nodes: {
+        list: { nodeId: 'list', rpcName: 'listSeq', next: 'step' },
+        step: {
+          nodeId: 'step',
+          rpcName: 'seqStep',
+          forEach: { $ref: 'list' },
+          mode: 'sequential',
+          input: { value: { $ref: '$item' } },
+        },
+      },
+    }
+
+    const { runId } = await runWorkflowGraph(
+      ws,
+      'fanoutSequential',
+      {},
+      mockRpcService,
+      true
+    )
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    assert.equal(maxConcurrent, 1, 'sequential mode must never overlap items')
+    assert.deepEqual(events, [
+      'start:a',
+      'end:a',
+      'start:b',
+      'end:b',
+      'start:c',
+      'end:c',
+    ])
+
+    delete metaState['fanoutSequential']
+  })
+
+  test('a non-array forEach source fails the run loudly', async () => {
+    const ws = new InMemoryWorkflowService()
+
+    const mockRpcService = {
+      rpcWithWire: async (rpcName: string) => {
+        if (rpcName === 'notAList') return { rows: { nope: true } }
+        return {}
+      },
+    }
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['fanoutNotArray'] = {
+      name: 'fanoutNotArray',
+      pikkuFuncId: 'fanoutNotArray',
+      source: 'graph',
+      entryNodeIds: ['list'],
+      graphHash: 'fanout-not-array-hash',
+      nodes: {
+        list: { nodeId: 'list', rpcName: 'notAList', next: 'handle' },
+        handle: {
+          nodeId: 'handle',
+          rpcName: 'handleRow',
+          forEach: { $ref: 'list', path: 'rows' },
+          input: { value: { $ref: '$item' } },
+        },
+      },
+    }
+
+    const { runId } = await runWorkflowGraph(
+      ws,
+      'fanoutNotArray',
+      {},
+      mockRpcService,
+      true
+    )
+
+    const run = await ws.getRun(runId)
+    assert.equal(run?.status, 'failed')
+    assert.match(
+      run?.error?.message ?? '',
+      /forEach source 'list\.rows'.*array/,
+      `expected a loud non-array error, got ${run?.error?.message}`
+    )
+
+    delete metaState['fanoutNotArray']
+  })
+
+  test('a fanned node chains into a second forEach', async () => {
+    const ws = new InMemoryWorkflowService()
+    const leaves: any[] = []
+
+    const mockRpcService = {
+      rpcWithWire: async (rpcName: string, data: any) => {
+        if (rpcName === 'listGroups') return [{ id: 'g1' }, { id: 'g2' }]
+        if (rpcName === 'expandGroup') {
+          return { items: [`${data.id}-x`, `${data.id}-y`] }
+        }
+        if (rpcName === 'flattenGroups') {
+          return data.groups.flatMap((g: any) => g.items)
+        }
+        if (rpcName === 'useLeaf') {
+          leaves.push(data.leaf)
+          return { ok: true }
+        }
+        return {}
+      },
+    }
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['fanoutChained'] = {
+      name: 'fanoutChained',
+      pikkuFuncId: 'fanoutChained',
+      source: 'graph',
+      entryNodeIds: ['groups'],
+      graphHash: 'fanout-chained-hash',
+      nodes: {
+        groups: { nodeId: 'groups', rpcName: 'listGroups', next: 'expand' },
+        expand: {
+          nodeId: 'expand',
+          rpcName: 'expandGroup',
+          forEach: { $ref: 'groups' },
+          input: { id: { $ref: '$item', path: 'id' } },
+          next: 'flatten',
+        },
+        flatten: {
+          nodeId: 'flatten',
+          rpcName: 'flattenGroups',
+          input: { groups: { $ref: 'expand' } },
+          next: 'leaf',
+        },
+        leaf: {
+          nodeId: 'leaf',
+          rpcName: 'useLeaf',
+          forEach: { $ref: 'flatten' },
+          input: { leaf: { $ref: '$item' } },
+        },
+      },
+    }
+
+    const { runId } = await runWorkflowGraph(
+      ws,
+      'fanoutChained',
+      {},
+      mockRpcService,
+      true
+    )
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    assert.deepEqual(leaves.sort(), ['g1-x', 'g1-y', 'g2-x', 'g2-y'])
+
+    const names = (await ws.getStepInstances(runId))
+      .map((i) => i.stepName)
+      .sort()
+    assert.deepEqual(names, [
+      'expand[0]',
+      'expand[1]',
+      'flatten',
+      'groups',
+      'leaf[0]',
+      'leaf[1]',
+      'leaf[2]',
+      'leaf[3]',
+    ])
+
+    delete metaState['fanoutChained']
+  })
+
+  test('an empty forEach source completes the node with no item instances', async () => {
+    const ws = new InMemoryWorkflowService()
+    let downstreamInput: any
+
+    const mockRpcService = {
+      rpcWithWire: async (rpcName: string, data: any) => {
+        if (rpcName === 'listEmpty') return []
+        if (rpcName === 'neverRuns') throw new Error('should not run')
+        if (rpcName === 'collectEmpty') {
+          downstreamInput = data
+          return { ok: true }
+        }
+        return {}
+      },
+    }
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['fanoutEmpty'] = {
+      name: 'fanoutEmpty',
+      pikkuFuncId: 'fanoutEmpty',
+      source: 'graph',
+      entryNodeIds: ['list'],
+      graphHash: 'fanout-empty-hash',
+      nodes: {
+        list: { nodeId: 'list', rpcName: 'listEmpty', next: 'each' },
+        each: {
+          nodeId: 'each',
+          rpcName: 'neverRuns',
+          forEach: { $ref: 'list' },
+          input: { value: { $ref: '$item' } },
+          next: 'collect',
+        },
+        collect: {
+          nodeId: 'collect',
+          rpcName: 'collectEmpty',
+          input: { results: { $ref: 'each' } },
+        },
+      },
+    }
+
+    const { runId } = await runWorkflowGraph(
+      ws,
+      'fanoutEmpty',
+      {},
+      mockRpcService,
+      true
+    )
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    assert.deepEqual(downstreamInput, { results: [] })
+
+    delete metaState['fanoutEmpty']
+  })
+
+  test('forEach over the trigger input fans out from an entry node', async () => {
+    const ws = new InMemoryWorkflowService()
+    const seen: any[] = []
+
+    const mockRpcService = {
+      rpcWithWire: async (rpcName: string, data: any) => {
+        if (rpcName === 'handleTriggerRow') {
+          seen.push(data.value)
+          return { ok: true }
+        }
+        return {}
+      },
+    }
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['fanoutTrigger'] = {
+      name: 'fanoutTrigger',
+      pikkuFuncId: 'fanoutTrigger',
+      source: 'graph',
+      entryNodeIds: ['handle'],
+      graphHash: 'fanout-trigger-hash',
+      nodes: {
+        handle: {
+          nodeId: 'handle',
+          rpcName: 'handleTriggerRow',
+          forEach: { $ref: 'trigger', path: 'rows' },
+          input: { value: { $ref: '$item' } },
+        },
+      },
+    }
+
+    const { runId } = await runWorkflowGraph(
+      ws,
+      'fanoutTrigger',
+      { rows: ['p', 'q'] },
+      mockRpcService,
+      true
+    )
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    assert.deepEqual(seen.sort(), ['p', 'q'])
+
+    delete metaState['fanoutTrigger']
+  })
+
+  test('an unknown forEach source is rejected before the run starts', async () => {
+    const ws = new InMemoryWorkflowService()
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['fanoutUnknownSource'] = {
+      name: 'fanoutUnknownSource',
+      pikkuFuncId: 'fanoutUnknownSource',
+      source: 'graph',
+      entryNodeIds: ['a'],
+      graphHash: 'fanout-unknown-hash',
+      nodes: {
+        a: { nodeId: 'a', rpcName: 'doA', next: 'b' },
+        b: {
+          nodeId: 'b',
+          rpcName: 'doB',
+          forEach: { $ref: 'missingNode' },
+          input: { value: { $ref: '$item' } },
+        },
+      },
+    }
+
+    await assert.rejects(
+      () =>
+        runWorkflowGraph(
+          ws,
+          'fanoutUnknownSource',
+          {},
+          { rpcWithWire: async () => ({}) },
+          true
+        ),
+      /unknown node 'missingNode' in forEach/
+    )
+
+    delete metaState['fanoutUnknownSource']
+  })
+
+  test('an existing single-param input node is untouched by the forEach change', async () => {
+    const ws = new InMemoryWorkflowService()
+    const seen: any[] = []
+
+    const mockRpcService = {
+      rpcWithWire: async (rpcName: string, data: any) => {
+        if (rpcName === 'plainFirst') return { name: 'ada', rows: [1, 2] }
+        if (rpcName === 'plainSecond') {
+          seen.push(data)
+          return { ok: true }
+        }
+        return {}
+      },
+    }
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['plainGraph'] = {
+      name: 'plainGraph',
+      pikkuFuncId: 'plainGraph',
+      source: 'graph',
+      entryNodeIds: ['first'],
+      graphHash: 'plain-hash',
+      nodes: {
+        first: { nodeId: 'first', rpcName: 'plainFirst', next: 'second' },
+        second: {
+          nodeId: 'second',
+          rpcName: 'plainSecond',
+          input: {
+            who: { $ref: 'first', path: 'name' },
+            all: { $ref: 'first', path: 'rows' },
+          },
+        },
+      },
+    }
+
+    const { runId } = await runWorkflowGraph(
+      ws,
+      'plainGraph',
+      {},
+      mockRpcService,
+      true
+    )
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    assert.deepEqual(seen, [{ who: 'ada', all: [1, 2] }])
+
+    const names = (await ws.getStepInstances(runId))
+      .map((i) => i.stepName)
+      .sort()
+    assert.deepEqual(
+      names,
+      ['first', 'second'],
+      'a graph without forEach must still produce plain, un-indexed step names'
+    )
+
+    delete metaState['plainGraph']
+  })
+})

--- a/packages/core/src/wirings/workflow/graph/graph-node.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-node.ts
@@ -1,7 +1,11 @@
 import type {
+  ForEachConfig,
+  ForEachMode,
   GraphNodeConfig,
+  ItemFn,
   NextConfig,
   RefValue,
+  TemplateFn,
 } from './workflow-graph.types.js'
 
 export interface RPCHandler<I = any, O = any> {
@@ -65,6 +69,8 @@ export function createGraph<RPCMap extends Record<string, RPCHandler>>() {
     for (const [nodeId, def] of Object.entries(nodes) as [string, any][]) {
       result[nodeId] = {
         func: funcMap[nodeId] as string,
+        forEach: def?.forEach,
+        mode: def?.mode,
         input: def?.input,
         next: def?.next,
         onError: def?.onError,
@@ -83,6 +89,13 @@ type GraphNodeConfigMap<
 > = {
   [K in Extract<keyof FuncMap, string>]?: {
     next?: NextConfig<Extract<keyof FuncMap, string>>
+    /**
+     * Run this node once per element of an upstream array. The node's own
+     * result becomes the ordered array of per-item results.
+     */
+    forEach?: ForEachConfig<Extract<keyof FuncMap, string>>
+    /** How the per-item instances run. Defaults to 'parallel'. */
+    mode?: ForEachMode
     input?: (
       ref: <
         N extends Extract<keyof FuncMap, string>,
@@ -90,7 +103,9 @@ type GraphNodeConfigMap<
       >(
         nodeId: N,
         path: P
-      ) => TypedRef<ComputeNodeOutputs<FuncMap, RPCMap>[N][P]>
+      ) => TypedRef<ComputeNodeOutputs<FuncMap, RPCMap>[N][P]>,
+      template: TemplateFn,
+      $item: ItemFn
     ) => InputWithRefs<ComputeNodeInputs<FuncMap, RPCMap>[K]>
     onError?: Extract<keyof FuncMap, string> | Extract<keyof FuncMap, string>[]
     retries?: number

--- a/packages/core/src/wirings/workflow/graph/graph-runner.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.ts
@@ -29,10 +29,28 @@ function buildTemplateRegex(nodeId: string): RegExp | null {
   return new RegExp(`^${escaped}$`)
 }
 
-function stripInstanceOrdinal(name: string): string {
-  const hash = name.lastIndexOf('#')
-  if (hash <= 0) return name
-  return /^\d+$/.test(name.slice(hash + 1)) ? name.slice(0, hash) : name
+const FANOUT_INSTANCE = /^(.+)\[(\d+)\]$/
+
+function fanoutInstanceKey(base: string, index: number): string {
+  return `${base}[${index}]`
+}
+
+function splitFanoutInstance(
+  name: string
+): { base: string; index: number } | null {
+  const match = FANOUT_INSTANCE.exec(name)
+  if (!match) return null
+  return { base: match[1]!, index: Number(match[2]!) }
+}
+
+export function stripInstanceOrdinal(name: string): string {
+  const fanout = splitFanoutInstance(name)
+  const withoutItem = fanout ? fanout.base : name
+  const hash = withoutItem.lastIndexOf('#')
+  if (hash <= 0) return withoutItem
+  return /^\d+$/.test(withoutItem.slice(hash + 1))
+    ? withoutItem.slice(0, hash)
+    : withoutItem
 }
 
 function remapStepNamesToNodeIds(
@@ -84,14 +102,22 @@ function closesCycle(
   return false
 }
 
+interface GraphFireInstruction {
+  logical: string
+  instanceKey: string
+  fromStepName?: string
+  itemIndex?: number
+}
+
 function planGraphTransitions(
   nodes: Record<string, any>,
   instances: Array<{ stepName: string; status: string; fromStepName?: string }>,
   branchByStep: Record<string, string>,
   entryNodeIds: string[],
-  graphName: string
+  graphName: string,
+  fanoutWidths: Record<string, number> = {}
 ): {
-  toFire: Array<{ logical: string; instanceKey: string; fromStepName?: string }>
+  toFire: GraphFireInstruction[]
   hasInFlight: boolean
   blockedWaiting: boolean
 } {
@@ -99,15 +125,37 @@ function planGraphTransitions(
     remapStepNamesToNodeIds([name], nodes, graphName)[0]!
 
   const countByLogical: Record<string, number> = {}
+  const instancesByLogical: Record<
+    string,
+    Array<{ stepName: string; status: string }>
+  > = {}
   const consumed = new Set<string>()
   for (const inst of instances) {
     const logical = toLogical(inst.stepName)
     countByLogical[logical] = (countByLogical[logical] ?? 0) + 1
+    ;(instancesByLogical[logical] ??= []).push(inst)
     consumed.add(`${inst.fromStepName ?? ENTRY_FROM}->${logical}`)
   }
 
+  const isFanned = (nodeId: string) => Boolean(nodes[nodeId]?.forEach)
+  const fanoutComplete = (nodeId: string) => {
+    const width = fanoutWidths[nodeId]
+    if (width === undefined) return false
+    const succeeded = (instancesByLogical[nodeId] ?? []).filter(
+      (i) => i.status === 'succeeded'
+    ).length
+    return succeeded >= width
+  }
+
   const completed = instances.filter((i) => i.status === 'succeeded')
-  const completedLogical = new Set(completed.map((i) => toLogical(i.stepName)))
+  const completedLogical = new Set<string>()
+  for (const inst of completed) {
+    const logical = toLogical(inst.stepName)
+    if (!isFanned(logical)) completedLogical.add(logical)
+  }
+  for (const nodeId of Object.keys(fanoutWidths)) {
+    if (isFanned(nodeId) && fanoutComplete(nodeId)) completedLogical.add(nodeId)
+  }
 
   const edges: Array<{
     from?: string
@@ -118,32 +166,88 @@ function planGraphTransitions(
   for (const entryId of entryNodeIds) {
     edges.push({ fromKey: ENTRY_FROM, target: entryId })
   }
+  const fannedEdgesEmitted = new Set<string>()
   for (const inst of completed) {
     const fromLogical = toLogical(inst.stepName)
     const node = nodes[fromLogical]
     if (!node?.next) continue
+    let from = inst.stepName
+    let branchKey = branchByStep[inst.stepName]
+    if (isFanned(fromLogical)) {
+      if (!completedLogical.has(fromLogical)) continue
+      if (fannedEdgesEmitted.has(fromLogical)) continue
+      fannedEdgesEmitted.add(fromLogical)
+      from = fromLogical
+      branchKey = branchByStep[fromLogical] ?? branchByStep[inst.stepName]
+    }
+    for (const target of resolveNextFromConfig(node.next, branchKey)) {
+      edges.push({ from, fromKey: from, fromLogical, target })
+    }
+  }
+  // A zero-width fanout produces no instances at all, so its outgoing edges
+  // have no completed instance to hang off — emit them from the logical node.
+  for (const [nodeId, width] of Object.entries(fanoutWidths)) {
+    if (width !== 0 || fannedEdgesEmitted.has(nodeId)) continue
+    const node = nodes[nodeId]
+    if (!node?.next) continue
+    fannedEdgesEmitted.add(nodeId)
     for (const target of resolveNextFromConfig(
       node.next,
-      branchByStep[inst.stepName]
+      branchByStep[nodeId]
     )) {
-      edges.push({
-        from: inst.stepName,
-        fromKey: inst.stepName,
-        fromLogical,
-        target,
-      })
+      edges.push({ from: nodeId, fromKey: nodeId, fromLogical: nodeId, target })
     }
   }
 
-  const toFire: Array<{
-    logical: string
-    instanceKey: string
-    fromStepName?: string
-  }> = []
+  const toFire: GraphFireInstruction[] = []
+  const plannedFanout = new Set<string>()
   let blockedWaiting = false
   for (const edge of edges) {
     const target = edge.target
     const edgeKey = `${edge.fromKey}->${target}`
+
+    if (isFanned(target)) {
+      if (plannedFanout.has(target)) continue
+      plannedFanout.add(target)
+      if (!areDependenciesSatisfied(nodes[target] ?? {}, completedLogical)) {
+        blockedWaiting = true
+        continue
+      }
+      const width = fanoutWidths[target]
+      if (width === undefined) {
+        blockedWaiting = true
+        continue
+      }
+      const existing = instancesByLogical[target] ?? []
+      const existingIndexes = new Set(
+        existing
+          .map((i) => splitFanoutInstance(i.stepName)?.index)
+          .filter((index): index is number => index !== undefined)
+      )
+      const pending: number[] = []
+      for (let index = 0; index < width; index++) {
+        if (!existingIndexes.has(index)) pending.push(index)
+      }
+      if (pending.length === 0) continue
+      const sequential = nodes[target]?.mode === 'sequential'
+      const anyInFlight = existing.some((i) => i.status !== 'succeeded')
+      const emit = sequential
+        ? anyInFlight
+          ? []
+          : pending.slice(0, 1)
+        : pending
+      for (const index of emit) {
+        toFire.push({
+          logical: target,
+          instanceKey: fanoutInstanceKey(target, index),
+          fromStepName: edge.from,
+          itemIndex: index,
+        })
+      }
+      if (emit.length === 0) blockedWaiting = true
+      continue
+    }
+
     if (consumed.has(edgeKey)) continue
     const visits = countByLogical[target] ?? 0
     const isBackEdge =
@@ -298,7 +402,7 @@ function resolveTemplate(
 
 function resolveValue(value: unknown, nodeResults: Record<string, any>): any {
   if (isDataRef(value)) {
-    if (value.$ref === '$item') {
+    if (value.$ref === '$item' && !('$item' in nodeResults)) {
       return value
     }
     const source = nodeResults[value.$ref]
@@ -364,6 +468,8 @@ function extractReferencedNodeIds(
 
 const IGNORED_REFS = new Set(['trigger', '$item', 'unknown'])
 
+const FOREACH_MODES = new Set(['parallel', 'sequential'])
+
 function normalizeNodeTargets(value: unknown): string[] {
   if (!value) return []
   if (typeof value === 'string') return [value]
@@ -407,6 +513,29 @@ function validateGraphReferences(
       }
     }
 
+    if (node.forEach !== undefined) {
+      const source = forEachSource(node)
+      if (!source) {
+        throw new Error(
+          `Workflow graph '${graphName}': node '${nodeId}' forEach must reference a node`
+        )
+      }
+      if (!IGNORED_REFS.has(source.$ref) && !nodeIds.has(source.$ref)) {
+        throw new Error(
+          `Workflow graph '${graphName}': node '${nodeId}' references unknown node '${source.$ref}' in forEach`
+        )
+      }
+      if (node.mode !== undefined && !FOREACH_MODES.has(node.mode)) {
+        throw new Error(
+          `Workflow graph '${graphName}': node '${nodeId}' has an unknown forEach mode '${node.mode}'`
+        )
+      }
+    } else if (node.mode !== undefined) {
+      throw new Error(
+        `Workflow graph '${graphName}': node '${nodeId}' sets mode '${node.mode}' without a forEach`
+      )
+    }
+
     const nextTargets = normalizeNodeTargets(node.next)
     for (const nextId of nextTargets) {
       if (!nodeIds.has(nextId)) {
@@ -427,14 +556,145 @@ function validateGraphReferences(
   }
 }
 
+function forEachSource(node: {
+  forEach?: unknown
+}): { $ref: string; path?: string } | undefined {
+  return isDataRef(node.forEach) ? node.forEach : undefined
+}
+
+function nodeDependencies(node: {
+  input?: Record<string, unknown>
+  forEach?: unknown
+}): string[] {
+  const deps = extractReferencedNodeIds(node.input)
+  const source = forEachSource(node)
+  if (source) deps.push(source.$ref)
+  return [...new Set(deps)].filter((id) => !IGNORED_REFS.has(id))
+}
+
+function describeValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (value === undefined) return 'undefined'
+  return typeof value
+}
+
+function resolveForEachItems(
+  graphName: string,
+  nodeId: string,
+  node: { forEach?: unknown },
+  nodeResults: Record<string, any>
+): unknown[] {
+  const source = forEachSource(node)
+  if (!source) {
+    throw new Error(
+      `Workflow graph '${graphName}': node '${nodeId}' has an unusable forEach configuration`
+    )
+  }
+  const raw = nodeResults[source.$ref]
+  const value = source.path ? getValueAtPath(raw, source.path) : raw
+  if (!Array.isArray(value)) {
+    const label = source.path ? `${source.$ref}.${source.path}` : source.$ref
+    throw new Error(
+      `Workflow graph '${graphName}': node '${nodeId}' forEach source '${label}' resolved to ${describeValue(
+        value
+      )}, expected an array`
+    )
+  }
+  return value
+}
+
 function areDependenciesSatisfied(
-  node: { input?: Record<string, unknown> },
+  node: { input?: Record<string, unknown>; forEach?: unknown },
   completedNodeIds: Set<string>
 ): boolean {
-  const deps = extractReferencedNodeIds(node.input).filter(
-    (id) => !IGNORED_REFS.has(id)
+  return nodeDependencies(node).every((dep) => completedNodeIds.has(dep))
+}
+
+interface GraphResultReader {
+  /** Per-item source arrays, keyed by fanned node id, for every ready fanout. */
+  fanoutItems: Record<string, unknown[]>
+  fanoutWidths: Record<string, number>
+  /** Reads node results, aggregating a fanned node into its ordered item array. */
+  read: (nodeIds: string[]) => Promise<Record<string, any>>
+}
+
+async function createGraphResultReader(
+  workflowService: PikkuWorkflowService,
+  runId: string,
+  graphName: string,
+  nodes: Record<string, any>,
+  triggerInput: any,
+  instances: Array<{ stepName: string; status: string }>
+): Promise<GraphResultReader> {
+  const succeeded = new Set(
+    instances.filter((i) => i.status === 'succeeded').map((i) => i.stepName)
   )
-  return deps.every((dep) => completedNodeIds.has(dep))
+  const fanoutItems: Record<string, unknown[]> = {}
+  const fanoutWidths: Record<string, number> = {}
+  const resultCache = new Map<string, any>()
+  const resolving = new Set<string>()
+
+  const readResult = async (nodeId: string): Promise<any> => {
+    if (nodeId === 'trigger') return triggerInput
+    if (resultCache.has(nodeId)) return resultCache.get(nodeId)
+    if (resolving.has(nodeId)) return undefined
+    resolving.add(nodeId)
+    try {
+      let value: any
+      if (nodes[nodeId]?.forEach) {
+        const items = await readFanoutItems(nodeId)
+        if (items === undefined) return undefined
+        const keys = items.map((_, index) => fanoutInstanceKey(nodeId, index))
+        if (keys.some((key) => !succeeded.has(key))) return undefined
+        const fetched = keys.length
+          ? await workflowService.getNodeResults(runId, keys)
+          : {}
+        value = keys.map((key) => fetched[key])
+      } else {
+        if (!succeeded.has(nodeId)) return undefined
+        const fetched = await workflowService.getNodeResults(runId, [nodeId])
+        value = fetched[nodeId]
+      }
+      resultCache.set(nodeId, value)
+      return value
+    } finally {
+      resolving.delete(nodeId)
+    }
+  }
+
+  const readFanoutItems = async (
+    nodeId: string
+  ): Promise<unknown[] | undefined> => {
+    if (fanoutItems[nodeId]) return fanoutItems[nodeId]
+    const node = nodes[nodeId]
+    const source = forEachSource(node)
+    if (!source) return undefined
+    const sourceValue = await readResult(source.$ref)
+    if (sourceValue === undefined) return undefined
+    const items = resolveForEachItems(graphName, nodeId, node, {
+      [source.$ref]: sourceValue,
+    })
+    fanoutItems[nodeId] = items
+    fanoutWidths[nodeId] = items.length
+    return items
+  }
+
+  for (const nodeId of Object.keys(nodes)) {
+    if (nodes[nodeId]?.forEach) await readFanoutItems(nodeId)
+  }
+
+  return {
+    fanoutItems,
+    fanoutWidths,
+    read: async (nodeIds: string[]) => {
+      const results: Record<string, any> = {}
+      for (const nodeId of nodeIds) {
+        const value = await readResult(nodeId)
+        if (value !== undefined) results[nodeId] = value
+      }
+      return results
+    },
+  }
 }
 
 async function queueGraphNode(
@@ -508,12 +768,22 @@ export async function continueGraph(
   }
 
   const instances = await workflowService.getStepInstances(runId)
+  const triggerInput = currentRun?.input
+  const reader = await createGraphResultReader(
+    workflowService,
+    runId,
+    graphName,
+    nodes,
+    triggerInput,
+    instances
+  )
   const plan = planGraphTransitions(
     nodes,
     instances,
     branchByStep,
     meta.entryNodeIds ?? [],
-    graphName
+    graphName,
+    reader.fanoutWidths
   )
 
   if (plan.toFire.length === 0) {
@@ -523,8 +793,6 @@ export async function continueGraph(
     return
   }
 
-  const triggerInput = currentRun?.input
-
   for (const fire of plan.toFire) {
     const node = nodes[fire.logical]
     if (!node?.rpcName) continue
@@ -532,11 +800,14 @@ export async function continueGraph(
     const referencedNodeIds = extractReferencedNodeIds(node.input).filter(
       (id) => !IGNORED_REFS.has(id)
     )
-    const fetchedResults = await workflowService.getNodeResults(
-      runId,
-      referencedNodeIds
-    )
-    const nodeResults = { trigger: triggerInput, ...fetchedResults }
+    const fetchedResults = await reader.read(referencedNodeIds)
+    const nodeResults: Record<string, any> = {
+      trigger: triggerInput,
+      ...fetchedResults,
+    }
+    if (fire.itemIndex !== undefined) {
+      nodeResults['$item'] = reader.fanoutItems[fire.logical]?.[fire.itemIndex]
+    }
     const resolvedInput = resolveSerializedInput(node.input, nodeResults)
 
     await queueGraphNode(
@@ -855,12 +1126,21 @@ async function continueGraphInline(
     }
 
     const instances = await workflowService.getStepInstances(runId)
+    const reader = await createGraphResultReader(
+      workflowService,
+      runId,
+      graphName,
+      nodes,
+      triggerInput,
+      instances
+    )
     const plan = planGraphTransitions(
       nodes,
       instances,
       branchByStep,
       entryNodeIds,
-      graphName
+      graphName,
+      reader.fanoutWidths
     )
 
     if (plan.toFire.length === 0) {
@@ -879,11 +1159,15 @@ async function continueGraphInline(
         const referencedNodeIds = extractReferencedNodeIds(node.input).filter(
           (id) => !IGNORED_REFS.has(id)
         )
-        const fetchedResults = await workflowService.getNodeResults(
-          runId,
-          referencedNodeIds
-        )
-        const nodeResults = { trigger: triggerInput, ...fetchedResults }
+        const fetchedResults = await reader.read(referencedNodeIds)
+        const nodeResults: Record<string, any> = {
+          trigger: triggerInput,
+          ...fetchedResults,
+        }
+        if (fire.itemIndex !== undefined) {
+          nodeResults['$item'] =
+            reader.fanoutItems[fire.logical]?.[fire.itemIndex]
+        }
         const resolvedInput = resolveSerializedInput(node.input, nodeResults)
 
         executed++
@@ -902,6 +1186,36 @@ async function continueGraphInline(
     )
     if (executed === 0) return
   }
+}
+
+function planEntryFirings(
+  graphName: string,
+  nodeId: string,
+  node: Record<string, any>,
+  triggerNodeResults: Record<string, any>,
+  triggerInput: any
+): Array<{ instanceKey: string; input: any }> {
+  if (!node.forEach) {
+    const input =
+      node.input && Object.keys(node.input).length > 0
+        ? resolveSerializedInput(node.input, triggerNodeResults)
+        : triggerInput
+    return [{ instanceKey: nodeId, input }]
+  }
+
+  const items = resolveForEachItems(graphName, nodeId, node, triggerNodeResults)
+  const width = node.mode === 'sequential' ? Math.min(items.length, 1) : items.length
+  const firings: Array<{ instanceKey: string; input: any }> = []
+  for (let index = 0; index < width; index++) {
+    firings.push({
+      instanceKey: fanoutInstanceKey(nodeId, index),
+      input: resolveSerializedInput(node.input, {
+        ...triggerNodeResults,
+        $item: items[index],
+      }),
+    })
+  }
+  return firings
 }
 
 export async function runWorkflowGraph(
@@ -977,20 +1291,27 @@ export async function runWorkflowGraph(
             const node = nodes[nodeId]
             if (!node?.rpcName) return
 
-            const resolvedInput =
-              node.input && Object.keys(node.input).length > 0
-                ? resolveSerializedInput(node.input, triggerNodeResults)
-                : triggerInput
-
-            await executeGraphNodeInline(
-              workflowService,
-              rpcService,
-              runId,
+            const firings = planEntryFirings(
               graphName,
               nodeId,
-              nodeId,
-              resolvedInput,
-              nodes
+              node,
+              triggerNodeResults,
+              triggerInput
+            )
+
+            await Promise.all(
+              firings.map((firing) =>
+                executeGraphNodeInline(
+                  workflowService,
+                  rpcService,
+                  runId,
+                  graphName,
+                  nodeId,
+                  firing.instanceKey,
+                  firing.input,
+                  nodes
+                )
+              )
             )
           })
         )
@@ -1026,20 +1347,25 @@ export async function runWorkflowGraph(
       const node = nodes[nodeId]
       if (!node?.rpcName) continue
 
-      const resolvedInput =
-        node.input && Object.keys(node.input).length > 0
-          ? resolveSerializedInput(node.input, triggerNodeResults)
-          : triggerInput
-
-      await queueGraphNode(
-        workflowService,
-        runId,
+      const firings = planEntryFirings(
         graphName,
         nodeId,
-        node.rpcName,
-        resolvedInput,
-        node
+        node,
+        triggerNodeResults,
+        triggerInput
       )
+
+      for (const firing of firings) {
+        await queueGraphNode(
+          workflowService,
+          runId,
+          graphName,
+          firing.instanceKey,
+          node.rpcName,
+          firing.input,
+          node
+        )
+      }
     }
     if (inline) {
       workflowService.unregisterInlineRun(runId)

--- a/packages/core/src/wirings/workflow/graph/workflow-graph.types.ts
+++ b/packages/core/src/wirings/workflow/graph/workflow-graph.types.ts
@@ -1,3 +1,5 @@
+import type { TemplateString } from './template.js'
+
 export interface RefValue {
   __isRef: true
   nodeId: string
@@ -24,9 +26,34 @@ export type RefFn<NodeIds extends string = string> = (
 export type NextConfig<NodeIds extends string = string> =
   NodeIds | NodeIds[] | Record<string, NodeIds | NodeIds[]>
 
+export type TemplateFn = (
+  templateStr: string,
+  refs: Array<{ $ref: string; path?: string }>
+) => TemplateString
+
+export type ItemFn = (path?: string) => RefValue
+
+export type ForEachConfig<NodeIds extends string = string> =
+  | NodeIds
+  | RefValue
+  | ((ref: RefFn<NodeIds>) => RefValue)
+
+export type ForEachMode = 'parallel' | 'sequential'
+
 export interface GraphNodeConfig<NodeIds extends string = string> {
   func: string
-  input?: (ref: RefFn<NodeIds>) => Record<string, unknown>
+  /**
+   * Run this node once per element of an upstream array. The node's own result
+   * becomes the ordered array of per-item results.
+   */
+  forEach?: ForEachConfig<NodeIds>
+  /** How the per-item instances of a `forEach` node run. Defaults to 'parallel'. */
+  mode?: ForEachMode
+  input?: (
+    ref: RefFn<NodeIds>,
+    template: TemplateFn,
+    $item: ItemFn
+  ) => Record<string, unknown>
   next?: NextConfig<NodeIds>
   onError?: NodeIds | NodeIds[]
   retries?: number

--- a/packages/core/src/wirings/workflow/index.ts
+++ b/packages/core/src/wirings/workflow/index.ts
@@ -94,4 +94,10 @@ export type {
   PikkuWorkflowWire,
 } from './workflow.types.js'
 export { createGraph } from './graph/graph-node.js'
-export type { GraphNodeConfig } from './graph/workflow-graph.types.js'
+export type {
+  GraphNodeConfig,
+  ForEachConfig,
+  ForEachMode,
+  ItemFn,
+  TemplateFn,
+} from './graph/workflow-graph.types.js'

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -36,6 +36,7 @@ import {
   executeGraphStep,
   runWorkflowGraph,
   runFromMeta,
+  stripInstanceOrdinal,
 } from './graph/graph-runner.js'
 import type { WorkflowService } from '../../services/workflow-service.js'
 import type { ScenarioPersonas } from '../../services/personas-service.js'
@@ -1349,9 +1350,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         if (stepName in workflowMeta.nodes) {
           graphNodeId = stepName
         } else {
-          const hash = stepName.lastIndexOf('#')
-          const base = hash > 0 ? stepName.slice(0, hash) : undefined
-          if (base && base in workflowMeta.nodes) graphNodeId = base
+          const base = stripInstanceOrdinal(stepName)
+          if (base !== stepName && base in workflowMeta.nodes)
+            graphNodeId = base
         }
       }
       if (graphNodeId) {

--- a/packages/inspector/src/add/add-workflow-graph-foreach.test.ts
+++ b/packages/inspector/src/add/add-workflow-graph-foreach.test.ts
@@ -1,0 +1,174 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { inspect } from '../inspector.js'
+import type { InspectorLogger } from '../types.js'
+
+function makeLogger(): InspectorLogger {
+  return {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    diagnostic: () => {},
+    critical: () => {},
+    hasCriticalErrors: () => false,
+  }
+}
+
+async function inspectGraph(graphSource: string[], graphName: string) {
+  const rootDir = await mkdtemp(join(tmpdir(), 'pikku-graph-foreach-'))
+  const stepFile = join(rootDir, 'my.steps.ts')
+  const graphFile = join(rootDir, 'my.graph.ts')
+
+  await writeFile(
+    stepFile,
+    [
+      "import { pikkuSessionlessFunc } from '@pikku/core'",
+      'export const listRows = pikkuSessionlessFunc({ func: async () => ({ rows: [] }) })',
+      'export const postVideo = pikkuSessionlessFunc({ func: async () => ({ ok: true }) })',
+    ].join('\n')
+  )
+  await writeFile(graphFile, graphSource.join('\n'))
+
+  try {
+    const state = await inspect(makeLogger(), [stepFile, graphFile], {
+      rootDir,
+    })
+    const graph = state.workflows.graphMeta[graphName]
+    assert.ok(graph, `graph meta '${graphName}' should be registered`)
+    return graph
+  } finally {
+    await rm(rootDir, { recursive: true, force: true })
+  }
+}
+
+describe('addWorkflowGraph — forEach extraction', () => {
+  test('forEach node id and $item() lower into the serialized meta', async () => {
+    const graph = await inspectGraph(
+      [
+        "import { pikkuWorkflowGraph } from '@pikku/core/workflow'",
+        'export const myGraph = pikkuWorkflowGraph({',
+        "  name: 'foreach-graph',",
+        "  nodes: { listRows: 'listRows', postVideo: 'postVideo' },",
+        '  config: {',
+        "    listRows: { next: 'postVideo' },",
+        '    postVideo: {',
+        "      forEach: 'listRows',",
+        '      input: (ref, template, $item) => ({',
+        "        url: $item('URL VIDEO'),",
+        '        whole: $item(),',
+        "        listed: ref('listRows'),",
+        '      }),',
+        '    },',
+        '  },',
+        '})',
+      ],
+      'foreach-graph'
+    )
+
+    const node = graph.nodes['postVideo'] as any
+    assert.deepEqual(node.forEach, { $ref: 'listRows' })
+    assert.equal(node.mode, undefined)
+    assert.deepEqual(node.input, {
+      url: { $ref: '$item', path: 'URL VIDEO' },
+      whole: { $ref: '$item', path: undefined },
+      listed: { $ref: 'listRows', path: undefined },
+    })
+  })
+
+  test('forEach accepts a (ref) callback with a path, plus a sequential mode', async () => {
+    const graph = await inspectGraph(
+      [
+        "import { pikkuWorkflowGraph } from '@pikku/core/workflow'",
+        'export const myGraph = pikkuWorkflowGraph({',
+        "  name: 'foreach-callback-graph',",
+        "  nodes: { listRows: 'listRows', postVideo: 'postVideo' },",
+        '  config: {',
+        "    listRows: { next: 'postVideo' },",
+        '    postVideo: {',
+        "      forEach: (ref) => ref('listRows', 'rows'),",
+        "      mode: 'sequential',",
+        "      input: (ref, template, $item) => ({ url: $item('URL') }),",
+        '    },',
+        '  },',
+        '})',
+      ],
+      'foreach-callback-graph'
+    )
+
+    const node = graph.nodes['postVideo'] as any
+    assert.deepEqual(node.forEach, { $ref: 'listRows', path: 'rows' })
+    assert.equal(node.mode, 'sequential')
+  })
+
+  test('an existing (ref) => ... node keeps its exact input and gains no forEach', async () => {
+    const graph = await inspectGraph(
+      [
+        "import { pikkuWorkflowGraph } from '@pikku/core/workflow'",
+        "import { template } from '@pikku/core/workflow'",
+        'export const myGraph = pikkuWorkflowGraph({',
+        "  name: 'plain-graph',",
+        "  nodes: { listRows: 'listRows', postVideo: 'postVideo' },",
+        '  config: {',
+        "    listRows: { next: 'postVideo' },",
+        '    postVideo: {',
+        '      input: (ref) => ({',
+        "        rows: ref('listRows', 'rows'),",
+        "        label: template('rows: $0', [ref('listRows', 'rows')]),",
+        '      }),',
+        '    },',
+        '  },',
+        '})',
+      ],
+      'plain-graph'
+    )
+
+    const node = graph.nodes['postVideo'] as any
+    assert.equal(node.forEach, undefined)
+    assert.equal(node.mode, undefined)
+    assert.deepEqual(node.input, {
+      rows: { $ref: 'listRows', path: 'rows' },
+      label: {
+        $template: {
+          parts: ['rows: ', ''],
+          expressions: [{ $ref: 'listRows', path: 'rows' }],
+        },
+      },
+    })
+  })
+
+  test('an existing (ref, template) => ... node still resolves template from the 2nd param', async () => {
+    const graph = await inspectGraph(
+      [
+        "import { pikkuWorkflowGraph } from '@pikku/core/workflow'",
+        'export const myGraph = pikkuWorkflowGraph({',
+        "  name: 'two-param-graph',",
+        "  nodes: { listRows: 'listRows', postVideo: 'postVideo' },",
+        '  config: {',
+        "    listRows: { next: 'postVideo' },",
+        '    postVideo: {',
+        '      input: (ref, template) => ({',
+        "        label: template('rows: $0', [ref('listRows', 'rows')]),",
+        '      }),',
+        '    },',
+        '  },',
+        '})',
+      ],
+      'two-param-graph'
+    )
+
+    const node = graph.nodes['postVideo'] as any
+    assert.equal(node.forEach, undefined)
+    assert.deepEqual(node.input, {
+      label: {
+        $template: {
+          parts: ['rows: ', ''],
+          expressions: [{ $ref: 'listRows', path: 'rows' }],
+        },
+      },
+    })
+  })
+})

--- a/packages/inspector/src/add/add-workflow-graph.ts
+++ b/packages/inspector/src/add/add-workflow-graph.ts
@@ -10,7 +10,8 @@ import type {
 function extractAstValue(
   expr: ts.Expression,
   refParamName: string,
-  templateParamName: string | undefined
+  templateParamName: string | undefined,
+  itemParamName?: string
 ): unknown {
   // `'GET' as const` / parenthesised values wrap the real initializer — see
   // through them or the whole property is silently dropped from the meta.
@@ -43,6 +44,12 @@ function extractAstValue(
           args[1] && ts.isStringLiteral(args[1]) ? args[1].text : undefined
         return { $ref: nodeId, path } as DataRef
       }
+      if (itemParamName && callee.text === itemParamName) {
+        const pathArg = expr.arguments[0]
+        const path =
+          pathArg && ts.isStringLiteral(pathArg) ? pathArg.text : undefined
+        return { $ref: '$item', path } as DataRef
+      }
       if (templateParamName && callee.text === templateParamName) {
         const templateStr =
           expr.arguments[0] && ts.isStringLiteral(expr.arguments[0])
@@ -55,7 +62,8 @@ function extractAstValue(
             const resolved = extractAstValue(
               el,
               refParamName,
-              templateParamName
+              templateParamName,
+              itemParamName
             )
             if (
               typeof resolved === 'object' &&
@@ -84,7 +92,7 @@ function extractAstValue(
   }
   if (ts.isArrayLiteralExpression(expr)) {
     return expr.elements.map((el) =>
-      extractAstValue(el, refParamName, templateParamName)
+      extractAstValue(el, refParamName, templateParamName, itemParamName)
     )
   }
   if (ts.isObjectLiteralExpression(expr)) {
@@ -100,7 +108,8 @@ function extractAstValue(
       obj[key] = extractAstValue(
         prop.initializer,
         refParamName,
-        templateParamName
+        templateParamName,
+        itemParamName
       )
     }
     return obj
@@ -160,6 +169,13 @@ function extractInputMapping(
       ? node.parameters[1].name.text
       : 'template'
 
+  // `$item` is appended after `template` so neither existing arrow shape —
+  // `(ref) => ...` nor `(ref, template) => ...` — shifts a parameter.
+  const itemParamName =
+    node.parameters.length > 2 && ts.isIdentifier(node.parameters[2].name)
+      ? node.parameters[2].name.text
+      : undefined
+
   const input: Record<string, unknown | DataRef> = {}
 
   for (const prop of bodyObj.properties) {
@@ -176,7 +192,8 @@ function extractInputMapping(
     const value = extractAstValue(
       prop.initializer,
       refParamName,
-      templateParamName
+      templateParamName,
+      itemParamName
     )
     if (value !== undefined) {
       input[key] = value
@@ -184,6 +201,49 @@ function extractInputMapping(
   }
 
   return input
+}
+
+/**
+ * Extract a `forEach` source, authored either as a bare node id (`'listRows'`)
+ * or as a callback returning a ref (`(ref) => ref('listRows', 'rows')`).
+ */
+function extractForEachConfig(node: ts.Node): DataRef | undefined {
+  while (ts.isAsExpression(node) || ts.isParenthesizedExpression(node)) {
+    node = node.expression
+  }
+
+  if (ts.isStringLiteral(node)) {
+    return { $ref: node.text }
+  }
+
+  if (ts.isArrowFunction(node)) {
+    const refParamName =
+      node.parameters.length > 0 && ts.isIdentifier(node.parameters[0].name)
+        ? node.parameters[0].name.text
+        : 'ref'
+
+    let body: ts.Node = node.body
+    if (ts.isBlock(body)) {
+      for (const stmt of body.statements) {
+        if (ts.isReturnStatement(stmt) && stmt.expression) {
+          body = stmt.expression
+        }
+      }
+    }
+    if (!ts.isExpression(body)) return undefined
+
+    const value = extractAstValue(body, refParamName, undefined)
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      '$ref' in value &&
+      typeof (value as DataRef).$ref === 'string'
+    ) {
+      return value as DataRef
+    }
+  }
+
+  return undefined
 }
 
 /**
@@ -380,6 +440,8 @@ function extractGraphFromNewFormat(
       nodeId,
       rpcName,
       input: {},
+      forEach: undefined,
+      mode: undefined,
       next: undefined,
       onError: undefined,
       retries: undefined,
@@ -410,6 +472,8 @@ function extractGraphFromNewFormat(
           nodes[nodeId].next = nodeConfig.next
           nodes[nodeId].onError = nodeConfig.onError
           nodes[nodeId].input = nodeConfig.input
+          nodes[nodeId].forEach = nodeConfig.forEach
+          nodes[nodeId].mode = nodeConfig.mode
           nodes[nodeId].retries = nodeConfig.retries
           nodes[nodeId].retryDelay = nodeConfig.retryDelay
           nodes[nodeId].notes = nodeConfig.notes
@@ -431,6 +495,8 @@ function extractNodeConfigFromObject(
   next: any
   onError: any
   input: Record<string, any>
+  forEach: DataRef | undefined
+  mode: string | undefined
   retries: number | undefined
   retryDelay: string | number | undefined
   notes: string | undefined
@@ -438,6 +504,8 @@ function extractNodeConfigFromObject(
   let next: any = undefined
   let onError: any = undefined
   let input: Record<string, any> = {}
+  let forEach: DataRef | undefined = undefined
+  let mode: string | undefined = undefined
   let retries: number | undefined = undefined
   let retryDelay: string | number | undefined = undefined
   let notes: string | undefined = undefined
@@ -453,6 +521,10 @@ function extractNodeConfigFromObject(
       onError = extractNextConfig(prop.initializer, checker)
     } else if (propName === 'input') {
       input = extractInputMapping(prop.initializer, checker)
+    } else if (propName === 'forEach') {
+      forEach = extractForEachConfig(prop.initializer)
+    } else if (propName === 'mode') {
+      mode = extractStringLiteral(prop.initializer, checker)
     } else if (propName === 'retries') {
       if (ts.isNumericLiteral(prop.initializer)) {
         retries = Number(prop.initializer.text)
@@ -468,7 +540,7 @@ function extractNodeConfigFromObject(
     }
   }
 
-  return { next, onError, input, retries, retryDelay, notes }
+  return { next, onError, input, forEach, mode, retries, retryDelay, notes }
 }
 
 /**

--- a/packages/inspector/src/utils/workflow/graph/serialize-workflow-graph.ts
+++ b/packages/inspector/src/utils/workflow/graph/serialize-workflow-graph.ts
@@ -1,4 +1,4 @@
-import { isRef } from '@pikku/core/workflow'
+import { isRef, template } from '@pikku/core/workflow'
 import type {
   SerializedWorkflowGraph,
   SerializedGraphNode,
@@ -34,6 +34,26 @@ function serializeInputMapping(
   }
 
   return result
+}
+
+/**
+ * Convert a `forEach` source — a bare node id, a ref, or a `(ref) => ref(...)`
+ * callback — to the serialized DataRef form
+ */
+function serializeForEach(
+  forEach: unknown,
+  createRef: (nodeId: string, path?: string) => { nodeId: string; path?: string }
+): DataRef | undefined {
+  if (forEach === undefined) return undefined
+  if (typeof forEach === 'string') return { $ref: forEach }
+  if (typeof forEach === 'function') {
+    return serializeForEach(
+      (forEach as (ref: unknown) => unknown)(createRef),
+      createRef
+    )
+  }
+  if (isRef(forEach)) return convertRef(forEach)
+  return undefined
 }
 
 /**
@@ -73,7 +93,9 @@ export function serializeWorkflowGraph(
       string,
       {
         func: { name?: string }
-        input?: (ref: any) => Record<string, unknown>
+        input?: (ref: any, template?: any, $item?: any) => Record<string, unknown>
+        forEach?: string | { nodeId: string; path?: string } | ((ref: any) => unknown)
+        mode?: 'parallel' | 'sequential'
         next?: string | string[] | Record<string, string | string[]>
         onError?: string | string[]
         notes?: string
@@ -95,6 +117,8 @@ export function serializeWorkflowGraph(
     nodeId,
     path,
   })
+
+  const createItemRef = (path?: string) => createRef('$item', path)
 
   // Track which nodes have incoming edges
   const hasIncomingEdge = new Set<string>()
@@ -124,7 +148,7 @@ export function serializeWorkflowGraph(
     // Evaluate input callback to get the mapping
     let input: Record<string, unknown | DataRef> = {}
     if (node.input) {
-      const rawInput = node.input(createRef)
+      const rawInput = node.input(createRef, template, createItemRef)
       input = serializeInputMapping(rawInput)
     }
 
@@ -137,6 +161,13 @@ export function serializeWorkflowGraph(
       input,
       next: serializeNext(node.next),
       onError: node.onError,
+    }
+    const forEach = serializeForEach(node.forEach, createRef)
+    if (forEach) {
+      funcNode.forEach = forEach
+      if (node.mode !== undefined) {
+        funcNode.mode = node.mode
+      }
     }
     if (node.notes !== undefined) {
       funcNode.notes = node.notes

--- a/packages/inspector/src/utils/workflow/graph/workflow-graph.types.ts
+++ b/packages/inspector/src/utils/workflow/graph/workflow-graph.types.ts
@@ -141,11 +141,21 @@ interface BaseNode {
 /**
  * Function node - calls an RPC
  */
+/** How the per-item instances of a `forEach` node run */
+export type ForEachMode = 'parallel' | 'sequential'
+
 export interface FunctionNode extends BaseNode {
   /** RPC function name */
   rpcName: string
   /** Input mapping - values can be literals or DataRefs */
   input?: Record<string, unknown | DataRef>
+  /**
+   * Run this node once per element of the referenced array. The node's own
+   * result becomes the ordered array of per-item results.
+   */
+  forEach?: DataRef
+  /** How the per-item instances run. Defaults to 'parallel'. */
+  mode?: ForEachMode
   /** Output variable name for storing result */
   outputVar?: string
   /** Hash of nodeId + RPC input/output schemas for version detection */

--- a/verifiers/workflows/package.json
+++ b/verifiers/workflows/package.json
@@ -32,7 +32,7 @@
     "pikku": "pikku",
     "serialize-dsl": "npx tsx src/tests/serialize-dsl.test.ts",
     "serialize-graph": "npx tsx src/tests/serialize-graph.test.ts",
-    "test": "pikku && npx tsx --test src/tests/complex-inline.assert.ts && npx tsx --test src/tests/dsl-validation.assert.ts && npx tsx --test src/tests/planned-steps.assert.ts && npx tsx --test src/tests/scenario.assert.ts && npx tsx src/tests/serialize-dsl.test.ts",
+    "test": "pikku && npx tsx --test src/tests/complex-inline.assert.ts && npx tsx --test src/tests/dsl-validation.assert.ts && npx tsx --test src/tests/graph-foreach.assert.ts && npx tsx --test src/tests/planned-steps.assert.ts && npx tsx --test src/tests/scenario.assert.ts && npx tsx src/tests/serialize-dsl.test.ts",
     "test:bullmq": "npx tsx src/runners/bullmq.runner.ts",
     "test:pgboss": "npx tsx src/runners/pgboss.runner.ts",
     "test:function-versioning": "npx tsx src/runners/function-versioning.runner.ts",

--- a/verifiers/workflows/src/functions/shipment.functions.ts
+++ b/verifiers/workflows/src/functions/shipment.functions.ts
@@ -1,0 +1,55 @@
+/**
+ * Shipment Functions
+ *
+ * Mock implementations shaped for graph fan-out: one function returns a
+ * collection, one runs per element, one folds the per-element results back up.
+ */
+
+import { pikkuSessionlessFunc } from '#pikku/function'
+
+export const shipmentList = pikkuSessionlessFunc<
+  { orderId: string },
+  { shipments: Array<{ shipmentId: string; weightKg: number }> }
+>({
+  title: 'List Shipments',
+  func: async ({ logger }, data) => {
+    logger.info(`Listing shipments for order: ${data.orderId}`)
+    return {
+      shipments: [
+        { shipmentId: `${data.orderId}-a`, weightKg: 1 },
+        { shipmentId: `${data.orderId}-b`, weightKg: 2 },
+        { shipmentId: `${data.orderId}-c`, weightKg: 3 },
+      ],
+    }
+  },
+})
+
+export const shipmentLabel = pikkuSessionlessFunc<
+  { shipmentId: string; weightKg: number },
+  { shipmentId: string; label: string; costCents: number }
+>({
+  title: 'Label Shipment',
+  func: async ({ logger }, data) => {
+    logger.info(`Labelling shipment: ${data.shipmentId}`)
+    return {
+      shipmentId: data.shipmentId,
+      label: `LBL-${data.shipmentId}`,
+      costCents: data.weightKg * 100,
+    }
+  },
+})
+
+export const shipmentManifest = pikkuSessionlessFunc<
+  { labels: Array<{ shipmentId: string; label: string; costCents: number }> },
+  { count: number; totalCents: number; labels: string[] }
+>({
+  title: 'Build Shipment Manifest',
+  func: async ({ logger }, data) => {
+    logger.info(`Building manifest for ${data.labels.length} shipments`)
+    return {
+      count: data.labels.length,
+      totalCents: data.labels.reduce((sum, l) => sum + l.costCents, 0),
+      labels: data.labels.map((l) => l.label),
+    }
+  },
+})

--- a/verifiers/workflows/src/tests/graph-foreach.assert.ts
+++ b/verifiers/workflows/src/tests/graph-foreach.assert.ts
@@ -1,0 +1,169 @@
+/**
+ * Verifies a declarative graph node that fans out over an upstream collection.
+ *
+ * Two layers at once: the inspector has to lower `forEach` + `$item` from real
+ * source into the generated meta, and the runner has to turn that meta into one
+ * step instance per element whose results fold back into a single array for the
+ * downstream node.
+ *
+ * Expects: pikku has been run first to generate .pikku/workflow/meta/ files
+ */
+
+import { readFile } from 'fs/promises'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import assert from 'node:assert/strict'
+import { test, describe } from 'node:test'
+
+import { InMemoryWorkflowService } from '@pikku/core/services'
+import { rpcService } from '@pikku/core/rpc'
+
+import '../../.pikku/pikku-bootstrap.gen.js'
+import { createConfig, createSingletonServices } from '../services.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const META_DIR = join(__dirname, '../../.pikku/workflow/meta')
+
+async function loadMeta(name: string) {
+  const files = [
+    join(META_DIR, `${name}-verbose.gen.json`),
+    join(META_DIR, `${name}.gen.json`),
+  ]
+  for (const f of files) {
+    try {
+      return JSON.parse(await readFile(f, 'utf-8'))
+    } catch (err: any) {
+      if (err?.code !== 'ENOENT') throw err
+    }
+  }
+  throw new Error(`Meta not found for workflow: ${name}`)
+}
+
+async function runGraph(name: string, input: unknown) {
+  const workflowService = new InMemoryWorkflowService()
+  const singletonServices = await createSingletonServices(
+    await createConfig(),
+    {
+      workflowService,
+    }
+  )
+  const rpc = rpcService.getContextRPCService(singletonServices as any, {})
+
+  const { runId } = await workflowService.startWorkflow(
+    name,
+    input,
+    { type: 'test' },
+    rpc,
+    { inline: true }
+  )
+
+  const deadline = Date.now() + 10_000
+  let run = await workflowService.getRun(runId)
+  while (run && run.status !== 'completed' && run.status !== 'failed') {
+    if (Date.now() > deadline) {
+      throw new Error(`graph ${name} timed out (status: ${run.status})`)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    run = await workflowService.getRun(runId)
+  }
+
+  const steps = await workflowService.getStepInstances(runId)
+  // A graph run carries no output of its own — the terminal node's result is
+  // read back off the run.
+  const resultOf = async (nodeId: string) =>
+    (await workflowService.getNodeResults(runId, [nodeId]))[nodeId]
+  return { run, steps, workflowService, runId, resultOf }
+}
+
+describe('graph forEach fan-out', () => {
+  test('meta: the fanned node carries its forEach source and $item input', async () => {
+    const meta = await loadMeta('graphShipmentFanout')
+    assert.equal(meta.source, 'graph')
+
+    const nodes: Record<string, any> = meta.nodes || {}
+    const label = nodes['label']
+    assert.ok(label, `no 'label' node, got: ${Object.keys(nodes).join(', ')}`)
+    assert.deepEqual(
+      label.forEach,
+      { $ref: 'list', path: 'shipments' },
+      'the (ref) callback should lower into a DataRef with its path'
+    )
+    assert.deepEqual(label.input, {
+      shipmentId: { $ref: '$item', path: 'shipmentId' },
+      weightKg: { $ref: '$item', path: 'weightKg' },
+    })
+    // Parallel is the default and is not written out.
+    assert.equal(label.mode, undefined)
+  })
+
+  test('meta: a sequential fan-out records its mode', async () => {
+    const meta = await loadMeta('graphShipmentFanoutSequential')
+    assert.equal(meta.nodes?.label?.mode, 'sequential')
+  })
+
+  test('runtime: one step instance per element, keyed node[i]', async () => {
+    const { run, steps } = await runGraph('graphShipmentFanout', {
+      orderId: 'order-1',
+    })
+
+    assert.equal(run?.status, 'completed', `run failed: ${run?.error?.message}`)
+    assert.deepEqual(
+      steps.map((s) => s.stepName).sort(),
+      ['label[0]', 'label[1]', 'label[2]', 'list', 'manifest'],
+      'each element should get its own instance, and the node itself none'
+    )
+  })
+
+  test('runtime: the downstream node folds the per-item results in order', async () => {
+    const { run, resultOf } = await runGraph('graphShipmentFanout', {
+      orderId: 'order-2',
+    })
+
+    assert.equal(run?.status, 'completed', `run failed: ${run?.error?.message}`)
+    assert.deepEqual(await resultOf('manifest'), {
+      count: 3,
+      totalCents: 600,
+      labels: ['LBL-order-2-a', 'LBL-order-2-b', 'LBL-order-2-c'],
+    })
+  })
+
+  test('runtime: each instance keeps its own item, and only its own', async () => {
+    const { resultOf } = await runGraph('graphShipmentFanout', {
+      orderId: 'order-4',
+    })
+
+    assert.deepEqual(
+      await Promise.all([
+        resultOf('label[0]'),
+        resultOf('label[1]'),
+        resultOf('label[2]'),
+      ]),
+      [
+        { shipmentId: 'order-4-a', label: 'LBL-order-4-a', costCents: 100 },
+        { shipmentId: 'order-4-b', label: 'LBL-order-4-b', costCents: 200 },
+        { shipmentId: 'order-4-c', label: 'LBL-order-4-c', costCents: 300 },
+      ]
+    )
+  })
+
+  test('runtime: a sequential fan-out reaches the same result', async () => {
+    const { run, steps, resultOf } = await runGraph(
+      'graphShipmentFanoutSequential',
+      { orderId: 'order-3' }
+    )
+
+    assert.equal(run?.status, 'completed', `run failed: ${run?.error?.message}`)
+    assert.deepEqual(steps.map((s) => s.stepName).sort(), [
+      'label[0]',
+      'label[1]',
+      'label[2]',
+      'list',
+      'manifest',
+    ])
+    assert.deepEqual(await resultOf('manifest'), {
+      count: 3,
+      totalCents: 600,
+      labels: ['LBL-order-3-a', 'LBL-order-3-b', 'LBL-order-3-c'],
+    })
+  })
+})

--- a/verifiers/workflows/src/workflows/shipment-fanout.graph.ts
+++ b/verifiers/workflows/src/workflows/shipment-fanout.graph.ts
@@ -1,0 +1,60 @@
+import { pikkuWorkflowGraph } from '#pikku/workflow/pikku-workflow-types.gen.js'
+
+// A graph node that fans out over an upstream array: `label` runs once per
+// shipment, binding each element through `$item`, and its own result is the
+// ordered array of per-item results that `manifest` folds back up.
+export const graphShipmentFanout = pikkuWorkflowGraph({
+  description: 'Graph fan-out: one label per shipment, then one manifest',
+  tags: ['fanout', 'graph'],
+  nodes: {
+    list: 'shipmentList',
+    label: 'shipmentLabel',
+    manifest: 'shipmentManifest',
+  },
+  config: {
+    list: {
+      input: (ref) => ({ orderId: ref('trigger', 'orderId') }),
+      next: 'label',
+    },
+    label: {
+      forEach: (ref) => ref('list', 'shipments'),
+      input: (ref, template, $item) => ({
+        shipmentId: $item('shipmentId'),
+        weightKg: $item('weightKg'),
+      }),
+      next: 'manifest',
+    },
+    manifest: {
+      input: (ref) => ({ labels: ref('label') }),
+    },
+  },
+})
+
+// The same fan-out, one item at a time.
+export const graphShipmentFanoutSequential = pikkuWorkflowGraph({
+  description: 'Graph fan-out: labels one shipment at a time',
+  tags: ['fanout', 'graph'],
+  nodes: {
+    list: 'shipmentList',
+    label: 'shipmentLabel',
+    manifest: 'shipmentManifest',
+  },
+  config: {
+    list: {
+      input: (ref) => ({ orderId: ref('trigger', 'orderId') }),
+      next: 'label',
+    },
+    label: {
+      forEach: (ref) => ref('list', 'shipments'),
+      mode: 'sequential',
+      input: (ref, template, $item) => ({
+        shipmentId: $item('shipmentId'),
+        weightKg: $item('weightKg'),
+      }),
+      next: 'manifest',
+    },
+    manifest: {
+      input: (ref) => ({ labels: ref('label') }),
+    },
+  },
+})


### PR DESCRIPTION
Closes #934

## Problem

A declarative workflow graph could not fan a node out over a collection. The only way to run one node per item was to drop out of the graph and into the DSL.

## Change

- `GraphNodeConfig` gains `forEach?: ForEachConfig` and `mode?: ForEachMode`.
- The node's input callback gains a third parameter, `$item`, **appended** after `ref` and `template`: `(ref, template, $item)`. Index 1 is already `template` (see `serialize-workflow-types.ts` and `deserialize-dsl-workflow.ts`, documented in `verifiers/types/type-tests/function/overload-shapes-are-private.ts`), so appending keeps every existing position intact — no existing graph changes meaning.
- Fan-out instances are keyed `node[i]`.
- The runner gains `createGraphResultReader`, `resolveForEachItems` and `planEntryFirings` to plan the firings and read the per-instance results back.

## Tests

New `graph-foreach.test.ts` (core), `graph-foreach.compile.test.ts` (CLI) and `add-workflow-graph-foreach.test.ts` (inspector). Core 2229, inspector 690, CLI 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-item `forEach` processing for workflow graph nodes.
  * Supports parallel and sequential execution modes.
  * Added `$item` references for accessing each array item in inputs.
  * Preserves result ordering and supports downstream fan-out chaining.
  * Added validation for invalid sources and execution modes.

* **Bug Fixes**
  * Improved handling of empty inputs, failed items, and repeated workflow execution.

* **Documentation**
  * Documented the new fan-out configuration and backward-compatible input options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->