### PR TITLE
fix(create,ci): retry the network fetches a template job depends on

### DIFF
--- a/.changeset/retry-transient-network-fetches.md
+++ b/.changeset/retry-transient-network-fetches.md
@@ -1,0 +1,15 @@
+---
+'create-pikku': patch
+---
+
+fix(create): retry a template download that failed on a blip
+
+`create-pikku` asked api.github.com for a template tarball exactly once. A 504
+from it — which that endpoint returns often enough to matter — ended the
+scaffold with "Failed to download templates", and in CI that reads as a broken
+pull request rather than as the weather.
+
+Transient failures (5xx, 429, connection resets, `fetch failed`) are now
+retried three times with backoff. A 404 is not transient: a template or branch
+that is genuinely gone still fails on the first attempt, so a deleted branch
+reports immediately instead of after a round of retries.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -26,5 +26,21 @@ runs:
       uses: actions/download-artifact@v8
       with:
         name: build-output
-    - run: yarn install
+    # A dependency whose postinstall downloads a release binary (serverless,
+    # workerd, esbuild) fails the whole install when that fetch blips, and the
+    # job then reads as a broken pull request. Yarn resumes from what it
+    # already resolved, so a repeat attempt is cheap.
+    - name: Install dependencies
       shell: bash
+      run: |
+        for attempt in 1 2 3; do
+          if yarn install; then
+            exit 0
+          fi
+          if [ "$attempt" = 3 ]; then
+            echo "::error::yarn install failed after $attempt attempts"
+            exit 1
+          fi
+          echo "::warning::yarn install failed (attempt $attempt), retrying"
+          sleep $((attempt * 15))
+        done

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -26,6 +26,7 @@ import {
   replaceFunctionReferences,
   serverlessChanges,
   updatePackageJSONScripts,
+  withNetworkRetry,
   wranglerChanges,
 } from './utils.js'
 import { program } from 'commander'
@@ -290,8 +291,8 @@ async function setupTemplate(cliOptions: CliOptions) {
     const functionsPath = `${tmpDirPrefix}/pikku/functions`
     const templatePath = `${tmpDirPrefix}/pikku/template`
 
-    await downloadTemplate(functionsUrl, { dir: functionsPath, force: true })
-    await downloadTemplate(templateUrl, { dir: templatePath, force: true })
+    await downloadWithRetry(functionsUrl, functionsPath, spinner)
+    await downloadWithRetry(templateUrl, templatePath, spinner)
 
     spinner.success()
 
@@ -356,6 +357,29 @@ async function setupTemplate(cliOptions: CliOptions) {
   console.log(chalk.bold(`cd ${name}`))
 }
 
+/**
+ * api.github.com answers a tarball request with a 504 often enough that a
+ * single attempt makes a whole scaffold — and every CI job that scaffolds —
+ * fail on the weather. A missing template still fails at once; only the blips
+ * are asked again.
+ */
+async function downloadWithRetry(
+  source: string,
+  dir: string,
+  spinner: ReturnType<typeof createSpinner>
+) {
+  return withNetworkRetry(
+    () => downloadTemplate(source, { dir, force: true }),
+    {
+      onRetry: (error, attempt) => {
+        spinner.update({
+          text: `Downloading template... (retry ${attempt} after ${(error as Error).message})`,
+        })
+      },
+    }
+  )
+}
+
 async function cloneRepo(cliOptions: CliOptions, repoName: string) {
   const { version, name } = cliOptions
   const targetPath = path.join(process.cwd(), name)
@@ -366,10 +390,11 @@ async function cloneRepo(cliOptions: CliOptions, repoName: string) {
   try {
     const tmpDirPrefix = tmpdir()
     const repoDirPath = `${tmpDirPrefix}/pikku/${repoName}`
-    await downloadTemplate(`gh:pikkujs/${repoName}${versionRef}`, {
-      dir: repoDirPath,
-      force: true,
-    })
+    await downloadWithRetry(
+      `gh:pikkujs/${repoName}${versionRef}`,
+      repoDirPath,
+      spinner
+    )
     lazymkdir(targetPath)
     mergeDirectories(repoDirPath, targetPath)
 

--- a/packages/create/src/utils.test.ts
+++ b/packages/create/src/utils.test.ts
@@ -17,6 +17,8 @@ import {
   updatePackageJSONScripts,
   deepMerge,
   filterFilesByFeatures,
+  withNetworkRetry,
+  isTransientNetworkError,
 } from './utils.js'
 
 describe('Functions Test Suite', () => {
@@ -777,5 +779,83 @@ describe('Functions Test Suite', () => {
       !remainingClientFiles.includes('websocket.ts'),
       'websocket.ts should be removed'
     )
+  })
+})
+
+/**
+ * A template download is one fetch against api.github.com, and a 504 from it
+ * failed the whole scaffold — which in CI reads as a broken pull request
+ * rather than as the blip it was. Retrying is only safe if a genuinely missing
+ * template still fails at once: a 404 for a branch that was deleted is an
+ * answer, not an outage, and burning three attempts on it turns a clear error
+ * into a slow one.
+ */
+describe('retrying a transient download', () => {
+  test('a gateway timeout is retried and the later attempt is the result', async () => {
+    let attempts = 0
+
+    const result = await withNetworkRetry(
+      async () => {
+        attempts++
+        if (attempts < 3) {
+          throw new Error(
+            'Failed to download https://api.github.com/repos/pikkujs/pikku/tarball/main: 504 Gateway Timeout'
+          )
+        }
+        return 'downloaded'
+      },
+      { attempts: 3, delayMs: 0 }
+    )
+
+    assert.equal(result, 'downloaded')
+    assert.equal(attempts, 3)
+  })
+
+  test("a postinstall's failed fetch is transient too", () => {
+    assert.equal(
+      isTransientNetworkError(
+        new Error('Error fetching release: fetch failed')
+      ),
+      true
+    )
+    assert.equal(isTransientNetworkError(new Error('read ECONNRESET')), true)
+    assert.equal(
+      isTransientNetworkError(new Error('503 Service Unavailable')),
+      true
+    )
+  })
+
+  test('a missing template fails on the first attempt', async () => {
+    let attempts = 0
+
+    await assert.rejects(
+      withNetworkRetry(
+        async () => {
+          attempts++
+          throw new Error(
+            'Failed to download https://api.github.com/repos/pikkujs/pikku/tarball/gone: 404 Not Found'
+          )
+        },
+        { attempts: 3, delayMs: 0 }
+      ),
+      /404 Not Found/
+    )
+    assert.equal(attempts, 1)
+  })
+
+  test('the last error survives when every attempt is transient', async () => {
+    let attempts = 0
+
+    await assert.rejects(
+      withNetworkRetry(
+        async () => {
+          attempts++
+          throw new Error(`502 Bad Gateway (attempt ${attempts})`)
+        },
+        { attempts: 3, delayMs: 0 }
+      ),
+      /attempt 3/
+    )
+    assert.equal(attempts, 3)
   })
 })

--- a/packages/create/src/utils.ts
+++ b/packages/create/src/utils.ts
@@ -525,3 +525,74 @@ export function preparePackageJsonForYarnLink(targetPath: string): void {
 
   fs.writeFileSync(packageFilePath, JSON.stringify(packageJson, null, 2))
 }
+
+const transientNetworkSignals = [
+  'fetch failed',
+  'socket hang up',
+  'network',
+  'timeout',
+  'timed out',
+  'econnreset',
+  'econnrefused',
+  'enotfound',
+  'eai_again',
+  'epipe',
+  'etimedout',
+  '408',
+  '425',
+  '429',
+  '500',
+  '502',
+  '503',
+  '504',
+]
+
+/**
+ * A download that failed because the far end was briefly unavailable is worth
+ * asking again; one that failed because the thing is not there is an answer.
+ * The distinction matters most for a deleted branch, whose 404 must surface
+ * immediately rather than after a round of retries.
+ */
+export function isTransientNetworkError(error: unknown): boolean {
+  const message = (
+    error instanceof Error ? error.message : String(error)
+  ).toLowerCase()
+
+  if (message.includes('404') || message.includes('not found')) {
+    return false
+  }
+
+  return transientNetworkSignals.some((signal) => message.includes(signal))
+}
+
+export type NetworkRetryOptions = {
+  attempts?: number
+  delayMs?: number
+  onRetry?: (error: unknown, attempt: number) => void
+}
+
+export async function withNetworkRetry<T>(
+  operation: () => Promise<T>,
+  { attempts = 3, delayMs = 1000, onRetry }: NetworkRetryOptions = {}
+): Promise<T> {
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await operation()
+    } catch (error) {
+      lastError = error
+      if (attempt === attempts || !isTransientNetworkError(error)) {
+        throw error
+      }
+      onRetry?.(error, attempt)
+      if (delayMs > 0) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, delayMs * 2 ** (attempt - 1))
+        )
+      }
+    }
+  }
+
+  throw lastError
+}

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -21,6 +21,22 @@ log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
 log_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
+# An install pulls binaries from registries and release hosts, and a single
+# blip on any of them fails a template job that has nothing wrong with it.
+retry() {
+    local attempt
+    for attempt in 1 2 3; do
+        if "$@"; then
+            return 0
+        fi
+        if [ "$attempt" = 3 ]; then
+            return 1
+        fi
+        log_warning "'$*' failed (attempt $attempt), retrying"
+        sleep $((attempt * 15))
+    done
+}
+
 # Get script directory and project root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -131,7 +147,7 @@ if [ "$PACKAGE_MANAGER" = "yarn" ]; then
 
     # Install dependencies (refreshes node_modules with the linked packages)
     log_info "Installing dependencies..."
-    if ! yarn install; then
+    if ! retry yarn install; then
         log_error "Failed to install dependencies"
         exit 1
     fi
@@ -258,7 +274,7 @@ Object.entries(all)
     # different half-written file every run. No template imports better-sqlite3,
     # none of them declare a postinstall, and codegen is re-run explicitly below.
     log_info "Installing dependencies..."
-    if ! "$PACKAGE_MANAGER" install --ignore-scripts; then
+    if ! retry "$PACKAGE_MANAGER" install --ignore-scripts; then
         log_error "Failed to install dependencies"
         exit 1
     fi


### PR DESCRIPTION
Closes #1343.

Two template jobs went red today on unrelated PRs, both from a one-shot network fetch with nothing behind it:

- `Templates (24, cli, yarn)` — `Failed to download https://api.github.com/repos/pikkujs/pikku/tarball/<branch>: 504 Gateway Timeout`
- `Templates (24, remote-rpc-pg, yarn)` — `serverless@npm:4.41.0 couldn't be built successfully … Error fetching release: fetch failed`

Both land in dependency setup, so the job reads as a regression on whichever pull request happened to be running — which is the expensive part, more than the lost minutes.

**`create-pikku`** gains `withNetworkRetry` / `isTransientNetworkError` in `utils.ts`, wrapped around all three `downloadTemplate` call sites. Transient failures (5xx, 429, connection resets, `fetch failed`) are retried three times with exponential backoff, and the spinner says which attempt it is on. A **404 is deliberately not transient**: a deleted branch or a missing template is an answer, not an outage, and must still fail on the first attempt rather than after three — that case is what `Templates (24, cli, yarn)` legitimately hit on #1337 last week.

**CI** — the shared `./.github/actions/setup` composite and `scripts/test-template.sh` retry their installs on the same three-attempt/backoff shape. Yarn resumes from what it already resolved, so a repeat attempt costs little.

### Tests

Four tests in `packages/create/src/utils.test.ts`, red before the change (the symbols did not exist) and green after — 25/25 in the package:

- a 504 is retried and the succeeding attempt's value is returned
- `fetch failed`, `ECONNRESET` and `503` all classify as transient
- a 404 fails on attempt 1, asserting the retry count is exactly 1
- when every attempt is transient, the **last** error propagates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Template and repository downloads now automatically retry transient network failures up to three times with increasing delays.
  - Missing resources and other non-transient errors fail immediately.
  - Dependency installation retries temporary failures before reporting an error.
- **Reliability**
  - Improved handling of gateway errors, rate limits, connection resets, and failed network requests.
  - Retry progress is reflected during downloads, with clear errors after all attempts are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->