### PR TITLE
fix: stop re-exporting package internals through entry points

### DIFF
--- a/.changeset/unexport-star-entrypoints.md
+++ b/.changeset/unexport-star-entrypoints.md
@@ -1,0 +1,24 @@
+---
+'@pikku/azure-functions': patch
+'@pikku/aws-services': patch
+'@pikku/tanstack-start': patch
+'@pikku/uws-handler': patch
+'@pikku/cloudflare': patch
+'@pikku/inspector': patch
+'@pikku/fastify': patch
+'@pikku/browser': patch
+'@pikku/express': patch
+'@pikku/lambda': patch
+'@pikku/core': patch
+'@pikku/cli': patch
+'@pikku/uws': patch
+'@pikku/ws': patch
+---
+
+Stop re-exporting package internals through entry points
+
+66 names reached consumers only because an `export *` in an entry point swept
+them up. Each one is referenced solely inside its own package, so the star is
+now an explicit named re-export listing what is genuinely public. The
+declarations themselves are untouched — this narrows the entry point, not the
+module.

--- a/packages/cli/src/functions/commands/new-addon.test.ts
+++ b/packages/cli/src/functions/commands/new-addon.test.ts
@@ -225,28 +225,45 @@ describe('getAddonFiles', () => {
     ).exports[subpath === '.' ? '.' : `.${subpath}`]
     assert.ok(target, `@pikku/core does not export ${specifier}`)
 
-    // The entry point is a barrel of `export *`, so what it carries is only
-    // visible by walking the chain — the names are declared in the same file
-    // either way, and a check on the declaration passes for a subpath that
-    // does not re-export them.
+    // The entry point re-exports rather than declares, so what it carries is
+    // only visible by walking the chain — the names are declared in the same
+    // file either way, and a check on the declaration passes for a subpath
+    // that does not re-export them.
     const reachable = (entry: string, seen = new Set<string>()): string => {
       if (seen.has(entry)) return ''
       seen.add(entry)
       const source = readFileSync(entry, 'utf8')
+      const resolve = (specifier: string) =>
+        join(dirname(entry), specifier.replace(/\.js$/, '.ts'))
       let text = source
       for (const star of source.matchAll(
         /export (?:type )?\* from '(\.[^']*)'/g
       )) {
-        text += reachable(
-          join(dirname(entry), star[1]!.replace(/\.js$/, '.ts')),
-          seen
-        )
+        text += reachable(resolve(star[1]!), seen)
+      }
+      for (const named of source.matchAll(
+        /export (?:type )?\{([^}]*)\} from '(\.[^']*)'/g
+      )) {
+        const carried = reachable(resolve(named[2]!), new Set(seen))
+        for (const name of named[1]!.split(',')) {
+          const exported = name.trim().split(/\s+as\s+/)[0]
+          if (!exported) continue
+          const declaration = carried.match(
+            new RegExp(
+              `\\bexport (?:interface|type|const|class) ${exported}\\b`
+            )
+          )
+          if (declaration) text += `\n${declaration[0]}`
+        }
       }
       return text
     }
 
     const exported = reachable(
-      join(coreRoot, target.replace(/^\.\/dist\//, 'src/').replace(/\.js$/, '.ts'))
+      join(
+        coreRoot,
+        target.replace(/^\.\/dist\//, 'src/').replace(/\.js$/, '.ts')
+      )
     )
     for (const name of applicationTypes.matchAll(/\bCore[A-Za-z]+/g)) {
       assert.match(

--- a/packages/cli/src/functions/surface/entrypoints-hide-internals.test.ts
+++ b/packages/cli/src/functions/surface/entrypoints-hide-internals.test.ts
@@ -1,0 +1,129 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { collectSurface } from './collect-surface.js'
+
+const repoRoot = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  '..',
+  '..'
+)
+
+const HIDDEN: Record<string, Record<string, string[]>> = {
+  'packages/core': {
+    './types': [
+      'CoreSecretlessSingletonServices',
+      'PikkuRawWire',
+      'SchemaRefLike',
+    ],
+    './scenario': [
+      'FeatureMetaEntry',
+      'FeaturePlanEntry',
+      'PikkuScenarioStepWire',
+      'ScenarioArtifactKind',
+      'ScenarioSkip',
+      'ScenarioStepInvocation',
+      'ScenarioSurfaceResolution',
+    ],
+    './dev': ['ReloadGeneratedMetaOptions'],
+  },
+  'packages/inspector': {
+    '.': [
+      'AddWiring',
+      'ExportedCLIContractsMeta',
+      'ExportedChannelContractsMeta',
+      'ExportedChannelRouteMeta',
+      'ExportedHTTPContractsMeta',
+      'ExportedHTTPRouteConfigMeta',
+      'ExportedHTTPRouteEntryMeta',
+      'ExportedHTTPRouteFunctionMeta',
+      'ExportedHTTPRouteMapMeta',
+      'ExportedHTTPRoutesGroupMeta',
+      'InspectorAIMiddlewareState',
+      'InspectorApprovalDescriptionDefinition',
+      'InspectorChannelMiddlewareState',
+      'InspectorChannelState',
+      'InspectorExportedContractsState',
+      'InspectorFilesAndMethods',
+      'InspectorFunctionState',
+      'InspectorMiddlewareDefinition',
+      'InspectorMiddlewareInstance',
+      'InspectorPermissionDefinition',
+      'InspectorPermissionInstance',
+      'PathToNameAndType',
+      'SchemaVendor',
+    ],
+    './workflow-graph': [
+      'FlowType',
+      'SerializedGraphNode',
+      'SerializedNext',
+      'StateRef',
+      'WorkflowSourceType',
+      'WorkflowWires',
+      'isFlowNode',
+      'isStateRef',
+    ],
+  },
+  'packages/runtimes/aws-lambda': { '.': ['LambdaServiceFactories'] },
+  'packages/runtimes/azure-functions': { '.': ['AzureServiceFactories'] },
+  'packages/runtimes/cloudflare': {
+    '.': ['RunFetchOptions'],
+    './workflow-do': [
+      'DoPendingAlarm',
+      'DoRunRecord',
+      'DoStepHistoryRecord',
+      'DoStepRecord',
+      'PikkuDoStepDispatch',
+      'PikkuStepStub',
+      'PikkuStepWorker',
+      'PikkuStepWorkerEnv',
+      'PikkuWorkflowDoEnv',
+      'PikkuWorkflowDoOptions',
+    ],
+  },
+  'packages/runtimes/express-server': { '.': ['ExpressCoreConfig'] },
+  'packages/runtimes/fastify-server': { '.': ['FastifyCoreConfig'] },
+  'packages/runtimes/tanstack-start': { '.': ['TanStackStartAuthContext'] },
+  'packages/runtimes/uws-handler': { '.': ['PikkuuWSHandlerOptions'] },
+  'packages/runtimes/uws-server': { '.': ['UWSCoreConfig'] },
+  'packages/runtimes/ws': { '.': ['PikkuWSHandlerOptions'] },
+  'packages/services/aws-services': { '.': ['SQSQueueServiceConfig'] },
+  'packages/services/browser': {
+    '.': [
+      'BrowserLaunchOptions',
+      'BrowserLimits',
+      'BrowserSession',
+      'BrowserSessionInfo',
+    ],
+  },
+}
+
+describe('entry points do not re-export package internals', () => {
+  for (const [location, bySubpath] of Object.entries(HIDDEN)) {
+    test(location, async () => {
+      const surface = await collectSurface(join(repoRoot, location))
+
+      for (const [subpath, hidden] of Object.entries(bySubpath)) {
+        const entrypoint = surface.find((each) => each.subpath === subpath)
+        assert.ok(
+          entrypoint,
+          `${location} no longer declares the ${subpath} entry point`
+        )
+
+        const exported = new Set(entrypoint.symbols.map((each) => each.name))
+        const leaked = hidden.filter((name) => exported.has(name))
+
+        assert.deepEqual(
+          leaked,
+          [],
+          `${location} ${subpath} re-exports internals: ${leaked.join(', ')}`
+        )
+      }
+    })
+  }
+})

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,8 +5,8 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2698 observable things**: 862 exported names, plus
-1836 members on the classes and interfaces among them, reachable
+**2674 observable things**: 851 exported names, plus
+1823 members on the classes and interfaces among them, reachable
 through 53 entry points.
 
 An entry point whose exports are mostly *exclusive* is a self-contained
@@ -15,13 +15,13 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | entry point | exports | exclusive | members on those |
 | --- | ---: | ---: | ---: |
 | `./services` | 135 | 110 | 396 |
-| `./scenario` | 52 | 52 | 141 |
+| `./scenario` | 45 | 45 | 133 |
 | `./workflow` | 82 | 33 | 134 |
 | `./virtual-user` | 34 | 34 | 115 |
 | `./agent` | 49 | 47 | 81 |
 | `./channel` | 32 | 32 | 84 |
-| `./types` | 26 | 23 | 74 |
 | `./queue` | 22 | 22 | 71 |
+| `./types` | 23 | 20 | 72 |
 | `./http` | 25 | 25 | 49 |
 | `./errors` | 49 | 49 | 20 |
 | `./persona` | 27 | 27 | 34 |
@@ -47,7 +47,6 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | `./scope` | 12 | 12 | 0 |
 | `./services/temporary-file-service` | 2 | 2 | 9 |
 | `./addon` | 8 | 8 | 2 |
-| `./dev` | 5 | 5 | 5 |
 | `./safe-fetch` | 6 | 6 | 3 |
 | `./role` | 9 | 9 | 0 |
 | `./state` | 9 | 8 | 0 |
@@ -57,6 +56,7 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | `./scheduler` | 6 | 6 | 0 |
 | `./variable` | 6 | 6 | 0 |
 | `./schema` | 6 | 6 | 0 |
+| `./dev` | 4 | 4 | 2 |
 | `./credential` | 5 | 5 | 0 |
 | `./services/istanbul-coverage` | 1 | 1 | 4 |
 | `./services/local-content-request-handler` | 5 | 5 | 0 |
@@ -189,9 +189,6 @@ export type CoreConfig<Config extends Record<string, unknown> = {}> = {
   webhook?: WebhookServiceConfig
   postgres?: PostgresConfig
 } & Config
-export type CoreSecretlessSingletonServices<
-  Config extends CoreConfig = CoreConfig,
-> = SecretlessServices<CoreSingletonServices<Config>>
 export type CoreServices<SingletonServices = CoreSingletonServices> =
   SingletonServices
 export interface CoreSingletonServices<Config extends CoreConfig = CoreConfig> {
@@ -278,7 +275,6 @@ export interface PikkuPackageState {
   misc: { errors: Map<PikkuErrorConstructor, ErrorDetails>; schemas: Map<string, any>; middleware: Record<string, CorePikkuMiddleware[]>; channelMiddleware: Record<string, CorePikkuChannelMiddleware[]>; permissions: Record<string, CorePermissionGroup | CorePikkuPermission[]> }
   package: { factories: { createConfig?: CreateConfig<CoreConfig>; createSingletonServices?: CreateSingletonServices< CoreConfig, CoreSingletonServices >; createWireServices?: CreateWireServices< CoreSingletonServices, CoreServices, CoreUserSession > } | null; singletonServices: CoreSingletonServices | null; authFactory:; ((services: CoreSingletonServices) => unknown | Promise<unknown>) | null; credentialsMeta: Record< string, { name: string; displayName: string; type: string; oauth2?: boolean } > | null; requiredParentServices: string[] | null; declaredSecrets: string[] | null }
 }
-export type PikkuRawWire = Omit<PikkuWire, 'rpc'>
 export type PikkuWire<
   In = unknown,
   Out = unknown,
@@ -355,10 +351,6 @@ export interface PostgresConfig {
   maxLifetime?: number
   statementTimeout?: number
   prepare?: boolean
-}
-export interface SchemaRefLike {
-  variableName: string
-  sourceFile: string
 }
 export type SecretlessServices<Services> = Omit<Services, 'secrets'>
 export interface SecurityAuditIssue {
@@ -1536,17 +1528,6 @@ export type FeatureMeta = {
   hasBefore: boolean
   hasAfter: boolean
 }
-export type FeatureMetaEntry = {
-  scenario: string
-  data?: unknown
-}
-export type FeaturePlanEntry = {
-  featureId: string
-  featureName: string
-  scenarioName: string
-  data?: unknown
-  tags: string[]
-}
 export type FeaturesMeta = Record<string, FeatureMeta>
 export interface PikkuBrowserWire {
   readonly actor: string
@@ -1569,14 +1550,6 @@ export class PikkuScenarioService implements WorkflowRunExtension {
   public async onAfterRunFunc(context: RunLifecycleContext, outcome: 'completed' | 'failed' | 'interrupted', failure: unknown): Promise<void>
   public async resolvePersonas(): Promise<ScenarioPersonas | undefined>
   public decorateWorkflowWire(wire: PikkuWorkflowWire, context: { name: string; runId: string; rpcService: any; addonNamespace?: string | null }): void
-}
-export interface PikkuScenarioStepWire {
-  name: string
-  stepName: string
-  runId: string
-  phase: ScenarioStepPhase
-  surface: ScenarioSurface
-  env?: ScenarioEnvironment
 }
 export interface PikkuScenarioWire<Out = unknown> extends PikkuWorkflowWire {
   context: ScenarioContext<Out>
@@ -1609,7 +1582,6 @@ export interface ScenarioArtifact {
   actor?: string
   name?: string
 }
-export type ScenarioArtifactKind = 'screenshot' | 'failure' | 'video'
 export interface ScenarioBrowserFailure {
   actor: string
   url?: string
@@ -1718,16 +1690,6 @@ export interface ScenarioRunSummary {
   skipped: number
   artifacts: number
 }
-export interface ScenarioSkip {
-  name: string
-  reason: string
-}
-export type ScenarioStepInvocation = <TOutput = any, TInput = any>(
-  stepName: string,
-  stepFunc: string,
-  data?: TInput,
-  options?: ScenarioStepOptions
-) => Promise<TOutput>
 export type ScenarioStepKind = 'persona' | 'platform' | 'addon'
 export interface ScenarioStepMeta {
   type: 'scenarioStep'
@@ -1754,17 +1716,6 @@ export interface ScenarioStepRow {
   error?: string
 }
 export type ScenarioSurface = 'browser' | 'cli' | 'default'
-export type ScenarioSurfaceResolution =
-  | {
-      kind: 'action'
-      surface: ScenarioSurface
-      fellBack: boolean
-    }
-  | {
-      kind: 'witness'
-      surfaces: ScenarioSurface[]
-      unwitnessed: boolean
-    }
 export class ScenarioWitnessDisagreement extends PikkuError {
   constructor(public readonly stepFunc: string, public readonly expected: { surface: ScenarioSurface; observed: unknown }, public readonly actual: { surface: ScenarioSurface; observed: unknown })
 }
@@ -5590,9 +5541,4 @@ export interface PikkuDevReloaderHandle {
 }
 reconcileAddonRegistry: (declaredNamespaces: Iterable<string>, logger?: Logger | undefined) => void
 reloadGeneratedMeta: (options: ReloadGeneratedMetaOptions) => Promise<void>
-export interface ReloadGeneratedMetaOptions {
-  pikkuDir: string
-  logger: Logger
-  schemaService?: SchemaService
-}
 ```

--- a/packages/core/src/dev/hot-reload.ts
+++ b/packages/core/src/dev/hot-reload.ts
@@ -11,7 +11,7 @@ import type { Logger } from '../services/logger.js'
 import type { CorePikkuFunctionConfig } from '../function/functions.types.js'
 import { createModuleRunner } from './module-runner.js'
 
-export * from './reload-meta.js'
+export { reloadGeneratedMeta, reconcileAddonRegistry } from './reload-meta.js'
 
 interface PikkuDevReloaderOptions {
   srcDirectories: string[]

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,2 +1,25 @@
-export * from './core.types.js'
+export type {
+  AuthInstance,
+  CommonWireMeta,
+  CoreConfig,
+  CoreServices,
+  CoreSingletonServices,
+  CoreUserSession,
+  CreateConfig,
+  CreateSingletonServices,
+  CreateWireServices,
+  GetCredential,
+  PikkuWire,
+  PikkuWiringTypes,
+  PostgresConfig,
+  SecretlessServices,
+  SecurityAuditIssue,
+  SecurityAuditReport,
+  SecurityAuditSummary,
+  SecurityAuditUpdate,
+  SecuritySeverity,
+  SecurityUpdateLevel,
+  ServerLifecycle,
+  WireServices,
+} from './core.types.js'
 export type * from './state.types.js'

--- a/packages/core/src/wirings/workflow/pikku-scenario-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-scenario-service.ts
@@ -59,8 +59,34 @@ const assertionStep = <T extends WorkflowStepOptions>(
   ({ ...options, retries: options?.retries ?? 0 }) as T & { retries: number }
 
 export { addFeature, resolveFeatureScenarios } from './feature.js'
-export type * from './scenario.types.js'
-export type * from './scenario-run.types.js'
+export type {
+  CoreFeature,
+  CoreFeatureScenario,
+  FeatureMeta,
+  FeaturesMeta,
+  PikkuBrowserWire,
+  PikkuScenarioWire,
+  ScenarioBrowserFailure,
+  ScenarioBrowserProvider,
+  ScenarioEnvironment,
+  ScenarioStepKind,
+  ScenarioStepMeta,
+  ScenarioStepOptions,
+  ScenarioStepPhase,
+  ScenarioSurface,
+  TestIdSelector,
+} from './scenario.types.js'
+export type {
+  ScenarioArtifact,
+  ScenarioFailureDetail,
+  ScenarioResult,
+  ScenarioRunRecord,
+  ScenarioRunReport,
+  ScenarioRunStatus,
+  ScenarioRunStore,
+  ScenarioRunSummary,
+  ScenarioStepRow,
+} from './scenario-run.types.js'
 export { SCENARIO_SURFACES } from './scenario-step.types.js'
 
 // Which of a step's bindings run: one for an action, every witness for a `then`
@@ -979,10 +1005,7 @@ export class PikkuScenarioService implements WorkflowRunExtension {
    * Whether a step is driven by a persona, and so must be given one. Stamped by
    * the definer from a `browser` binding or an explicit `actor: true`.
    */
-  private requiresActor(
-    packageName: string | null,
-    stepFunc: string
-  ): boolean {
+  private requiresActor(packageName: string | null, stepFunc: string): boolean {
     return (
       this.scenarioStepConfig(packageName, stepFunc)?.requiresActor === true
     )

--- a/packages/inspector/src/index.ts
+++ b/packages/inspector/src/index.ts
@@ -1,6 +1,21 @@
 export { inspect, getInitialInspectorState } from './inspector.js'
 export type { TypesMap } from './types-map.js'
-export type * from './types.js'
+export type {
+  AddonConfig,
+  AuthDefinition,
+  InspectorDiagnostic,
+  InspectorFilters,
+  InspectorHTTPState,
+  InspectorLogger,
+  InspectorMiddlewareState,
+  InspectorOptions,
+  InspectorPermissionState,
+  InspectorState,
+  MetaInputTypes,
+  MiddlewareGroupMeta,
+  MiddlewareRegistration,
+  SchemaRef,
+} from './types.js'
 export type { FilesAndMethodsErrors } from './utils/get-files-and-methods.js'
 export { ErrorCode } from './error-codes.js'
 export type { DiagnosticSeverity, CodedDiagnostic } from './error-codes.js'

--- a/packages/inspector/src/utils/workflow/graph/index.ts
+++ b/packages/inspector/src/utils/workflow/graph/index.ts
@@ -1,7 +1,24 @@
 /**
  * Workflow graph serialization exports
  */
-export * from './workflow-graph.types.js'
+export {
+  isDataRef,
+  isFunctionNode,
+  ref,
+  state,
+} from './workflow-graph.types.js'
+export type {
+  BranchCondition,
+  ContextVariable,
+  DataRef,
+  FlowNode,
+  ForEachMode,
+  FunctionNode,
+  NodeOptions,
+  SerializedWorkflowGraph,
+  SerializedWorkflowGraphs,
+  WorkflowContext,
+} from './workflow-graph.types.js'
 export { serializeWorkflowGraph } from './serialize-workflow-graph.js'
 export { convertDslToGraph } from './convert-dsl-to-graph.js'
 export { finalizeWorkflows } from './finalize-workflows.js'

--- a/packages/runtimes/aws-lambda/src/index.ts
+++ b/packages/runtimes/aws-lambda/src/index.ts
@@ -2,6 +2,10 @@ export * from './http/index.js'
 export * from './websocket/index.js'
 export * from './queue/index.js'
 export * from './scheduled/index.js'
-export * from './handler-factories.js'
+export {
+  createLambdaHandler,
+  createLambdaWorkerHandler,
+  createLambdaWebSocketHandler,
+} from './handler-factories.js'
 export { SQSQueueService } from './sqs-queue-service.js'
 export { LambdaDeploymentService } from './lambda-deployment-service.js'

--- a/packages/runtimes/azure-functions/src/index.ts
+++ b/packages/runtimes/azure-functions/src/index.ts
@@ -1,5 +1,9 @@
 export * from './pikku-az-functions-logger.js'
 export * from './pikku-az-timer-request.js'
-export * from './handler-factories.js'
+export {
+  createAzureHandler,
+  createAzureWorkerHandler,
+  createAzureWebSocketHandler,
+} from './handler-factories.js'
 export { AzureQueueService } from './azure-queue-service.js'
 export { AzureDeploymentService } from './azure-deployment-service.js'

--- a/packages/runtimes/cloudflare/src/index.ts
+++ b/packages/runtimes/cloudflare/src/index.ts
@@ -1,4 +1,4 @@
-export * from './run-fetch.js'
+export { runFetch } from './run-fetch.js'
 export * from './run-scheduled.js'
 export * from './cloudflare-hibernation-websocket-server.js'
 export * from './cloudflare-eventhub-service.js'

--- a/packages/runtimes/cloudflare/src/workflow-do/index.ts
+++ b/packages/runtimes/cloudflare/src/workflow-do/index.ts
@@ -1,5 +1,4 @@
-export * from './do-storage-types.js'
-export * from './pikku-workflow-do-service.js'
-export * from './pikku-workflow-do.js'
-export * from './pikku-step-worker.js'
+export type { DoWorkflowVersionRecord } from './do-storage-types.js'
+export { PikkuWorkflowDoService } from './pikku-workflow-do-service.js'
+export { PikkuWorkflowDO } from './pikku-workflow-do.js'
 export * from './pikku-workflow-do-client.js'

--- a/packages/runtimes/express-server/src/index.ts
+++ b/packages/runtimes/express-server/src/index.ts
@@ -2,4 +2,4 @@
  * @module @pikku/express
  */
 
-export * from './pikku-express-server.js'
+export { PikkuExpressServer } from './pikku-express-server.js'

--- a/packages/runtimes/fastify-server/src/index.ts
+++ b/packages/runtimes/fastify-server/src/index.ts
@@ -6,4 +6,4 @@
  * @module @pikku/fastify
  */
 
-export * from './pikku-fastify-server.js'
+export { PikkuFastifyServer } from './pikku-fastify-server.js'

--- a/packages/runtimes/tanstack-start/src/index.ts
+++ b/packages/runtimes/tanstack-start/src/index.ts
@@ -1,1 +1,1 @@
-export * from './pikku-tanstack-start.js'
+export { toTanStackStartAuthHandler } from './pikku-tanstack-start.js'

--- a/packages/runtimes/uws-handler/src/index.ts
+++ b/packages/runtimes/uws-handler/src/index.ts
@@ -2,5 +2,5 @@
  * @module @pikku/uws-handler
  */
 
-export * from './pikku-uws-http-handler.js'
+export { pikkuHTTPHandler } from './pikku-uws-http-handler.js'
 export * from './pikku-uws-websocket-handler.js'

--- a/packages/runtimes/uws-server/src/index.ts
+++ b/packages/runtimes/uws-server/src/index.ts
@@ -2,4 +2,4 @@
  * @module @pikku/uws
  */
 
-export * from './pikku-uws-server.js'
+export { PikkuUWSServer } from './pikku-uws-server.js'

--- a/packages/runtimes/ws/src/index.ts
+++ b/packages/runtimes/ws/src/index.ts
@@ -2,4 +2,7 @@
  * @module @pikku/ws
  */
 
-export * from './pikku-ws-server.js'
+export {
+  DEFAULT_WS_MAX_PAYLOAD,
+  pikkuWebsocketHandler,
+} from './pikku-ws-server.js'

--- a/packages/services/aws-services/src/index.ts
+++ b/packages/services/aws-services/src/index.ts
@@ -1,4 +1,4 @@
 export * from './aws-config.js'
 export * from './aws-secrets.js'
 export * from './s3-content.js'
-export * from './sqs-queue-service.js'
+export { SQSQueueService } from './sqs-queue-service.js'

--- a/packages/services/browser/src/index.ts
+++ b/packages/services/browser/src/index.ts
@@ -1,2 +1,2 @@
-export * from './browser-service.interface.js'
+export type { BrowserService } from './browser-service.interface.js'
 export { LocalBrowserService } from './local-browser.service.js'


### PR DESCRIPTION
Closes the unexport half of #1233.

## What an `export *` costs

An entry point that says `export * from './handler-factories.js'` publishes
every name that module declares, not the ones it means to. #1238's tooling
could only see explicit named re-exports, so the names riding out on a star
stayed invisible to it — the issue's "63 behind `export *`".

Enumerating each package's `exports` map with the CLI's own
`collectSurface` (a real `ts.Program`, `checker.getExportsOfModule()`, so
stars resolve) and cross-referencing every name against the monorepo, the
generated `e2e/.pikku` output, the strings the CLI emits into user code,
`templates/`, `verifiers/`, the docs and skills, and
`packages/core/src/public-surface.json` leaves **66 names that nothing outside
their own package ever touches**.

Every such star becomes an explicit named re-export of what is genuinely
public. Declarations are untouched — this narrows the entry point, not the
module. Pre-0.13, no deprecated aliases: the re-export is simply gone.

## Removed, by package

| package | entry point | names |
| --- | --- | --- |
| `@pikku/inspector` | `.` | `AgentMeta`-adjacent internals — 23 names dropped from `export type * from './types.js'` |
| `@pikku/inspector` | `./workflow-graph` | `StateRef`, `isStateRef`, `SerializedNext`, `FlowType`, `SerializedGraphNode`, `isFlowNode`, `WorkflowSourceType`, `WorkflowWires` |
| `@pikku/core` | `./scenario` | `ScenarioStepInvocation`, `PikkuScenarioStepWire`, `ScenarioSurfaceResolution`, `FeatureMetaEntry`, `FeaturePlanEntry`, `ScenarioArtifactKind`, `ScenarioSkip` |
| `@pikku/core` | `./types` | `PikkuRawWire`, `CoreSecretlessSingletonServices`, `SchemaRefLike` |
| `@pikku/core` | `./dev` | `ReloadGeneratedMetaOptions` |
| `@pikku/cloudflare` | `./workflow-do` | 10 names across the DO storage, service, and step-worker modules |
| `@pikku/cloudflare` | `.` | `RunFetchOptions` |
| `@pikku/browser` | `.` | `BrowserSession`, `BrowserSessionInfo`, `BrowserLaunchOptions`, `BrowserLimits` |
| `@pikku/lambda` | `.` | `LambdaServiceFactories` |
| `@pikku/azure-functions` | `.` | `AzureServiceFactories` |
| `@pikku/express` | `.` | `ExpressCoreConfig` |
| `@pikku/fastify` | `.` | `FastifyCoreConfig` |
| `@pikku/tanstack-start` | `.` | `TanStackStartAuthContext` |
| `@pikku/uws-handler` | `.` | `PikkuuWSHandlerOptions` |
| `@pikku/uws` | `.` | `UWSCoreConfig` |
| `@pikku/ws` | `.` | `PikkuWSHandlerOptions` |
| `@pikku/aws-services` | `.` | `SQSQueueServiceConfig` |

## The guard

`packages/cli/src/functions/surface/entrypoints-hide-internals.test.ts` runs
`collectSurface` over each affected package and asserts these names are absent
from the entry point. It failed before the change and passes after, and a
future `export *` that re-widens the surface fails it.

`packages/core/api-report.md` is regenerated: 862 → 851 exported names.

`new-addon.test.ts`'s reachability walker followed only `export *`; it now
follows named re-exports too, and was checked to still fail when a name is
genuinely unreachable rather than passing vacuously.

## One name put back

`CommonWireMeta` was in the removal set until `yarn build` produced
`TS2883: The inferred type of 'getWorkflowMetaById' cannot be named without a
reference to 'CommonWireMeta'` in `@pikku/addon-console`. A type that appears
in another package's declaration emit is public whether or not anything
imports it by name, so it stays exported. That is the whole reason the tally
is 66 and not 67.

## Verification

Against `origin/main` in the same worktree, so pre-existing failures are
separated by evidence rather than assertion:

| command | `origin/main` | this branch |
| --- | --- | --- |
| `yarn build` | EXIT=0, 14 pre-existing `error TS` lines | EXIT=0, **the same 14** — zero new |
| `yarn test` | EXIT=0 | EXIT=0 |
| `yarn test:verifiers` | EXIT=1 — `@pikku/verifiers-tanstack-start-better-auth` | EXIT=1 — **the same one workspace** |
| `yarn tsc` | EXIT=1 | EXIT=1 — **identical set of failing workspaces** |

`yarn tsc` fails on both sides for reasons that predate this branch (verifier
and template projects whose `.pikku` output is not generated in a bare
checkout). The only line present on this branch and not on main is inside
`templates/nextjs`'s generated `pikku-nextjs.gen.ts`, which the branch run had
on disk because `yarn build` ran first and the baseline run did not — the
baseline reports the same file as missing entirely.

The 16 surface guards in `@pikku/core` — `public-surface`, `no-root-barrel`,
`app-leaf-surface`, `api-report`, `removed-legacy-exports` — all pass.
`public-surface.json` needed no edit: it pins runtime exports, and every core
removal here is type-only.

## Still open on #1233

The 32 names referenced nowhere at all, and the CI ratchet in #1241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined package entry points to expose only supported public APIs, reducing accidental access to internal symbols.
  * Preserved documented handlers, services, workflow utilities, and type definitions across runtime and service packages.
  * Removed several previously exposed internal declarations from the public API surface.

* **Tests**
  * Added coverage to verify entry points do not expose internal symbols and correctly resolve named re-exports.

* **Documentation**
  * Updated API reports and patch release notes to reflect the reduced public surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->