### PR TITLE
fix(cli): stop the Bun resolve plugin from emptying `exports` subpath modules

### DIFF
--- a/.changeset/bun-resolve-plugin-narrow-filter.md
+++ b/.changeset/bun-resolve-plugin-narrow-filter.md
@@ -1,0 +1,9 @@
+---
+'@pikku/cli': patch
+---
+
+Narrow the Bun resolve plugin's `onResolve` filter to the specifiers it actually
+rewrites. A catch-all filter that deferred to Bun for everything else made Bun
+bundle any bare specifier resolved through a package.json `exports` subpath
+(`@pikku/core/workflow`) as an empty module, so every deployed worker died at
+startup with `ReferenceError: PikkuWorkflowService is not defined`.

--- a/packages/cli/src/deploy/bundler/bun-bundler.ts
+++ b/packages/cli/src/deploy/bundler/bun-bundler.ts
@@ -69,6 +69,9 @@ function getBun(): BunBuildApi {
   return bun
 }
 
+const escapeRegExp = (s: string): string =>
+  s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
 const pkgHead = (spec: string): string =>
   spec.startsWith('@')
     ? spec.split('/').slice(0, 2).join('/')
@@ -83,6 +86,13 @@ const pkgHead = (spec: string): string =>
  *   - `externals`: keep external (node:*, cloudflare:*, declared npm deps) and
  *     CAPTURE the real npm package names — Bun's metafile omits external
  *     imports, so capture is how per-unit dependency extraction works.
+ *
+ * The `onResolve` filter is built from exactly those three lists, so the callback
+ * only ever runs on a specifier it rewrites. It must never fire and then return
+ * undefined to defer to Bun: a deferred bare specifier that resolves through a
+ * package.json `exports` subpath (`@pikku/core/workflow`) silently bundles as an
+ * empty module, and the worker dies at startup on `ReferenceError: X is not
+ * defined` for every binding it exported.
  */
 function createBunResolvePlugin(opts: {
   aliases?: Record<string, string>
@@ -98,10 +108,22 @@ function createBunResolvePlugin(opts: {
     }
     return (s: string) => s === pat || s.startsWith(pat + '/')
   })
+  const filter = new RegExp(
+    [
+      ...Object.keys(aliases ?? {}).map((name) => `^${escapeRegExp(name)}$`),
+      ...stubPatterns.map((re) => re.source),
+      '^node:',
+      ...externals.map((pat) =>
+        pat.endsWith('*')
+          ? `^${escapeRegExp(pat.slice(0, -1))}`
+          : `^${escapeRegExp(pat)}($|\\/)`
+      ),
+    ].join('|')
+  )
   return {
     name: 'pikku-bun-resolve',
     setup(build) {
-      build.onResolve({ filter: /.*/ }, (args) => {
+      build.onResolve({ filter }, (args) => {
         let path = args.path
         // Relative / absolute → let Bun resolve natively.
         if (path.startsWith('.') || path.startsWith('/')) return
@@ -119,7 +141,7 @@ function createBunResolvePlugin(opts: {
           if (!path.includes(':')) captured.add(pkgHead(path))
           return { path, external: true }
         }
-        // Everything else → Bun bundles it (resolving the .bun store natively).
+        // Unreachable: the filter above is built from these same three lists.
         return
       })
       build.onLoad({ filter: /.*/, namespace: 'pikku-stub' }, () => ({


### PR DESCRIPTION
## Problem

Every Cloudflare deploy produced by `pikku deploy plan` under Bun shipped workers that Cloudflare rejected at upload:

```
8 workers:  CF 400: Uncaught ReferenceError: eY is not defined
13 workers: CF 400: Uncaught ReferenceError: pY is not defined
worker:auth-handler: CF 400: Uncaught ReferenceError: PU is not defined
…
```

The build reported no error — the bundles were simply wrong.

## Cause

`createBunResolvePlugin` registered `onResolve({ filter: /.*/ })` and returned `undefined` for anything it did not rewrite, which is most of the module graph. When a plugin callback runs for a bare specifier and then defers to Bun, resolution of a package.json `exports` subpath loses its target: `@pikku/core/workflow` was bundled as an empty module while `KyselyWorkflowService extends PikkuWorkflowService` kept the reference.

Minimal reproduction on a real plan — a plugin whose callback does nothing at all:

| `onResolve` filter | `class PikkuWorkflowService` in output |
| --- | --- |
| no plugin | ✅ |
| `/^zzzzz$/` (never fires) | ✅ |
| `/.*/`, callback returns `undefined` | ❌ |
| `/^@pikku\/core\/workflow$/`, returns `undefined` | ❌ |
| `/^@pikku\/core$/` (bare package, not a subpath) | ✅ |

Identifier mangling was not involved; it only made the failure unreadable.

## Fix

Build the `onResolve` filter from the same three lists the callback consults — aliases, stub patterns, externals — so the callback only ever runs on a specifier it returns a concrete result for. Everything else reaches Bun's resolver untouched.

## Verification

Against a real 54-worker Cloudflare plan, with minification unchanged: all 54 bundles now evaluate their module scope without error (before: `ReferenceError` on the first one tried).

🤖 Generated with [Claude Code](https://claude.com/claude-code)