### PR TITLE
chore: keep every changeset on patch until 0.13

### DIFF
--- a/.changeset/dev-actor-switcher-package.md
+++ b/.changeset/dev-actor-switcher-package.md
@@ -1,6 +1,6 @@
 ---
-'@pikku/react': minor
-'@pikku/mantine': minor
+'@pikku/react': patch
+'@pikku/mantine': patch
 '@pikku/cli': patch
 '@pikku/skills': patch
 ---


### PR DESCRIPTION
`dev-actor-switcher-package.md` declared `@pikku/react` and `@pikku/mantine` as `minor`, which made every `changeset status` run — and every pre-commit hook — report a minor bump for those two packages.

Minor and major are reserved until 0.13, so both are now `patch`. That is the only changeset on main declaring anything but `patch`; after this, `changeset status` lists all 56 packages under `patch`.

No code change — changeset metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)