### PR TITLE
fix(workflow): don't replay a settled run, and back off the stalled sweep

### DIFF
--- a/.changeset/pg-run-lock-cannot-be-held-forever.md
+++ b/.changeset/pg-run-lock-cannot-be-held-forever.md
@@ -1,0 +1,34 @@
+---
+'@pikku/kysely-postgres': patch
+---
+
+fix(kysely-postgres): bound the workflow run lock, and never pool a held one
+
+`withRunLock` takes a session-level advisory lock so the critical section can be
+the whole workflow body — right, because that body may await a build or an LLM
+for minutes, and a transaction lock would leave the connection `idle in
+transaction` for the duration. What a session lock does not come with is a
+bound: nothing reclaims it while the process lives, so a body that never settles
+never reaches the `finally` that unlocks, and every later message for that run
+pays `lock_timeout` before failing. Enough of them and a bounded worker pool is
+entirely queued behind runs that will never finish.
+
+Three opt-in guards now supply the bound the primitive lacks, each answering a
+different way to lose a holder:
+
+- `maxLockHoldMs` gives up on a body that hangs in-process, releases the lock
+  and rejects with `RunLockHoldTimeoutError`. The abandoned body keeps running —
+  a promise cannot be cancelled — so this trades serialisation for liveness;
+  `claimStepForExecution`, not the run lock, is what keeps a duplicated
+  orchestration from becoming a duplicated side effect.
+- `lockIdleTimeoutMs` sets `idle_session_timeout` on the lock session so
+  Postgres reclaims a holder that vanished without closing its connection. It
+  ships with a keepalive on the same connection, because a body legitimately
+  awaiting a twenty-minute build looks exactly as idle to the server as a dead
+  one — setting the GUC by hand, on the role or in the connection string, reaps
+  legitimate holders and hands the run to a second worker.
+- An unlock that throws now terminates its own backend rather than return a
+  connection to the pool still holding the lock.
+
+All three are off by default, so nothing changes for an existing deployment
+until it opts in.

--- a/.changeset/workflow-recovery-backs-off-per-run.md
+++ b/.changeset/workflow-recovery-backs-off-per-run.md
@@ -1,0 +1,26 @@
+---
+'@pikku/core': patch
+---
+
+fix(workflow): back off the stalled-run sweep, and skip runs that cannot move
+
+`sweepUndispatchedSteps` has always consulted a per-run backoff so a genuine
+queue backlog is not amplified by a tick that keeps firing at the steps the
+backlog is already delaying. `sweepStalledRuns` — its sibling, doing the same
+re-drive through the same orchestrator queue — had none, and re-resumed every
+stalled run on every tick. A resume does not clear whatever wedged a run, so
+the same runs came back on the next tick and the next: in production seven
+permanently stuck runs refilled a purged orchestrator queue at seven messages a
+minute, and a backlog of six thousand could never drain because each pass added
+work the previous pass had not finished. It now takes the same backoff, and
+both sweeps share one instance — the record belongs to the re-drive, not to the
+signal that asked for it, so a run the relay nudged a moment ago is not nudged
+again by the sweep.
+
+`runWorkflowJob` also now returns immediately for a run in a terminal state
+instead of taking the run lock and replaying the workflow body. The orchestrator
+queue is at-least-once and the relay re-dispatches on purpose, so a message for
+a run that already settled is routine — and replaying one could park the body on
+a wait that nothing would ever satisfy, holding the run lock, and the pooled
+connection under it, until something external gave up. `suspended` is
+deliberately not included: it ends a pass, not the run.

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -59,6 +59,7 @@ import {
   WORKFLOW_POLL_FACTOR,
   WORKFLOW_POLL_MIN_MS,
   WORKFLOW_TERMINAL_STATES,
+  isRunSettled,
 } from './workflow-constants.js'
 import {
   WorkflowAsyncException,
@@ -672,6 +673,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   }): Promise<{ resumed: string[] }> {
     return sweepStalledRuns(
       (before, limit) => this.findStalledRunIds(before, limit),
+      this.redispatchBackoff,
       options,
       this.sweepDeps
     )
@@ -1084,6 +1086,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     if (!run) {
       throw new WorkflowRunNotFoundError(runId)
     }
+    if (isRunSettled(run.status)) return
 
     const resolved = resolveWorkflowMeta(run.workflow)
     const workflowMeta = resolved?.meta

--- a/packages/core/src/wirings/workflow/workflow-constants.ts
+++ b/packages/core/src/wirings/workflow/workflow-constants.ts
@@ -15,6 +15,25 @@ export const WORKFLOW_TERMINAL_STATES: ReadonlySet<string> = new Set([
   'cancelled',
 ])
 
+/**
+ * True for a run that will never move again, whatever arrives for it.
+ *
+ * Worth checking before doing anything with an orchestrator message, because
+ * such a message is routine rather than exceptional: the queue is
+ * at-least-once, the relay re-dispatches on purpose, and a run can settle
+ * while a message for it is still in flight. Replaying one is not free —
+ * `runWorkflowJob` takes the run lock and re-enters the workflow body, and a
+ * body re-entered after its run failed can park on a wait that nothing will
+ * ever satisfy, holding the lock and the connection under it until something
+ * external gives up. Every leaked advisory lock seen in production traced back
+ * to that: a granted lock, an idle session, and a run already `failed`.
+ *
+ * Note `suspended` is deliberately absent. It ends a run's *current* pass but
+ * not the run, which resumes when its approval or signal arrives.
+ */
+export const isRunSettled = (status: string): boolean =>
+  WORKFLOW_TERMINAL_STATES.has(status)
+
 export const WORKFLOW_POLL_MIN_MS = 10
 
 export const WORKFLOW_POLL_FACTOR = 1.6

--- a/packages/core/src/wirings/workflow/workflow-recovery.ts
+++ b/packages/core/src/wirings/workflow/workflow-recovery.ts
@@ -17,6 +17,15 @@ import {
  * owed a job, so holding off a single step while resuming its run would
  * suppress nothing.
  *
+ * For the same reason one instance is shared by every sweep rather than kept
+ * per sweep. The record is of the action, not of the signal that prompted it:
+ * a stalled run and an undispatched step are different observations, but both
+ * are answered by the one orchestrator message, so a run the relay re-drove a
+ * moment ago gains nothing from the stalled sweep re-driving it again. Sharing
+ * is what makes the guarantee a message-per-run-per-window instead of one per
+ * sweep, and no recovery is lost by it: whichever sweep gets there first
+ * performs the identical re-drive, and the cap keeps the delay at 10m.
+ *
  * Losing this on restart costs extra dispatches, never correctness.
  */
 export class RedispatchBackoff {
@@ -88,19 +97,40 @@ const resumeEach = async (
  * actually stuck costs an orchestration pass and changes nothing. That
  * idempotence is what makes an idle-time heuristic safe here; a run that is
  * legitimately mid-sleep is excluded anyway, since its step is `scheduled`.
+ *
+ * Idempotent is not free, though: a run stays stalled until something clears
+ * the reason it stalled, so an unconditional sweep re-queues the same runs on
+ * every tick forever. That is how a handful of wedged runs became a queue of
+ * thousands that could not drain — each pass added work the previous pass had
+ * not finished. The same per-run backoff the relay uses bounds it: a run is
+ * re-driven, then held off for a doubling delay, so a sweep costs at most one
+ * message per run per window rather than one per run per tick.
  */
 export const sweepStalledRuns = async (
   findStalledRunIds: (before: Date, limit: number) => Promise<string[]>,
+  backoff: RedispatchBackoff,
   options: { stalledAfterMs?: number; limit?: number } | undefined,
   deps: SweepDeps
 ): Promise<{ resumed: string[] }> => {
   const before = new Date(
     Date.now() - (options?.stalledAfterMs ?? DEFAULT_STALLED_RUN_MS)
   )
-  const runIds = await findStalledRunIds(
+  const found = await findStalledRunIds(
     before,
     options?.limit ?? DEFAULT_STALLED_RUN_LIMIT
   )
+
+  const now = Date.now()
+  const runIds: string[] = []
+  for (const runId of found) {
+    if (!backoff.isEligible(runId, now)) continue
+    // Noted before the resume, not after: a run whose resume throws is exactly
+    // the run most likely to still be here next tick, and re-driving it every
+    // tick is the amplification this backoff exists to stop.
+    backoff.note(runId, now)
+    runIds.push(runId)
+  }
+
   return {
     resumed: await resumeEach(
       runIds,

--- a/packages/core/src/wirings/workflow/workflow-stalled-recovery.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-stalled-recovery.test.ts
@@ -89,6 +89,52 @@ describe('stalled run recovery', () => {
     assert.deepEqual(resumed, [], 'a run that just moved is not swept')
   })
 
+  test('backs off rather than re-resuming the same run every tick', async () => {
+    const resumes = trackResumes()
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+    await ws.insertStepState(runId, 'Wait 15s', null, { duration: 15000 })
+    await backdate(ws, runId, 10 * 60_000)
+
+    const first = await ws.recoverStalledRuns()
+    // Still stalled: a resume does not clear whatever wedged the run, so an
+    // unconditional sweep would re-queue it on this tick and on every tick
+    // after it.
+    const second = await ws.recoverStalledRuns()
+
+    assert.deepEqual(first.resumed, [runId], 'the first sweep resumes it')
+    assert.deepEqual(
+      second.resumed,
+      [],
+      'the next sweep is held off by the backoff'
+    )
+    assert.deepEqual(resumes.runIds, [runId], 'only one queue message')
+  })
+
+  test('does not re-drive a run the relay has just re-dispatched', async () => {
+    const resumes = trackResumes()
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+    // Old enough to read as both an undispatched step and a stalled run.
+    await ws.insertStepState(runId, 'Wait 15s', null, { duration: 15000 })
+    await backdate(ws, runId, 10 * 60_000)
+
+    const relayed = await ws.relayUndispatchedSteps()
+    const swept = await ws.recoverStalledRuns()
+
+    assert.deepEqual(relayed.redispatched, [runId], 'the relay re-drives it')
+    assert.deepEqual(
+      swept.resumed,
+      [],
+      'the sweep adds nothing the relay has not already queued'
+    )
+    assert.deepEqual(resumes.runIds, [runId], 'only one queue message')
+  })
+
   test('leaves a finished run alone', async () => {
     trackResumes()
     const ws = new InMemoryWorkflowService()

--- a/packages/core/src/wirings/workflow/workflow-terminal-run-guard.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-terminal-run-guard.test.ts
@@ -1,0 +1,105 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState, resetPikkuState } from '../../pikku-state.js'
+
+const silentLogger = { error() {}, info() {}, warn() {}, debug() {} }
+
+/** Records every run lock taken, which is the whole point of the guard. */
+class LockSpyWorkflowService extends InMemoryWorkflowService {
+  public readonly locked: string[] = []
+
+  public override async withRunLock<T>(
+    id: string,
+    fn: () => Promise<T>
+  ): Promise<T> {
+    this.locked.push(id)
+    return super.withRunLock(id, fn)
+  }
+}
+
+/** A registered, fully described workflow, so nothing else can short-circuit. */
+const startRun = async (): Promise<{
+  service: LockSpyWorkflowService
+  runId: string
+  entered: () => boolean
+}> => {
+  resetPikkuState()
+  pikkuState(null, 'package', 'singletonServices', {
+    logger: silentLogger,
+    queueService: { add: async () => 'job-1' },
+  } as any)
+
+  let bodyEntered = false
+  const func = async () => {
+    bodyEntered = true
+  }
+  pikkuState(null, 'workflows', 'meta', {
+    flow: { name: 'flow', pikkuFuncId: 'flow', source: 'dsl' },
+  } as any)
+  pikkuState(null, 'workflows', 'registrations').set('flow', {
+    name: 'flow',
+    func,
+  } as any)
+  pikkuState(null, 'function', 'meta', {
+    flow: {
+      pikkuFuncId: 'flow',
+      inputSchemaName: null,
+      outputSchemaName: null,
+      sessionless: true,
+    },
+  } as any)
+  pikkuState(null, 'function', 'functions').set('flow', { func } as any)
+
+  const service = new LockSpyWorkflowService()
+  const runId = await service.createRun('flow', {}, false, '', { type: 'test' })
+  return { service, runId, entered: () => bodyEntered }
+}
+
+/**
+ * The leak this guards, read straight off production: every granted advisory
+ * lock held by an idle session mapped to a run that was already `failed`. The
+ * orchestrator queue is at-least-once, so a message for a settled run is
+ * routine — and answering it by taking the run lock and replaying the body is
+ * how a run that can never move again ends up holding a lock and a pooled
+ * connection while it waits on something that will never arrive.
+ */
+describe('an orchestrator message for a run that already settled', () => {
+  for (const status of ['failed', 'completed', 'cancelled'] as const) {
+    test(`a ${status} run is answered without taking its lock`, async () => {
+      const { service, runId, entered } = await startRun()
+      await service.updateRunStatus(runId, status)
+
+      await service.runWorkflowJob(runId, {} as any)
+
+      assert.deepEqual(
+        service.locked,
+        [],
+        'the run lock was taken for a run that can never move again'
+      )
+      assert.equal(
+        entered(),
+        false,
+        'the workflow body was replayed after the run had settled'
+      )
+    })
+  }
+
+  /**
+   * Guards the tests above: they would pass just as well for a service that
+   * refused to orchestrate anything at all.
+   */
+  test('a suspended run is still orchestrated', async () => {
+    const { service, runId } = await startRun()
+    await service.updateRunStatus(runId, 'suspended')
+
+    await service.runWorkflowJob(runId, {} as any)
+
+    assert.deepEqual(
+      service.locked,
+      [runId],
+      'suspended ends a pass, not the run — it resumes when its signal arrives'
+    )
+  })
+})

--- a/packages/services/kysely-postgres/src/index.ts
+++ b/packages/services/kysely-postgres/src/index.ts
@@ -1,5 +1,6 @@
 export { PgKyselyWorkflowService } from './pg-kysely-workflow-service.js'
 export type { PgWorkflowQueueOptions } from './pg-kysely-workflow-service.js'
+export { RunLockHoldTimeoutError } from './pg-kysely-workflow-service.js'
 export { PgKyselyDeploymentService } from './pg-kysely-deployment-service.js'
 export { PgKyselyAgentStorageService } from './pg-kysely-agent-storage-service.js'
 export { PgKyselyAgentRunService } from './pg-kysely-agent-run-service.js'

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
@@ -32,17 +32,35 @@ import { PgKyselyWorkflowService } from './pg-kysely-workflow-service.js'
  * without the queue two overlapping transactions would interleave onto the one
  * underlying session and corrupt each other.
  */
+/**
+ * How a statement is treated instead of being run: `throw` stands in for a
+ * connection that broke mid-statement, `skip` records one PGlite must not
+ * actually execute — a single-session database cannot survive terminating its
+ * own backend.
+ */
+type Intercept = (statement: string) => 'throw' | 'skip' | undefined
+
 class PGliteDriver implements Driver {
   #connection: DatabaseConnection
   #queue: Promise<void> = Promise.resolve()
 
-  constructor(private readonly pglite: PGlite) {
+  constructor(
+    private readonly pglite: PGlite,
+    private readonly intercept?: Intercept
+  ) {
     this.#connection = {
       executeQuery: async <R>(compiled: {
         sql: string
         parameters: readonly unknown[]
       }): Promise<QueryResult<R>> => {
         executedSql.push(compiled.sql)
+        const intercepted = this.intercept?.(compiled.sql)
+        if (intercepted === 'throw') {
+          throw new Error(`connection is broken: ${compiled.sql}`)
+        }
+        if (intercepted === 'skip') {
+          return { rows: [], numAffectedRows: BigInt(0) }
+        }
         const result = await this.pglite.query<R>(compiled.sql, [
           ...compiled.parameters,
         ])
@@ -99,12 +117,15 @@ const releases = new Map<DatabaseConnection, Array<() => void>>()
 const executedSql: string[] = []
 
 class PGliteDialect implements Dialect {
-  constructor(private readonly pglite: PGlite) {}
+  constructor(
+    private readonly pglite: PGlite,
+    private readonly intercept?: Intercept
+  ) {}
   createAdapter() {
     return new PostgresAdapter()
   }
   createDriver() {
-    return new PGliteDriver(this.pglite)
+    return new PGliteDriver(this.pglite, this.intercept)
   }
   createIntrospector(db: Kysely<any>) {
     return new PostgresIntrospector(db)
@@ -118,9 +139,9 @@ let db: Kysely<KyselyPikkuDB>
 let service: PgKyselyWorkflowService
 let open: Kysely<KyselyPikkuDB>[] = []
 
-const createDb = () => {
+const createDb = (intercept?: Intercept) => {
   const created = new Kysely<KyselyPikkuDB>({
-    dialect: new PGliteDialect(new PGlite()),
+    dialect: new PGliteDialect(new PGlite(), intercept),
     // `CamelCasePlugin` alone, matching `PikkuKysely` — the SQLite-style
     // `SerializePlugin` is deliberately absent on Postgres, which takes JSON
     // and booleans natively.
@@ -471,6 +492,141 @@ describe('advisory locks', () => {
     assert.ok(
       executedSql.some((statement) => statement === 'RESET lock_timeout'),
       'lock_timeout rode the connection back into the pool'
+    )
+  })
+
+  /**
+   * The leak this guards, seen in production: a workflow body that never
+   * settles never reaches the `finally` that unlocks, so the session keeps the
+   * advisory lock and the pooled connection for as long as the process lives.
+   * Every later message for that run then blocks for the full `lock_timeout`
+   * before failing, and a bounded worker pool ends up entirely queued behind
+   * runs that will never finish.
+   */
+  test(
+    'takes the lock back from a body that never settles',
+    { timeout: 10_000 },
+    async () => {
+      const bounded = new PgKyselyWorkflowService(db, {
+        wireQueues: false,
+        maxLockHoldMs: 100,
+      } as any)
+      await bounded.init()
+
+      executedSql.length = 0
+      await assert.rejects(
+        bounded.withRunLock('run-1', () => new Promise<never>(() => {})),
+        (err: Error) => {
+          assert.equal(err.name, 'RunLockHoldTimeoutError')
+          return true
+        }
+      )
+
+      assert.ok(
+        executedSql.some((statement) =>
+          statement.includes('pg_advisory_unlock')
+        ),
+        'the abandoned body kept the run lock'
+      )
+      // The connection matters as much as the lock: PGlite's single session
+      // stands in for the pool the leak drains.
+      const rows = await sql<{ one: number }>`select 1 as one`.execute(db)
+      assert.equal(rows.rows[0]!.one, 1, 'the lock connection never came back')
+    }
+  )
+
+  test('an unbounded hold is still the default', async () => {
+    const { run, bodyEntered, release } = heldBody()
+
+    const held = service.withRunLock('run-1', run)
+    await bodyEntered
+    await new Promise((r) => setTimeout(r, 150))
+
+    release()
+    assert.equal(await held, undefined, 'a slow body was cut short')
+  })
+
+  /**
+   * `idle_session_timeout` is what reclaims a holder that went away without
+   * closing its connection, but on its own it cannot tell that holder from a
+   * body legitimately awaiting a twenty-minute build — both leave the session
+   * idle. The keepalive is what makes idleness mean something, so the two only
+   * ever ship together.
+   */
+  test('a keepalive keeps a long hold from reading as idle', async () => {
+    const kept = new PgKyselyWorkflowService(db, {
+      wireQueues: false,
+      lockIdleTimeoutMs: 3_000,
+    } as any)
+    await kept.init()
+    const { run, bodyEntered, release } = heldBody()
+
+    executedSql.length = 0
+    const held = kept.withRunLock('run-1', run)
+    await bodyEntered
+    await new Promise((r) => setTimeout(r, 2_200))
+    release()
+    await held
+
+    assert.ok(
+      executedSql.some(
+        (statement) => statement === 'SET idle_session_timeout = 3000'
+      ),
+      'the idle timeout was never applied'
+    )
+    const beats = executedSql.filter((statement) =>
+      statement.includes('pikku run lock heartbeat')
+    )
+    assert.ok(
+      beats.length >= 2,
+      `a 2.2s hold under a 3s idle timeout sent ${beats.length} keepalives, so the session read as idle`
+    )
+    assert.ok(
+      executedSql.some(
+        (statement) => statement === 'RESET idle_session_timeout'
+      ),
+      'the idle timeout rode the connection back into the pool'
+    )
+  })
+
+  /**
+   * A session lock outlives the statement that failed to release it, so an
+   * unlock that throws hands the next caller a pooled connection that still
+   * holds the run lock. Terminating our own backend is the release Postgres
+   * always honours.
+   */
+  test('a failed unlock kills the session rather than pool a held lock', async () => {
+    const brittle = createDb((statement) =>
+      statement.includes('pg_advisory_unlock')
+        ? 'throw'
+        : statement.includes('pg_terminate_backend')
+          ? 'skip'
+          : undefined
+    )
+    const unlucky = new PgKyselyWorkflowService(db, {
+      wireQueues: false,
+      lockDb: brittle,
+      lockTimeoutMs: 250,
+    } as any)
+    await unlucky.init()
+
+    executedSql.length = 0
+    const result = await unlucky.withRunLock('run-1', async () => 'done')
+
+    assert.equal(
+      result,
+      'done',
+      "the body's outcome was replaced by the unlock's own failure"
+    )
+    assert.ok(
+      executedSql.some((statement) =>
+        statement.includes('pg_terminate_backend')
+      ),
+      'a connection still holding the run lock went back to the pool'
+    )
+    assert.ok(
+      !executedSql.includes('RESET lock_timeout'),
+      'a terminated session was issued on anyway'
     )
   })
 

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
@@ -5,6 +5,33 @@ import type { Kysely } from 'kysely'
 import { sql } from 'kysely'
 import { jsonbText } from './jsonb.js'
 
+/**
+ * Fraction of `lockIdleTimeoutMs` between keepalives, so a heartbeat can be
+ * lost or slow twice over and the session is still not reaped as idle.
+ */
+const LOCK_HEARTBEAT_DIVISOR = 3
+
+/** Floor on the keepalive interval, so a small idle timeout cannot busy-poll. */
+const MIN_LOCK_HEARTBEAT_MS = 1_000
+
+/**
+ * The run lock was held past `maxLockHoldMs` and taken back.
+ *
+ * Carries the run so the orchestrator log names the workflow that wedged
+ * rather than only the lock.
+ */
+export class RunLockHoldTimeoutError extends Error {
+  constructor(
+    public readonly runId: string,
+    public readonly heldForMs: number
+  ) {
+    super(
+      `Workflow run ${runId} held its run lock for longer than ${heldForMs}ms and was released`
+    )
+    this.name = 'RunLockHoldTimeoutError'
+  }
+}
+
 export interface PgWorkflowQueueOptions extends WorkflowQueueOptions {
   /**
    * A dedicated pool for the run lock, which is held for the whole workflow
@@ -21,20 +48,174 @@ export interface PgWorkflowQueueOptions extends WorkflowQueueOptions {
    * of `lockDb` — that queue is the backpressure the pool exists to apply.
    */
   lockTimeoutMs?: number
+  /**
+   * Longest a workflow body may hold the run lock before the lock is taken
+   * back and the caller rejected with `RunLockHoldTimeoutError`. `0` (the
+   * default) is unbounded, which is the old behaviour: a body that never
+   * settles holds its lock and its connection until the process dies, and
+   * every later message for that run burns `lockTimeoutMs` waiting on it.
+   *
+   * Bounding it trades serialisation for liveness. The abandoned body keeps
+   * running — a promise cannot be cancelled — so a second orchestration of the
+   * run may overlap it. That is survivable because the run lock is not the
+   * correctness boundary: `claimStepForExecution` is, and it already has to
+   * hold against the duplicate dispatches the relay makes routinely. Set this
+   * above the slowest legitimate body (a build, an LLM, a webhook round trip),
+   * not above the average one.
+   */
+  maxLockHoldMs?: number
+  /**
+   * `idle_session_timeout` for the lock session, so Postgres reclaims a holder
+   * that went away without closing its connection — a SIGKILLed container or a
+   * partitioned worker, where the server sees a session that is simply idle
+   * and keeps its advisory locks until TCP keepalives eventually notice.
+   * Requires Postgres 14. `0` (the default) leaves the GUC alone.
+   *
+   * Only safe because of the keepalive below. A workflow body awaiting a build
+   * for twenty minutes is *also* idle from the server's point of view, so
+   * setting this on the pool by hand — in the connection string, or on the
+   * role — reaps legitimate holders and hands the run to a second worker. The
+   * option lives here so the two always ship together.
+   */
+  lockIdleTimeoutMs?: number
+}
+
+/**
+ * Reads an optional millisecond option, rejecting values that would otherwise
+ * reach Postgres as `SET lock_timeout = NaN`.
+ */
+const millis = (name: string, value: number | undefined): number => {
+  const ms = value ?? 0
+  if (!Number.isFinite(ms)) {
+    throw new RangeError(`${name} must be a finite number of ms`)
+  }
+  return Math.max(0, Math.trunc(ms))
+}
+
+/**
+ * Keeps the lock session non-idle while the body runs, so that a session
+ * Postgres sees as idle means the holder is gone rather than merely slow.
+ *
+ * The comment rides along in the statement because `pg_stat_activity.query`
+ * keeps the last one: an inherited lock leak is diagnosed by reading that
+ * column, and `SELECT pg_advisory_lock($1)` sitting there is exactly the
+ * evidence of a holder that stopped driving its connection.
+ */
+const startLockHeartbeat = (
+  conn: Kysely<KyselyPikkuDB>,
+  intervalMs: number
+): { stop: () => Promise<void> } => {
+  if (intervalMs <= 0) {
+    return { stop: async () => {} }
+  }
+  // Serialised against itself so a slow keepalive cannot overlap the unlock
+  // that follows it on the same connection.
+  let inFlight: Promise<unknown> = Promise.resolve()
+  const timer = setInterval(() => {
+    inFlight = inFlight
+      .then(() => sql`SELECT 1 /* pikku run lock heartbeat */`.execute(conn))
+      // A keepalive that fails means the session is already gone, and the lock
+      // with it. Releasing below reports that; there is nothing to do here.
+      .catch(() => {})
+  }, intervalMs)
+  // A held lock must never be the reason a process stays alive.
+  timer?.unref?.()
+  return {
+    stop: async () => {
+      clearInterval(timer)
+      await inFlight
+    },
+  }
+}
+
+/**
+ * Runs the body, giving up on it after `maxHoldMs` so the lock can be released.
+ *
+ * Racing rather than cancelling is the whole of it: nothing can stop a promise
+ * that will never settle, so the choice is between abandoning the body and
+ * leaking the lock behind it forever.
+ */
+const withHoldBound = async <T>(
+  runId: string,
+  fn: () => Promise<T>,
+  maxHoldMs: number
+): Promise<T> => {
+  if (maxHoldMs <= 0) {
+    return fn()
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      fn(),
+      new Promise<never>((_resolve, reject) => {
+        // Deliberately not unref'd: this timer firing is the recovery, so it
+        // has to outlive an event loop that has nothing else left to do.
+        timer = setTimeout(
+          () => reject(new RunLockHoldTimeoutError(runId, maxHoldMs)),
+          maxHoldMs
+        )
+      }),
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Releases the run lock, and kills the session rather than let a connection go
+ * back to the pool still holding it.
+ *
+ * A session lock outlives the statement that failed to release it, so an
+ * unlock that throws is the one way this shape leaks a lock while the process
+ * is still healthy: the pooled connection is handed to the next caller, the
+ * lock stays taken, and every acquirer of that run blocks until it times out.
+ * Terminating our own backend is the reliable release — Postgres drops every
+ * session lock with the session, and the driver discards a connection whose
+ * backend is gone.
+ *
+ * Returns false when it came to that, so the caller stops issuing on a session
+ * that no longer exists.
+ */
+const releaseRunLock = async (
+  conn: Kysely<KyselyPikkuDB>,
+  lockId: number
+): Promise<boolean> => {
+  try {
+    await sql`SELECT pg_advisory_unlock(${lockId})`.execute(conn)
+    return true
+  } catch {
+    try {
+      await sql`SELECT pg_terminate_backend(pg_backend_pid())`.execute(conn)
+    } catch {
+      // The connection is already unusable, which releases the lock too.
+    }
+    return false
+  }
 }
 
 export class PgKyselyWorkflowService extends KyselyWorkflowService {
   private lockDb: Kysely<KyselyPikkuDB>
   private lockTimeoutMs: number
+  private maxLockHoldMs: number
+  private lockIdleTimeoutMs: number
+  private lockHeartbeatMs: number
 
   constructor(db: Kysely<KyselyPikkuDB>, options: PgWorkflowQueueOptions = {}) {
     super(db, options)
     this.lockDb = options.lockDb ?? db
-    const lockTimeoutMs = options.lockTimeoutMs ?? 0
-    if (!Number.isFinite(lockTimeoutMs)) {
-      throw new RangeError('lockTimeoutMs must be a finite number of ms')
-    }
-    this.lockTimeoutMs = Math.max(0, Math.trunc(lockTimeoutMs))
+    this.lockTimeoutMs = millis('lockTimeoutMs', options.lockTimeoutMs)
+    this.maxLockHoldMs = millis('maxLockHoldMs', options.maxLockHoldMs)
+    this.lockIdleTimeoutMs = millis(
+      'lockIdleTimeoutMs',
+      options.lockIdleTimeoutMs
+    )
+    this.lockHeartbeatMs =
+      this.lockIdleTimeoutMs > 0
+        ? Math.max(
+            MIN_LOCK_HEARTBEAT_MS,
+            Math.floor(this.lockIdleTimeoutMs / LOCK_HEARTBEAT_DIVISOR)
+          )
+        : 0
   }
 
   /**
@@ -70,6 +251,22 @@ export class PgKyselyWorkflowService extends KyselyWorkflowService {
    * holds the same lock without an open transaction; the session still dies
    * with the connection, so a crashed holder still releases.
    *
+   * What a session lock does not give for free is a bound. Nothing reclaims it
+   * while the process lives, so a body that never settles keeps its lock and
+   * its connection forever, and every later message for that run pays
+   * `lockTimeoutMs` before failing — enough of them and the whole worker pool
+   * is queued behind runs that will never finish. The three guards below are
+   * the bound the primitive lacks, and each answers a different way to lose a
+   * holder: `maxLockHoldMs` for a body that hangs in-process, the keepalive
+   * plus `idle_session_timeout` for a holder that vanished without closing its
+   * connection, and `releaseRunLock` for an unlock that fails on the way out.
+   * All are off by default; a deployment that wants the guarantee opts in.
+   *
+   * They are a backstop, not the cure. Cheaper by far is not to enter the
+   * critical section for a run that cannot move — which is what `isRunSettled`
+   * in `@pikku/core` now does, and what every leaked lock observed in
+   * production turned out to need.
+   *
    * `lock_timeout` is set and reset rather than `SET LOCAL`, which only exists
    * inside a transaction, and the reset is what stops the setting from riding
    * the connection back into the pool.
@@ -77,19 +274,37 @@ export class PgKyselyWorkflowService extends KyselyWorkflowService {
   async withRunLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
     const lockId = this.hashStringToInt(`run:${id}`)
     return this.lockDb.connection().execute(async (conn) => {
+      let sessionAlive = true
       try {
         if (this.lockTimeoutMs > 0) {
-          await sql.raw(`SET lock_timeout = ${this.lockTimeoutMs}`).execute(conn)
+          await sql
+            .raw(`SET lock_timeout = ${this.lockTimeoutMs}`)
+            .execute(conn)
+        }
+        if (this.lockIdleTimeoutMs > 0) {
+          await sql
+            .raw(`SET idle_session_timeout = ${this.lockIdleTimeoutMs}`)
+            .execute(conn)
         }
         await sql`SELECT pg_advisory_lock(${lockId})`.execute(conn)
+        const heartbeat = startLockHeartbeat(conn, this.lockHeartbeatMs)
         try {
-          return await fn()
+          return await withHoldBound(id, fn, this.maxLockHoldMs)
         } finally {
-          await sql`SELECT pg_advisory_unlock(${lockId})`.execute(conn)
+          await heartbeat.stop()
+          sessionAlive = await releaseRunLock(conn, lockId)
         }
       } finally {
-        if (this.lockTimeoutMs > 0) {
-          await sql.raw('RESET lock_timeout').execute(conn)
+        // Nothing is left to reset on a session that had to be terminated, and
+        // issuing on it would only replace the body's outcome with a
+        // connection error.
+        if (sessionAlive) {
+          if (this.lockTimeoutMs > 0) {
+            await sql.raw('RESET lock_timeout').execute(conn)
+          }
+          if (this.lockIdleTimeoutMs > 0) {
+            await sql.raw('RESET idle_session_timeout').execute(conn)
+          }
         }
       }
     })


### PR DESCRIPTION
Root-caused from a total workflow outage in a production deployment. Two commits, one per package, separable if you'd rather take them apart.

## What went wrong in production

The orchestrator queue grew to ~6,300 messages and could not drain. Sampling `pg_locks` joined to `pg_stat_activity` repeatedly over ~10 minutes, **every** granted advisory lock held by an `idle` session whose last statement was `SELECT pg_advisory_lock($1)` mapped — via `hashStringToInt("run:" + id)` — to a run that was **already `failed`**. Four distinct runs across separate samples, no exceptions:

| advisory key | run | workflow | status |
|---|---|---|---|
| `896335179` | `a21a575a-…` | `createSandboxWorkflow` | failed |
| `2613557293` (`-1681410003`) | `8dd9a411-…` | `waitForOrchestratorReady` | failed |

Purging the backlog was not enough — it refilled at ~7 messages/minute from `sweepStalledRuns` alone, because seven runs sat in `running` having never executed a single step (`updated_at == created_at`, zero rows in `workflow_step`).

## The two defects

**1. `runWorkflowJobInner` had no terminal-state guard.** It loads a run, checks graph hash and meta, then takes `withRunLock` and re-enters the workflow body — for a run that may already be `failed`. The queue is at-least-once and the relay re-dispatches deliberately, so a message for a settled run is routine. Replaying one parks the body on a wait nothing will satisfy, holding a session-level advisory lock and the pooled connection under it.

The fix is one line, before the lock is ever acquired:

```ts
if (isRunSettled(run.status)) return
```

Scoped to `WORKFLOW_TERMINAL_STATES`, deliberately **not** `suspended` — that ends a pass, not the run. Nothing in the codebase moves a terminal run back to `running`.

**2. `sweepStalledRuns` had no backoff**, while `sweepUndispatchedSteps` — its sibling, re-driving through the same queue — has always had one, precisely *"so a genuine queue backlog is not amplified by a tick that keeps firing at the steps the backlog is already delaying."* Resuming doesn't clear whatever wedged a run, so the same runs came back every tick.

Both sweeps now share one `RedispatchBackoff`. The record belongs to the action, not the signal: a stalled run and an undispatched step are different observations answered by the identical orchestrator message. Sharing makes the guarantee *one message per run per window* rather than one per sweep per window, and nothing is lost — whichever sweep arrives first performs the same re-drive.

## The lock hardening (backstop, all off by default)

Commit 2 gives `withRunLock` the bound a session lock doesn't come with: `maxLockHoldMs`, `lockIdleTimeoutMs` + keepalive, and an unlock that terminates its own backend rather than pooling a connection still holding the lock.

**On `idle_session_timeout` specifically** — a naive setting of this GUC is wrong and this PR does not ship it that way. A body legitimately awaiting a twenty-minute build is `idle` to Postgres in exactly the same way a dead holder is; the server cannot distinguish them. Reaping the live one releases the lock mid-run and hands the run to a second worker, which is strictly worse than the leak. The keepalive is what makes idleness a real signal, and the two ship as one option deriving the other because setting the GUC by hand (role, connection string, pool) without it is the foot-gun. This catches what the JS side cannot catch at all: a SIGKILLed container leaves a half-open TCP connection holding locks until TCP keepalives notice, typically 2h+ — and `maxLockHoldMs` can't help, its timer died with the process.

The heartbeat statement carries its comment inline so `pg_stat_activity.query` reads as a heartbeat on a live holder, rather than the misleading `SELECT pg_advisory_lock($1)` this incident was diagnosed from.

## Testing

```
core                2304 tests · 2294 pass · 0 fail · 10 skipped
kysely-postgres       31 tests ·   31 pass · 0 fail
kysely               267 tests ·  267 pass · 0 fail
tsc (all three) → exit 0 · prettier --check → clean
```

Every new test verified red against unpatched source:

- Terminal guard: 3 of 4 fail (failed/completed/cancelled each take the lock and replay). The `suspended` control passes both before and after — that's what stops the other three passing vacuously.
- Hold bound: times out after 10s, and its hung hold poisons the shared PGlite session and cancels the next test — the pool-starvation symptom in miniature.
- `an unbounded hold is still the default` passes before and after, guarding against the guards silently becoming default-on.

## Not verified

- PGlite is a single in-process session: cross-session lock contention is untested, `idle_session_timeout` is asserted as *set* rather than observed reaping, and the `pg_terminate_backend(pg_backend_pid())` path records its statement rather than executing it (terminating PGlite's only backend would end the test DB).
- `SET idle_session_timeout` needs PG 14+; the PG 13 path (where it would throw and take `withRunLock` down) is untested. Documented on the option.
- e2e / template / verifier suites not run.

## Two things flagged, deliberately not fixed here

**`findStalledRunIds` starvation.** The query is `ORDER BY updated_at ASC LIMIT 100`. A run with zero steps satisfies the stalled predicate permanently, and resuming never updates `updated_at` — so those runs are the *oldest* rows and permanently occupy the front of every window, able to starve genuinely recoverable runs out of the limit entirely. That's an availability bug independent of the queue amplification. The backoff caps the volume but not the futility; a give-up path (N re-drives with no step ever produced ⇒ fail the run) seems right, but it's a policy decision. Worth first tracing why those runs stay `running` with zero steps — candidates that return from `orchestrateWorkflow` without a status change are the graph branch (`continueGraph` with no eligible node), the version-mismatch fallback, and a swallowed `WorkflowAsyncException`.

**`hashStringToInt` is 32-bit.** The advisory key space is 2^32, shared by `run:` and `step:` keys, so distinct runs can collide onto one key (~0.01% at 1000 concurrent locks). The consequence is liveness, not correctness — but under `lockTimeoutMs` it surfaces as a spurious `55P03` failing a *healthy* run. Not fixed inline because changing the derivation is a rolling-deploy hazard: during the overlap old workers compute the 32-bit key and new workers the 64-bit key, and since `pg_advisory_lock(int8)` and `pg_advisory_lock(int4, int4)` are different lock spaces, exclusion silently vanishes with no error. Wants a two-phase migration or an opt-in flag flipped after every worker is upgraded.

## One incidental note

`pikku-workflow-service.ts` now sits at 1998 lines against the repo's own `MAX_LINES = 2000` composability test — 1 line of headroom, which is a landmine for whoever touches it next. It wants composing out, but that felt out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPHno9Bq6vWshM1s4Mp4C7
