### PR TITLE
feat(react): `createLocaleStore` — the locale store every frontend was hand-writing

### DIFF
--- a/.changeset/react-create-locale-store.md
+++ b/.changeset/react-create-locale-store.md
@@ -1,0 +1,22 @@
+---
+'@pikku/react': patch
+---
+
+feat(react): `createLocaleStore` — the locale store every frontend was hand-writing
+
+Measured across five apps, 35 of ~52 non-comment lines of `src/i18n/config.ts`
+were identical, and two of the five were byte-identical. What was duplicated is
+not app config but a store: the active locale, a listener set, the
+`useSyncExternalStore` hook, the RTL check, a persisting setter and a
+non-persisting one, and the `overwriteGetLocale` bridge that points Paraglide's
+`getLocale()` at all of it.
+
+The bridge is why this mattered. It is one line and the least obvious one, and
+an app that copied the store but dropped it renders one locale while believing
+in another — which is exactly what happened. Copy-paste loses the interesting
+line first.
+
+What stays in each app is what actually differs: its locale list, its storage
+key, and its `detectInitialLocale` policy. `overwriteGetLocale` is injected
+rather than imported, so the package takes no dependency on one app's compiled
+Paraglide output.

--- a/packages/frontend/react/README.md
+++ b/packages/frontend/react/README.md
@@ -57,6 +57,49 @@ const { actors, signInAs, isPending } = useDevActors({
 production build renders nothing without you testing for it. The endpoint only
 accepts users flagged `actor: true`, so it can never impersonate a real user.
 
+## Locale store
+
+`createLocaleStore()` is the reactive locale store a Paraglide frontend needs:
+an active locale, a `useSyncExternalStore` hook so messages re-render on switch,
+`<html lang>`/`<html dir>` upkeep, and the bridge that points Paraglide's
+`getLocale()` at all of it.
+
+```typescript
+import { createLocaleStore } from '@pikku/react'
+import { overwriteGetLocale } from './paraglide/runtime.js'
+
+export const {
+  useLocale,
+  setActiveLocale,
+  setRouteLocale,
+  getLocale,
+  localeDir,
+  toLocale,
+} = createLocaleStore({
+  locales: ['en', 'de', 'ar'],
+  defaultLocale: 'en',
+  storageKey: 'app.language',
+  // Passed in, not imported: the runtime is your app's compiled output.
+  overwriteGetLocale,
+  // Optional — the i18n-debug locale from `@pikku/paraglide`.
+  debugLocale: 'zz',
+})
+```
+
+That bridge is the point. Every compiled message calls Paraglide's own
+`getLocale()` to pick a variant, and left alone it resolves through Paraglide's
+cookie and URL strategies — which know nothing about your store. An app that has
+a store but never calls `overwriteGetLocale` renders one locale while believing
+in another.
+
+Two setters, because the app changes locale for two different reasons:
+`setActiveLocale` is a user choosing, and persists; `setRouteLocale` is the URL
+saying so, and does not.
+
+`detectInitialLocale` defaults to persisted choice → browser language →
+`<html lang>` → `defaultLocale`. Pass your own when locale comes from somewhere
+else, such as the route or the signed-in user.
+
 ## Docs
 
 https://pikku.dev/docs

--- a/packages/frontend/react/package.json
+++ b/packages/frontend/react/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "tsc": "tsc",
-    "test": "node --test src/dev-actors.test.ts",
+    "test": "node --test src/*.test.ts",
     "build:esm": "tsc -b && echo '{\"type\": \"module\"}' > dist/esm/package.json",
     "build:cjs": "tsc -b tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json",
     "build": "yarn build:esm && yarn build:cjs",

--- a/packages/frontend/react/src/index.ts
+++ b/packages/frontend/react/src/index.ts
@@ -12,10 +12,16 @@ export type { CreatePikkuOptions } from './create-pikku.js'
 
 // i18n brand types — pure, framework-agnostic. `I18nString` is structurally
 // Paraglide JS's `LocalizedString`, so a Paraglide `m()` message satisfies the
-// `@pikku/mantine` gate natively. Apps own their reactive locale store (the
-// `@/i18n` Paraglide scaffold); `@pikku/react` only owns the brand.
+// `@pikku/mantine` gate natively.
 export type { I18nString, I18nNode } from './i18n-types.js'
 export { asI18n } from './i18n-types.js'
+
+// The reactive locale store behind those messages. An app supplies its locale
+// list, its storage key and its startup policy, and passes in Paraglide's
+// `overwriteGetLocale` from its own compiled runtime — this package never
+// imports one app's generated output.
+export { createLocaleStore } from './locale-store.js'
+export type { CreateLocaleStoreOptions, LocaleStore } from './locale-store.js'
 
 // Dev-only scenario actor sign-in — the logic half of the "Sign in as …"
 // switcher. UI-free, so `@pikku/mantine/dev` (which peer-depends on this

--- a/packages/frontend/react/src/locale-store.test.ts
+++ b/packages/frontend/react/src/locale-store.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Run: node --test packages/frontend/react/src/locale-store.test.ts
+ */
+import { test, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createLocaleStore } from './locale-store.ts'
+
+const install = (search = '', stored: Record<string, string> = {}): void => {
+  const storage = new Map(Object.entries(stored))
+  const fake = {
+    location: { search },
+    localStorage: {
+      getItem: (k: string) => storage.get(k) ?? null,
+      setItem: (k: string, v: string) => void storage.set(k, v),
+    },
+    navigator: { language: 'en-GB' },
+    document: { documentElement: { lang: '', dir: '' } },
+  }
+  ;(globalThis as any).window = fake
+  ;(globalThis as any).document = fake.document
+}
+
+const LOCALES = ['en', 'de', 'ar'] as const
+
+const store = (options: Record<string, unknown> = {}) =>
+  createLocaleStore({
+    locales: LOCALES,
+    defaultLocale: 'en',
+    storageKey: 'app.language',
+    ...options,
+  })
+
+beforeEach(() => {
+  delete (globalThis as any).window
+  delete (globalThis as any).document
+  delete process.env.I18N_DEBUG
+})
+
+test('a persisted locale wins over the browser default', () => {
+  install('', { 'app.language': 'de' })
+  assert.equal(store().getLocale(), 'de')
+})
+
+test('an unsupported persisted value falls back rather than being trusted', () => {
+  install('', { 'app.language': 'fr' })
+  assert.equal(store().getLocale(), 'en')
+})
+
+test('the browser language is read when nothing is persisted', () => {
+  install()
+  assert.equal(store({ locales: ['en', 'de'] as const }).getLocale(), 'en')
+})
+
+test('without a window the default locale is used', () => {
+  assert.equal(store().getLocale(), 'en')
+})
+
+test('setActiveLocale persists the choice and notifies subscribers', () => {
+  install()
+  const s = store()
+  let notified = 0
+  s.subscribe(() => notified++)
+
+  s.setActiveLocale('de')
+
+  assert.equal(s.getLocale(), 'de')
+  assert.equal(notified, 1)
+  assert.equal(
+    (globalThis as any).window.localStorage.getItem('app.language'),
+    'de'
+  )
+})
+
+test('setRouteLocale changes the locale without persisting it', () => {
+  install()
+  const s = store()
+  s.setRouteLocale('de')
+
+  assert.equal(s.getLocale(), 'de')
+  assert.equal(
+    (globalThis as any).window.localStorage.getItem('app.language'),
+    null
+  )
+})
+
+test('an unchanged locale notifies nobody', () => {
+  install()
+  const s = store()
+  let notified = 0
+  s.subscribe(() => notified++)
+
+  s.setActiveLocale('en')
+
+  assert.equal(notified, 0)
+})
+
+test('unsubscribing stops the notifications', () => {
+  install()
+  const s = store()
+  let notified = 0
+  const off = s.subscribe(() => notified++)
+  off()
+
+  s.setActiveLocale('de')
+
+  assert.equal(notified, 0)
+})
+
+test('the document carries both lang and dir', () => {
+  install()
+  const s = store()
+  s.setActiveLocale('ar')
+
+  const html = (globalThis as any).document.documentElement
+  assert.equal(html.lang, 'ar')
+  assert.equal(html.dir, 'rtl')
+})
+
+test('the document is written before anything renders, not on first change', () => {
+  install('', { 'app.language': 'ar' })
+  store()
+
+  assert.equal((globalThis as any).document.documentElement.dir, 'rtl')
+})
+
+test('direction reads the language subtag, not the whole locale', () => {
+  install()
+  const s = store()
+  assert.equal(s.localeDir('ar-EG'), 'rtl')
+  assert.equal(s.localeDir('de-CH'), 'ltr')
+})
+
+test('toLocale narrows a route param to a supported locale', () => {
+  install()
+  const s = store()
+  assert.equal(s.toLocale('de'), 'de')
+  assert.equal(s.toLocale('klingon'), 'en')
+  assert.equal(s.toLocale(null), 'en')
+})
+
+test('the paraglide bridge resolves through the store', () => {
+  install()
+  let bridged: (() => string) | undefined
+  const s = store({ overwriteGetLocale: (fn: () => string) => (bridged = fn) })
+
+  s.setActiveLocale('de')
+
+  assert.equal(bridged?.(), 'de')
+})
+
+test('debug mode bridges to the mask locale, and only when asked', () => {
+  install('?i18n-debug')
+  let bridged: (() => string) | undefined
+  store({
+    debugLocale: 'zz',
+    overwriteGetLocale: (fn: () => string) => (bridged = fn),
+  })
+
+  assert.equal(bridged?.(), 'zz')
+})
+
+test('debug mode without a debug locale changes nothing', () => {
+  install('?i18n-debug')
+  let bridged: (() => string) | undefined
+  store({ overwriteGetLocale: (fn: () => string) => (bridged = fn) })
+
+  assert.equal(bridged?.(), 'en')
+})
+
+test('the mask locale stays out of the supported list', () => {
+  install('?i18n-debug')
+  const s = store({ debugLocale: 'zz' })
+
+  assert.equal(s.getLocale(), 'en')
+  assert.equal(s.isI18nDebug(), true)
+})
+
+test('i18n-debug=0 turns it off explicitly', () => {
+  install('?i18n-debug=0')
+  assert.equal(store().isI18nDebug(), false)
+})
+
+test('a custom detectInitialLocale replaces the default policy', () => {
+  install('', { 'app.language': 'de' })
+  const s = store({ detectInitialLocale: () => 'ar' })
+
+  assert.equal(s.getLocale(), 'ar')
+})

--- a/packages/frontend/react/src/locale-store.ts
+++ b/packages/frontend/react/src/locale-store.ts
@@ -1,0 +1,205 @@
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Locales whose scripts run right-to-left. The whole layout mirrors off the
+ * `dir` attribute, so this has to be right before anything renders.
+ */
+const RTL_LANGUAGES = ['ar', 'he', 'fa', 'ur']
+
+export interface CreateLocaleStoreOptions<L extends string> {
+  /** Every locale the app serves. Drives URL prefixes, hreflang and narrowing. */
+  locales: readonly L[]
+  /** The locale used when nothing else resolves. */
+  defaultLocale: L
+  /**
+   * `localStorage` key the chosen locale is persisted under. Omit and the choice
+   * lasts for the session — a route locale never persists either way.
+   */
+  storageKey?: string
+  /**
+   * Paraglide's `overwriteGetLocale`, imported by the app from its own compiled
+   * runtime and passed in — a package that imported it would be taking a
+   * dependency on one app's compiled output.
+   *
+   * Every compiled message calls the runtime's `getLocale()` to pick a variant.
+   * Left alone it resolves through Paraglide's own cookie and URL strategies,
+   * which know nothing about this store, so `m.foo()` renders a locale the app
+   * does not believe is active. Passing it makes this store the single source of
+   * truth.
+   */
+  overwriteGetLocale?: (getLocale: () => string) => void
+  /**
+   * The i18n-debug pseudo-locale (`paraglideMaskLocale` in `@pikku/paraglide`
+   * writes it). When set, debug mode resolves messages through it instead of the
+   * active locale. Deliberately not a member of `locales`: that list drives URL
+   * prefixes, hreflang and any backend `locale` param, none of which should see
+   * it.
+   */
+  debugLocale?: string
+  /** Override the RTL language list. */
+  rtlLanguages?: readonly string[]
+  /**
+   * The app's own startup policy. The default is persisted choice → browser
+   * language → `<html lang>` → `defaultLocale`, which is what every app doing
+   * this by hand had written; replace it when the app resolves locale from
+   * somewhere else, such as its route or the signed-in user.
+   */
+  detectInitialLocale?: (context: {
+    /** Narrows an arbitrary string to a supported locale, or undefined. */
+    normalize: (value: string | null | undefined) => L | undefined
+    defaultLocale: L
+  }) => L
+}
+
+export interface LocaleStore<L extends string> {
+  /** Subscribes a component to locale changes so messages re-render on switch. */
+  useLocale: () => {
+    locale: L
+    dir: 'ltr' | 'rtl'
+    setLocale: (locale: L) => void
+  }
+  /** The active locale, for code that formats dates and numbers. */
+  getLocale: () => L
+  /** Switches locale and remembers the choice. */
+  setActiveLocale: (next: L) => void
+  /** Switches locale without remembering it — the URL already said so. */
+  setRouteLocale: (next: L) => void
+  /** Writing direction for a locale. */
+  localeDir: (locale?: string) => 'ltr' | 'rtl'
+  /** Narrows a route param, which is only ever `string`, to a locale. */
+  toLocale: (value: string | null | undefined) => L
+  /** Raw store subscription, for a non-React consumer. */
+  subscribe: (listener: () => void) => () => void
+  /** Whether the app is rendering the mask locale. */
+  isI18nDebug: () => boolean
+}
+
+/**
+ * The reactive locale store every Pikku frontend was writing by hand.
+ *
+ * What each app kept was identical: a module-level active locale, a listener
+ * set, a `useSyncExternalStore` hook, an RTL check, a persisting setter and a
+ * non-persisting one, and the bridge that points Paraglide's `getLocale()` at
+ * all of it. What differed was only the locale list, the storage key and the
+ * startup policy — the three things this takes as options.
+ *
+ * The bridge is why the duplication mattered rather than merely being untidy.
+ * It is one line, it is the least obvious line, and an app that copied the store
+ * but dropped it renders one locale while believing in another — which is
+ * exactly what happened.
+ */
+export const createLocaleStore = <L extends string>(
+  options: CreateLocaleStoreOptions<L>
+): LocaleStore<L> => {
+  const { locales, defaultLocale, storageKey, debugLocale } = options
+  const rtl = options.rtlLanguages ?? RTL_LANGUAGES
+
+  const listeners = new Set<() => void>()
+  let activeLocale: L = defaultLocale
+
+  const localeDir = (locale: string = defaultLocale): 'ltr' | 'rtl' =>
+    rtl.includes(locale.split('-')[0]!) ? 'rtl' : 'ltr'
+
+  const normalize = (value: string | null | undefined): L | undefined => {
+    const short = value?.slice(0, 2).toLowerCase() as L | undefined
+    return short && locales.includes(short) ? short : undefined
+  }
+
+  const toLocale = (value: string | null | undefined): L =>
+    normalize(value) ?? defaultLocale
+
+  const detectInitialLocale =
+    options.detectInitialLocale ??
+    (() => {
+      if (typeof window === 'undefined') return defaultLocale
+      return (
+        (storageKey
+          ? normalize(window.localStorage?.getItem(storageKey))
+          : undefined) ??
+        normalize(window.navigator?.language) ??
+        normalize(window.document?.documentElement?.lang) ??
+        defaultLocale
+      )
+    })
+
+  /**
+   * Read once and cached: this is consulted on every message call, and the
+   * answer cannot change without a navigation.
+   */
+  let debugMode: boolean | undefined
+  const isI18nDebug = (): boolean => {
+    if (debugMode !== undefined) return debugMode
+    debugMode = (() => {
+      if (typeof process !== 'undefined' && process.env?.I18N_DEBUG === '1') {
+        return true
+      }
+      if (typeof window === 'undefined') return false
+      const params = new URLSearchParams(window.location.search)
+      if (params.has('i18n-debug')) return params.get('i18n-debug') !== '0'
+      return window.localStorage?.getItem('i18n-debug') === '1'
+    })()
+    return debugMode
+  }
+
+  /**
+   * `dir` matters as much as `lang`, and both are applied at startup rather than
+   * on first change: the server renders the base locale because it cannot see
+   * `localStorage`, and React does not patch mismatched attributes during
+   * hydration — so a persisted RTL locale would otherwise come back as
+   * right-to-left text inside a left-to-right layout after every full load.
+   */
+  const applyDocumentLocale = (locale: L): void => {
+    if (typeof document === 'undefined') return
+    document.documentElement.lang = locale
+    document.documentElement.dir = localeDir(locale)
+  }
+
+  const notify = (): void => {
+    for (const listener of listeners) listener()
+  }
+
+  const setRouteLocale = (next: L): void => {
+    if (next === activeLocale) return
+    activeLocale = next
+    applyDocumentLocale(next)
+    notify()
+  }
+
+  const setActiveLocale = (next: L): void => {
+    if (next === activeLocale) return
+    if (storageKey && typeof window !== 'undefined') {
+      window.localStorage?.setItem(storageKey, next)
+    }
+    setRouteLocale(next)
+  }
+
+  activeLocale = detectInitialLocale({ normalize, defaultLocale })
+  applyDocumentLocale(activeLocale)
+
+  options.overwriteGetLocale?.(() =>
+    debugLocale && isI18nDebug() ? debugLocale : activeLocale
+  )
+
+  const subscribe = (listener: () => void): (() => void) => {
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+    }
+  }
+
+  const getLocale = (): L => activeLocale
+
+  return {
+    useLocale: () => {
+      const locale = useSyncExternalStore(subscribe, getLocale, getLocale)
+      return { locale, dir: localeDir(locale), setLocale: setActiveLocale }
+    },
+    getLocale,
+    setActiveLocale,
+    setRouteLocale,
+    localeDir,
+    toLocale,
+    subscribe,
+    isI18nDebug,
+  }
+}


### PR DESCRIPTION
Closes #1035.

## What was duplicated

Measured across five apps (starter, chalkline, perauset, germantax, heygermany): 35 of ~52 non-comment lines of `src/i18n/config.ts` were shared, and two of the five were byte-identical.

It is not app config. It is a store — module-level active locale, listener `Set`, `subscribe`, `useSyncExternalStore`, the RTL check behind `localeDir`, a persisting setter, a non-persisting one, and the `overwriteGetLocale` bridge.

## Why the bridge is the reason this mattered

Every compiled Paraglide message calls the runtime's own `getLocale()` to pick a variant. Left alone it resolves through Paraglide's cookie and URL strategies, which know nothing about the app's store — so `m.foo()` renders a locale the app does not believe is active.

heygermany had the store and never called `overwriteGetLocale`. That is precisely the failure copy-paste produces: one line, the least obvious one, and the first to be dropped.

It is **injected, not imported** — the package would otherwise depend on one app's compiled output.

## What the app keeps

Its locale list, its storage key, and its `detectInitialLocale` policy. The last defaults to persisted choice → browser language → `<html lang>` → default, which is what all five had written by hand; pass your own when locale comes from the route or the signed-in user instead.

## Two places this takes the better version, not the common one

- **`<html dir>` is maintained alongside `lang`.** Only perauset did this, and it is not optional: the whole layout mirrors off `dir` for ar/he/fa/ur.
- **Both are applied at creation, not on first change.** SSR renders the base locale because the server cannot see `localStorage`, and React does not patch mismatched attributes during hydration — so a persisted RTL locale otherwise comes back as right-to-left text inside a left-to-right layout after every full page load. There is a test for exactly this.

`setActiveLocale` (a user choosing, persists) and `setRouteLocale` (the URL saying so, does not) stay separate for the same reason they were separate in every app.

## `debugLocale`

Optional, and the whole switch into the mask locale from #1386: `debugLocale: 'zz'` makes the bridge resolve to the pseudo-locale while `?i18n-debug` is on, and to the active locale otherwise. It stays out of `locales` deliberately — that list drives URL prefixes, hreflang and any backend `locale` param.

## Test coverage

18 new cases, red before the module existed, driving the store through fake `window`/`document` globals: startup resolution and its fallbacks, persistence on one setter and not the other, subscribe/unsubscribe and the no-op on an unchanged locale, `lang`+`dir` upkeep including at creation, `localeDir` reading the language subtag, `toLocale` narrowing, the bridge resolving through the store, and debug mode on/off/explicitly-off.

`useLocale` itself is not covered — it is `useSyncExternalStore(subscribe, getLocale, getLocale)` over primitives that are, and testing it would mean adding a renderer to a package that has none. The package is green at 23/23 with `tsc --noEmit` clean; its `test` script now globs `src/*.test.ts` rather than naming one file, which is what let the new file run at all.

## Companion

#1386 (issue #1036) adds `paraglideMaskLocale`, which writes the catalogue `debugLocale` points at. Independent — neither PR needs the other to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)