### PR TITLE
chore: drop narrating comments added by #1363 and #1364

### DIFF
--- a/packages/cli/src/functions/commands/enable.ts
+++ b/packages/cli/src/functions/commands/enable.ts
@@ -3,7 +3,6 @@ import { join } from 'path'
 import { pikkuVoidFunc } from '#pikku/function'
 import type { PikkuScaffoldFeature } from '../../../types/config.js'
 
-/** Features that scaffold a surface. */
 type SurfaceFeature =
   | 'rpc'
   | 'console'
@@ -13,7 +12,6 @@ type SurfaceFeature =
   | 'events'
   | 'remoteRpc'
 
-/** Features that scaffold a worker rather than a surface. */
 type WorkerFeature = 'webhook'
 
 type Feature = SurfaceFeature | WorkerFeature
@@ -35,9 +33,6 @@ async function enableFeature(
     json.scaffold.pikkuDir = 'pikku'
   }
 
-  // The flag says the surface exists, nothing more. Who may call what it
-  // generates is declared on the function, its wiring, its scopes and its
-  // addon, and enforced there on every call.
   const value: PikkuScaffoldFeature = true
 
   json.scaffold[feature] = value

--- a/packages/cli/src/functions/wirings/middleware/serialize-middleware-types.test.ts
+++ b/packages/cli/src/functions/wirings/middleware/serialize-middleware-types.test.ts
@@ -88,11 +88,6 @@ describe('serializeMiddlewareTypes', () => {
     )
   })
 
-  // Agent middleware hooks a run, and a run is not a request — it can start
-  // from a scheduler or a workflow with no wire behind it. The runtime has
-  // always passed the singleton services alone, so a signature promising the
-  // wider `Services` let a middleware destructure a wire service, typecheck,
-  // and silently receive `undefined`.
   test('agent middleware is typed against the singleton services', () => {
     const content = emit()
 

--- a/packages/cli/src/functions/wirings/middleware/serialize-middleware-types.ts
+++ b/packages/cli/src/functions/wirings/middleware/serialize-middleware-types.ts
@@ -170,12 +170,6 @@ export const pikkuChannelMiddlewareFactory = <In = any>(
 export const addChannelMiddleware = (tag: string, middleware: PikkuChannelMiddleware[]) =>
   addChannelMiddlewareCore(tag, middleware, ${packageNameValue})
 
-/**
- * Agent middleware hooks a *run*, not a request, so it is handed the singleton
- * services alone — a run can start from a scheduler or a workflow with nothing
- * wire-shaped behind it. A tool the run calls is an ordinary function call and
- * still receives its own wire services.
- */
 export const pikkuAgentMiddleware = <
   State extends Record<string, unknown> = Record<string, unknown>,
   RequiredServices extends SingletonServices = WiredSingletonServices,

--- a/packages/cli/src/functions/wirings/scaffold-dispatchers-decline-to-gate.test.ts
+++ b/packages/cli/src/functions/wirings/scaffold-dispatchers-decline-to-gate.test.ts
@@ -12,13 +12,6 @@ const leaf = (name: string) => `#pikku/${name}`
 const authFields = (output: string) =>
   output.match(/^\s*auth: (true|false),?$/gm)?.map((line) => line.trim()) ?? []
 
-/**
- * The dispatcher surfaces forward to whichever function the caller named, so
- * they decline to gate: every emitted `pikkuSessionlessFunc` and every emitted
- * wiring says `auth: false`. Omitting the field would not be neutral — a wiring
- * with no `auth` defaults to requiring a session, and the wrapper would then
- * reject the call before the function it forwards to ever answers for itself.
- */
 describe('the scaffold dispatchers decline to gate', () => {
   const dispatchers: Array<[string, string]> = [
     ['public rpc', serializePublicRPC(leaf).functions],
@@ -44,13 +37,6 @@ describe('the scaffold dispatchers decline to gate', () => {
   }
 })
 
-/**
- * The scoped admin surfaces are not dispatchers — they are the functions that
- * decide. They are `pikkuFunc`, which requires a session by construction, and
- * they carry their own `scopes`. Emitting `auth` there says nothing new, and
- * `auth: false` on a sessioned function is refused by `runPikkuFunc` with a
- * warning telling you to use `pikkuSessionlessFunc` instead.
- */
 describe('the scoped admin surfaces emit no auth field', () => {
   const surfaces: Array<[string, string]> = [
     ['user admin', serializeUserAdminFunctions(leaf).functions],

--- a/packages/cli/src/functions/wirings/scenarios/register-scenario-instrumentation.ts
+++ b/packages/cli/src/functions/wirings/scenarios/register-scenario-instrumentation.ts
@@ -145,10 +145,7 @@ const instrumentation: Record<
  *
  * They are registered sessionless with `auth: true`, so a caller still needs a
  * session: the `/rpc/:rpcName` dispatcher declines to gate, which leaves each
- * function to answer for itself, and these answer that they are not public.
- * Only `pikku dev` and `pikku serve` register them at all, so they exist on a
- * development process and nowhere else — a deployed bootstrap never imports
- * them — but that is a second line, not the first.
+ * function to answer for itself.
  */
 export const registerScenarioInstrumentation = () => {
   const meta = pikkuState(null, 'function', 'meta') as FunctionsMeta

--- a/packages/cli/src/functions/wirings/user-admin/user-admin-functions.test.ts
+++ b/packages/cli/src/functions/wirings/user-admin/user-admin-functions.test.ts
@@ -88,8 +88,6 @@ describe('serializeUserAdminFunctions', () => {
   })
 
   test('gates on the session and the scope, never on a scaffold flag', () => {
-    // `pikkuFunc` already refuses a call with no session, and each function
-    // names the scope it needs — so the generated surface asserts no `auth`.
     assert.match(out, /pikkuAdminListUsers = pikkuFunc\(/)
     assert.match(out, /scopes: \['admin:users:list'\]/)
     assert.doesNotMatch(out, /^\s*auth: (true|false),?$/m)

--- a/packages/cli/src/utils/resolve-scaffold-feature.test.ts
+++ b/packages/cli/src/utils/resolve-scaffold-feature.test.ts
@@ -36,8 +36,6 @@ describe('resolveScaffoldFeature', () => {
   })
 
   test('says nothing about auth', () => {
-    // The scaffold flag decides whether a surface exists, never who may reach
-    // it — so nothing it resolves to may be read as an auth answer.
     for (const value of [undefined, false, true, { path: 'a/b.ts' }] as const) {
       assert.ok(
         !('auth' in resolveScaffoldFeature('rpc', value)),

--- a/packages/core/src/wirings/agent/agent-middleware.types.test.ts
+++ b/packages/core/src/wirings/agent/agent-middleware.types.test.ts
@@ -1,14 +1,4 @@
-/**
- * Type-level tests: no runtime assertions — valid shapes must compile and
- * invalid shapes must fail with `@ts-expect-error`. Type-checked by
- * `tsconfig.type-tests.json`, which lists this file.
- *
- * Agent middleware hooks a run rather than a request, and a run can start with
- * no wire behind it, so the hooks are handed the singleton services alone. The
- * types used to promise the wider wire services while the runtime passed only
- * the singletons, which let a middleware destructure a wire service, typecheck,
- * and silently receive `undefined`.
- */
+// Type-checked via tsconfig.type-tests.json; no runtime assertions.
 
 import { pikkuAgentMiddleware } from '../../middleware/middleware-factories.js'
 import type { PikkuAgentMiddlewareHooks } from './agent.types.js'

--- a/packages/core/src/wirings/agent/agent.types.ts
+++ b/packages/core/src/wirings/agent/agent.types.ts
@@ -179,15 +179,6 @@ export interface AgentToolDef extends Partial<ApprovalPolicy> {
   forwardsApproval?: boolean
 }
 
-/**
- * Hooks on an agent *run*, not on a request.
- *
- * Every hook receives the singleton services only. A run is not a wire: it can
- * start from a scheduler or a workflow with no request behind it, so there are
- * no per-request services to hand a middleware. A tool call inside the run is a
- * real function call and does get its own wire services — through
- * `runPikkuFunc`, not through here.
- */
 export interface PikkuAgentMiddlewareHooks<
   State extends Record<string, unknown> = Record<string, unknown>,
   SingletonServices extends CoreSingletonServices = CoreSingletonServices,


### PR DESCRIPTION
#1363 and #1364 merged carrying explanatory comments that restate the code or recount the bug being fixed. `CLAUDE.md` sets the bar at "a complex algorithm that resists refactoring, a non-obvious reason for an approach, or a workaround for a known limitation" — these clear none of it, and the reasoning already lives in both PRs' commit messages and bodies.

Removed:
- `/** Hooks on an agent *run*, not on a request. … */` and the matching serializer JSDoc + test comment (#1363)
- the type-test file header, reduced to one line naming the `tsconfig.type-tests.json` mechanism (#1363)
- `/** Features that scaffold a surface. */`, `/** Features that scaffold a worker rather than a surface. */`, the `// The flag says the surface exists, nothing more` block, and both dispatcher/scoped-admin JSDoc blocks (#1364)
- two narrating test comments in `user-admin-functions.test.ts` and `resolve-scaffold-feature.test.ts` (#1364)

Kept: every comment that predates these PRs, including ones the PRs updated to track a rename. The `@ts-expect-error` reason annotations stay — a bare suppression with no reason is worse.

Comment-only; `packages/cli` 1225/1225 and `packages/core` 2274/2274 pass, `tsc --noEmit` clean in both plus the type-tests project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)