### PR TITLE
fix(cli): require the framework singletons in every addon's services map

### DIFF
--- a/.changeset/olive-pugs-hammer.md
+++ b/.changeset/olive-pugs-hammer.md
@@ -1,0 +1,15 @@
+---
+'@pikku/cli': patch
+---
+
+fix(cli): always require the framework singletons in a generated services map
+
+`serializeServicesMap` added `config`/`logger`/`variables`/`schema`/`secrets` to
+the used-services set, but built the map by iterating the project's declared
+`SingletonServices`. An application's type carries those singletons, so the
+marking took effect; an addon's declares only the addon's own services, so no
+key was ever created for them, nothing came out required, and the emitted type
+fell back to `Partial<SingletonServices>` — which does not satisfy
+`CoreSecretlessSingletonServices`, so every generated file in the addon failed
+to compile. The defaults are now unioned into the iterated key set, leaving
+application output byte-identical.

--- a/packages/cli/src/functions/wirings/functions/pikku-command-services.test.ts
+++ b/packages/cli/src/functions/wirings/functions/pikku-command-services.test.ts
@@ -61,6 +61,91 @@ describe('serializeServicesMap', () => {
     assert.match(content, /Required<Pick<Services,[^>]*'customWire'/)
   })
 
+  test('marks the framework singletons required for an addon build', () => {
+    const content = serializeServicesMap(
+      ['stripe', 'stripeWebhookVerifier'],
+      [],
+      new Set(['stripe']),
+      [],
+      SERVICES_IMPORT,
+      WIRE_IMPORT,
+      [],
+      false,
+      false
+    )
+
+    assert.doesNotMatch(
+      content,
+      /export type RequiredSingletonServices = Partial<SingletonServices>/
+    )
+    for (const service of [
+      'config',
+      'logger',
+      'variables',
+      'schema',
+      'secrets',
+    ]) {
+      assert.match(content, new RegExp(`'${service}': true,`))
+      assert.match(
+        content,
+        new RegExp(`Required<Pick<SingletonServices,[^>]*'${service}'`)
+      )
+    }
+    assert.match(content, /'stripe': true,/)
+    assert.match(content, /'stripeWebhookVerifier': false,/)
+  })
+
+  test('emits an unchanged map for an app build that already declares the framework singletons', () => {
+    const content = serializeServicesMap(
+      [
+        'config',
+        'logger',
+        'variables',
+        'schema',
+        'secrets',
+        'kysely',
+        'todoStore',
+      ],
+      [],
+      new Set(['kysely']),
+      [],
+      SERVICES_IMPORT,
+      WIRE_IMPORT,
+      [],
+      false,
+      false
+    )
+
+    assert.equal(
+      content,
+      [
+        SERVICES_IMPORT,
+        WIRE_IMPORT,
+        '',
+        '// Singleton services map: true if required, false if available but unused',
+        'export const requiredSingletonServices = {',
+        "  'config': true,",
+        "  'kysely': true,",
+        "  'logger': true,",
+        "  'schema': true,",
+        "  'secrets': true,",
+        "  'todoStore': false,",
+        "  'variables': true,",
+        '} as const',
+        '',
+        '// Wire services map: true if required, false if available but unused',
+        'export const requiredWireServices = {',
+        '} as const',
+        '',
+        '// Type exports',
+        "export type RequiredSingletonServices = Required<Pick<SingletonServices, 'config' | 'kysely' | 'logger' | 'schema' | 'secrets' | 'variables'>> & Partial<Omit<SingletonServices, 'config' | 'kysely' | 'logger' | 'schema' | 'secrets' | 'variables'>>",
+        '',
+        'export type RequiredWireServices = Partial<Services>',
+        '',
+      ].join('\n')
+    )
+  })
+
   test('leaves agentRunService optional when no agent scaffold is configured', () => {
     const content = serializeServicesMap(
       ['agentRunService', 'todoStore'],

--- a/packages/cli/src/functions/wirings/functions/pikku-command-services.ts
+++ b/packages/cli/src/functions/wirings/functions/pikku-command-services.ts
@@ -67,7 +67,7 @@ export const serializeServicesMap = (
 
   // Create singleton services map: all singleton services with true/false based on usage
   const singletonServicesMap: Record<string, boolean> = {}
-  allSingletonServices.forEach((service) => {
+  new Set([...allSingletonServices, ...defaultServices]).forEach((service) => {
     singletonServicesMap[service] = usedServices.has(service)
   })
 


### PR DESCRIPTION
## The asymmetry

`serializeServicesMap` (`packages/cli/src/functions/wirings/functions/pikku-command-services.ts`) marks the framework's own singletons as used:

```ts
const defaultServices = ['config', 'logger', 'variables', 'schema', 'secrets']
defaultServices.forEach((service) => usedServices.add(service))
```

…but then builds the emitted map by iterating `allSingletonServices`, the project's declared `SingletonServices`:

```ts
allSingletonServices.forEach((service) => {
  singletonServicesMap[service] = usedServices.has(service)
})
```

So adding a name to `usedServices` does nothing unless that name is *also* in the declared list.

- **App build** — `SingletonServices` extends `CoreSingletonServices`, so `logger` and friends are in the list, get marked `true`, and the emitted type takes the `Required<Pick<…>> & Partial<Omit<…>>` branch. Fine.
- **Addon build** — the addon declares only its own services (`stripe`, `stripeWebhookVerifier`, …). No `logger` key is ever created, so the core services land in the `Partial<Omit<…>>` half — or, with nothing required at all, the whole type degrades to `export type RequiredSingletonServices = Partial<SingletonServices>`.

Either way `config`/`logger`/`variables`/`schema`/`secrets` come out optional, which does not satisfy `CoreSecretlessSingletonServices` (`packages/core/src/types/core.types.ts`). Downstream that is ~18 `Type 'RequiredServices' does not satisfy the constraint 'CoreSecretlessSingletonServices'` errors per addon, spread across the generated `auth`, `function`, `middleware`, `setup`, `trigger` and `pikku-package.gen.ts` files.

The existing empty-list guard does not catch this: an addon's list is not empty, merely missing the core services.

## The fix

Union `defaultServices` into the iterated key set, so the framework singletons are always *keys* in the map and always required — not merely members of `usedServices`.

The wire map's `internalServices` exclusion (`rpc`, `mcp`, `channel`, `userSession`, `cli`, `http`, `queue`, `scheduledTask`) is untouched; none of the defaults are internal services.

## `forceRequiredServices`

This removes the need for addons to carry a `forceRequiredServices` entry just to cover the core services. `forceRequiredServices` only ever made the required list *non-empty* — it never moved `logger` out of the `Partial<Omit<…>>` half, so the constraint error survived it anyway. The option is **not** removed or deprecated; it keeps its legitimate use of forcing an addon's own undetected service required.

## Proof that app-build output is unchanged

- A golden-output unit test (`emits an unchanged map for an app build that already declares the framework singletons`) asserts the full emitted string for an app-shaped input. **It passes both before and after the fix.**
- A throwaway differential harness ran `origin/main`'s serializer and the patched one over **15360** app-shaped input combinations (subsets of extra singletons × required sets × `forceRequiredServices` × `authInjected` × `agentScaffoldEnabled`): **0 mismatches**.

## TDD evidence

`marks the framework singletons required for an addon build` fails on `origin/main`:

```
AssertionError: The input did not match the regular expression /'config': true,/
export type RequiredSingletonServices = Required<Pick<SingletonServices, 'stripe'>> & Partial<Omit<SingletonServices, 'stripe'>>
```

and passes after the fix, with `config | logger | schema | secrets | stripe | variables` all in the `Required<Pick<…>>` half.

## Verification

`packages/cli` suite via `./run-tests.sh`:

| | tests | pass | fail |
|---|---|---|---|
| pristine `origin/main` | 1014 | 992 | 18 |
| this branch | 1016 | 994 | 18 |

Same 18 failures on both sides — all pre-existing, and in this local harness they are environmental (the worktree has no generated `.pikku`, so the linked `@pikku/inspector` build predates `ErrorCode.SINGLETON_SERVICES_TYPE_UNRESOLVED`). The 2 added tests both pass. `tsc` reports no error attributable to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)