### PR TITLE
fix(kysely-postgres): hold the workflow run lock on a session, not a transaction

### DIFF
--- a/.changeset/pg-run-lock-holds-no-transaction.md
+++ b/.changeset/pg-run-lock-holds-no-transaction.md
@@ -1,0 +1,5 @@
+---
+'@pikku/kysely-postgres': patch
+---
+
+the Postgres run lock is now a session advisory lock, so a long workflow body no longer parks its connection `idle in transaction`

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
@@ -41,6 +41,7 @@ class PGliteDriver implements Driver {
         sql: string
         parameters: readonly unknown[]
       }): Promise<QueryResult<R>> => {
+        executedSql.push(compiled.sql)
         const result = await this.pglite.query<R>(compiled.sql, [
           ...compiled.parameters,
         ])
@@ -91,6 +92,10 @@ class PGliteDriver implements Driver {
 }
 
 const releases = new Map<DatabaseConnection, Array<() => void>>()
+
+/** Every statement the dialect issued, so a test can assert on the shape of a
+ *  critical section rather than only on its result. */
+const executedSql: string[] = []
 
 class PGliteDialect implements Dialect {
   constructor(private readonly pglite: PGlite) {}
@@ -412,6 +417,59 @@ describe('advisory locks', () => {
 
     release()
     await held
+  })
+
+  /**
+   * The bug this guards: the run lock used to be `pg_advisory_xact_lock` inside
+   * `lockDb.transaction()`, so a workflow body awaiting a build or an LLM left
+   * the connection `idle in transaction` for as long as it ran. On a shared
+   * pool that starves every other caller, and Postgres cannot vacuum past the
+   * pinned xid.
+   */
+  test('a run lock holds no transaction while the body runs', async () => {
+    const { run, bodyEntered, release } = heldBody()
+
+    executedSql.length = 0
+    const held = service.withRunLock('run-1', run)
+    await bodyEntered
+
+    assert.deepEqual(
+      executedSql.filter((statement) => statement === 'begin'),
+      [],
+      'the run lock opened a transaction around the workflow body'
+    )
+    assert.ok(
+      executedSql.some((statement) => statement.includes('pg_advisory_lock')),
+      'the run lock was never taken'
+    )
+
+    release()
+    await held
+
+    assert.ok(
+      executedSql.some((statement) => statement.includes('pg_advisory_unlock')),
+      'the run lock was never released'
+    )
+  })
+
+  test('a lock timeout is reset before the connection goes back', async () => {
+    const timed = new PgKyselyWorkflowService(db, {
+      wireQueues: false,
+      lockTimeoutMs: 250,
+    } as any)
+    await timed.init()
+
+    executedSql.length = 0
+    await timed.withRunLock('run-1', async () => 'done')
+
+    assert.ok(
+      executedSql.some((statement) => statement === 'SET lock_timeout = 250'),
+      'lock_timeout was never applied'
+    )
+    assert.ok(
+      executedSql.some((statement) => statement === 'RESET lock_timeout'),
+      'lock_timeout rode the connection back into the pool'
+    )
   })
 
   test('a non-finite lock timeout is rejected', () => {

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
@@ -11,7 +11,7 @@ export interface PgWorkflowQueueOptions extends WorkflowQueueOptions {
    * body. Its size caps concurrent runs per process; size it above the deepest
    * chain of runs that start each other inline, or a parent waiting on a child
    * deadlocks. Every worker's lock pool must point at the same database —
-   * `pg_advisory_xact_lock` is database-scoped, so pools on different databases
+   * `pg_advisory_lock` is database-scoped, so pools on different databases
    * never contend and the same run executes twice. Defaults to `db`.
    */
   lockDb?: Kysely<KyselyPikkuDB>
@@ -72,16 +72,37 @@ export class PgKyselyWorkflowService extends KyselyWorkflowService {
     return hash
   }
 
+  /**
+   * A session lock, not a transaction one: the critical section is the whole
+   * workflow body, so it may await a build, an LLM or a webhook for minutes.
+   * Under `pg_advisory_xact_lock` that left the connection `idle in
+   * transaction` for the duration — an xid Postgres cannot vacuum past, and a
+   * shape that turns one wedged run into a pool outage. `pg_advisory_lock`
+   * holds the same lock without an open transaction; the session still dies
+   * with the connection, so a crashed holder still releases.
+   *
+   * `lock_timeout` is set and reset rather than `SET LOCAL`, which only exists
+   * inside a transaction, and the reset is what stops the setting from riding
+   * the connection back into the pool.
+   */
   async withRunLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
     const lockId = this.hashStringToInt(`run:${id}`)
-    return this.lockDb.transaction().execute(async (trx) => {
-      if (this.lockTimeoutMs > 0) {
-        await sql
-          .raw(`SET LOCAL lock_timeout = ${this.lockTimeoutMs}`)
-          .execute(trx)
+    return this.lockDb.connection().execute(async (conn) => {
+      try {
+        if (this.lockTimeoutMs > 0) {
+          await sql.raw(`SET lock_timeout = ${this.lockTimeoutMs}`).execute(conn)
+        }
+        await sql`SELECT pg_advisory_lock(${lockId})`.execute(conn)
+        try {
+          return await fn()
+        } finally {
+          await sql`SELECT pg_advisory_unlock(${lockId})`.execute(conn)
+        }
+      } finally {
+        if (this.lockTimeoutMs > 0) {
+          await sql.raw('RESET lock_timeout').execute(conn)
+        }
       }
-      await sql`SELECT pg_advisory_xact_lock(${lockId})`.execute(trx)
-      return fn()
     })
   }
 


### PR DESCRIPTION
## The failure

A Fabric control plane went fully unavailable: every authenticated request hung indefinitely while unauthenticated ones still answered in 250ms. Postgres showed why.

```
3 sessions  idle in transaction  holding pg_advisory_xact_lock  (oldest 3h43m)
17 sessions active, blocked, waiting on 2 advisory keys
```

`withRunLock` wraps the entire workflow body (`runPikkuFunc` in `pikku-workflow-service.ts`), so its critical section is arbitrary user code — in this case a deploy workflow awaiting a container build. Taking the lock as `pg_advisory_xact_lock` inside `lockDb.transaction()` means:

1. the connection sits **`idle in transaction`** for as long as the workflow runs, pinning an xid Postgres cannot vacuum past, and
2. because the lock **blocks**, every redundant relay redispatch queues behind it rather than losing the claim — one connection each, arriving about once a minute until the pool is gone.

`lockDb` bounds the blast radius when it is configured, but it defaults to `db`, so out of the box the queue pool is what dies. With `lockTimeoutMs` defaulting to `0` the wait is unbounded.

## The change

`withRunLock` now takes `pg_advisory_lock` on a connection pinned with `lockDb.connection()`, releases it in `finally`, and holds no transaction. Same lock, same scope, same `lockDb` and `lockTimeoutMs` semantics — a crashed holder still releases, because the session dies with the connection.

`lock_timeout` moves from `SET LOCAL` (which only exists inside a transaction) to a set/`RESET` pair, so the setting cannot ride the connection back into the pool.

`withStepLock` is deliberately untouched: its critical section is the handful of statements that claim the step, which is exactly what a transaction is for.

## Tests

Two new cases in the existing PGlite suite, both verified to fail on `main` and pass here:

- `a run lock holds no transaction while the body runs` — asserts no `begin` is issued around the body, and that an explicit unlock follows it.
- `a lock timeout is reset before the connection goes back`.

Full suite: 20/20.

## Worth a follow-up

`lockTimeoutMs` defaulting to `0` — wait forever — is a sharp default for a lock whose holder runs arbitrary user code, since it still lets waiters accumulate one connection at a time. Left alone here because it is documented behaviour and this PR is meant to stay surgical, but it is the other half of the same failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)