### PR TITLE
fix(templates): ai-postgres asks for the CLI version the lockfile records

### DIFF
--- a/templates/ai-postgres/package.json
+++ b/templates/ai-postgres/package.json
@@ -29,7 +29,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@pikku/cli": "^0.12.109",
+    "@pikku/cli": "^0.12.110",
     "@types/node": "^24"
   },
   "exports": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5910,7 +5910,7 @@ __metadata:
     "@ai-sdk/anthropic": "npm:^4.0.39"
     "@ai-sdk/openai": "npm:^4.0.42"
     "@pikku/ai-vercel": "npm:^0.12.13"
-    "@pikku/cli": "npm:^0.12.109"
+    "@pikku/cli": "npm:^0.12.110"
     "@pikku/core": "npm:^0.12.88"
     "@pikku/express": "npm:^0.12.14"
     "@pikku/kysely-postgres": "npm:^0.12.21"


### PR DESCRIPTION
Fixes #1380. `main` is red at 274cab3ff — `yarn install --immutable` refuses, so **Build** and **Lint & Format** fail and everything gated behind them never runs.

```
YN0028: -    "@pikku/cli": "npm:^0.12.109"
YN0028: +    "@pikku/cli": "npm:^0.12.110"
YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

#1377 added `@pikku/cli` to `templates/ai-postgres` — its new `migrate` script runs `pikku`, and knip fails the build on an unlisted binary — at the then-current `^0.12.109`. #1379 (Version Packages) merged first, bumped the other ten templates to `^0.12.110` and regenerated the lockfile, whose `@pikku/cli` key no longer carries a `^0.12.109` descriptor. The two changes touch different lines, so git merged them cleanly into a state neither branch was ever tested in.

This brings the range in line with every other template and updates the one lockfile line. `yarn install --immutable` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development tooling to the latest compatible CLI patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->