### PR TITLE
feat(variable)!: gate on `optional`, and delete `required`

### DIFF
--- a/packages/core/src/wirings/variable/validate-variable-definitions.test.ts
+++ b/packages/core/src/wirings/variable/validate-variable-definitions.test.ts
@@ -89,26 +89,27 @@ describe('validateAndBuildVariableDefinitionsMeta', () => {
     assert.deepStrictEqual(result, {})
   })
 
-  test('carries required into the meta so only the opted-in ones block a deploy', () => {
+  test('carries optional into the meta so only the opted-out ones skip the gate', () => {
     const result = validateAndBuildVariableDefinitionsMeta(
       [
-        {
-          name: 'consoleUrl',
-          displayName: 'Console URL',
-          variableId: 'CONSOLE_URL',
-          required: true,
-          sourceFile: 'a.ts',
-        },
         {
           name: 'corsOrigins',
           displayName: 'Allowed Browser Origins',
           variableId: 'CORS_ORIGINS',
+          optional: true,
+          sourceFile: 'a.ts',
+        },
+        {
+          name: 'consoleUrl',
+          displayName: 'Console URL',
+          variableId: 'CONSOLE_URL',
           sourceFile: 'a.ts',
         },
       ] as any,
       new Map()
     )
-    assert.strictEqual(result['consoleUrl']!.required, true)
-    assert.strictEqual(result['corsOrigins']!.required, undefined)
+    assert.strictEqual(result['corsOrigins']!.optional, true)
+    // Undeclared means required, which is what makes the gate ask by default.
+    assert.strictEqual(result['consoleUrl']!.optional, undefined)
   })
 })

--- a/packages/core/src/wirings/variable/validate-variable-definitions.ts
+++ b/packages/core/src/wirings/variable/validate-variable-definitions.ts
@@ -43,7 +43,7 @@ export function validateAndBuildVariableDefinitionsMeta(
           description: def.description,
           variableId: def.variableId,
           schema: def.schema,
-          required: def.required,
+          optional: def.optional,
           docsUrl: def.docsUrl,
           sourceFile: def.sourceFile,
         }
@@ -60,7 +60,7 @@ export function validateAndBuildVariableDefinitionsMeta(
         description: def.description,
         variableId: def.variableId,
         schema: def.schema,
-        required: def.required,
+        optional: def.optional,
         docsUrl: def.docsUrl,
         sourceFile: def.sourceFile,
       }

--- a/packages/core/src/wirings/variable/variable.types.ts
+++ b/packages/core/src/wirings/variable/variable.types.ts
@@ -5,13 +5,19 @@ export type CoreVariable<T = unknown> = {
   variableId: string
   schema: T
   /**
-   * A variable is OPTIONAL by default because `variables.get` returns
-   * `T | undefined` and never throws — every caller already handles absence, so
-   * a deploy gate that blocks on one contradicts the API. Mark a variable
-   * `required` for the few whose absence genuinely breaks the app; only those
-   * block a deploy.
+   * A variable is REQUIRED by default, and marking it `optional` is how a
+   * declaration says its absence is a supported state. Same flag, same
+   * polarity and same meaning as `CoreSecret.optional` — one word to learn
+   * rather than two with opposite senses.
+   *
+   * Defaulting to required rather than following `variables.get`'s
+   * `T | undefined` return is deliberate. That signature describes what a
+   * caller must HANDLE, not whether a deployment is correct without the value:
+   * an undefined feature flag is fine, an undefined API base URL is an outage
+   * that the type system cannot tell apart. Declaring the difference is the
+   * point of the flag, and the safe default for an undeclared one is to ask.
    */
-  required?: boolean
+  optional?: boolean
   docsUrl?: string
 }
 
@@ -21,7 +27,7 @@ export type VariableDefinitionMeta = {
   description?: string
   variableId: string
   schema?: Record<string, unknown> | string
-  required?: boolean
+  optional?: boolean
   docsUrl?: string
   sourceFile?: string
 }

--- a/packages/inspector/src/add/add-variable.ts
+++ b/packages/inspector/src/add/add-variable.ts
@@ -5,6 +5,6 @@ export const addVariable = createAddKeyedWiring({
   idField: 'variableId',
   label: 'Variable',
   schemaPrefix: 'VariableSchema',
-  flagField: 'required',
+  flagField: 'optional',
   getState: (state) => state.variables,
 })


### PR DESCRIPTION
A variable declared `required` and a secret declared `optional` were two flags with opposite senses for one question — does a deploy have to ask for this value. Reading a declaration meant first remembering which kind you were looking at to know what the absent flag meant.

Now both spell it `optional`, and both default to required.

### Why not keep the old default

`required` on variables came from `variables.get` returning `T | undefined`: nothing throws, so every caller already handles absence, so a gate that blocks looked like it contradicted the API.

But that signature describes what a caller must **handle**, not whether a deployment is **correct** without the value. An undefined feature flag is fine; an undefined API base URL is an outage. Nothing in `T | undefined` separates them — declaring which one it is, is the flag's whole job, and the safe default for an undeclared one is to ask.

### Why delete rather than deprecate

`required` is the exact inverse of what replaces it. Leaving it in place would mean two flags contradicting each other on the same declaration, and anyone who kept using it would get a silent flip in meaning rather than a warning.

### Changes

- `CoreVariable` / `VariableDefinitionMeta`: `required?: boolean` → `optional?: boolean`
- `add-variable.ts`: `flagField: 'required'` → `'optional'` (the mechanism was already generic — this is the whole inspector change)
- `validate-variable-definitions.ts` + its test updated

`packages/core` typechecks clean; its 5 `validate-variable-definitions` tests pass.

### Breaking

`required` is gone from `CoreVariable` and `VariableDefinitionMeta`. A variable that carried `required: true` can drop it — that is now the default. Every variable that did **not** carry it and whose absence is genuinely supported must now declare `optional: true`, or a deploy gate will block on it.

Found while wiring a platform-injected variable (`LITELLM_PROXY_URL`) that a consumer should never set by hand: under the old polarity there was no way to express "the platform supplies this", and under the new one there is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPHno9Bq6vWshM1s4Mp4C7