### PR TITLE
fix(inspector): raise an addon's deploy conflict only where the app uses it

### DIFF
--- a/.changeset/addon-deploy-conflict-scope.md
+++ b/.changeset/addon-deploy-conflict-scope.md
@@ -1,0 +1,8 @@
+---
+'@pikku/inspector': patch
+---
+
+Raise an addon's deploy conflict only where the consuming app wires it. A
+function an addon publishes as `deploy: 'serverless'` while naming one of its
+own services serverless-incompatible previously failed the build of any app
+that merely declared the addon, whether or not that function was used.

--- a/packages/inspector/src/utils/filter-inspector-state.test.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.test.ts
@@ -1614,6 +1614,54 @@ describe('addonServerlessIncompatible scoping', () => {
   })
 })
 
+describe("an addon's own deploy conflict is the consumer's only when used", () => {
+  // An addon publishes metadata for everything it exports. A function it marks
+  // `deploy: 'serverless'` while also naming one of its services
+  // serverless-incompatible is the addon author's contradiction — but the
+  // deploy scan walks every published function, so without care it fails the
+  // build of a consumer that never wires that function.
+  const withConflictingAddonFunction = (route?: string) => {
+    const state = createMockInspectorState()
+    ;(state as any).addonFunctions = {
+      ffmpeg: {
+        transcode: {
+          deploy: 'serverless',
+          services: { services: ['FfmpegService'] },
+        },
+      },
+    }
+    state.addonServerlessIncompatible = new Map([['ffmpeg', ['FfmpegService']]])
+    if (route) {
+      ;(state.http.meta.get as any)[route] = {
+        pikkuFuncId: 'ffmpeg:transcode',
+        route,
+        method: 'GET',
+        tags: [],
+        middleware: [],
+        permissions: [],
+      }
+    }
+    return state
+  }
+
+  test('a conflicting addon function nothing wires does not fail the build', () => {
+    const state = withConflictingAddonFunction()
+
+    assert.doesNotThrow(() =>
+      filterInspectorState(state, { target: ['serverless'] }, mockLogger)
+    )
+  })
+
+  test('wiring that same function reports the conflict', () => {
+    const state = withConflictingAddonFunction('/transcode')
+
+    assert.throws(
+      () => filterInspectorState(state, { target: ['serverless'] }, mockLogger),
+      /FfmpegService/
+    )
+  })
+})
+
 describe('addonServerlessIncompatible serialization roundtrip', () => {
   // Uses getInitialInspectorState to guarantee all Map fields are initialized —
   // the lightweight mock in createMockInspectorState() omits fields like

--- a/packages/inspector/src/utils/filter-inspector-state.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.ts
@@ -7,7 +7,19 @@ import type { PikkuWiringTypes } from '@pikku/core/types'
 import { parseVersionedId } from '@pikku/core/utils'
 import { makeContextBasedId } from './extract-function-name.js'
 import { aggregateRequiredServices } from './post-process.js'
-import { resolveDeployTarget } from './resolve-deploy-target.js'
+import {
+  IncompatibleDeployTargetError,
+  resolveDeployTarget,
+} from './resolve-deploy-target.js'
+
+/**
+ * The deploy filter, asked about one function at a time rather than handed over
+ * as a set, so that a function's own deploy conflict is raised only if this app
+ * turns out to wire it.
+ */
+type DeployFilter = {
+  has(pikkuFuncId: string): boolean
+}
 
 // Module-level Set to track warned groups across multiple filter calls
 const globalWarnedGroups = new Set<string>()
@@ -113,9 +125,10 @@ function matchesFilters(
   },
   logger: InspectorLogger,
   warnedGroups?: Set<string>,
-  // Set of pikkuFuncIds to keep based on the deploy filter; null when
-  // the deploy filter is inactive.
-  keptByDeploy?: Set<string> | null
+  // Kept pikkuFuncIds under the deploy filter; null when the filter is
+  // inactive. Asked about one id at a time, which is what lets a conflict in an
+  // addon's own metadata surface only for a function this app actually wires.
+  keptByDeploy?: DeployFilter | null
 ): boolean {
   // If no filters, allow everything
   if (Object.keys(filters).length === 0) return true
@@ -343,7 +356,7 @@ export function filterInspectorState(
   // Precompute kept-function set for the deploy filter (if active).
   // resolveDeployTarget throws IncompatibleDeployTargetError when an
   // explicit deploy: 'serverless' clashes with serverlessIncompatible.
-  let keptByDeploy: Set<string> | null = null
+  let keptByDeploy: DeployFilter | null = null
   if (
     (filters.target && filters.target.length > 0) ||
     (filters.excludeTarget && filters.excludeTarget.length > 0)
@@ -354,7 +367,19 @@ export function filterInspectorState(
       : null
     const incompatible = new Set(filters.serverlessIncompatible ?? [])
     const defaultTarget = filters.defaultTarget ?? 'serverless'
-    keptByDeploy = new Set<string>()
+    const kept = new Set<string>()
+    // An addon publishes metadata for everything it exports, so a conflict in a
+    // function this app never wires is not this app's build error. Holding it
+    // here and raising it from `has` reports it at the one place the app is
+    // known to depend on that function.
+    const conflicts = new Map<string, IncompatibleDeployTargetError>()
+    keptByDeploy = {
+      has: (funcId: string) => {
+        const conflict = conflicts.get(funcId)
+        if (conflict) throw conflict
+        return kept.has(funcId)
+      },
+    }
     const keepByTarget = (
       funcId: string,
       funcMeta: unknown,
@@ -368,7 +393,7 @@ export function filterInspectorState(
       )
       if (allowed && !allowed.has(target)) return
       if (excluded && excluded.has(target)) return
-      keptByDeploy!.add(funcId)
+      kept.add(funcId)
     }
     for (const [funcId, funcMeta] of Object.entries(state.functions.meta)) {
       keepByTarget(funcId, funcMeta, incompatible)
@@ -384,7 +409,13 @@ export function filterInspectorState(
         state.addonServerlessIncompatible?.get(namespace) ?? []
       )
       for (const [funcName, funcMeta] of Object.entries(addonMeta)) {
-        keepByTarget(`${namespace}:${funcName}`, funcMeta, addonIncompatible)
+        const funcId = `${namespace}:${funcName}`
+        try {
+          keepByTarget(funcId, funcMeta, addonIncompatible)
+        } catch (e) {
+          if (!(e instanceof IncompatibleDeployTargetError)) throw e
+          conflicts.set(funcId, e)
+        }
       }
     }
   }


### PR DESCRIPTION
Follow-up to #1326, addressing the open CodeRabbit finding on that PR after it merged.

## The problem

The deploy scan added in #1326 walks **every** function an addon publishes. `resolveDeployTarget` throws `IncompatibleDeployTargetError` when a function declares `deploy: 'serverless'` alongside a service the same addon marked serverless-incompatible.

That contradiction belongs to the addon author — but as written it failed the build of any consumer that merely *declared* the addon, including one that never wires the offending function. An addon could break a consumer over metadata the consumer never touches.

## The fix

`keptByDeploy` was a `Set<string>` handed to every wiring check. It is now a small `DeployFilter` asked about one id at a time, which is the point at which a function is known to be referenced. A conflict found while scanning an addon is held in a map and raised from `has` — so it surfaces exactly where a wiring depends on that function, and nowhere else.

The call sites pass the same variable unchanged; only the type and the two use sites move.

## Tests

Two cases in `filter-inspector-state.test.ts`: a conflicting addon function nothing wires does not fail the build, and wiring that same function still reports the conflict. Verified red before the change and green after; inspector suite 706/706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)