### PR TITLE
refactor(cli)!: rename startServerFnsFile to tanstackStartFile

### DIFF
--- a/.changeset/tanstack-start-file-key.md
+++ b/.changeset/tanstack-start-file-key.md
@@ -1,0 +1,9 @@
+---
+'@pikku/cli': patch
+---
+
+refactor(cli)!: `clientFiles.startServerFnsFile` is now `clientFiles.tanstackStartFile`
+
+The old name read as "start the server fns" when it meant "the TanStack **Start**
+server-fns file". A config still using it now fails to load with the new name in
+the message, rather than silently generating nothing.

--- a/packages/cli/src/functions/runtimes/tanstack-start/pikku-command-tanstack-start.ts
+++ b/packages/cli/src/functions/runtimes/tanstack-start/pikku-command-tanstack-start.ts
@@ -6,14 +6,14 @@ import { serializeTanStackStartShim } from './serialize-tanstack-start-shim.js'
 
 export const pikkuTanStackStart = pikkuSessionlessFunc<void, void>({
   func: async ({ logger, config }) => {
-    const startServerFnsFile = config.clientFiles?.startServerFnsFile
+    const tanstackStartFile = config.clientFiles?.tanstackStartFile
     const rpcWiringsFile = config.clientFiles?.rpcWiringsFile
     const { packageMappings } = config
 
-    if (!startServerFnsFile) {
+    if (!tanstackStartFile) {
       logger.debug({
         message:
-          "Skipping generating TanStack Start shim since startServerFnsFile isn't set in the pikku config.",
+          "Skipping generating TanStack Start shim since tanstackStartFile isn't set in the pikku config.",
         type: 'skip',
       })
       return
@@ -21,19 +21,19 @@ export const pikkuTanStackStart = pikkuSessionlessFunc<void, void>({
 
     if (!rpcWiringsFile) {
       logger.warn(
-        'Skipping TanStack Start shim: startServerFnsFile is set but rpcWiringsFile is not — the shim imports the PikkuRPC class from rpcWiringsFile.'
+        'Skipping TanStack Start shim: tanstackStartFile is set but rpcWiringsFile is not — the shim imports the PikkuRPC class from rpcWiringsFile.'
       )
       return
     }
 
     const rpcWiringsPath = getFileImportRelativePath(
-      startServerFnsFile,
+      tanstackStartFile,
       rpcWiringsFile,
       packageMappings
     )
 
     const content = serializeTanStackStartShim(rpcWiringsPath)
-    await writeFileInDir(logger, startServerFnsFile, content)
+    await writeFileInDir(logger, tanstackStartFile, content)
   },
   middleware: [
     logCommandInfoAndTime({

--- a/packages/cli/src/utils/pikku-cli-config.test.ts
+++ b/packages/cli/src/utils/pikku-cli-config.test.ts
@@ -41,6 +41,34 @@ describe('getPikkuCLIConfig', () => {
     return root
   }
 
+  test('rejects the old startServerFnsFile key by name', async () => {
+    const root = await writeConfig({
+      clientFiles: { startServerFnsFile: './src/lib/pikku-start.gen.ts' },
+    })
+
+    await assert.rejects(
+      () => getPikkuCLIConfig(silentLogger, join(root, 'pikku.config.json'), []),
+      /startServerFnsFile is now clientFiles\.tanstackStartFile/
+    )
+  })
+
+  test('resolves tanstackStartFile relative to the config', async () => {
+    const root = await writeConfig({
+      clientFiles: { tanstackStartFile: './src/lib/pikku-start.gen.ts' },
+    })
+
+    const config = await getPikkuCLIConfig(
+      silentLogger,
+      join(root, 'pikku.config.json'),
+      []
+    )
+
+    assert.equal(
+      config.clientFiles?.tanstackStartFile,
+      join(root, 'src/lib/pikku-start.gen.ts')
+    )
+  })
+
   test('preserves db.engine and db.pgVersion from pikku.config.json', async () => {
     const root = await mkdtemp(join(tmpdir(), 'pikku-config-'))
     tempDirs.push(root)

--- a/packages/cli/src/utils/pikku-cli-config.ts
+++ b/packages/cli/src/utils/pikku-cli-config.ts
@@ -18,7 +18,7 @@ const CLIENT_FILE_KEYS = [
   'mcpJsonFile',
   'nextBackendFile',
   'nextHTTPFile',
-  'startServerFnsFile',
+  'tanstackStartFile',
 ] as const
 
 export const getPikkuCLIConfig = async (
@@ -1093,6 +1093,11 @@ const _getPikkuCLIConfig = async (
 
     // Resolve clientFiles paths relative to configDir
     if (result.clientFiles) {
+      if ('startServerFnsFile' in result.clientFiles) {
+        throw new PikkuCLIConfigError(
+          `clientFiles.startServerFnsFile is now clientFiles.tanstackStartFile — rename it in ${result.configDir}/pikku.config.json`
+        )
+      }
       for (const key of CLIENT_FILE_KEYS) {
         const val = result.clientFiles[key]
         if (val && typeof val === 'string' && !isAbsolute(val)) {

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -343,7 +343,7 @@ export type PikkuCLIInput = {
      * URL from `import.meta.env.VITE_API_URL` (throws if unset). Requires
      * `rpcWiringsFile` (where the `PikkuRPC` class is generated).
      */
-    startServerFnsFile?: string
+    tanstackStartFile?: string
   }
 
   /** Directory containing email templates, locales, partials, and theme.json. */

--- a/verifiers/tanstack-start-better-auth/pikku.config.json
+++ b/verifiers/tanstack-start-better-auth/pikku.config.json
@@ -6,7 +6,7 @@
   "clientFiles": {
     "fetchFile": "./src/lib/pikku-fetch.gen.ts",
     "rpcWiringsFile": "./src/lib/pikku-rpc.gen.ts",
-    "startServerFnsFile": "./src/lib/pikku-start.gen.ts"
+    "tanstackStartFile": "./src/lib/pikku-start.gen.ts"
   },
   "schema": {
     "supportsImportAttributes": true


### PR DESCRIPTION
## Why

`clientFiles.startServerFnsFile` parses as "start the server fns file". It actually means "the TanStack **Start** server-fns file" — the shim exporting `makeApi(): PikkuRPC` for Start loaders, actions and components. The name only makes sense once you already know what it does.

## Change

- `clientFiles.startServerFnsFile` → `clientFiles.tanstackStartFile`, matching the `packages/cli/src/functions/runtimes/tanstack-start/` directory that implements it.
- A config still carrying the old key now throws a `PikkuCLIConfigError` naming the new one. Without that it would load fine and generate nothing, which is the hardest kind of config bug to see.
- The one in-repo consumer, `verifiers/tanstack-start-better-auth/pikku.config.json`, is updated.

## Test

`pikku-cli-config.test.ts` — 11 pass / 0 fail, including two new cases: the old key is rejected by name, and the new key resolves relative to the config directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)