### PR TITLE
build(repo): stop api-report.md conflicting on every rebase

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,14 @@
 /.yarn/releases/*    binary
 /.yarn/plugins/**/*  binary
 /.pnp.*              binary linguist-generated
+
+# `api-report.md` is generated from packages/core's public surface, so any two
+# branches that touch that surface rewrite the same ~9000 lines and collide on
+# every rebase. Resolving that by hand is busywork with no right answer in it:
+# neither side is correct, only a regeneration from the merged sources is.
+#
+# The driver scripts/setup-merge-drivers.mjs registers keeps one side verbatim
+# so the merge completes, and `api-report.test.ts` is what then fails until the
+# report is regenerated. Without the driver registered, git falls back to an
+# ordinary conflict, which is annoying rather than wrong.
+packages/core/api-report.md  merge=api-report linguist-generated

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "scripts": {
-    "postinstall": "husky",
+    "postinstall": "husky && node scripts/setup-merge-drivers.mjs",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
     "pre-commit": "yarn test && yarn prettier && yarn lint && yarn typedoc",

--- a/packages/core/src/api-report.test.ts
+++ b/packages/core/src/api-report.test.ts
@@ -67,3 +67,68 @@ describe('the API report matches the code', () => {
     )
   })
 })
+
+/**
+ * Every branch that touches the public surface rewrites the whole report, so
+ * two of them meeting is a ~9000-line conflict with no meaningful resolution
+ * in it. A merge driver takes the conflict away; the test above is what still
+ * insists on a report that matches the code.
+ *
+ * knowledge: decisions/internals/the-api-report-pins-members-not-just-names.md
+ */
+describe('merging the API report is not hand work', () => {
+  const repoRoot = join(packageRoot, '..', '..')
+
+  test('.gitattributes routes the report through the driver', () => {
+    const attributes = readFileSync(join(repoRoot, '.gitattributes'), 'utf-8')
+
+    assert.match(
+      attributes,
+      /^packages\/core\/api-report\.md\s+merge=api-report\b/m,
+      'the report must name the merge driver, or git conflicts on it as usual'
+    )
+  })
+
+  test('the setup script registers the driver .gitattributes names', () => {
+    execFileSync(
+      'node',
+      [join(repoRoot, 'scripts', 'setup-merge-drivers.mjs')],
+      { cwd: repoRoot, stdio: 'pipe' }
+    )
+    const driver = execFileSync('git', ['config', 'merge.api-report.driver'], {
+      cwd: repoRoot,
+      stdio: 'pipe',
+    })
+      .toString()
+      .trim()
+
+    assert.notEqual(driver, '', 'a driver git has never heard of is inert')
+  })
+
+  test('the driver does not regenerate the report mid-merge', () => {
+    // The tempting driver regenerates from the merged sources. Git runs it
+    // while the rest of the tree is still unmerged, so it reads the old
+    // sources and resolves to a report missing exactly the API the incoming
+    // branch adds — conflict-free and wrong, which is worse than a conflict.
+    const setup = readFileSync(
+      join(repoRoot, 'scripts', 'setup-merge-drivers.mjs'),
+      'utf-8'
+    )
+    const driver = /driver: '([^']*)'/.exec(setup)?.[1] ?? ''
+
+    assert.doesNotMatch(
+      driver,
+      /api-report/,
+      'the driver must not run the generator — the guard above regenerates ' +
+        'once the merge is finished and the sources are actually complete'
+    )
+  })
+
+  test('postinstall runs the setup, so a fresh clone is not left without it', () => {
+    const manifest = JSON.parse(
+      readFileSync(join(repoRoot, 'package.json'), 'utf-8')
+    )
+
+    assert.match(manifest.scripts.postinstall, /setup-merge-drivers\.mjs/)
+  })
+})

--- a/packages/core/src/api-report.test.ts
+++ b/packages/core/src/api-report.test.ts
@@ -1,7 +1,8 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { join, dirname } from 'node:path'
 
@@ -89,39 +90,42 @@ describe('merging the API report is not hand work', () => {
     )
   })
 
-  test('the setup script registers the driver .gitattributes names', () => {
-    execFileSync(
-      'node',
-      [join(repoRoot, 'scripts', 'setup-merge-drivers.mjs')],
-      { cwd: repoRoot, stdio: 'pipe' }
-    )
-    const driver = execFileSync('git', ['config', 'merge.api-report.driver'], {
-      cwd: repoRoot,
-      stdio: 'pipe',
-    })
-      .toString()
-      .trim()
+  test('the setup script registers the driver as a plain take-one-side', () => {
+    // Against a throwaway repository rather than this one: a driver is written
+    // to `.git/config`, which every worktree of a checkout shares, so running
+    // this in place would reach into whatever else is checked out beside it.
+    const sandbox = mkdtempSync(join(tmpdir(), 'pikku-merge-driver-'))
+    try {
+      execFileSync('git', ['init', '--quiet', sandbox], { stdio: 'pipe' })
+      execFileSync(
+        'node',
+        [join(repoRoot, 'scripts', 'setup-merge-drivers.mjs')],
+        { cwd: sandbox, stdio: 'pipe' }
+      )
+      const driver = execFileSync(
+        'git',
+        ['config', '--local', 'merge.api-report.driver'],
+        { cwd: sandbox, stdio: 'pipe' }
+      )
+        .toString()
+        .trim()
 
-    assert.notEqual(driver, '', 'a driver git has never heard of is inert')
-  })
-
-  test('the driver does not regenerate the report mid-merge', () => {
-    // The tempting driver regenerates from the merged sources. Git runs it
-    // while the rest of the tree is still unmerged, so it reads the old
-    // sources and resolves to a report missing exactly the API the incoming
-    // branch adds — conflict-free and wrong, which is worse than a conflict.
-    const setup = readFileSync(
-      join(repoRoot, 'scripts', 'setup-merge-drivers.mjs'),
-      'utf-8'
-    )
-    const driver = /driver: '([^']*)'/.exec(setup)?.[1] ?? ''
-
-    assert.doesNotMatch(
-      driver,
-      /api-report/,
-      'the driver must not run the generator — the guard above regenerates ' +
-        'once the merge is finished and the sources are actually complete'
-    )
+      // `true` writes nothing and succeeds, which is how a driver tells git to
+      // keep the side already in %A. Anything that regenerates the report is
+      // the trap this pins shut: git runs a driver while merging that one
+      // path, with the rest of the tree still unmerged, so the generator reads
+      // the old sources and resolves to a report missing exactly the API the
+      // incoming branch adds — conflict-free and wrong, which is worse than a
+      // conflict. The regeneration belongs to the guard above, which runs
+      // against a finished tree.
+      assert.equal(
+        driver,
+        'true',
+        'the driver must resolve to one side verbatim and run nothing'
+      )
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true })
+    }
   })
 
   test('postinstall runs the setup, so a fresh clone is not left without it', () => {

--- a/scripts/setup-merge-drivers.mjs
+++ b/scripts/setup-merge-drivers.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Registers the merge drivers `.gitattributes` names.
+ *
+ * A driver lives in git config, which is per-clone and never travels with the
+ * repository, so `.gitattributes` alone leaves `merge=api-report` pointing at
+ * nothing and git silently falls back to an ordinary conflict. Running this
+ * from `postinstall` is what makes a fresh clone behave like every other one.
+ *
+ * The only driver so far is the API report, which is generated from
+ * packages/core's public surface: two branches that both touch that surface
+ * rewrite the same ~9000 lines and collide on every rebase.
+ *
+ * The obvious driver — regenerate the report from the merged sources — does not
+ * work, and quietly produces a wrong answer rather than failing. Git invokes a
+ * driver while merging that one path, with the rest of the tree still
+ * unmerged, so the generator reads the old sources and writes a report missing
+ * exactly the API the incoming branch adds. A conflict-free wrong report is
+ * worse than a conflict.
+ *
+ * So the driver keeps one side verbatim and lets the merge complete, and
+ * `packages/core/src/api-report.test.ts` is what holds the line: it regenerates
+ * against the finished tree and fails until `yarn api-report` has been run.
+ * The conflict goes away; the guard does not.
+ */
+import { execFileSync } from 'node:child_process'
+
+const DRIVERS = [
+  {
+    name: 'api-report',
+    description: 'keep one side of packages/core/api-report.md and regenerate',
+    // Git hands the driver %A already holding the current side and reads the
+    // resolution back out of it, so succeeding without writing is how a driver
+    // says "take this one".
+    driver: 'true',
+  },
+]
+
+const git = (...args) =>
+  execFileSync('git', args, { stdio: 'pipe' }).toString().trim()
+
+const isGitRepository = () => {
+  try {
+    return git('rev-parse', '--is-inside-work-tree') === 'true'
+  } catch {
+    return false
+  }
+}
+
+// A published tarball has no .git, and `npm install`ing this package still runs
+// postinstall. Nothing to register, and nothing worth failing over.
+if (!isGitRepository()) {
+  process.exit(0)
+}
+
+for (const { name, description, driver } of DRIVERS) {
+  git('config', `merge.${name}.name`, description)
+  git('config', `merge.${name}.driver`, driver)
+}


### PR DESCRIPTION
Closes #1333.

`packages/core/api-report.md` is generated from the whole public surface, so any two branches that touch that surface rewrite the same ~9000 lines and collide. #1327 is currently blocked on exactly this, and it is its *only* conflict.

## What this does

A `.gitattributes` merge driver keeps one side of the report verbatim so the merge completes without a conflict. `api-report.test.ts` — which regenerates and diffs — is what then fails until `yarn api-report` has been run.

The conflict goes away; the guard does not.

## What it deliberately does not do

The obvious driver regenerates the report from the merged sources. It does not work, and it fails *silently*:

```
git merge --no-commit --no-ff origin/feat/934-graph-foreach-fanout
  api-report.md written for 52 entry points          ← driver ran here
  Auto-merging .../serialize-workflow-types.ts       ← sources merged after
```

Git invokes a driver while merging that one path, with the rest of the tree still unmerged, so the generator read the old sources and resolved to a report missing `ForEachConfig`, `ForEachMode` and `forEach` — exactly the API the incoming branch adds. Zero conflict markers, wrong content. That is worse than a conflict, and a test now pins the driver against ever doing it.

## Registration

Merge drivers live in per-clone git config and never travel with the repository, so `.gitattributes` alone names a driver git has never heard of and falls back to an ordinary conflict. `scripts/setup-merge-drivers.mjs` registers it from `postinstall`.

## Verification

Re-ran the merge that was blocking, with the driver registered:

- `packages/core/api-report.md` auto-merged, 0 conflict markers
- the guard then failed with `2691 observable things` vs `2697` and `Run \`yarn api-report\``
- after `yarn api-report`, 6/6 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved handling of generated API reports during Git merges.
  * Automatically configures the required merge behavior after installation.
  * Installations outside Git repositories continue successfully.

* **Tests**
  * Added coverage verifying API report merge configuration and installation setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->