### PR TITLE
chore(core): regenerate the api report for the persona app field

### DIFF
--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -3852,6 +3852,7 @@ export type CorePersona = {
   linkedAccounts?: Record<string, CorePersonaAccount>
   environments?: string[]
   runnable?: boolean
+  app?: string
 }
 export type CorePersonas = Record<string, CorePersona>
 createHttpPersonas: (config: HttpPersonasConfig) => ScenarioPersonas
@@ -3915,6 +3916,7 @@ export type PersonaMeta = {
   linkedAccounts?: Record<string, PersonaAccountMeta>
   environments?: string[]
   runnable: boolean
+  app?: string
   sourceFile?: string
 }
 export type PersonasMeta = Record<string, PersonaMeta>


### PR DESCRIPTION
main is red. #1328 added `app?: string` to `CorePersona` and `PersonaMeta` without regenerating `packages/core/api-report.md`, so `the API report matches the code › regenerating produces no diff` fails on main and on every branch rebased onto it.

Two generated lines, no behaviour change. Verified by running the core suite against `origin/main` locally: red before, and this is the only failure in the whole unit suite.

This is exactly the mid-merge drift #1334 exists to make cheap; that PR keeps the driver from resolving conflicts by regeneration, while this test is what still insists the committed report matches the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)