### PR TITLE
fix(core): read a ref-wired addon function's schemas from its own package

### DIFF
--- a/.changeset/addon-ref-function-package-scope.md
+++ b/.changeset/addon-ref-function-package-scope.md
@@ -1,0 +1,9 @@
+---
+'@pikku/core': patch
+---
+
+A `ref()`-wired addon route now reads the function's schemas, services and permissions from the addon's package rather than the consuming app's.
+
+Resolving a namespaced target by namespace re-pointed the function's config and metadata into the addon's package state but left every other package-scoped lookup on the wire's package. The addon registers `SignDataInput` under its own package, so the runner looked it up under `main`, and the route answered 500 for every input it was given — along with the addon's package singleton services, which is what left its credentials unreachable.
+
+The wiring itself is still the consuming app's, so middleware, addon tags, addon auth and addon scopes keep resolving against the app: those read the declarations the app made about the addon, and moving them would put back the unrun credential and session middleware that resolving by namespace was introduced to fix.

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -171,6 +171,15 @@ export const runPikkuFunc = async <In = any, Out = any>(
     }
   }
 
+  /**
+   * The package the *function* belongs to, which is the wire's own until a
+   * `ref()` resolves the target into an addon. The wiring stays the consuming
+   * app's — that is what keeps the app's middleware running rather than the
+   * addon's — but everything the function is declared with lives in the addon's
+   * package state, so its schemas, services and permissions are read from here.
+   */
+  let funcPackageName = packageName
+
   if (!funcMeta) {
     const addonTarget = resolveAddonFunctionTarget(funcName, packageName)
     if (addonTarget) {
@@ -182,6 +191,9 @@ export const runPikkuFunc = async <In = any, Out = any>(
       funcMeta = pikkuState(addonTarget.packageName, 'function', 'meta')[
         addonTarget.localName
       ]
+      if (funcMeta) {
+        funcPackageName = addonTarget.packageName
+      }
     }
   }
 
@@ -194,17 +206,17 @@ export const runPikkuFunc = async <In = any, Out = any>(
 
   const resolvedFunctionId = funcMeta.pikkuFuncId ?? funcName
 
-  const resolvedSingletonServices = packageName
+  const resolvedSingletonServices = funcPackageName
     ? await getOrCreatePackageSingletonServices(
-        packageName,
+        funcPackageName,
         singletonServices,
         addonInstance
       )
     : singletonServices
 
   let resolvedCreateWireServices = createWireServices
-  if (packageName) {
-    const factories = pikkuState(packageName, 'package', 'factories')
+  if (funcPackageName) {
+    const factories = pikkuState(funcPackageName, 'package', 'factories')
     if (factories?.createWireServices) {
       resolvedCreateWireServices = factories.createWireServices
     }
@@ -362,17 +374,21 @@ export const runPikkuFunc = async <In = any, Out = any>(
       actualData = applyDefaultsFromSchema(
         inputSchemaName,
         actualData,
-        packageName
+        funcPackageName
       )
       if (coerceDataFromSchema) {
-        coerceTopLevelDataFromSchema(inputSchemaName, actualData, packageName)
+        coerceTopLevelDataFromSchema(
+          inputSchemaName,
+          actualData,
+          funcPackageName
+        )
       }
       await validateSchema(
         resolvedSingletonServices.logger,
         resolvedSingletonServices.schema,
         inputSchemaName,
         actualData,
-        packageName
+        funcPackageName
       )
     }
 
@@ -385,7 +401,7 @@ export const runPikkuFunc = async <In = any, Out = any>(
       // knowledge: decisions/security/a-permission-gets-a-wire-it-cannot-reply-on.md
       wire: invocationWire as PermissionWire,
       data: actualData,
-      packageName,
+      packageName: funcPackageName,
     })
 
     let wireServices: Record<string, unknown> | undefined
@@ -412,7 +428,7 @@ export const runPikkuFunc = async <In = any, Out = any>(
         )
         services = { ...services, auditLog: invocationAuditLog }
       }
-      const callerPackageName = packageName
+      const callerPackageName = funcPackageName
       Object.defineProperty(invocationWire, 'rpc', {
         get() {
           const rpc = rpcService.getContextRPCService(

--- a/packages/core/src/wirings/http/http-runner-addon-ref.test.ts
+++ b/packages/core/src/wirings/http/http-runner-addon-ref.test.ts
@@ -2,6 +2,7 @@ import { test, describe, beforeEach } from 'node:test'
 import * as assert from 'assert'
 import { addHTTPMiddleware, fetch, wireHTTP } from './http-runner.js'
 import { pikkuState, resetPikkuState } from '../../pikku-state.js'
+import { addSchema } from '../../schema.js'
 import { PikkuMockRequest } from '../channel/local/local-channel-runner.test.js'
 import { httpRouter } from './routers/http-router.js'
 import type { CoreHTTPFunctionWiring, HTTPMethod } from './http.types.js'
@@ -19,7 +20,10 @@ class ParamsRequest extends PikkuMockRequest {
   }
 }
 
-const registerAddon = (sessionless = true) => {
+const registerAddon = (
+  sessionless = true,
+  inputSchemaName: string | null = null
+) => {
   pikkuState(null, 'addons', 'packages').set(ADDON_NAMESPACE, {
     package: ADDON_PACKAGE,
   } as never)
@@ -28,7 +32,7 @@ const registerAddon = (sessionless = true) => {
       pikkuFuncId: 'greet',
       name: 'greet',
       sessionless,
-      inputSchemaName: null,
+      inputSchemaName,
       outputSchemaName: null,
       inputs: [],
       outputs: [],
@@ -127,6 +131,54 @@ describe('http routes wired with ref() to an addon function', () => {
     assert.deepStrictEqual(await withParam.json(), { id: '42' })
     assert.deepStrictEqual(await withoutParam.json(), {})
     assert.deepEqual(seen, [{ id: '42' }, {}])
+  })
+
+  /**
+   * The addon registers its schemas in its own package state, and the name the
+   * runner validates against comes from the addon's metadata. Resolving the
+   * target's metadata by namespace while still reading the schema registry of
+   * the wire's package looks the name up under 'main', where the addon never
+   * put it — the route then answers 500 for every input it was given.
+   */
+  test("validates input against the addon package's schema registry", async () => {
+    registerAddon(true, 'GreetInput')
+    addSchema(
+      'GreetInput',
+      { type: 'object', properties: { id: { type: 'string' } } },
+      ADDON_PACKAGE
+    )
+    setRouteMeta('/addon/greet-schema/:id', 'get', {
+      auth: false,
+      params: ['id'],
+    })
+
+    const compiled: string[] = []
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      schema: {
+        compileSchema: (key: string) => {
+          compiled.push(key)
+        },
+        validateSchema: () => {},
+        getSchemaKeys: () => [],
+      },
+    } as never)
+
+    wireHTTP({
+      route: '/addon/greet-schema/:id',
+      method: 'get',
+      auth: false,
+      func: { func: async (_s: never, data: unknown) => data },
+    } as unknown as CoreHTTPFunctionWiring<unknown, unknown, string>)
+    httpRouter.initialize()
+
+    const response = await fetch(
+      new ParamsRequest('/addon/greet-schema/42', 'get')
+    )
+
+    assert.strictEqual(response.status, 200)
+    assert.deepStrictEqual(await response.json(), { id: '42' })
+    assert.deepStrictEqual(compiled.length > 0, true)
   })
 
   test("runs the consuming app's middleware, not the addon package's", async () => {


### PR DESCRIPTION
main is red on `E2E Standard` — 139/148 scenarios — and every open PR inherits it. #1334 fails the same job while touching only a test file and `.gitattributes`, which is what rules the PRs out as the cause.

## What broke

#1326 stopped a `ref()`-wired route from carrying the addon's `packageName`, because doing so ran the addon's middleware instead of the consuming app's and left the app's credential and session middleware unrun. The route became the app's, and the target resolves by namespace instead.

That fallback re-points `funcConfig` and `funcMeta` into the addon's package state and nothing else. Every other package-scoped lookup stayed on the wire's package, which for a `ref()` the app wired is `null` — so the addon registers `SignDataInput` under `@pikku/addon-hmac-signer` and the runner looks for it under `main`:

```
Schema 'SignDataInput' not found for package 'main'
```

Nine scenarios, all `Credential Service API`: the hmac ones answer 500 on `SignDataInput`/`VerifySignatureInput`, the OAuth ones on `GetProfileInput` plus the addon's package singleton services, which is what leaves `user-oauth` credentials unreachable.

## The fix

`funcPackageName` names the package the *function* belongs to, distinct from the wire's:

- **follows the function** — schema defaults/coercion/validation, package singleton services and wire-service factories, permissions, nested-RPC caller scope
- **stays the app's** — `combineMiddleware`, `combineChannelMiddleware`, `resolveAddonTagMiddleware`, `resolveAddonAuth`, `resolveAddonScopes`

The second group reads the declarations the *app* made about the addon, so keeping them on the wire's package is deliberate: moving them would restore exactly the unrun middleware #1326 set out to fix.

## Verification

- new test in `http-runner-addon-ref.test.ts` — 500 before, 200 after
- `packages/core`: 2245 pass, 0 fail
- e2e: **139/148 → 148/148**

Reproduced locally first: E2E Standard needs no service containers, so `yarn build` + the two-pass e2e codegen + `yarn test:e2e` gives the identical 9 failures CI reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved addon route execution so schemas, services, permissions, and RPC context resolve from the addon package.
  * Preserved consuming-app configuration for middleware, tags, authentication, and scopes.
  * Added support for validating addon route inputs with the addon’s registered schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->