### PR TITLE
fix(core): make working-memory array semantics explicit and documented

### DIFF
--- a/.changeset/lucky-buttons-repeat.md
+++ b/.changeset/lucky-buttons-repeat.md
@@ -1,0 +1,13 @@
+---
+'@pikku/core': patch
+---
+
+fix(agent): make working-memory array semantics explicit
+
+`deepMergeWorkingMemory` replaced arrays wholesale as a side effect of its
+object-recursion guard, while `buildWorkingMemoryPrompt` told the model to
+"only include changed fields" — so a model that emitted just the new array item
+silently lost the rest. The merge now handles arrays in an explicit, documented
+branch, and the prompt states that arrays are replaced and must be re-emitted in
+full. Replace is kept over append: the full state is echoed back every turn, so
+appending would duplicate every item whenever the model re-emitted the array.

--- a/.changeset/lucky-buttons-repeat.md
+++ b/.changeset/lucky-buttons-repeat.md
@@ -5,9 +5,14 @@
 fix(agent): make working-memory array semantics explicit
 
 `deepMergeWorkingMemory` replaced arrays wholesale as a side effect of its
-object-recursion guard, while `buildWorkingMemoryPrompt` told the model to
-"only include changed fields" — so a model that emitted just the new array item
-silently lost the rest. The merge now handles arrays in an explicit, documented
-branch, and the prompt states that arrays are replaced and must be re-emitted in
-full. Replace is kept over append: the full state is echoed back every turn, so
-appending would duplicate every item whenever the model re-emitted the array.
+object-recursion guard, so nothing in the code said whether that was the
+contract or an accident. The merge now handles arrays in an explicit,
+documented branch. Replace is kept over append: the full state is echoed back
+every turn, so appending would duplicate every item whenever the model re-emitted
+the array.
+
+`buildWorkingMemoryPrompt` now states that contract to the model rather than
+leaving "only include changed fields" to be read as permission to send a partial
+array. This is defensive: measured against `gpt-4.1-mini` the wording changes
+nothing, because that model already re-emits the whole list. It is there for
+models that do not.

--- a/e2e/packages/functions/src/agents/shopping-list.agent.ts
+++ b/e2e/packages/functions/src/agents/shopping-list.agent.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+import { pikkuAgent } from '#pikku/agent/pikku-agent-types.gen.js'
+
+/**
+ * An agent whose whole memory is one array.
+ *
+ * Working memory is echoed back to the model in full every turn and updated by
+ * a partial JSON patch, and arrays in that patch replace rather than append. A
+ * model that reads "only include changed fields" and emits just the new item
+ * therefore deletes everything already on the list — issue #1331. Nothing but a
+ * real model can show whether the prompt stops it doing that, so this agent
+ * exists for the `ai-live` tier: a single array field, no tools, and a goal
+ * that keeps the model from parking the list anywhere else.
+ */
+export const ShoppingListWorkingMemory = z.object({
+  items: z
+    .array(z.string())
+    .describe('Every item the user still wants to buy')
+    .optional(),
+})
+
+export const shoppingListAgent = pikkuAgent({
+  name: 'shopping-list-agent',
+  description: 'Keeps a shopping list in working memory',
+  goal: [
+    'You keep track of a shopping list for the user.',
+    'Every item they mention wanting to buy belongs in the items array of your',
+    'working memory, and it stays there until they say they no longer need it.',
+    'Reply in one short sentence naming the items currently on the list.',
+  ].join('\n'),
+  model: 'openai/gpt-4.1-mini',
+  memory: { workingMemory: ShoppingListWorkingMemory },
+  tools: [],
+  maxSteps: 1,
+  toolChoice: 'none',
+})

--- a/e2e/packages/functions/src/functions/agent-probe.functions.ts
+++ b/e2e/packages/functions/src/functions/agent-probe.functions.ts
@@ -25,3 +25,25 @@ export const resetLlmLog = pikkuSessionlessFunc<void, { reset: true }>({
     return { reset: true }
   },
 })
+
+/**
+ * The working memory notepad a thread currently holds.
+ *
+ * Nothing else exposes it: the console renders the schema rather than the value,
+ * and the merged state only ever reaches the model. Reading it back is the only
+ * way a scenario can tell what survived a turn, and on the `ai-live` tier it is
+ * the only way at all — the model call log is the mock provider's, and there is
+ * no mock provider once the runs are real.
+ */
+export const agentWorkingMemory = pikkuSessionlessFunc<
+  { threadId: string },
+  Record<string, unknown> | null
+>({
+  expose: true,
+  func: async ({ agentStorage }, { threadId }) => {
+    if (!agentStorage) {
+      throw new Error('agentStorage is not configured on this deployment')
+    }
+    return agentStorage.getWorkingMemory(threadId, 'thread')
+  },
+})

--- a/e2e/packages/functions/tests/scenarios/agent-assert.steps.ts
+++ b/e2e/packages/functions/tests/scenarios/agent-assert.steps.ts
@@ -645,3 +645,36 @@ export const expectsResultObject = pikkuScenarioStep<
     return { fields: Object.keys(fields) }
   },
 })
+
+/**
+ * What a thread's working memory array holds, read back through
+ * `agentWorkingMemory`.
+ *
+ * Matching is substring and case-insensitive because the entries are the
+ * model's own wording — "Milk" or "2 litres of milk" are the same item as far
+ * as this assertion is concerned. What it is actually asking is whether the
+ * entry survived the turn at all.
+ */
+export const expectsWorkingMemoryList = pikkuScenarioStep<
+  { call: { body: unknown }; field: string; holds: string[] },
+  { items: string[] }
+>({
+  name: 'expectsWorkingMemoryList',
+  description: 'expects which entries a working memory array still holds',
+  template: 'expects {field} to still hold every entry',
+  default: async (_services, { call, field, holds }) => {
+    const memory = (call.body ?? null) as Record<string, unknown> | null
+    const raw = memory?.[field]
+    const items = Array.isArray(raw) ? raw.map((entry) => String(entry)) : []
+    const missing = holds.filter(
+      (needle) =>
+        !items.some((item) => item.toLowerCase().includes(needle.toLowerCase()))
+    )
+    if (missing.length > 0) {
+      throw new Error(
+        `Expected working memory "${field}" to still hold ${describeValue(missing)}, got ${describeValue(items)}`
+      )
+    }
+    return { items }
+  },
+})

--- a/e2e/packages/functions/tests/scenarios/agent-working-memory-live.feature.ts
+++ b/e2e/packages/functions/tests/scenarios/agent-working-memory-live.feature.ts
@@ -1,31 +1,31 @@
 /**
- * Working memory arrays, against a real model.
+ * Working memory, against a real model.
  *
  * The unit tests around `deepMergeWorkingMemory` pin what the merge does with
  * an array — it replaces one wholesale — and one of them pins that the prompt
- * says so. Neither can answer the question issue #1331 was actually about:
- * whether a model, handed that prompt, stops emitting only the item it just
- * learned and wiping the rest of the list.
+ * says so. None of them exercise the path a real run takes: the notepad reaches
+ * the runner as a system-role context message, and until that was lifted onto
+ * the `system` option every run that declared `memory.workingMemory` answered
+ * 500 with "System messages are not allowed in the prompt or messages fields."
+ * This scenario is the only thing that catches that, and it is what the title
+ * claims — a round trip, not a verdict on the prompt.
  *
- * That is a decision only a model makes, so this is `ai-live`. It is also not a
- * browser scenario: the console renders the working memory *schema* and never
- * its value, and the model call log the deterministic agent suite asserts on
+ * It is deliberately not the evidence for the prompt's array wording. Measured
+ * against `gpt-4.1-mini`, that wording changes nothing: the model keeps the
+ * whole list without it, over three items and over seven with an edit-style
+ * turn. `gpt-4.1-nano` fails either way, and fails by never writing the notepad
+ * at all, which is a different thing entirely. The wording is defensible
+ * guidance for weaker models; it is not something this test can show.
+ *
+ * It is `ai-live` because only a model can make the decision, and not a browser
+ * scenario: the console renders the working memory *schema* and never its
+ * value, and the model call log the deterministic agent suite asserts on
  * belongs to the mock provider, which does not exist once the runs are real.
  * The notepad is read back directly instead.
  *
- * A single run of a non-deterministic model is weak evidence on its own — a
- * pass here means the prompt was enough this time, not that it is enough
- * always. It is still the only evidence of the kind that matters.
- *
- * Unverified at the time of writing, for want of a key. What a mocked dry run
- * did show is that declaring `memory.workingMemory` at all makes a run answer
- * 500 with "System messages are not allowed in the prompt or messages fields.
- * Use the instructions option instead" — the notepad reaches the runner as a
- * system-role context message, which the AI SDK in that checkout rejected
- * inside `messages`. Whether that is the repo's bug or that checkout's
- * dependency drift is undetermined: the deterministic agent suite was red
- * beside it, most of it reporting no model calls at all. No agent here declared
- * working memory before this one, so nothing had ever exercised the path.
+ * The runner-side lift lands in the delegate-mode change stacked on top of this
+ * branch, so this scenario passes there and not here. `ai-live` runs in no CI
+ * suite, so nothing goes red in the meantime.
  */
 import { pikkuFeature, pikkuScenario } from '#pikku/scenario'
 
@@ -37,9 +37,9 @@ export const workingMemoryArrayKeepsEarlierItemsScenario = pikkuScenario<
   void,
   { items: string[] }
 >({
-  title: 'Adding to a remembered list does not delete what was already on it',
+  title: 'A thread’s notepad round-trips through a real model',
   description:
-    'A second turn adds one item, and the two from the first turn are still there',
+    'A second turn adds an item and the notepad comes back holding all of them',
   tags: ['scenario', 'agent-working-memory-live', 'ai-live'],
   func: async (_services, _data, { scenario }) => {
     const thread = await scenario.given('opens a thread', 'startsAgentThread')
@@ -85,9 +85,9 @@ export const workingMemoryArrayKeepsEarlierItemsScenario = pikkuScenario<
 })
 
 export const agentWorkingMemoryLiveFeature = pikkuFeature({
-  name: 'Working memory arrays survive a real model’s update',
+  name: 'Working memory round-trips against a real model',
   description:
-    'A model told that arrays are replaced repeats the items it is keeping',
+    'The notepad survives a real run, which no mocked scenario can show',
   tags: ['agent-working-memory-live', 'ai-live'],
   scenarios: [workingMemoryArrayKeepsEarlierItemsScenario],
 })

--- a/e2e/packages/functions/tests/scenarios/agent-working-memory-live.feature.ts
+++ b/e2e/packages/functions/tests/scenarios/agent-working-memory-live.feature.ts
@@ -1,0 +1,93 @@
+/**
+ * Working memory arrays, against a real model.
+ *
+ * The unit tests around `deepMergeWorkingMemory` pin what the merge does with
+ * an array — it replaces one wholesale — and one of them pins that the prompt
+ * says so. Neither can answer the question issue #1331 was actually about:
+ * whether a model, handed that prompt, stops emitting only the item it just
+ * learned and wiping the rest of the list.
+ *
+ * That is a decision only a model makes, so this is `ai-live`. It is also not a
+ * browser scenario: the console renders the working memory *schema* and never
+ * its value, and the model call log the deterministic agent suite asserts on
+ * belongs to the mock provider, which does not exist once the runs are real.
+ * The notepad is read back directly instead.
+ *
+ * A single run of a non-deterministic model is weak evidence on its own — a
+ * pass here means the prompt was enough this time, not that it is enough
+ * always. It is still the only evidence of the kind that matters.
+ *
+ * Unverified at the time of writing, for want of a key. What a mocked dry run
+ * did show is that declaring `memory.workingMemory` at all makes a run answer
+ * 500 with "System messages are not allowed in the prompt or messages fields.
+ * Use the instructions option instead" — the notepad reaches the runner as a
+ * system-role context message, which the AI SDK in that checkout rejected
+ * inside `messages`. Whether that is the repo's bug or that checkout's
+ * dependency drift is undetermined: the deterministic agent suite was red
+ * beside it, most of it reporting no model calls at all. No agent here declared
+ * working memory before this one, so nothing had ever exercised the path.
+ */
+import { pikkuFeature, pikkuScenario } from '#pikku/scenario'
+
+const AGENT = 'shoppingListAgent'
+const RESOURCE_ID = 'agent-working-memory-live'
+const ALICE = { userId: 'alice' }
+
+export const workingMemoryArrayKeepsEarlierItemsScenario = pikkuScenario<
+  void,
+  { items: string[] }
+>({
+  title: 'Adding to a remembered list does not delete what was already on it',
+  description:
+    'A second turn adds one item, and the two from the first turn are still there',
+  tags: ['scenario', 'agent-working-memory-live', 'ai-live'],
+  func: async (_services, _data, { scenario }) => {
+    const thread = await scenario.given('opens a thread', 'startsAgentThread')
+
+    await scenario.given('names two things to buy', 'runsAgent', {
+      agent: AGENT,
+      message: 'I need to buy milk and eggs.',
+      threadId: thread.threadId,
+      resourceId: RESOURCE_ID,
+      identity: ALICE,
+    })
+
+    await scenario.when('names a third', 'runsAgent', {
+      agent: AGENT,
+      message: 'Also bread.',
+      threadId: thread.threadId,
+      resourceId: RESOURCE_ID,
+      identity: ALICE,
+    })
+
+    const memory = await scenario.when(
+      'reads the thread’s working memory',
+      'callsRpcAs',
+      {
+        rpcName: 'agentWorkingMemory',
+        data: { threadId: thread.threadId },
+        identity: ALICE,
+      }
+    )
+
+    const list = await scenario.then(
+      'sees all three still on the list',
+      'expectsWorkingMemoryList',
+      {
+        call: memory,
+        field: 'items',
+        holds: ['milk', 'eggs', 'bread'],
+      }
+    )
+
+    return list
+  },
+})
+
+export const agentWorkingMemoryLiveFeature = pikkuFeature({
+  name: 'Working memory arrays survive a real model’s update',
+  description:
+    'A model told that arrays are replaced repeats the items it is keeping',
+  tags: ['agent-working-memory-live', 'ai-live'],
+  scenarios: [workingMemoryArrayKeepsEarlierItemsScenario],
+})

--- a/packages/core/src/wirings/agent/agent-memory.test.ts
+++ b/packages/core/src/wirings/agent/agent-memory.test.ts
@@ -74,6 +74,72 @@ describe('agent-memory', () => {
     })
   })
 
+  test('deepMergeWorkingMemory replaces an array re-emitted in full', () => {
+    const result = deepMergeWorkingMemory(
+      { steps: [{ id: 1 }, { id: 2 }], other: 'kept' },
+      { steps: [{ id: 1 }, { id: 2 }, { id: 3 }] }
+    )
+
+    assert.deepEqual(result, {
+      steps: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      other: 'kept',
+    })
+  })
+
+  test('deepMergeWorkingMemory replaces rather than appends a partial array', () => {
+    const result = deepMergeWorkingMemory(
+      { steps: [{ id: 1 }, { id: 2 }] },
+      { steps: [{ id: 3 }] }
+    )
+
+    assert.deepEqual(result, { steps: [{ id: 3 }] })
+  })
+
+  test('deepMergeWorkingMemory clears an array field set to null', () => {
+    const result = deepMergeWorkingMemory(
+      { steps: [1, 2, 3], city: 'Berlin' },
+      {
+        steps: null,
+      }
+    )
+
+    assert.deepEqual(result, { city: 'Berlin' })
+  })
+
+  test('deepMergeWorkingMemory replaces arrays nested inside merged objects', () => {
+    const result = deepMergeWorkingMemory(
+      {
+        profile: {
+          name: 'Yasser',
+          tags: ['a', 'b'],
+        },
+      },
+      {
+        profile: {
+          tags: ['c'],
+        },
+      }
+    )
+
+    assert.deepEqual(result, {
+      profile: {
+        name: 'Yasser',
+        tags: ['c'],
+      },
+    })
+  })
+
+  test('deepMergeWorkingMemory replaces across array and object shape changes', () => {
+    assert.deepEqual(
+      deepMergeWorkingMemory({ value: { a: 1 } }, { value: [1, 2] }),
+      { value: [1, 2] }
+    )
+    assert.deepEqual(
+      deepMergeWorkingMemory({ value: [1, 2] }, { value: { a: 1 } }),
+      { value: { a: 1 } }
+    )
+  })
+
   test('deepMergeWorkingMemory ignores prototype-polluting keys', () => {
     const before = ({} as any).isAdmin
     deepMergeWorkingMemory(
@@ -105,6 +171,13 @@ describe('agent-memory', () => {
     assert.match(prompt, /age \(number\)/)
     assert.match(prompt, /Current working memory:\n\{"city":"Berlin"\}/)
     assert.match(prompt, /<working_memory>/)
+  })
+
+  test('buildWorkingMemoryPrompt tells the model arrays are replaced whole', () => {
+    const prompt = buildWorkingMemoryPrompt({ steps: [1] })
+
+    assert.match(prompt, /Arrays are replaced, not merged/)
+    assert.match(prompt, /repeat every item you want to keep/)
   })
 
   test('buildWorkingMemoryPrompt marks empty memory explicitly', () => {

--- a/packages/core/src/wirings/agent/agent-memory.ts
+++ b/packages/core/src/wirings/agent/agent-memory.ts
@@ -39,6 +39,17 @@ export function isWorkingMemoryEnabled(
   return !!memoryConfig?.workingMemory && !!storage
 }
 
+/**
+ * Merges a model-emitted working memory update into the stored state.
+ *
+ * Objects merge key by key, and `null` deletes a key. Arrays are replaced
+ * wholesale — deliberately, not as a side effect of the object guard below.
+ * The full state is echoed back to the model every turn by
+ * {@link buildWorkingMemoryPrompt}, so it can always re-emit an array in full,
+ * and appending instead would duplicate every item each time it did.
+ * `buildWorkingMemoryPrompt` states this contract to the model; the two must
+ * stay in agreement.
+ */
 export function deepMergeWorkingMemory(
   existing: Record<string, unknown>,
   updates: Record<string, unknown>
@@ -51,9 +62,10 @@ export function deepMergeWorkingMemory(
     const value = updates[key]
     if (value === null) {
       delete result[key]
+    } else if (Array.isArray(value)) {
+      result[key] = value
     } else if (
       typeof value === 'object' &&
-      !Array.isArray(value) &&
       typeof result[key] === 'object' &&
       result[key] !== null &&
       !Array.isArray(result[key])
@@ -100,7 +112,9 @@ export function buildWorkingMemoryPrompt(
     'When you learn new information, output a partial JSON update in <working_memory> tags. ' +
       'Only include durable facts you have actually derived or the user has confirmed. ' +
       'Do not output templates, placeholders, or narration. ' +
-      'Only include changed fields. Leave unknown fields untouched. Set a field to null to delete it.'
+      'Only include changed fields. Leave unknown fields untouched. Set a field to null to delete it. ' +
+      'Arrays are replaced, not merged: to change one, repeat every item you want to keep alongside the new ones, ' +
+      'because any item you leave out is deleted.'
   )
 
   return parts.join('\n\n')


### PR DESCRIPTION
Fixes #1331

## The framing

The issue reads the wholesale array replace in `deepMergeWorkingMemory` as data loss and suggests append/patch operators. Tracing it, that framing is incomplete: `buildWorkingMemoryPrompt` echoes the **entire** current working memory back into the model's context every turn ("Current working memory: {...}"). The model always sees the existing array and can re-emit it whole, so replace is recoverable, not inherently lossy.

Worse, concatenating would be a strictly bigger bug: because the full state is echoed every turn, a model that correctly re-emits the whole array — which echoing actively invites — would duplicate every existing item on every turn. Unbounded growth, silently.

The real defect is a **mismatch between the prompt and the merge**. The prompt said "Only include changed fields. Leave unknown fields untouched." For an array field a model reads that as "send just the new item" — and the merge then silently drops the rest.

## What this changes

Keeps REPLACE semantics and makes the instruction agree with it. No new syntax; the existing `null`-deletes-a-key path already gives the reset escape hatch.

1. **Prompt** now ends with:
   > Arrays are replaced, not merged: to change one, repeat every item you want to keep alongside the new ones, because any item you leave out is deleted.

   Stated in both directions so it cannot be read as "send only the new element". One sentence — that prompt is paid for on every turn.

2. **Merge** gives arrays their own explicit branch (`else if (Array.isArray(value)) result[key] = value`) instead of letting them fall through the object guard, plus a JSDoc recording why replace is intentional and that the two must stay in agreement. Behaviour is unchanged — it just no longer reads as an oversight.

3. **Tests** pin the contract: whole re-emit replaces cleanly, a partial array replaces (documented, not appended), `null` clears an array field, arrays nested in merged objects replace, and shape changes between array and object replace both ways. Plus a test asserting the prompt states the rule.

No append semantics are required anywhere in the repo — no declared working-memory schema, e2e scenario, or agent config depends on appending (checked `e2e/`, `packages/`, `templates/`, `docs/`).

## Verification

TDD: the five merge tests passed against the old code (pinning existing behaviour), the prompt test failed — `19 pass / 1 fail`. After the change, `20 pass / 0 fail`.

Full `packages/core` suite: **2284 tests, 2274 pass, 0 fail, 10 skipped** (pre-existing skips). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed working-memory updates so arrays are replaced consistently and retained items are not lost unexpectedly.
  * Clarified that complete arrays must be provided when updating array-based memory.
  * Updated variable metadata to use the `optional` setting.

* **New Features**
  * Added live validation for shopping-list working memory, including retrieval and list assertions.

* **Tests**
  * Added coverage for array replacement, clearing, nesting, and shape changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->