### PR TITLE
feat(scenario): a persona names their app, and each actor browses it

### DIFF
--- a/.changeset/per-app-scenario-urls.md
+++ b/.changeset/per-app-scenario-urls.md
@@ -1,0 +1,8 @@
+---
+'@pikku/core': patch
+'@pikku/inspector': patch
+'@pikku/cli': patch
+'@pikku/playwright': patch
+---
+
+A persona can name the `app` they sign into, and a browser run takes a url per app (`--app-url <app>=<url>`, or `appUrls` on the environment). Each actor's browser context navigates against its own app's base, so a product that is more than one frontend can be proved in one run — including a scenario that crosses from one app to the other. A run whose personas name an app nobody gave a url for is refused rather than browsing the wrong app's pages.

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -662,7 +662,7 @@ wireCLI({
             },
             appUrl: {
               description:
-                "Override the environment's appUrl for this run (the frontend browser steps navigate against)",
+                "Override the environment's appUrl for this run (the frontend browser steps navigate against). One url for everybody, or `<app>=<url>` pairs for a product whose personas sign into different apps — comma-separated, and a bare url is the fallback",
             },
           },
         }),

--- a/packages/cli/src/functions/commands/environment.test.ts
+++ b/packages/cli/src/functions/commands/environment.test.ts
@@ -131,4 +131,49 @@ describe('resolveEnvironment', () => {
 
     assert.equal(env.appUrl, 'https://preview-a1b2.example.com')
   })
+
+  test('--app-url takes a url per app, so each actor browses their own', () => {
+    const env = resolveEnvironment({
+      environment: 'local',
+      environments,
+      appUrl:
+        'workshop=https://host.test/,storefront=https://host.test/_frontend/storefront/',
+    })
+
+    assert.deepEqual(env.appUrls, {
+      workshop: 'https://host.test/',
+      storefront: 'https://host.test/_frontend/storefront/',
+    })
+    assert.equal(
+      env.appUrl,
+      'http://localhost:5001',
+      'the configured fallback stands for a persona naming no app'
+    )
+  })
+
+  test('a bare url among the pairs is the fallback, not an app called nothing', () => {
+    const env = resolveEnvironment({
+      environment: 'local',
+      environments,
+      appUrl:
+        'https://host.test/,storefront=https://host.test/_frontend/storefront/',
+    })
+
+    assert.equal(env.appUrl, 'https://host.test/')
+    assert.deepEqual(env.appUrls, {
+      storefront: 'https://host.test/_frontend/storefront/',
+    })
+  })
+
+  test("an app's url is checked like any other, and names the app when it is wrong", () => {
+    assert.throws(
+      () =>
+        resolveEnvironment({
+          environment: 'local',
+          environments,
+          appUrl: 'storefront=/_frontend/storefront/',
+        }),
+      /--app-url storefront '\/_frontend\/storefront\/' is not a valid absolute URL/
+    )
+  })
 })

--- a/packages/cli/src/functions/commands/environment.ts
+++ b/packages/cli/src/functions/commands/environment.ts
@@ -14,6 +14,18 @@ export interface PikkuEnvironment {
   signInPath?: string
   rpcPath?: string
   appUrl?: string
+  /**
+   * Where each app is served, keyed by the `app` its personas declare.
+   *
+   * A product can be more than one frontend — staff in one, customers in
+   * another — and the two are usually different paths on one host. A browser
+   * step navigates as its actor, so the actor's app decides which of these it
+   * navigates against, and `appUrl` is the fallback for a persona that names
+   * no app. Without this a run has one base for everybody: whichever app owns
+   * it is proved twice and the other never, silently, because both sets of
+   * paths resolve against the wrong app and load.
+   */
+  appUrls?: Record<string, string>
   /** Real consequences: only an `accountable` persona may run against it. */
   production?: boolean
 }
@@ -96,9 +108,44 @@ export const resolveEnvironment = ({
   }
 
   if (appUrl !== undefined) {
-    assertAbsoluteUrl('--app-url', appUrl)
-    resolved.appUrl = appUrl
+    const { base, byApp } = parseAppUrls(appUrl)
+    if (base !== undefined) resolved.appUrl = base
+    if (Object.keys(byApp).length > 0) {
+      resolved.appUrls = { ...resolved.appUrls, ...byApp }
+    }
   }
 
   return resolved
+}
+
+/**
+ * `--app-url` as one url, or as `<app>=<url>` pairs, or both.
+ *
+ *   --app-url https://host/
+ *   --app-url workshop=https://host/,storefront=https://host/_frontend/storefront/
+ *   --app-url https://host/,storefront=https://host/_frontend/storefront/
+ *
+ * Comma-separated to match `--flows` and `--tags` rather than taking the flag
+ * repeatedly, which the option parser types as a single string. A bare url is
+ * the fallback for personas naming no app; a pair binds one app.
+ */
+export const parseAppUrls = (
+  value: string
+): { base?: string; byApp: Record<string, string> } => {
+  const byApp: Record<string, string> = {}
+  let base: string | undefined
+  for (const raw of value.split(',')) {
+    const segment = raw.trim()
+    if (!segment) continue
+    const pair = /^([a-z0-9][a-z0-9-]*)=(.+)$/i.exec(segment)
+    if (!pair) {
+      assertAbsoluteUrl('--app-url', segment)
+      base = segment
+      continue
+    }
+    const [, app, url] = pair as unknown as [string, string, string]
+    assertAbsoluteUrl(`--app-url ${app}`, url)
+    byApp[app] = url
+  }
+  return { base, byApp }
 }

--- a/packages/cli/src/functions/commands/scenario-browser.test.ts
+++ b/packages/cli/src/functions/commands/scenario-browser.test.ts
@@ -178,6 +178,56 @@ describe('resolveScenarioBrowserProvider', () => {
     assert.equal(seen.config.appUrl, 'https://sandbox-a1b2.example.com')
   })
 
+  test('the app urls reach the driver, so each actor browses their own', async () => {
+    const d = driver()
+    await resolveScenarioBrowserProvider({
+      ...options({
+        appUrls: {
+          workshop: 'http://localhost:4077/',
+          storefront: 'http://localhost:4077/_frontend/storefront/',
+        },
+        actors: {
+          mechanic: { email: 'mechanic@test', app: 'workshop' },
+          customer: { email: 'customer@test', app: 'storefront' },
+        },
+      }),
+      importDriver: d.importDriver,
+    } as any)
+
+    assert.deepEqual(d.built[0].config.appUrls, {
+      workshop: 'http://localhost:4077/',
+      storefront: 'http://localhost:4077/_frontend/storefront/',
+    })
+  })
+
+  test('an app nobody gave a url for is refused, not quietly browsed as another app', async () => {
+    await assert.rejects(
+      resolveScenarioBrowserProvider({
+        ...options({
+          appUrls: { workshop: 'http://localhost:4077/' },
+          actors: {
+            mechanic: { email: 'mechanic@test', app: 'workshop' },
+            customer: { email: 'customer@test', app: 'storefront' },
+          },
+        }),
+        importDriver: driver().importDriver,
+      } as any),
+      /No app url for 'storefront'[\s\S]*--app-url storefront=<url>/
+    )
+  })
+
+  test('with no app urls at all, one appUrl covers everybody as it always did', async () => {
+    const d = driver()
+    await resolveScenarioBrowserProvider({
+      ...options({
+        actors: { mechanic: { email: 'mechanic@test', app: 'workshop' } },
+      }),
+      importDriver: d.importDriver,
+    } as any)
+
+    assert.equal(d.built[0].config.appUrl, 'http://localhost:4077/console')
+  })
+
   test('a driver falling back to its own placeholder is reported as a missing appUrl', async () => {
     await assert.rejects(
       resolveScenarioBrowserProvider({

--- a/packages/cli/src/functions/commands/scenario-browser.ts
+++ b/packages/cli/src/functions/commands/scenario-browser.ts
@@ -51,6 +51,7 @@ export interface ScenarioBrowserDriver {
    */
   browserConfigFromEnv?: (overrides: {
     appUrl?: string
+    appUrls?: Record<string, string>
     apiUrl: string
   }) => unknown
 }
@@ -78,6 +79,8 @@ export interface ResolveScenarioBrowserProviderOptions {
   environment: string
   apiUrl: string
   appUrl?: string
+  /** Base url per app, for a product whose personas sign into more than one. */
+  appUrls?: Record<string, string>
   secret: string
   actors: Record<string, ResolvedPersona>
   signInPath?: string
@@ -102,6 +105,7 @@ export interface ResolveScenarioBrowserProviderOptions {
  */
 interface ResolvedBrowserConfig {
   appUrl?: string
+  appUrls?: Record<string, string>
   appUrlSource?: 'override' | 'env' | 'default'
 }
 
@@ -121,6 +125,7 @@ export const resolveScenarioBrowserProvider = async ({
   environment,
   apiUrl,
   appUrl,
+  appUrls,
   secret,
   actors,
   signInPath,
@@ -140,14 +145,30 @@ export const resolveScenarioBrowserProvider = async ({
         `${install}, or run with --no-browser to skip them.`
     )
   })
-  const config = (module.browserConfigFromEnv?.({ appUrl, apiUrl }) ?? {
-    appUrl,
-    apiUrl,
-  }) as ResolvedBrowserConfig
+  const overrides = { appUrl, apiUrl, ...(appUrls ? { appUrls } : {}) }
+  const config = (module.browserConfigFromEnv?.(overrides) ??
+    overrides) as ResolvedBrowserConfig
   if (!config.appUrl || config.appUrlSource === 'default') {
     throw new Error(
       `Scenario environment '${environment}' has browser steps but no 'appUrl', and '${driver}' resolved none from the environment. ` +
         `Add it to environments.${environment} in pikku.config.json, pass --app-url for a target that only exists at run time, or run with --no-browser to skip them.`
+    )
+  }
+
+  // An actor whose app has no url would browse the fallback: the wrong app's
+  // pages, loading fine, asserting nothing about the app the scenario meant.
+  // Cheaper to refuse now than to read a green run that proved one app twice.
+  const unmapped = [
+    ...new Set(
+      Object.values(actors)
+        .map((persona) => persona.app)
+        .filter((app): app is string => !!app && !config.appUrls?.[app])
+    ),
+  ]
+  if (unmapped.length > 0 && Object.keys(config.appUrls ?? {}).length > 0) {
+    throw new Error(
+      `No app url for ${unmapped.map((app) => `'${app}'`).join(', ')}, which ${unmapped.length > 1 ? 'personas sign' : 'a persona signs'} into. ` +
+        `Pass --app-url ${unmapped[0]}=<url> (repeatable, comma-separated) or add it to environments.${environment}.appUrls in pikku.config.json.`
     )
   }
   const options: ScenarioBrowserDriverOptions = {

--- a/packages/cli/src/functions/commands/scenario.ts
+++ b/packages/cli/src/functions/commands/scenario.ts
@@ -441,6 +441,7 @@ export const scenarioRun = pikkuSessionlessFunc<
               environment,
               apiUrl: env.apiUrl,
               appUrl: env.appUrl,
+              appUrls: env.appUrls,
               secret,
               actors: scenarioActors,
               signInPath: env.signInPath,

--- a/packages/core/src/wirings/persona/persona.types.ts
+++ b/packages/core/src/wirings/persona/persona.types.ts
@@ -107,6 +107,18 @@ export type CorePersona = {
    * into a flaky suite.
    */
   runnable?: boolean
+  /**
+   * The app this person signs into, when the product is more than one frontend.
+   *
+   * A person uses one of them — staff their app, customers theirs — and that is
+   * what decides where a browser step navigates: `/dashboard` is a different
+   * page in each, so the actor settles which one without the scenario saying.
+   * The runner takes the base url per app (`--app-url <app>=<url>`, or
+   * `appUrls` on the environment) and each actor browses against its own.
+   *
+   * Omitted is the normal case: one app, one url, nothing to say.
+   */
+  app?: string
 }
 
 /** Personas to declare, keyed by id. */
@@ -135,6 +147,8 @@ export type PersonaMeta = {
   /** Absent means "everywhere but production", which is resolved, not stored. */
   environments?: string[]
   runnable: boolean
+  /** The app this person signs into; picks their base url on a browser run. */
+  app?: string
   sourceFile?: string
 }
 

--- a/packages/inspector/src/add/add-personas.test.ts
+++ b/packages/inspector/src/add/add-personas.test.ts
@@ -108,6 +108,30 @@ describe('addPersonas inspector', () => {
     assert.equal(susan.runnable, true)
   })
 
+  test('the app a person signs into survives into the meta', async () => {
+    const { state, criticals } = await inspectSource(
+      withRoles(
+        'definePersonas({',
+        '  susan: {',
+        "    name: 'Susan',",
+        "    app: 'storefront',",
+        '  },',
+        '})'
+      )
+    )
+
+    assert.deepEqual(criticals, [])
+    assert.equal(state.personas.definitions[0]!.app, 'storefront')
+  })
+
+  test('a person who names no app has none, rather than a guessed one', async () => {
+    const { state } = await inspectSource(
+      withRoles('definePersonas({', "  susan: { name: 'Susan' },", '})')
+    )
+
+    assert.equal(state.personas.definitions[0]!.app, undefined)
+  })
+
   test('extracts a declared avatar', async () => {
     const { state } = await inspectSource(
       withRoles(

--- a/packages/inspector/src/add/add-personas.ts
+++ b/packages/inspector/src/add/add-personas.ts
@@ -265,6 +265,8 @@ export const addPersonas: AddWiring = (logger, node, _checker, state) => {
     if (avatarUrl !== undefined) persona.avatarUrl = avatarUrl
     const personality = stringProperty(config, 'personality')
     if (personality !== undefined) persona.personality = personality
+    const app = stringProperty(config, 'app')
+    if (app !== undefined) persona.app = app
     if (disposition !== undefined) {
       persona.disposition = disposition as PersonaMeta['disposition']
     }

--- a/packages/playwright/src/config.ts
+++ b/packages/playwright/src/config.ts
@@ -21,6 +21,12 @@ export interface BrowserConfig {
    * misconfiguration rather than silently testing localhost.
    */
   appUrlSource?: 'override' | 'env' | 'default'
+  /**
+   * Where each app is served, keyed by the `app` its personas declare. A
+   * session navigates against its own actor's app; `appUrl` covers a persona
+   * that names none.
+   */
+  appUrls?: Record<string, string>
   /** Base URL of the API (default: same origin under /api). */
   apiUrl: string
   /** Per-action Playwright timeout (ms). */
@@ -63,6 +69,7 @@ export function browserConfigFromEnv(
   return {
     appUrl,
     appUrlSource: overrides.appUrl ? 'override' : envAppUrl ? 'env' : 'default',
+    ...(overrides.appUrls ? { appUrls: overrides.appUrls } : {}),
     apiUrl:
       overrides.apiUrl ?? env.E2E_API_URL ?? env.API_URL ?? `${appUrl}/api`,
     timeout: overrides.timeout ?? Number(env.E2E_TIMEOUT ?? 30_000),

--- a/packages/playwright/src/provider.test.ts
+++ b/packages/playwright/src/provider.test.ts
@@ -156,6 +156,52 @@ describe('PlaywrightScenarioBrowserProvider', () => {
     assert.equal(contexts.length, 1)
   })
 
+  test('an actor browses the app their persona signs into', async () => {
+    const { browser } = fakeBrowser()
+    const provider = new PlaywrightScenarioBrowserProvider({
+      config: config({
+        appUrls: {
+          workshop: 'https://app.test',
+          storefront: 'https://app.test/_frontend/storefront',
+        },
+      }),
+      secret: 's',
+      actors: {
+        mechanic: { email: 'mechanic@test', app: 'workshop' },
+        customer: { email: 'customer@test', app: 'storefront' },
+      },
+      connectBrowser: async () => ({ browser }),
+      signIn: async () => {},
+    } as any)
+
+    const mechanic = await provider.sessionFor('mechanic')
+    const customer = await provider.sessionFor('customer')
+
+    assert.equal(mechanic.url('/jobs'), 'https://app.test/jobs')
+    assert.equal(
+      customer.url('/jobs'),
+      'https://app.test/_frontend/storefront/jobs',
+      'the same path is a different page in each app'
+    )
+  })
+
+  test('a persona naming no app browses the single appUrl', async () => {
+    const { browser } = fakeBrowser()
+    const provider = new PlaywrightScenarioBrowserProvider({
+      config: config({
+        appUrls: { storefront: 'https://app.test/_frontend/storefront' },
+      }),
+      secret: 's',
+      actors: { shopper: { email: 'shopper@test' } },
+      connectBrowser: async () => ({ browser }),
+      signIn: async () => {},
+    } as any)
+
+    const shopper = await provider.sessionFor('shopper')
+
+    assert.equal(shopper.url('/jobs'), 'https://app.test/jobs')
+  })
+
   test('an unregistered actor is a clear error, not a silent anonymous window', async () => {
     const { browser } = fakeBrowser()
     const provider = new PlaywrightScenarioBrowserProvider({

--- a/packages/playwright/src/provider.ts
+++ b/packages/playwright/src/provider.ts
@@ -336,7 +336,8 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
     actorConfig: ResolvedPersona
   ): Promise<ActorSession> {
     const { browser } = await this.browser()
-    const session = new ActorSession(actorName, this.config)
+    const config = this.configFor(actorConfig)
+    const session = new ActorSession(actorName, config)
     const capture = this.options.capture
     await session.open(
       browser,
@@ -356,12 +357,29 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
         secret: this.options.secret,
       },
       {
-        apiUrl: this.config.apiUrl,
-        appUrl: this.config.appUrl,
+        apiUrl: config.apiUrl,
+        appUrl: config.appUrl,
         signInPath: this.options.signInPath ?? '/auth/sign-in/actor',
       }
     )
     return session
+  }
+
+  /**
+   * The config this actor browses with — their own app's base url.
+   *
+   * A person signs into one app, so the persona's `app` is the whole answer: it
+   * decides what `/dashboard` means for them, and which origin their session
+   * cookie is planted on. Everything downstream (`url()`, `gotoApp`, the
+   * sign-in Origin header, `parseCookie`) reads it off the session's config, so
+   * choosing it here is the only place that has to know.
+   *
+   * An unnamed app, or one no url was given for, falls back to the single
+   * `appUrl` — which is the whole story for the common one-app project.
+   */
+  private configFor(persona: ResolvedPersona): BrowserConfig {
+    const appUrl = persona.app ? this.config.appUrls?.[persona.app] : undefined
+    return appUrl ? { ...this.config, appUrl } : this.config
   }
 
   private browser(): Promise<BrowserConnection> {


### PR DESCRIPTION
## The problem

A product can be more than one frontend — staff in one app, customers in another — but a browser run had a single `appUrl` for everybody. Whichever app owned that url got proved twice and the other never, **silently**: both sets of paths resolve against the wrong app and load fine, so the run goes green having tested half the product.

## The change

A persona declares the `app` they sign into:

```ts
definePersonas({
  teacher: { name: 'Tara', app: 'workshop' },
  shopper: { name: 'Sam', app: 'storefront' },
})
```

and a run takes a url per app:

```
pikku scenario run staging \
  --app-url workshop=https://host/,storefront=https://host/_frontend/storefront/
```

(or `appUrls` on the environment in `pikku.config.json`; a bare `--app-url <url>` still works and is the fallback for personas naming no app.)

The playwright provider already opens one `BrowserContext` per actor, so this is a config-shape change rather than an architecture one — `configFor(persona)` picks the actor's base, and everything downstream (`url()`, `gotoApp`, the sign-in `Origin` header, the cookie's origin) reads it off the session config. That also makes a scenario that **crosses** apps — teacher sets the practice, student completes it — expressible in a single run.

A run whose personas name an app nobody gave a url for is refused before the first scenario starts, rather than browsing the wrong app's pages green.

## Surface

- `@pikku/core` — `app?: string` on `CorePersona` and `PersonaMeta`
- `@pikku/inspector` — reads `app` off `definePersonas()` into the meta
- `@pikku/cli` — `parseAppUrls` (`<app>=<url>` pairs, comma-separated), `appUrls` on `PikkuEnvironment`, passed through to the driver; the unmapped-app refusal
- `@pikku/playwright` — `appUrls` on `BrowserConfig`, `configFor()` in the provider

## Tests

New: `playwright/src/provider.test.ts` (actor browses its own app; no-app persona uses `appUrl`), `cli/.../environment.test.ts` (pairs, bare-url fallback, per-app url validation), `cli/.../scenario-browser.test.ts` (urls reach the driver, unmapped app refused, no-`appUrls` unchanged), `inspector/.../add-personas.test.ts` (`app` survives into meta, absent when unnamed).

Suites: playwright 17/17, environment 14/14, scenario-browser 19/19, inspector 21/21. `tsc --noEmit` clean on core, inspector and playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)