### PR TITLE
feat(paraglide): the i18n-debug mask locale, generated rather than wrapped

### DIFF
--- a/.changeset/paraglide-mask-locale.md
+++ b/.changeset/paraglide-mask-locale.md
@@ -1,0 +1,20 @@
+---
+'@pikku/paraglide': patch
+---
+
+feat(paraglide): the i18n-debug mask locale, generated rather than wrapped
+
+`paraglideMaskLocale` writes a copy of the base catalog with every visible
+character replaced by a block glyph, for Paraglide to compile like any other
+locale. Switch to it and anything still readable on screen never went through a
+message — the hardcoded string that `tsc` and the `@pikku/mantine` `I18nNode`
+gate cannot see, because it sits in plain JSX, an `aria-label`, an `alt` or a
+`document.title`.
+
+Making the mask a locale rather than a runtime wrapper around the `m` namespace
+is what keeps messages tree-shakeable: a wrapper touches every export. It is
+also free in production — the catalogue is deleted on a build, so Paraglide
+compiles the locale to aliases of the base one.
+
+`{placeholders}` and whitespace are preserved: a placeholder is a message input,
+not copy, and mangling one changes the compiled function's signature.

--- a/packages/paraglide/README.md
+++ b/packages/paraglide/README.md
@@ -120,3 +120,63 @@ For CI / non-Vite flows, run right after `paraglide-js compile`:
 # paraglide-enums <catalog.json> <out.gen.ts> [messagesImport] [enums.gen.ts]
 paraglide-enums ./messages/en.json ./src/i18n/i18n-enum.gen.ts ./messages.js ./packages/functions/.pikku/db/enums.gen.ts
 ```
+
+## The i18n-debug mask locale
+
+`tsc` catches an invalid message, and the `@pikku/mantine` `I18nNode` gate catches a raw
+string literal on a gated prop. Neither sees a hardcoded string in plain JSX, an
+`aria-label`, an `alt`, a `document.title`, or anything handed to a non-Mantine component.
+
+i18n-debug covers that gap: render every message as block glyphs, and whatever is still
+readable on screen never went through a message.
+
+```
+████ ███████        ← a message
+Save changes        ← a hardcoded string
+```
+
+The mask is a **locale**, not a runtime wrapper. Wrapping the `m` namespace so each
+message pipes through a `mask()` touches every export, which is exactly what stops a
+bundler tree-shaking unused messages; it also adds a check to every call and forces every
+component to import `m` from the wrapper rather than from Paraglide. Masked text is just
+text, and rendering different text per locale is what Paraglide already does.
+
+Place the plugin **before** `paraglideVitePlugin` — it writes into the catalog directory
+that Paraglide then compiles:
+
+```ts
+import { paraglideVitePlugin } from '@inlang/paraglide-js'
+import { paraglideMaskLocale } from '@pikku/paraglide/vite'
+
+export default defineConfig({
+  plugins: [
+    paraglideMaskLocale({
+      catalog: './messages/en.json',
+      locale: 'zz', // writes messages/zz.json
+    }),
+    paraglideVitePlugin({
+      project: './project.inlang',
+      outdir: './src/paraglide',
+    }),
+  ],
+})
+```
+
+Switching is then one line in the locale bridge — see `createLocaleStore` in
+`@pikku/react`, whose `debugLocale` option does exactly this:
+
+```ts
+overwriteGetLocale(() => (isI18nDebug() ? 'zz' : activeLocale))
+```
+
+Two properties worth keeping:
+
+- **Keep the locale out of the app's own supported list.** That list drives URL prefixes,
+  hreflang and any backend `locale` param, none of which should ever see it.
+- **It costs the bundle effectively nothing.** On a build the catalogue is deleted rather
+  than written, so Paraglide compiles the locale to aliases of the base locale — one
+  `const` per message, no duplicated strings.
+
+`{placeholders}` are left intact: they are message inputs rather than copy, and mangling
+one changes the compiled function's signature. Whitespace is left alone too, so masked
+text keeps the shape of the original and a layout bug still looks like a layout bug.

--- a/packages/paraglide/package.json
+++ b/packages/paraglide/package.json
@@ -3,7 +3,7 @@
   "version": "0.12.5",
   "author": "yasser.fadl@gmail.com",
   "license": "MIT",
-  "description": "Paraglide tooling for pikku apps — generates typed enum-lookup maps from `enum__*` message keys.",
+  "description": "Paraglide tooling for pikku apps — typed enum-lookup maps from `enum__*` message keys, and the i18n-debug mask locale.",
   "type": "module",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/paraglide/src/generate-mask-locale.test.ts
+++ b/packages/paraglide/src/generate-mask-locale.test.ts
@@ -1,0 +1,86 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { maskMessage, maskCatalog } from './generate-mask-locale.js'
+import { paraglideMaskLocale } from './vite.js'
+
+test('every visible character becomes a block', () => {
+  assert.equal(maskMessage('Save changes'), '████ ███████')
+})
+
+test('placeholders survive intact', () => {
+  assert.equal(
+    maskMessage('Delete {name} for everyone'),
+    '██████ {name} ███ ████████'
+  )
+})
+
+test('whitespace and line breaks are preserved', () => {
+  assert.equal(maskMessage('one\ttwo\nthree'), '███\t███\n█████')
+})
+
+test('a message that is only a placeholder is untouched', () => {
+  assert.equal(maskMessage('{count}'), '{count}')
+})
+
+test('$schema is carried through unmasked', () => {
+  const masked = maskCatalog({
+    $schema: 'https://inlang.com/schema/inlang-message-format',
+    greeting: 'Hello',
+  })
+  assert.equal(
+    masked.$schema,
+    'https://inlang.com/schema/inlang-message-format'
+  )
+  assert.equal(masked.greeting, '█████')
+})
+
+test('non-string values pass through unchanged', () => {
+  const variants = { match: { 'count=one': 'one item' } }
+  const masked = maskCatalog({ items: variants })
+  assert.deepEqual(masked.items, variants)
+})
+
+test('key order is preserved so the diff stays readable', () => {
+  const masked = maskCatalog({ b: 'x', a: 'y', $schema: 'z' })
+  assert.deepEqual(Object.keys(masked), ['b', 'a', '$schema'])
+})
+
+const withCatalog = (): { dir: string; catalog: string; out: string } => {
+  const dir = mkdtempSync(join(tmpdir(), 'pikku-mask-'))
+  const catalog = join(dir, 'en.json')
+  writeFileSync(catalog, JSON.stringify({ greeting: 'Hello there' }))
+  return { dir, catalog, out: join(dir, 'zz.json') }
+}
+
+test('the plugin writes the mask catalogue when serving', () => {
+  const { catalog, out } = withCatalog()
+  const plugin = paraglideMaskLocale({ catalog, outFile: out })
+  ;(plugin.config as any)({}, { command: 'serve' })
+
+  assert.equal(JSON.parse(readFileSync(out, 'utf8')).greeting, '█████ █████')
+})
+
+test('the plugin deletes the mask catalogue on a build', () => {
+  const { catalog, out } = withCatalog()
+  writeFileSync(out, '{}')
+
+  const plugin = paraglideMaskLocale({ catalog, outFile: out })
+  ;(plugin.config as any)({}, { command: 'build' })
+
+  assert.equal(existsSync(out), false)
+})
+
+test('the mask catalogue defaults to the locale name beside the catalog', () => {
+  const { dir, catalog } = withCatalog()
+  const plugin = paraglideMaskLocale({ catalog, locale: 'qq' })
+  ;(plugin.config as any)({}, { command: 'serve' })
+
+  assert.equal(existsSync(join(dir, 'qq.json')), true)
+})
+
+test('the plugin runs before paraglide compiles', () => {
+  assert.equal(paraglideMaskLocale().enforce, 'pre')
+})

--- a/packages/paraglide/src/generate-mask-locale.ts
+++ b/packages/paraglide/src/generate-mask-locale.ts
@@ -1,0 +1,52 @@
+/**
+ * Generates the i18n-debug pseudo-locale: a copy of the base catalog with every
+ * visible character replaced by a block glyph.
+ *
+ * `tsc` catches an invalid message and the `@pikku/mantine` `I18nNode` gate
+ * catches a raw string literal on a gated prop. Neither sees a hardcoded string
+ * in plain JSX, an `aria-label`, an `alt`, a `document.title`, or anything
+ * handed to a non-Mantine component. Switch to this locale and every message
+ * renders as blocks — whatever is still readable never went through a message.
+ *
+ * The obvious implementation is a runtime wrapper that walks the `m` namespace
+ * and pipes each message through a `mask()`. That walk is exactly what stops a
+ * bundler tree-shaking unused messages, it adds a check to every call, and it
+ * forces every component to import `m` from the wrapper rather than from
+ * Paraglide. Masked text is just text, and rendering different text per locale
+ * is what Paraglide already does — so the mask is a locale, written at build
+ * time and compiled like any other.
+ */
+
+/** The glyph a masked character becomes. Full block: no ascenders, no gaps. */
+const BLOCK = '█'
+
+/**
+ * Masks one message. `{placeholders}` are left verbatim — they are message
+ * inputs rather than copy, and mangling one changes the compiled function's
+ * signature. Whitespace is left alone too, so the masked text keeps the shape
+ * of the original and a layout bug still looks like a layout bug.
+ */
+export const maskMessage = (value: string): string =>
+  value
+    .split(/(\{[^}]*\})/g)
+    .map((part) => (part.startsWith('{') ? part : part.replace(/\S/g, BLOCK)))
+    .join('')
+
+/**
+ * Masks a whole catalog. Keys beginning with `$` are metadata rather than copy
+ * and are carried through, as is any non-string value: a message with variants
+ * is an object whose shape the compiler reads, and flattening it here would
+ * change what compiles rather than what renders.
+ */
+export const maskCatalog = (
+  catalog: Record<string, unknown>
+): Record<string, unknown> => {
+  const masked: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(catalog)) {
+    masked[key] =
+      typeof value === 'string' && !key.startsWith('$')
+        ? maskMessage(value)
+        : value
+  }
+  return masked
+}

--- a/packages/paraglide/src/index.ts
+++ b/packages/paraglide/src/index.ts
@@ -6,3 +6,5 @@ export {
   type EnumGroup,
   type DbEnum,
 } from './generate-enums.js'
+
+export { maskCatalog, maskMessage } from './generate-mask-locale.js'

--- a/packages/paraglide/src/vite.ts
+++ b/packages/paraglide/src/vite.ts
@@ -1,11 +1,18 @@
 import type { Plugin } from 'vite'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, relative, resolve } from 'node:path'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
 import {
   generateEnumsSource,
   parseDbEnums,
   type GenerateEnumsOptions,
 } from './generate-enums.js'
+import { maskCatalog } from './generate-mask-locale.js'
 
 export interface ParaglideEnumsOptions extends GenerateEnumsOptions {
   /** Base-locale catalog JSON. Default `'./messages/en.json'`. */
@@ -91,6 +98,75 @@ export function paraglideEnums(options: ParaglideEnumsOptions = {}): Plugin {
       }
       server.watcher.on('add', onChange)
       server.watcher.on('change', onChange)
+    },
+  }
+}
+
+export interface ParaglideMaskLocaleOptions {
+  /** Base-locale catalog JSON to mask. Default `'./messages/en.json'`. */
+  catalog?: string
+  /** The pseudo-locale's code. Default `'zz'`. */
+  locale?: string
+  /** Where to write it. Default `<locale>.json` beside the catalog. */
+  outFile?: string
+}
+
+/**
+ * Vite plugin that writes the i18n-debug pseudo-locale beside the base catalog,
+ * for Paraglide to compile like any other locale. Place it BEFORE
+ * `paraglideVitePlugin`, which reads the catalog directory it writes into.
+ *
+ * Dev only: on a build the catalogue is deleted rather than written, and
+ * Paraglide then compiles the locale to aliases of the base locale — one
+ * `const` per message, no duplicated strings — so shipping it costs the bundle
+ * effectively nothing. Keep the locale out of the app's own supported list
+ * either way: that list drives URL prefixes, hreflang and any backend `locale`
+ * param, none of which should ever see it.
+ *
+ * In dev the catalogue is rewritten when the base one changes. A stale mask
+ * renders a newly added message as readable text, which is indistinguishable
+ * from the hardcoded string this mode exists to find.
+ */
+export function paraglideMaskLocale(
+  options: ParaglideMaskLocaleOptions = {}
+): Plugin {
+  const catalog = options.catalog ?? './messages/en.json'
+  const locale = options.locale ?? 'zz'
+  const outFile =
+    options.outFile ?? join(dirname(resolve(catalog)), `${locale}.json`)
+
+  const generate = (isBuild: boolean): void => {
+    const outPath = resolve(outFile)
+    if (isBuild) {
+      if (existsSync(outPath)) rmSync(outPath)
+      return
+    }
+
+    const catalogPath = resolve(catalog)
+    if (!existsSync(catalogPath)) return
+
+    const masked = maskCatalog(
+      JSON.parse(readFileSync(catalogPath, 'utf8')) as Record<string, unknown>
+    )
+    const next = `${JSON.stringify(masked, null, 2)}\n`
+    const prev = existsSync(outPath) ? readFileSync(outPath, 'utf8') : null
+    if (prev === next) return
+    mkdirSync(dirname(outPath), { recursive: true })
+    writeFileSync(outPath, next)
+  }
+
+  return {
+    name: '@pikku/paraglide:mask-locale',
+    enforce: 'pre',
+    config(_config, { command }) {
+      generate(command === 'build')
+    },
+    configureServer(server) {
+      const catalogPath = resolve(catalog)
+      server.watcher.add(catalogPath)
+      server.watcher.on('change', (file: string) => {
+        if (resolve(file) === catalogPath) generate(false)
+      })
     },
   }
 }


### PR DESCRIPTION
Closes #1036.

## What it is

`paraglideMaskLocale` writes a copy of the base catalog with every visible character replaced by `█`, beside the catalog, for Paraglide to compile like any other locale.

```
████ ███████        ← a message
Save changes        ← a hardcoded string
```

That is the whole diagnostic. `tsc` catches an invalid message and the `@pikku/mantine` `I18nNode` gate catches a raw string literal on a gated prop, but neither sees a hardcoded string in plain JSX, an `aria-label`, an `alt`, a `document.title`, or anything handed to a non-Mantine component. Switch to the mask locale and whatever is still readable never went through a message.

## Why a locale and not a wrapper

The obvious implementation is a module that walks the `m` namespace and pipes each message through a `mask()`. heygermany shipped exactly that, and it is a bad trade three ways: touching every export defeats tree-shaking, it adds a check to every call, and it forces every component to import `m` from the wrapper rather than from Paraglide.

Masked text is just text, and rendering different text per locale is what Paraglide already does. So the mask is a locale — no wrapper, nothing per call, and no rule to hold about where `m` is imported from.

It also costs the bundle effectively nothing: on `command === 'build'` the catalogue is deleted rather than written, and Paraglide compiles the absent locale to aliases of the base one (one `const` per message, no duplicated strings).

## Details worth knowing

- **Plugin order matters, and is documented in both directions.** `paraglideMaskLocale` goes *before* `paraglideVitePlugin` (it writes into the directory Paraglide compiles); the existing `paraglideEnums` goes *after* it (the generated module imports the compiled `m`).
- **`{placeholders}` survive verbatim.** They are message inputs rather than copy — masking one changes the compiled function's signature.
- **Whitespace survives too**, so masked text keeps the shape of the original and a layout bug still looks like a layout bug rather than like the mask.
- **Non-string values pass through.** A message with variants is an object whose shape the compiler reads; flattening it would change what compiles rather than what renders.
- **Dev regenerates on catalog change.** This is correctness, not convenience: a stale mask renders a newly added message as readable text, which is indistinguishable from the hardcoded string the mode exists to find.

Keep the locale out of the app's own supported list — that list drives URL prefixes, hreflang and any backend `locale` param, none of which should see it.

## Test coverage

11 new cases in `generate-mask-locale.test.ts`, red before the module existed: masking, placeholder and whitespace preservation, `$schema` and non-string pass-through, key order, and the plugin's two states driven through its real `config` hook — writes on `serve`, deletes on `build` — plus the default output path and `enforce: 'pre'`.

`packages/paraglide` is green at 18/18 with `tsc --noEmit` clean.

## Companion

#1035 moves `createLocaleStore` into `@pikku/react`; its `debugLocale` option is the one line that switches into this locale. The two are independent — this PR needs nothing from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)