### PR TITLE
fix(cli): a scaffold feature refuses the removed `auth` key instead of ignoring it

### DIFF
--- a/.changeset/scaffold-refuses-removed-auth-key.md
+++ b/.changeset/scaffold-refuses-removed-auth-key.md
@@ -1,0 +1,20 @@
+---
+'@pikku/cli': patch
+---
+
+fix(cli): a scaffold feature refuses the removed `auth` key instead of ignoring it
+
+`scaffold.<feature>` stopped taking `auth` when a scaffold flag became a
+statement about whether a surface is generated rather than about who may call
+it. The key was removed from the type, but a `pikku.config.json` still carrying
+it loaded clean and was silently dropped — a config that reads as if it closed
+the console to anonymous callers while configuring nothing at all.
+
+It is now refused at config load, by name, with the reason and the fix. Any
+other unrecognised key is refused too, so a typo'd `paths` fails at load rather
+than generating a file at the default location. `null` and arrays are refused
+with the same message a bare string already got, rather than crashing on a
+property read.
+
+These arrive as `PikkuCLIConfigError`, so the message reaches the developer
+verbatim rather than as "failed to load config file".

--- a/packages/cli/src/utils/pikku-cli-config-error.ts
+++ b/packages/cli/src/utils/pikku-cli-config-error.ts
@@ -1,0 +1,8 @@
+/**
+ * A config that was found and parsed, but says something impossible.
+ *
+ * Its message reaches the developer verbatim — every other error out of the
+ * loader is reported as "failed to load", which sends the reader hunting for a
+ * broken file rather than the line that is wrong.
+ */
+export class PikkuCLIConfigError extends Error {}

--- a/packages/cli/src/utils/pikku-cli-config.test.ts
+++ b/packages/cli/src/utils/pikku-cli-config.test.ts
@@ -47,8 +47,21 @@ describe('getPikkuCLIConfig', () => {
     })
 
     await assert.rejects(
-      () => getPikkuCLIConfig(silentLogger, join(root, 'pikku.config.json'), []),
+      () =>
+        getPikkuCLIConfig(silentLogger, join(root, 'pikku.config.json'), []),
       /startServerFnsFile is now clientFiles\.tanstackStartFile/
+    )
+  })
+
+  test('rejects a console scaffold still carrying the removed auth key', async () => {
+    const root = await writeConfig({
+      scaffold: { console: { auth: false } },
+    })
+
+    await assert.rejects(
+      () =>
+        getPikkuCLIConfig(silentLogger, join(root, 'pikku.config.json'), []),
+      /scaffold\.console no longer takes "auth"/
     )
   })
 

--- a/packages/cli/src/utils/pikku-cli-config.ts
+++ b/packages/cli/src/utils/pikku-cli-config.ts
@@ -7,6 +7,7 @@ import type {
 import { resolveScaffoldFeature } from './resolve-scaffold-feature.js'
 import type { CLILogger } from '../services/cli-logger.service.js'
 import { setScaffoldWriteGuard } from './file-writer.js'
+import { PikkuCLIConfigError } from './pikku-cli-config-error.js'
 
 const CLIENT_FILE_KEYS = [
   'fetchFile',
@@ -91,8 +92,7 @@ async function findConfigFile(): Promise<string> {
   return configFile
 }
 
-/** A config that was found and parsed, but says something impossible. */
-export class PikkuCLIConfigError extends Error {}
+export { PikkuCLIConfigError }
 
 /**
  * The two schema registers must be two directories.

--- a/packages/cli/src/utils/resolve-scaffold-feature.test.ts
+++ b/packages/cli/src/utils/resolve-scaffold-feature.test.ts
@@ -62,4 +62,35 @@ describe('resolveScaffoldFeature', () => {
       /must be true, false, or an object/
     )
   })
+
+  test('the removed auth key is refused by name', () => {
+    assert.throws(
+      () => resolveScaffoldFeature('console', { auth: false } as never),
+      (error: Error) => {
+        assert.match(error.message, /scaffold\.console/)
+        assert.match(error.message, /no longer takes "auth"/)
+        assert.match(error.message, /who may call it/)
+        return true
+      }
+    )
+  })
+
+  test('an unknown key is refused rather than ignored', () => {
+    assert.throws(
+      () => resolveScaffoldFeature('rpc', { paths: 'src/rpc.gen.ts' } as never),
+      (error: Error) => {
+        assert.match(error.message, /scaffold\.rpc/)
+        assert.match(error.message, /"paths"/)
+        assert.match(error.message, /"path"/)
+        return true
+      }
+    )
+  })
+
+  test('null is off, not an empty object', () => {
+    assert.throws(
+      () => resolveScaffoldFeature('rpc', null as never),
+      /must be true, false, or an object/
+    )
+  })
 })

--- a/packages/cli/src/utils/resolve-scaffold-feature.ts
+++ b/packages/cli/src/utils/resolve-scaffold-feature.ts
@@ -1,4 +1,5 @@
 import type { PikkuScaffoldFeature } from '../../types/config.js'
+import { PikkuCLIConfigError } from './pikku-cli-config-error.js'
 
 export type ResolvedScaffoldFeature = {
   /** Whether to generate this surface at all. */
@@ -6,6 +7,8 @@ export type ResolvedScaffoldFeature = {
   /** An explicit output path, or undefined to derive one from `pikkuDir`. */
   path?: string
 }
+
+const SCAFFOLD_FEATURE_KEYS = ['path']
 
 /**
  * Reads one `scaffold.<feature>` value.
@@ -18,6 +21,12 @@ export type ResolvedScaffoldFeature = {
  * A bare string is refused rather than read as a path: under `boolean | object`
  * no string is valid, and guessing one into `path` would turn a typo into a
  * generated file nobody asked for.
+ *
+ * An unrecognised key is refused for the same reason, and `auth` is refused by
+ * name. It was a real key once, and one a config can still be carrying: a
+ * config that sets it is asking for a gate that no longer exists there, so
+ * ignoring it silently would leave the file saying something untrue about the
+ * surface it configures.
  */
 export const resolveScaffoldFeature = (
   feature: string,
@@ -31,12 +40,29 @@ export const resolveScaffoldFeature = (
     return { enabled: true }
   }
 
-  if (typeof value !== 'object') {
-    throw new Error(
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new PikkuCLIConfigError(
       `pikku.config.json: scaffold.${feature} must be true, false, or an object ` +
         `like { "path": "src/${feature}.gen.ts" } — received ${JSON.stringify(value)}. ` +
         `A bare string is never a shorthand for a path.`
     )
+  }
+
+  for (const key of Object.keys(value)) {
+    if (key === 'auth') {
+      throw new PikkuCLIConfigError(
+        `pikku.config.json: scaffold.${feature} no longer takes "auth" — a scaffold ` +
+          `flag says whether a surface is generated, not who may call it. ` +
+          `Authentication is declared on the function, its wiring, its scopes and ` +
+          `its addon, and enforced there on every call. Remove the key.`
+      )
+    }
+    if (!SCAFFOLD_FEATURE_KEYS.includes(key)) {
+      throw new PikkuCLIConfigError(
+        `pikku.config.json: scaffold.${feature} has no "${key}" option — the only ` +
+          `key is "path", which overrides where the generated file is written.`
+      )
+    }
   }
 
   return {

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -13,7 +13,9 @@ import { PikkuWiringTypes } from '@pikku/core/types'
  *
  * A bare string is refused by the loader rather than reinterpreted: under this
  * shape a string could plausibly mean a path, so guessing one would be worse
- * than failing. See `resolveScaffoldFeature`.
+ * than failing. So is any key other than `path` — including `auth`, which this
+ * type carried once and some configs still do, and which would otherwise load
+ * clean while configuring nothing. See `resolveScaffoldFeature`.
  */
 export type PikkuScaffoldFeature =
   | boolean


### PR DESCRIPTION
Closes #846.

## The gap this closes

#1364 settled what a scaffold flag means: whether a surface is generated, not who may call it. It dropped `auth` from `PikkuScaffoldFeature`, and the string forms `'auth'` / `'no-auth'` had already been refused by name.

What was left was the object form. A `pikku.config.json` still carrying `{ "console": { "auth": false } }` loaded clean and the key was dropped on the floor — the exact config that motivated the issue, since fabric's sandbox-orchestrator carried the `no-auth` console that broke a prod deploy on the 0.12.67 bump. As #846's last comment put it: a config key that lies, where before it was a build that broke.

## What changed

`resolveScaffoldFeature` now validates the object's keys.

- **`auth` is refused by name**, with the reason and the fix. It was a real key once, so a config setting it is asking for a gate that no longer exists there — ignoring it silently leaves the file saying something untrue about the surface it configures.
- **Any other unrecognised key is refused** on the same grounds a bare string already was: a typo'd `paths` should fail at load, not generate a file at the default location while the developer reads their config and believes otherwise.
- **`null` and arrays** now get that same message instead of `TypeError: Cannot read properties of null (reading 'path')`.

All three arrive as `PikkuCLIConfigError`, which is the only error class the loader's catch re-throws intact — everything else is replaced with `Failed to load config file: <path>`. Without that the new message was written and then thrown away, which the loader-level test caught. The class moves to `pikku-cli-config-error.ts` so the resolver can throw one without importing the loader that calls it; `pikku-cli-config.ts` still exports it, so no import site changes.

## On the issue's original ask

#846 asked for `scaffold.console` to get its own type. That is no longer the right shape: #1364 removed `auth` from *every* scaffold feature, so console is not special — `boolean | { path?: string }` is the whole contract for all nine, and a console-only clone of it would be an identical type with a different name. The behaviour #846 wanted (a meaningless `auth` value must not be accepted) is what this delivers, for all of them.

## Test coverage

Fails before, passes after.

- `resolve-scaffold-feature.test.ts` — three new cases, one per rejection. Each was red against the old resolver: `auth` and the unknown key returned `{ enabled: true }`, `null` threw a `TypeError`.
- `pikku-cli-config.test.ts` — the end-to-end case: a real `pikku.config.json` on disk carrying `{ "console": { "auth": false } }` must fail to load with the message. This is what proved the `PikkuCLIConfigError` half necessary; with a plain `Error` it failed with `Failed to load config file`.

`packages/cli` is green standalone at 1258/1258, and `tsc --noEmit` is clean. No config in the repo uses the object form of any scaffold feature, so nothing here changes behaviour for an existing project — only for one carrying the removed key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)