### PR TITLE
fix(cli): generate SCENARIO_ACTOR_SECRET as optional + export the paraglide enum generators

### DIFF
--- a/.changeset/paraglide-export-enum-values.md
+++ b/.changeset/paraglide-export-enum-values.md
@@ -1,0 +1,15 @@
+---
+'@pikku/paraglide': patch
+---
+
+fix(paraglide): export the enum generators, not just their types
+
+The package barrel re-exported `GenerateEnumsOptions`, `EnumGroup` and `DbEnum`
+as types only, so `dist/esm/index.js` compiled down to `export {}` and the
+package had no runtime surface at all. Anything importing `generateEnumsSource`
+or `parseDbEnums` from `@pikku/paraglide` died at load with "does not provide an
+export named 'generateEnumsSource'", and the `exports` map offers no deep path
+to reach them another way — the only consumers that worked were the bundled
+`./vite` plugin and the `paraglide-enums` bin, which import the module directly.
+The barrel now exports `generateEnumsSource`, `parseDbEnums` and
+`collectEnumGroups` alongside the existing types.

--- a/.changeset/personas-secret-optional.md
+++ b/.changeset/personas-secret-optional.md
@@ -1,0 +1,7 @@
+---
+'@pikku/cli': patch
+---
+
+Generate `SCENARIO_ACTOR_SECRET` as an optional secret. A stage that runs no
+scenarios is a supported state — the actor sign-in refuses every request — but
+the required declaration failed the deploy config gate on every such stage.

--- a/packages/cli/src/functions/wirings/personas/serialize-personas-secrets.test.ts
+++ b/packages/cli/src/functions/wirings/personas/serialize-personas-secrets.test.ts
@@ -12,6 +12,12 @@ describe('serializePersonasSecrets', () => {
     assert.match(content, /displayName: '[^']+'/)
   })
 
+  test('is optional, because a stage that runs no scenarios is supported', () => {
+    const content = serializePersonasSecrets()
+
+    assert.match(content, /optional: true,/)
+  })
+
   test('schema is a variable reference, which is what the inspector accepts', () => {
     const content = serializePersonasSecrets()
 

--- a/packages/cli/src/functions/wirings/personas/serialize-personas-secrets.ts
+++ b/packages/cli/src/functions/wirings/personas/serialize-personas-secrets.ts
@@ -10,6 +10,11 @@
  * regardless of what the user wired should be collected by the platform, not
  * discovered missing at the first sign-in.
  *
+ * It is `optional` because a stage that runs no scenarios is a supported state:
+ * the actor sign-in then refuses every request, which is how the surface is
+ * switched off. A required declaration fails the deploy config gate on every
+ * such stage instead.
+ *
  * The schema is a named const because the inspector only accepts a variable
  * reference for `schema`, never an inline expression.
  */
@@ -27,6 +32,7 @@ defineSecret({
   displayName: 'Scenario Actor Secret',
   description:
     'Signing secret that lets scenarios and virtual users sign in as a declared persona',
+  optional: true,
   secretId: 'SCENARIO_ACTOR_SECRET',
   schema: ScenarioActorSecretSchema,
 })

--- a/packages/paraglide/src/index.ts
+++ b/packages/paraglide/src/index.ts
@@ -1,4 +1,7 @@
 export {
+  collectEnumGroups,
+  generateEnumsSource,
+  parseDbEnums,
   type GenerateEnumsOptions,
   type EnumGroup,
   type DbEnum,


### PR DESCRIPTION
Two independent fixes, both blocking every Fabric customer deploy today.

### `SCENARIO_ACTOR_SECRET` is declared required

`serializePersonasSecrets` emits `defineSecret({ ... secretId: 'SCENARIO_ACTOR_SECRET' })` with no `optional`, so the secret is required. A stage that runs no scenarios is a supported state — the actor sign-in refuses every request, which is how the surface is switched off — but with `#1369` gating deploys on `optional`, every such stage now fails the config gate with `needs_config`.

The generated declaration also wins over a hand-written `optional: true` in the project: `pikku-secrets-meta.gen.json` keys on `name`, and its `sourceFile` is always `.pikku/scopes/pikku-personas-secrets.gen.ts`. So a project cannot opt out.

Marks it `optional: true`, with a test.

### `@pikku/paraglide` barrel re-exports types only

`packages/paraglide/src/index.ts` re-exported only types, so `dist/esm/index.js` compiled to `export {};` and any consumer importing `generateEnumsSource` got `SyntaxError: The requested module ... does not provide an export named ...`. Re-exports the three values alongside the types. (Verified against a real consumer, then restored — see the commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)