### PR TITLE
fix(cli): fabric validate enforces the bun-only contract the container already has

### DIFF
--- a/.changeset/fabric-validate-is-bun-only.md
+++ b/.changeset/fabric-validate-is-bun-only.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+fabric validate and fabric smoke now agree with the build container that Fabric is bun-only, and validate refuses @pikku/cloudflare below 0.12.20

--- a/packages/cli/src/fabric/functions/smoke.function.ts
+++ b/packages/cli/src/fabric/functions/smoke.function.ts
@@ -22,7 +22,7 @@ import {
 import { headSha, isWorkingTreeClean } from '../lib/git.js'
 import { added, changed, dim, removed } from '../lib/output.js'
 
-const DEFAULT_YARN_VERSION = 'yarn@4.9.2'
+const DEFAULT_BUN_VERSION = 'bun@1.3.14'
 const DEFAULT_STEP_TIMEOUT_SECONDS = 300
 const DEFAULT_STARTUP_TIMEOUT_SECONDS = 60
 const DEV_LOG_TAIL_BYTES = 16_000
@@ -227,8 +227,8 @@ function rewriteFrontendCommand(command: string[]): {
 
   if (command[0] === 'yarn') {
     return {
-      command: 'yarn',
-      args: command.slice(1),
+      command: 'bun',
+      args: ['run', ...command.slice(1)],
     }
   }
 
@@ -350,8 +350,8 @@ async function runFrontendChecks(args: {
     for (const script of scriptOrder) {
       const result = await runCommandStep({
         name: `frontend:${slug}:${script}`,
-        command: 'yarn',
-        commandArgs: [script],
+        command: 'bun',
+        commandArgs: ['run', script],
         cwd,
         env: args.env,
         timeoutMs: args.timeoutMs,
@@ -363,7 +363,7 @@ async function runFrontendChecks(args: {
         detail: result.ok
           ? `${slug} ${script} passed`
           : `${slug} ${script} failed`,
-        command: commandLabel('yarn', [script]),
+        command: commandLabel('bun', ['run', script]),
       })
 
       if (!result.ok) {
@@ -742,7 +742,7 @@ export const FabricSmoke = pikkuSessionlessFunc({
     const packageJson = await readJsonSafe<RootPackageJson>(
       join(tempDir, 'package.json')
     )
-    const packageManager = packageJson?.packageManager ?? DEFAULT_YARN_VERSION
+    const packageManager = packageJson?.packageManager ?? DEFAULT_BUN_VERSION
     const pikkuBin = resolvePikkuBin()
     const currentCliPackageRoot = resolveCurrentCliPackageRoot(pikkuBin)
     const env = {
@@ -756,7 +756,7 @@ export const FabricSmoke = pikkuSessionlessFunc({
       )
     }
 
-    if (!packageManager.startsWith('yarn@')) {
+    if (!packageManager.startsWith('bun@')) {
       const result = {
         ok: false,
         root,
@@ -767,7 +767,7 @@ export const FabricSmoke = pikkuSessionlessFunc({
         steps,
         failure: `Unsupported packageManager for Fabric smoke: ${packageManager}`,
         logTail:
-          'Fabric smoke expects package.json to declare a Yarn packageManager like "yarn@4.9.2".',
+          'Fabric is bun-only, so smoke runs the same way the build container does. Declare "packageManager": "bun@1.3.14" in package.json.',
       }
       process.exitCode = 1
       return result
@@ -827,9 +827,9 @@ export const FabricSmoke = pikkuSessionlessFunc({
 
       for (const step of [
         {
-          name: 'yarn install',
-          command: 'yarn',
-          commandArgs: ['install', '--mode=skip-build'],
+          name: 'bun install',
+          command: 'bun',
+          commandArgs: ['install', '--ignore-scripts'],
         },
         {
           name: 'pikku bootstrap',

--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -39,6 +39,7 @@ async function makeValidProject(root: string) {
     environments: { local: { apiUrl: 'http://localhost:4002' } },
   })
   await writeJson(join(root, 'package.json'), {
+    packageManager: 'bun@1.3.14',
     workspaces: ['packages/*', 'apps/*'],
     dependencies: { '@pikku/core': '^1.0.0' },
   })
@@ -528,12 +529,100 @@ describe('pikku fabric validate', () => {
     })
   })
 
+  describe('packageManager', () => {
+    test('yarn → error (Fabric is bun-only)', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        await writeJson(join(tmp, 'package.json'), {
+          packageManager: 'yarn@4.6.0',
+          workspaces: ['packages/*', 'apps/*'],
+          dependencies: { '@pikku/core': '^1.0.0' },
+        })
+        const result = await runValidate(tmp)
+        assert.strictEqual(result.ok, false)
+        const finding = result.findings.find(
+          (f) => f.id === 'package-manager-not-bun'
+        )
+        assert.ok(finding)
+        assert.strictEqual(finding!.severity, 'error')
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+
+    test('undeclared → error', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        await writeJson(join(tmp, 'package.json'), {
+          workspaces: ['packages/*', 'apps/*'],
+          dependencies: { '@pikku/core': '^1.0.0' },
+        })
+        const result = await runValidate(tmp)
+        assert.strictEqual(result.ok, false)
+        assert.ok(
+          result.findings.some((f) => f.id === 'package-manager-undeclared')
+        )
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+
+    test('bun → no finding', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        const result = await runValidate(tmp)
+        assert.ok(
+          !result.findings.some((f) => f.id.startsWith('package-manager-'))
+        )
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe('@pikku/cloudflare floor', () => {
+    test('0.12.19 → error (imports @pikku/core/internal, bundles 0 workers)', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        await writeJson(join(tmp, 'packages', 'functions', 'package.json'), {
+          type: 'module',
+          imports: {
+            '#pikku/*.js': './.pikku/*.ts',
+            '#pikku/*': './.pikku/*/index.ts',
+          },
+          dependencies: {
+            '@pikku/cloudflare': '^0.12.19',
+            '@pikku/schema-cfworker': '^0.12.0',
+            '@pikku/kysely': '^0.12.0',
+            '@pikku/addon-console': '^0.12.0',
+            '@pikku/better-auth': '^0.12.0',
+            zod: '^4',
+          },
+        })
+        const result = await runValidate(tmp)
+        assert.strictEqual(result.ok, false)
+        assert.ok(
+          result.findings.some(
+            (f) => f.id === 'pikku-version-below-min--pikku-cloudflare'
+          )
+        )
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+  })
+
   describe('root package.json', () => {
     test('missing @pikku/core → error', async () => {
       const tmp = await makeTmp()
       try {
         await makeValidProject(tmp)
         await writeJson(join(tmp, 'package.json'), {
+          packageManager: 'bun@1.3.14',
           workspaces: ['packages/*'],
           dependencies: {},
           devDependencies: { '@pikku/fabric-cli': '^1.0.0' },
@@ -551,6 +640,7 @@ describe('pikku fabric validate', () => {
       try {
         await makeValidProject(tmp)
         await writeJson(join(tmp, 'package.json'), {
+          packageManager: 'bun@1.3.14',
           dependencies: { '@pikku/core': '^1.0.0' },
           devDependencies: { '@pikku/fabric-cli': '^1.0.0' },
         })
@@ -571,6 +661,7 @@ describe('pikku fabric validate', () => {
       try {
         await makeValidProject(tmp)
         await writeJson(join(tmp, 'package.json'), {
+          packageManager: 'bun@1.3.14',
           workspaces: ['packages/*'],
           dependencies: {
             '@pikku/core': 'file:./vendor/pikku-core.tgz',
@@ -601,6 +692,7 @@ describe('pikku fabric validate', () => {
         await mkdir(join(tmp, 'vendor'), { recursive: true })
         await writeFile(join(tmp, 'vendor', 'pikku-core.tgz'), 'fake', 'utf8')
         await writeJson(join(tmp, 'package.json'), {
+          packageManager: 'bun@1.3.14',
           workspaces: ['packages/*'],
           dependencies: { '@pikku/core': 'file:./vendor/pikku-core.tgz' },
           devDependencies: { '@pikku/fabric-cli': '^1.0.0' },
@@ -626,7 +718,7 @@ describe('pikku fabric validate', () => {
             '#pikku/*': './.pikku/*/index.ts',
           },
           dependencies: {
-            '@pikku/cloudflare': '^0.12.6',
+            '@pikku/cloudflare': '^0.12.20',
             '@pikku/schema-cfworker': '^0.12.0',
             '@pikku/kysely': '^0.12.0',
             '@pikku/addon-console': '^0.12.0',
@@ -823,6 +915,7 @@ describe('pikku fabric validate', () => {
       try {
         await makeValidProject(tmp)
         await writeJson(join(tmp, 'package.json'), {
+          packageManager: 'bun@1.3.14',
           workspaces: ['packages/*'],
           dependencies: {
             '@pikku/core': '^1.0.0',

--- a/packages/cli/src/fabric/functions/validate.function.ts
+++ b/packages/cli/src/fabric/functions/validate.function.ts
@@ -174,9 +174,14 @@ const ACTOR_QUICK_LOGIN_PATTERNS = [
 //     listening (the sandbox never serves routes).
 //   - @pikku/core mismatches split pikkuState into duplicate copies, so app
 //     and console routes 404; pin the floor that matches the runtime.
+//   - @pikku/cloudflare < 0.12.20 imports '@pikku/core/internal', a subpath no
+//     published @pikku/core exports, so every worker fails to resolve and the
+//     deploy ends at "0 workers bundled (0B total)". The broken import is in
+//     the dependency's own dist, which no source-level check can see.
 const PIKKU_MIN_VERSIONS: Record<string, string> = {
   '@pikku/cli': '0.12.43',
   '@pikku/core': '0.12.34',
+  '@pikku/cloudflare': '0.12.20',
 }
 
 type Semver = [number, number, number]
@@ -269,9 +274,45 @@ export async function runValidate(
   const pikkuConfigPath = join(root, 'pikku.config.json')
   const rootPkgPath = join(root, 'package.json')
   const rootPkg = await readJsonSafe<{
+    packageManager?: string
     dependencies?: Record<string, string>
     devDependencies?: Record<string, string>
   }>(rootPkgPath)
+
+  // ── packageManager ─────────────────────────────────────────────────────
+  // The build container is bun-only end to end — install, pikku codegen and
+  // the frontend build all run under bun — and it refuses the repository
+  // before cloning finishes if package.json declares anything else. Nothing
+  // else in validate reads packageManager, so a yarn or pnpm project passed
+  // every check here and then died on the first line of the deploy.
+  {
+    const declared = rootPkg?.packageManager
+    if (!declared) {
+      e(
+        'package-manager-undeclared',
+        'package.json does not declare "packageManager" — Fabric is bun-only and the build container aborts with "Unsupported packageManager"',
+        rootPkgPath,
+        lines(
+          'Add it to the root package.json:',
+          '  "packageManager": "bun@1.3.14"',
+          'then run `bun install` to generate bun.lock and commit both.'
+        )
+      )
+    } else if (!declared.startsWith('bun@')) {
+      e(
+        'package-manager-not-bun',
+        `package.json declares packageManager "${declared}" — Fabric is bun-only and the build container aborts with "Unsupported packageManager"`,
+        rootPkgPath,
+        lines(
+          'Set the root package.json to bun:',
+          '  "packageManager": "bun@1.3.14"',
+          'then migrate the lockfile:',
+          '  bun install && rm -f yarn.lock pnpm-lock.yaml package-lock.json',
+          'and commit bun.lock.'
+        )
+      )
+    }
+  }
 
   // ── pikkufabric.config.json ────────────────────────────────────────────
   // Not required to run validate — downgraded to info so any pikku project
@@ -460,8 +501,8 @@ export async function runValidate(
           seen.manifest,
           lines(
             `Bump ${pkg} to ^${floorStr} (or newer) and reinstall:`,
-            `  yarn up ${pkg}@^${floorStr}`,
-            'Then run `yarn install` and re-run `pikku fabric validate`.'
+            `  bun add ${pkg}@^${floorStr}`,
+            'Then run `bun install` and re-run `pikku fabric validate`.'
           )
         )
       }
@@ -818,7 +859,7 @@ export async function runValidate(
           'missing-schema-cfworker',
           '@pikku/schema-cfworker is not in packages/functions dependencies — every Cloudflare worker entry requires it',
           fnPkgPath,
-          'Run `yarn add @pikku/schema-cfworker` in packages/functions — must be in dependencies, not devDependencies'
+          'Run `bun add @pikku/schema-cfworker` in packages/functions — must be in dependencies, not devDependencies'
         )
       }
       if (!fnPkg.dependencies?.['@pikku/kysely']) {
@@ -826,7 +867,7 @@ export async function runValidate(
           'missing-pikku-kysely',
           '@pikku/kysely is not in packages/functions dependencies — every Cloudflare worker entry requires it (KyselySecretService)',
           fnPkgPath,
-          'Run `yarn add @pikku/kysely` in packages/functions — must be in dependencies, not devDependencies'
+          'Run `bun add @pikku/kysely` in packages/functions — must be in dependencies, not devDependencies'
         )
       }
     }
@@ -843,7 +884,7 @@ export async function runValidate(
           'missing-ai-vercel',
           'Project declares agent units but @pikku/ai-vercel is not in packages/functions dependencies',
           fnPkgPath,
-          'Run `yarn add @pikku/ai-vercel` in packages/functions — must be in dependencies, not devDependencies'
+          'Run `bun add @pikku/ai-vercel` in packages/functions — must be in dependencies, not devDependencies'
         )
       }
       if (!fnPkg?.dependencies?.['@ai-sdk/openai-compatible']) {
@@ -851,7 +892,7 @@ export async function runValidate(
           'missing-ai-sdk-openai-compatible',
           'Project declares agent units but @ai-sdk/openai-compatible is not in packages/functions dependencies',
           fnPkgPath,
-          'Run `yarn add @ai-sdk/openai-compatible` in packages/functions — must be in dependencies, not devDependencies'
+          'Run `bun add @ai-sdk/openai-compatible` in packages/functions — must be in dependencies, not devDependencies'
         )
       }
       // `ai` is a peer dep of @pikku/ai-vercel — not auto-installed. Without it
@@ -862,7 +903,7 @@ export async function runValidate(
           'missing-ai-sdk-core',
           'Project declares agent units but `ai` (the Vercel AI SDK) is not in packages/functions dependencies — it is a peer dependency of @pikku/ai-vercel and is not installed automatically',
           fnPkgPath,
-          'Run `yarn add ai` in packages/functions — must be in dependencies, not devDependencies'
+          'Run `bun add ai` in packages/functions — must be in dependencies, not devDependencies'
         )
       }
     }
@@ -1526,7 +1567,7 @@ export async function runValidate(
             appPath,
             lines(
               `"${pkg}" is installed more than once (e.g. one hoisted to the repo root and one nested under apps/${name}).`,
-              `Declare "${pkg}" in exactly ONE workspace manifest (the root OR apps/${name}, not both), delete yarn.lock, and reinstall so it hoists to a single copy.`,
+              `Declare "${pkg}" in exactly ONE workspace manifest (the root OR apps/${name}, not both), delete bun.lock, and reinstall so it hoists to a single copy.`,
               '`resolutions` version-pins do NOT collapse a peer-virtualized duplicate.'
             )
           )


### PR DESCRIPTION
`pikku fabric validate` passed clean on a project the build container rejects on its first line. Three fixes.

## 1. `validate` had no `packageManager` check

`containers/ci/entrypoint.sh:89` refuses anything that isn't bun:

```
[deploy] Unsupported packageManager — Fabric is bun-only. Set packageManager: bun@1.3.14 in package.json.
```

Nothing in the 1825 lines of `validate.function.ts` read `packageManager`, so a yarn workspace validated clean and then failed the deploy 20 seconds in. New `package-manager-not-bun` / `package-manager-undeclared` errors mirror the container gate.

## 2. `smoke` asserted the opposite

```ts
const DEFAULT_YARN_VERSION = 'yarn@4.9.2'
if (!packageManager.startsWith('yarn@')) { failure: `Unsupported packageManager for Fabric smoke: ...` }
```

So `fabric smoke` rejected every project that can actually deploy. Inverted to bun, along with `bun install --ignore-scripts` and `bun run <script>` for the frontend steps. A project whose `dev.command` still starts with `yarn` is translated to `bun run …` rather than rejected.

## 3. `@pikku/cloudflare` floored at 0.12.20

Below that it does `import { pikkuState } from '@pikku/core/internal'` — a subpath no published `@pikku/core` exports. Every worker fails to resolve and the deploy ends at `0 workers bundled (0B total)`. The broken import lives in the dependency's own `dist`, so the undeclared-dependency check is structurally blind to it; the version floor is the only place it can be caught.

Fix hints across both files now say `bun add` / `bun install` instead of `yarn add` / `yarn up`.

## Verification

- `validate.function.test.ts`: 90/90 pass (86 before, 4 new covering both checks). Fixtures that overwrite the root `package.json` now declare `packageManager`, and the one fixture pinning `@pikku/cloudflare@^0.12.6` moved to `^0.12.20`.
- No new `tsc` errors — compared the error set before and after the patch on the same tree.
- Run against real projects:
  - **tazamun** → `package-manager-not-bun: packageManager "yarn@4.6.0"` — the exact blocker that killed its deploy
  - **seminarhof** → `@pikku/cloudflare is 0.12.19 (spec "^0.12.19") — Fabric requires >= 0.12.20`
  - **germantax** (bun + 0.12.20) → neither finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)