### PR TITLE
fix(cli): validate should flag a dead Design tab, not mention it

### DIFF
--- a/.changeset/validate-design-tab-severity.md
+++ b/.changeset/validate-design-tab-severity.md
@@ -1,0 +1,14 @@
+---
+'@pikku/cli': patch
+---
+
+fix(cli): validate flags a dead Design tab instead of mentioning it
+
+A project that renders Mantine but has no `packages/mantine-theme/` (or no
+`themes/<id>.json`) gets a Design tab that renders "No themes yet". That was
+reported at info, under a summary ending "no errors". It is now a warning when
+an app depends on `@mantine/core` or `@pikku/mantine`, and stays info otherwise.
+
+The `components-missing` check is replaced by `design-no-stories`, which looks
+where the design server actually globs stories — `apps/*/src/components/**/*.stories.tsx`
+— rather than at `packages/components/`.

--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -1258,20 +1258,106 @@ describe('pikku fabric validate', () => {
       }
     })
 
-    test('missing packages/components → info', async () => {
+    const addMantineApp = async (root: string) => {
+      await mkdir(join(root, 'apps', 'web', 'src', 'components'), {
+        recursive: true,
+      })
+      await writeJson(join(root, 'apps', 'web', 'package.json'), {
+        name: '@project/web',
+        type: 'module',
+        dependencies: {
+          react: '^19.0.0',
+          '@mantine/core': '^9.0.0',
+          '@pikku/mantine': '^0.12.5',
+        },
+      })
+    }
+
+    test('missing packages/mantine-theme with a Mantine frontend → warn', async () => {
       const tmp = await makeTmp()
       try {
         await makeValidProject(tmp)
-        await rm(join(tmp, 'packages', 'components'), {
+        await addMantineApp(tmp)
+        await rm(join(tmp, 'packages', 'mantine-theme'), {
           recursive: true,
           force: true,
         })
         const result = await runValidate(tmp)
+        const finding = result.findings.find((f) => f.id === 'theme-missing')
+        assert.ok(finding, 'expected theme-missing finding')
+        assert.strictEqual(finding!.severity, 'warn')
+        assert.match(finding!.message, /No themes yet/)
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+
+    test('theme package but no spec, with a Mantine frontend → theme-no-spec warn', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        await addMantineApp(tmp)
+        await rm(join(tmp, 'packages', 'mantine-theme', 'themes'), {
+          recursive: true,
+          force: true,
+        })
+        await rm(join(tmp, 'packages', 'mantine-theme', 'active.json'), {
+          force: true,
+        })
+        const result = await runValidate(tmp)
+        const finding = result.findings.find((f) => f.id === 'theme-no-spec')
+        assert.ok(finding, 'expected theme-no-spec finding')
+        assert.strictEqual(finding!.severity, 'warn')
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+
+    test('an app with components but no stories → design-no-stories', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        await addMantineApp(tmp)
+        const result = await runValidate(tmp)
         const finding = result.findings.find(
-          (f) => f.id === 'components-missing'
+          (f) => f.id === 'design-no-stories'
         )
-        assert.ok(finding, 'expected components-missing finding')
-        assert.strictEqual(finding!.severity, 'info')
+        assert.ok(finding, 'expected design-no-stories finding')
+        assert.strictEqual(finding!.severity, 'warn')
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+
+    test('a story beside a component clears it', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        await addMantineApp(tmp)
+        await writeFile(
+          join(tmp, 'apps', 'web', 'src', 'components', 'Wordmark.stories.tsx'),
+          "export default { title: 'Wordmark' }\nexport const Default = {}\n",
+          'utf8'
+        )
+        const result = await runValidate(tmp)
+        assert.ok(
+          !result.findings.some((f) => f.id === 'design-no-stories'),
+          'design-no-stories should not fire when a story exists'
+        )
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+
+    test('no apps at all → silence, there is nothing to story', async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidProject(tmp)
+        const result = await runValidate(tmp)
+        assert.ok(
+          !result.findings.some((f) => f.id === 'design-no-stories'),
+          'design-no-stories should not fire without a component kit'
+        )
       } finally {
         await rm(tmp, { recursive: true, force: true })
       }

--- a/packages/cli/src/fabric/functions/validate.function.ts
+++ b/packages/cli/src/fabric/functions/validate.function.ts
@@ -1199,6 +1199,7 @@ export async function runValidate(
     dir: string
     deploy: boolean
   }> = []
+  let hasMantineFrontend = false
   /** every syntactically valid cwd, including ones whose directory is missing */
   const declaredCwdList: string[] = []
   const rawFrontends = fabricConfig?.frontends
@@ -1345,6 +1346,9 @@ export async function runValidate(
         appAllDeps['@pikku/mantine'] ||
         appAllDeps['react']
       )
+      if (appAllDeps['@mantine/core'] || appAllDeps['@pikku/mantine']) {
+        hasMantineFrontend = true
+      }
       if (isReactFrontend) {
         const srcFiles = await listSourceFiles(join(appPath, 'src'))
         let usesMessages = false
@@ -1663,11 +1667,14 @@ export async function runValidate(
 
   // ── packages/theme + packages/components ──────────────────────────────
   const designDocUrl = 'https://pikkufabric.dev/docs/design'
+  const designSeverity = hasMantineFrontend ? w : info
   const themePkgDir = join(root, 'packages', 'mantine-theme')
   if (!existsSync(themePkgDir)) {
-    info(
+    designSeverity(
       'theme-missing',
-      'packages/mantine-theme/ not found — Fabric design features require a theme package',
+      hasMantineFrontend
+        ? 'packages/mantine-theme/ not found — the Fabric console Design tab has no themes to list and reports "No themes yet"'
+        : 'packages/mantine-theme/ not found — Fabric design features require a theme package',
       themePkgDir,
       `Create packages/mantine-theme/ with your Mantine theme tokens. See ${designDocUrl}`
     )
@@ -1692,7 +1699,7 @@ export async function runValidate(
       }
     }
     if (specIds.length === 0) {
-      info(
+      designSeverity(
         'theme-no-spec',
         'packages/mantine-theme/ has no themes/<id>.json spec — the Fabric console Design tab reports "no theme set" (and cannot edit the theme) even if the app is branded via a hand-written createTheme()',
         themesDir,
@@ -1739,12 +1746,39 @@ export async function runValidate(
       }
     }
   }
-  if (!existsSync(join(root, 'packages', 'components'))) {
-    info(
-      'components-missing',
-      'packages/components/ not found — Fabric design features require a components package',
-      join(root, 'packages', 'components'),
-      `Create packages/components/ with your shared UI components. See ${designDocUrl}`
+  // The design server globs stories from apps/*/src/components, not packages/components.
+  const storyFiles: string[] = []
+  let hasComponentKit = false
+  for (const name of existsSync(appsDir) ? await readdir(appsDir) : []) {
+    const kitDir = join(appsDir, name, 'src', 'components')
+    if (!existsSync(kitDir)) continue
+    hasComponentKit = true
+    for (const file of await listSourceFiles(kitDir)) {
+      if (file.endsWith('.stories.tsx')) storyFiles.push(file)
+    }
+  }
+  if (hasComponentKit && storyFiles.length === 0) {
+    designSeverity(
+      'design-no-stories',
+      "no apps/*/src/components/**/*.stories.tsx found — the Fabric console Design tab's Library and App lenses have nothing to show",
+      join(appsDir, '*', 'src', 'components'),
+      lines(
+        'Add a story beside a component. The Library lens reads <Name>.stories.tsx',
+        '(each named export is a visual variant); the App lens reads',
+        '<Name>.app.stories.tsx (each named export is one data state of the query',
+        'or mutation the page drives it with). A minimal Library story:',
+        '',
+        "  import type { Story, StoryMeta } from './csf.types'",
+        "  import { Wordmark } from './Wordmark'",
+        '',
+        '  export default {',
+        "    title: 'Wordmark',",
+        '    component: Wordmark,',
+        '  } satisfies StoryMeta',
+        '',
+        "  export const Default: Story = { args: { name: 'Acme' } }",
+        `See ${designDocUrl}`
+      )
     )
   }
 


### PR DESCRIPTION
`pikku fabric validate` reports two things about Fabric's Design tab that it gets wrong in different ways. Both surfaced on a real project whose Design tab was empty and whose validate run ended `✓ no errors — project can be linked to fabric`.

### 1. A missing theme package is reported at `info`

The console's Design tab reads `packages/mantine-theme/themes/<id>.json` and nothing else. With no package the tab is not degraded, it is dead — it renders "No themes yet" and offers no way forward. Reported at `info`, that lands under a summary line saying there are no errors, which is how it goes unread.

For a project with no Mantine frontend, `info` is right: there is genuinely nothing to theme yet. So `theme-missing` and `theme-no-spec` now take their severity from whether any app depends on `@mantine/core` or `@pikku/mantine` — `warn` when one does, `info` when none does.

`theme-no-active` and `theme-active-mismatch` stay at `info`: they describe a theme that exists and is merely mis-pointed, which the console recovers from by falling back to the default id. `components-missing` is handled separately below.

### 2. `components-missing` names a directory the design server stopped reading

It told every project to create `packages/components/`. The design server stopped globbing that in 53579fb ("point the Library/App lenses at where the kit actually lives", 2026-07-22), because it exists in no project — the kit lives inside the app, and both lenses read `apps/*/src/components/**/*.stories.tsx`.

So the advice sent anyone who followed it to build a package neither lens would ever open, while the actual reason their lenses were empty went unmentioned. Replaced with `design-no-stories`, which reports that and shows a minimal Library story in the fix hint. It stays quiet when no app has a `src/components/` at all — a project with no components has nothing to story, and empty lenses are then a fact about the project rather than something to fix.

### Tests

Five added, covering both severities of `theme-missing` and `theme-no-spec`, the `design-no-stories` fire/clear/silent cases. Suite: 89 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project validation for Mantine-based frontends.
  * Missing themes and theme configuration now receive appropriate warnings when Mantine is detected.
  * Replaced the outdated component-directory check with design-story validation.
  * Projects with components but no design stories now receive a warning.
  * Projects containing stories, or without applicable apps, avoid unnecessary warnings.
* **Documentation**
  * Updated CLI release documentation to reflect the revised validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->