### PR TITLE
fix(core,inspector): finish the variable `required` → `optional` rename

### DIFF
--- a/.changeset/spotty-hounds-invite.md
+++ b/.changeset/spotty-hounds-invite.md
@@ -1,0 +1,8 @@
+---
+'@pikku/core': patch
+'@pikku/inspector': patch
+---
+
+Follow through on the variable `required` → `optional` rename: regenerate the
+core API report and update the inspector's `defineVariable` gating-flag test,
+both of which #1369 left describing the deleted `required` flag.

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -3960,7 +3960,7 @@ export type CoreVariable<T = unknown> = {
   description?: string
   variableId: string
   schema: T
-  required?: boolean
+  optional?: boolean
   docsUrl?: string
 }
 defineVariable: <T>(_config: CoreVariable<T>) => void
@@ -3971,7 +3971,7 @@ export type VariableDefinitionMeta = {
   description?: string
   variableId: string
   schema?: Record<string, unknown> | string
-  required?: boolean
+  optional?: boolean
   docsUrl?: string
   sourceFile?: string
 }

--- a/packages/inspector/src/add/config-value-metadata.test.ts
+++ b/packages/inspector/src/add/config-value-metadata.test.ts
@@ -169,7 +169,7 @@ describe('config value metadata (docsUrl)', () => {
 })
 
 /**
- * `optional` and `required` are the deploy gate's whole input. A flag the
+ * `optional` is the deploy gate's whole input. A flag the
  * inspector drops leaves the gate seeing a bare declaration, which is how an
  * optional secret suspends a deploy over a value production is meant NOT to
  * have.
@@ -218,8 +218,8 @@ describe('config value gating flags', () => {
     }
   })
 
-  test('carries required from defineVariable into the definition', async () => {
-    const rootDir = await mkdtemp(`${fixtureRoot}-variable-required-`)
+  test('carries optional from defineVariable into the definition', async () => {
+    const rootDir = await mkdtemp(`${fixtureRoot}-variable-optional-`)
     const file = join(rootDir, 'variable.ts')
 
     await writeFile(
@@ -233,7 +233,7 @@ describe('config value gating flags', () => {
         "  name: 'consoleUrl',",
         "  displayName: 'Console URL',",
         "  variableId: 'CONSOLE_URL',",
-        '  required: true,',
+        '  optional: true,',
         '  schema: ConsoleUrlSchema,',
         '})',
         'defineVariable({',
@@ -248,14 +248,14 @@ describe('config value gating flags', () => {
     const criticals: Array<{ code: ErrorCode; message: string }> = []
     try {
       const state = await inspect(makeLogger(criticals), [file], { rootDir })
-      const required = state.variables.definitions.find(
+      const optional = state.variables.definitions.find(
         (d) => d.variableId === 'CONSOLE_URL'
       )
-      const optional = state.variables.definitions.find(
+      const required = state.variables.definitions.find(
         (d) => d.variableId === 'CORS_ORIGINS'
       )
-      assert.equal(required!.required, true)
-      assert.equal(optional!.required, undefined)
+      assert.equal(optional!.optional, true)
+      assert.equal(required!.optional, undefined)
     } finally {
       await rm(rootDir, { recursive: true, force: true })
     }


### PR DESCRIPTION
Unit Tests have been red on `main` since [#1369](https://github.com/pikkujs/pikku/pull/1369) (`4dcd1043e`), which renamed `required` to `optional` on `CoreVariable` and `VariableDefinitionMeta` but left two committed snapshots of the old flag behind — both of which the unit suite checks.

## What was failing

**1. `packages/core/api-report.md`** — the committed public-API snapshot still declared `required?: boolean`, so `src/api-report.test.ts` failed its byte-for-byte comparison against a freshly generated report:

```
✖ regenerating produces no diff (1645.652959ms)
  AssertionError: the public API changed but api-report.md was not regenerated.
  First difference at line 3963:
    committed:     required?: boolean
    regenerated:   optional?: boolean
```

Fixed by running `yarn api-report` in `packages/core`.

**2. `packages/inspector/src/add/config-value-metadata.test.ts`** — the `config value gating flags` suite still fed `required: true` to `defineVariable` and asserted it round-tripped into the definition, which now reads back `undefined`:

```
✖ carries required from defineVariable into the definition (744.334917ms)
  AssertionError: Expected values to be strictly equal:
  + actual - expected
  + undefined
  - true
```

Fixed by moving the fixture and the assertions onto `optional`, mirroring the sibling `defineSecret` test in the same suite. The suite JSDoc was updated to stop naming the deleted flag.

## Verification

Full unit suite (`yarn test`, the same command the Unit Tests job runs) after the fix — 13 test-runner suites, **4739 tests, 4729 pass, 0 fail, 10 skipped**. `packages/core` on its own: `tests 2284 / pass 2274 / fail 0 / skipped 10`. `packages/inspector`: `tests 714 / pass 714 / fail 0`.

Nothing else in the tree referenced `required` on a variable; `public-surface.json` needed no change (its guards are part of the green core run). No other package failed.

Two local-only notes, neither a repo problem: `create-pikku` and `@pikku/lambda` do not build in my checkout because the shared `node_modules` is missing `@inquirer/prompts` and has a nested `@smithy/types` mismatch, and `@pikku/paraglide` reported `command not found: tsx` under my hand-linked `node_modules` — run directly it is `tests 7 / pass 7 / fail 0`. All three are green on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)