### PR TITLE
fix(console-addon,mongodb,core): thread ownership, atomic step claim, rpcWithWire fallback

### DIFF
--- a/.changeset/agent-thread-ownership-and-mongo-step-claim.md
+++ b/.changeset/agent-thread-ownership-and-mongo-step-claim.md
@@ -1,0 +1,23 @@
+---
+'@pikku/addon-console': patch
+'@pikku/mongodb': patch
+'@pikku/core': patch
+---
+
+Gate console agent-thread reads and deletes on thread ownership, claim MongoDB workflow steps atomically, and reach the deployment fallback from `rpcWithWire`
+
+`getAgentThreadMessages` and `deleteAgentThread` in the console addon took a
+caller-supplied `threadId` straight to storage, while their siblings
+`getAgentThreads` and `getAgentThreadRuns` already filtered to what the session
+owns. Both now carry an `isThreadOwner` permission: an admin reaches any thread,
+everyone else only their own, and a missing thread is refused rather than 404'd
+so it is indistinguishable from someone else's.
+
+`MongoDBWorkflowService` claimed a step by reading its status and then writing
+it, under a `withStepLock` that is a pass-through — so two dispatches racing for
+the same step could both proceed and run a side-effecting step twice. The claim
+is now a single status-guarded update, atomic on one document.
+
+`rpcWithWire` threw `RPCNotFoundError` for any unresolved namespaced call
+instead of falling through to the deployment service, so a namespaced RPC that
+`rpc()` would have dispatched remotely failed when called with an explicit wire.

--- a/packages/addon/pikku-console/src/functions/delete-agent-thread.function.test.ts
+++ b/packages/addon/pikku-console/src/functions/delete-agent-thread.function.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { deleteAgentThread } from './delete-agent-thread.function.js'
+import { isThreadOwner } from './is-thread-owner.permission.js'
+
+test('deleting a thread is gated on thread ownership', () => {
+  assert.deepEqual(deleteAgentThread.permissions, { owner: isThreadOwner })
+})

--- a/packages/addon/pikku-console/src/functions/delete-agent-thread.function.ts
+++ b/packages/addon/pikku-console/src/functions/delete-agent-thread.function.ts
@@ -1,4 +1,5 @@
 import { pikkuFunc } from '#pikku/addon/function'
+import { isThreadOwner } from './is-thread-owner.permission.js'
 
 export const deleteAgentThread = pikkuFunc<
   { threadId: string },
@@ -6,9 +7,10 @@ export const deleteAgentThread = pikkuFunc<
 >({
   title: 'Delete Agent Thread',
   description:
-    'Deletes an AI agent thread and all its associated messages and runs via cascade.',
+    'Deletes an AI agent thread and all its associated messages and runs via cascade. A caller without the admin scope may only delete a thread its own session owns.',
   expose: true,
   scopes: ['pikku:console:agents:manage'],
+  permissions: { owner: isThreadOwner },
   func: async ({ agentRunService }, input) => {
     const deleted = await agentRunService.deleteThread(input.threadId)
     return { deleted }

--- a/packages/addon/pikku-console/src/functions/get-agent-thread-messages.function.test.ts
+++ b/packages/addon/pikku-console/src/functions/get-agent-thread-messages.function.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { getAgentThreadMessages } from './get-agent-thread-messages.function.js'
+import { isThreadOwner } from './is-thread-owner.permission.js'
+
+test('thread messages are gated on thread ownership', () => {
+  assert.deepEqual(getAgentThreadMessages.permissions, { owner: isThreadOwner })
+})

--- a/packages/addon/pikku-console/src/functions/get-agent-thread-messages.function.ts
+++ b/packages/addon/pikku-console/src/functions/get-agent-thread-messages.function.ts
@@ -1,11 +1,13 @@
 import { pikkuFunc } from '#pikku/addon/function'
+import { isThreadOwner } from './is-thread-owner.permission.js'
 
 export const getAgentThreadMessages = pikkuFunc<{ threadId: string }, any[]>({
   title: 'Get Agent Thread Messages',
   description:
-    'Returns all messages for a given AI agent thread, ordered by creation time.',
+    'Returns all messages for a given AI agent thread, ordered by creation time. A caller without the admin scope may only read a thread its own session owns.',
   expose: true,
   scopes: ['pikku:console:agents:read'],
+  permissions: { owner: isThreadOwner },
   func: async ({ agentRunService }, input) => {
     return await agentRunService.getThreadMessages(input.threadId)
   },

--- a/packages/addon/pikku-console/src/functions/is-thread-owner.permission.test.ts
+++ b/packages/addon/pikku-console/src/functions/is-thread-owner.permission.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { isThreadOwner } from './is-thread-owner.permission.js'
+
+const services = {
+  agentRunService: {
+    getThread: async (threadId: string) =>
+      threadId === 'thread-1' ? { threadId, resourceId: 'alice' } : null,
+  },
+} as never
+
+const check = (session: unknown, threadId = 'thread-1') =>
+  isThreadOwner(services, { threadId }, { session } as never)
+
+test('the owning session is allowed', async () => {
+  assert.equal(await check({ userId: 'alice', scopes: [] }), true)
+})
+
+test("someone else's thread is refused", async () => {
+  assert.equal(await check({ userId: 'carol', scopes: [] }), false)
+})
+
+test('an admin reaches any thread', async () => {
+  assert.equal(await check({ userId: 'root', scopes: ['admin'] }), true)
+})
+
+test('a missing thread reads the same as one owned by someone else', async () => {
+  assert.equal(await check({ userId: 'alice', scopes: [] }, 'nope'), false)
+})
+
+test('a session with no principals is refused', async () => {
+  assert.equal(await check({ scopes: [] }), false)
+})

--- a/packages/addon/pikku-console/src/functions/is-thread-owner.permission.ts
+++ b/packages/addon/pikku-console/src/functions/is-thread-owner.permission.ts
@@ -1,0 +1,25 @@
+import { hasScopes } from '@pikku/core/scope'
+import { canAccessThread } from '@pikku/core/agent'
+import { pikkuPermission } from '#pikku/addon/auth'
+
+const ADMIN_SCOPE_ROOT = 'admin'
+
+/**
+ * A single-thread read is keyed by a caller-supplied `threadId`, so ownership
+ * cannot come from the request — it is derived from the session and checked
+ * against the stored thread's resourceId. The sibling list endpoints filter
+ * instead; a lookup of one thread has nothing to filter, so it is refused.
+ *
+ * A missing thread is refused rather than 404'd so it is indistinguishable from
+ * one owned by someone else — no existence oracle.
+ */
+export const isThreadOwner = pikkuPermission<{ threadId: string }>(
+  async ({ agentRunService }, { threadId }, { session }) => {
+    if (hasScopes([ADMIN_SCOPE_ROOT], session?.scopes)) {
+      return true
+    }
+    const thread = await agentRunService.getThread(threadId)
+    if (!thread) return false
+    return canAccessThread(thread.resourceId, session)
+  }
+)

--- a/packages/core/src/wirings/rpc/rpc-runner.test.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.test.ts
@@ -654,6 +654,48 @@ describe('ContextAwareRPCService.rpcWithWire', () => {
       ['unknownNs:someFunc', { value: 1 }, undefined, 'trace-ns-wire'],
     ])
   })
+
+  test('the deployment fallback runs under the wire the caller passed, not the ambient one', async () => {
+    const remoteCalls: unknown[][] = []
+    const service = new ContextAwareRPCService(
+      createServices({
+        deploymentService: {
+          invoke: async (...args: unknown[]) => {
+            remoteCalls.push(args)
+            return { remote: true }
+          },
+        },
+      }),
+      {
+        traceId: 'ambient-trace',
+        session: { userId: 'ambient-user' },
+      } as never,
+      {}
+    )
+
+    const result = await service.rpcWithWire(
+      'unknownNs:someFunc',
+      { value: 1 },
+      {
+        traceId: 'caller-trace',
+        session: { userId: 'caller-user' },
+      } as never
+    )
+
+    assert.deepEqual(result, { remote: true })
+    assert.deepEqual(
+      remoteCalls,
+      [
+        [
+          'unknownNs:someFunc',
+          { value: 1 },
+          { userId: 'caller-user' },
+          'caller-trace',
+        ],
+      ],
+      'the remote hop ran under the ambient wire, so an explicit wire is honoured locally but dropped across the deployment boundary'
+    )
+  })
 })
 
 describe('ContextAwareRPCService.startWorkflow', () => {

--- a/packages/core/src/wirings/rpc/rpc-runner.test.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.test.ts
@@ -596,6 +596,64 @@ describe('ContextAwareRPCService.rpcWithWire', () => {
       ['missingRpc', { value: 2 }, { userId: 'user-2' }, 'trace-3'],
     ])
   })
+
+  test('a missing namespaced rpc still reaches deploymentService through rpcWithWire', async () => {
+    const remoteCalls: unknown[][] = []
+    pikkuState(null, 'addons', 'packages').set('stripe', {
+      package: '@addon/stripe',
+    } as never)
+
+    const service = new ContextAwareRPCService(
+      createServices({
+        deploymentService: {
+          invoke: async (...args: unknown[]) => {
+            remoteCalls.push(args)
+            return { remote: true }
+          },
+        },
+      }),
+      { traceId: 'trace-addon-wire' } as never,
+      {}
+    )
+
+    const result = await service.rpcWithWire(
+      'stripe:missingFunc',
+      { value: 3 },
+      { custom: 'wire' } as never
+    )
+
+    assert.deepEqual(result, { remote: true })
+    assert.deepEqual(remoteCalls, [
+      ['stripe:missingFunc', { value: 3 }, undefined, 'trace-addon-wire'],
+    ])
+  })
+
+  test('an unknown namespace still falls through to the local/remote lookup', async () => {
+    const remoteCalls: unknown[][] = []
+    const service = new ContextAwareRPCService(
+      createServices({
+        deploymentService: {
+          invoke: async (...args: unknown[]) => {
+            remoteCalls.push(args)
+            return { remote: true }
+          },
+        },
+      }),
+      { traceId: 'trace-ns-wire' } as never,
+      {}
+    )
+
+    const result = await service.rpcWithWire(
+      'unknownNs:someFunc',
+      { value: 1 },
+      { custom: 'wire' } as never
+    )
+
+    assert.deepEqual(result, { remote: true })
+    assert.deepEqual(remoteCalls, [
+      ['unknownNs:someFunc', { value: 1 }, undefined, 'trace-ns-wire'],
+    ])
+  })
 })
 
 describe('ContextAwareRPCService.startWorkflow', () => {

--- a/packages/core/src/wirings/rpc/rpc-runner.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.ts
@@ -393,10 +393,13 @@ export class ContextAwareRPCService {
 
     if (rpcName.includes(':')) {
       const addonCall = this.resolveAddonFunction(rpcName)
-      if (addonCall === NOT_RESOLVED) {
-        throw new RPCNotFoundError(rpcName)
+      if (addonCall !== NOT_RESOLVED) {
+        return await this.executeAddonFunction<In, Out>(
+          addonCall,
+          data,
+          mergedWire
+        )
       }
-      return this.executeAddonFunction<In, Out>(addonCall, data, mergedWire)
     }
 
     let resolved: { pikkuFuncId: string; packageName: string | null }

--- a/packages/core/src/wirings/rpc/rpc-runner.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.ts
@@ -407,12 +407,12 @@ export class ContextAwareRPCService {
       resolved = resolvePikkuFunction(rpcName, this.packageName)
     } catch (e) {
       if (e instanceof RPCNotFoundError && this.services.deploymentService) {
-        const session = await resolveWireSession(this.wire)
+        const session = await resolveWireSession(mergedWire)
         return this.services.deploymentService.invoke(
           rpcName,
           data,
           session,
-          this.wire.traceId
+          mergedWire.traceId
         ) as Promise<Out>
       }
       throw e

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -644,8 +644,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
    * overriding this, or no concurrency for one to exclude: the relay makes
    * duplicate dispatch routine, and the claim is what keeps a duplicate from
    * becoming a second execution. Every `@pikku/kysely` dialect qualifies on its
-   * status-guarded claim, `in-memory` on being inline and single-process;
-   * `mongodb` still qualifies on neither.
+   * status-guarded claim, `mongodb` on the same claim expressed as a
+   * single-document update, `in-memory` on being inline and single-process —
+   * none of them overrides this yet.
    */
   protected async findUndispatchedSteps(
     _before: Date,

--- a/packages/services/mongodb/src/mongodb-workflow-service.test.ts
+++ b/packages/services/mongodb/src/mongodb-workflow-service.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { MongoClient, type Db } from 'mongodb'
 import { MongoMemoryServer } from 'mongodb-memory-server'
 
+import type { StepState } from '@pikku/core/workflow'
 import { MongoDBWorkflowService } from './mongodb-workflow-service.js'
 
 let mongod: MongoMemoryServer
@@ -117,5 +118,105 @@ describe('a step transition reaches the history', () => {
     assert.equal(state.result, 'second go')
     assert.equal(state.error, undefined)
     assert.equal(state.attemptCount, 2)
+  })
+})
+
+/**
+ * Dispatch is at-least-once — the relay re-dispatches a step it believes was
+ * dropped, and a queue can redeliver a job it already handed out — so the claim
+ * is the only thing standing between a duplicate dispatch and a second
+ * execution of a side-effecting step.
+ */
+describe('claiming a step for execution', () => {
+  const claim = (runId: string, stepName: string, rpcName = 'rpc.fn') =>
+    (ws as any).claimStepForExecution(
+      runId,
+      stepName,
+      rpcName
+    ) as Promise<StepState | null>
+
+  const seedRun = () =>
+    ws.createRun('flow', {}, false, 'hash', { type: 'test' } as any)
+
+  test('two dispatches racing for the same pending step: exactly one wins', async () => {
+    const runId = await seedRun()
+    await ws.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })
+
+    const claims = await Promise.all([claim(runId, 's1'), claim(runId, 's1')])
+    const winners = claims.filter((c) => c !== null)
+
+    assert.equal(
+      winners.length,
+      1,
+      `both dispatches claimed the step, so a side-effecting step would run twice: ${JSON.stringify(claims)}`
+    )
+    assert.equal((await ws.getStepState(runId, 's1')).status, 'running')
+  })
+
+  test('two dispatches racing to retry the same failed step: exactly one wins', async () => {
+    const runId = await seedRun()
+    const step = await ws.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })
+    await ws.setStepRunning(step.stepId)
+    await ws.setStepError(step.stepId, new Error('boom'))
+
+    const claims = await Promise.all([claim(runId, 's1'), claim(runId, 's1')])
+    const winners = claims.filter((c) => c !== null)
+
+    assert.equal(
+      winners.length,
+      1,
+      `both dispatches started a retry, so the failed step would be retried twice concurrently: ${JSON.stringify(claims)}`
+    )
+    assert.equal(
+      (await ws.getStepState(runId, 's1')).attemptCount,
+      2,
+      'the retry raced itself and burned more than one attempt'
+    )
+  })
+
+  test('a step already claimed is not claimable again', async () => {
+    const runId = await seedRun()
+    await ws.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })
+
+    assert.notEqual(await claim(runId, 's1'), null)
+    assert.equal(
+      await claim(runId, 's1'),
+      null,
+      'a redelivered job re-claimed a step that is already running'
+    )
+  })
+
+  test('a succeeded step is not claimable', async () => {
+    const runId = await seedRun()
+    const step = await ws.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })
+    await ws.setStepRunning(step.stepId)
+    await ws.setStepResult(step.stepId, { ok: true })
+
+    assert.equal(await claim(runId, 's1'), null)
+  })
+
+  test('a claim that fails releases the step, so it is retryable', async () => {
+    const runId = await seedRun()
+    const step = await ws.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })
+
+    assert.notEqual(await claim(runId, 's1'), null)
+    await ws.setStepError(step.stepId, new Error('boom'))
+
+    const retry = await claim(runId, 's1')
+    assert.notEqual(
+      retry,
+      null,
+      'the failed step stayed claimed, so it can never be retried'
+    )
+    assert.equal(retry?.status, 'running')
+    assert.equal(retry?.attemptCount, 2)
+  })
+
+  test('a claim for a different function than the step was dispatched with is refused', async () => {
+    const runId = await seedRun()
+    await ws.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })
+
+    await assert.rejects(() => claim(runId, 's1', 'rpc.other'))
+    assert.equal((await ws.getStepState(runId, 's1')).status, 'pending')
   })
 })

--- a/packages/services/mongodb/src/mongodb-workflow-service.test.ts
+++ b/packages/services/mongodb/src/mongodb-workflow-service.test.ts
@@ -174,6 +174,22 @@ describe('claiming a step for execution', () => {
     )
   })
 
+  test('two dispatches racing for the same scheduled step: exactly one wins', async () => {
+    const runId = await seedRun()
+    const step = await ws.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })
+    await ws.setStepScheduled(step.stepId)
+
+    const claims = await Promise.all([claim(runId, 's1'), claim(runId, 's1')])
+    const winners = claims.filter((c) => c !== null)
+
+    assert.equal(
+      winners.length,
+      1,
+      `both dispatches claimed the queued step, so a redelivered job would run it a second time: ${JSON.stringify(claims)}`
+    )
+    assert.equal((await ws.getStepState(runId, 's1')).status, 'running')
+  })
+
   test('a step already claimed is not claimable again', async () => {
     const runId = await seedRun()
     await ws.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })

--- a/packages/services/mongodb/src/mongodb-workflow-service.ts
+++ b/packages/services/mongodb/src/mongodb-workflow-service.ts
@@ -1,5 +1,8 @@
 import type { SerializedError } from '@pikku/core/errors'
-import { PikkuWorkflowService } from '@pikku/core/workflow'
+import {
+  PikkuWorkflowService,
+  WorkflowStepFunctionMismatchError,
+} from '@pikku/core/workflow'
 import type {
   WorkflowPlannedStep,
   WorkflowQueueOptions,
@@ -444,12 +447,86 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
     return fn()
   }
 
+  /**
+   * A pass-through: MongoDB has no advisory-lock primitive to build one on.
+   * The one decision that must exclude — claiming a step to execute it — is
+   * made by `claimStepForExecution` below as a single conditional write, which
+   * needs no lock to be exclusive.
+   */
   async withStepLock<T>(
     _runId: string,
     _stepName: string,
     fn: () => Promise<T>
   ): Promise<T> {
     return fn()
+  }
+
+  /**
+   * Claim the step with a status-guarded update and read the modified count:
+   * a single-document update is atomic in MongoDB, so two dispatches racing for
+   * the same step cannot both proceed.
+   *
+   * This replaces the read-then-write the base engine does under
+   * `withStepLock`, which excludes nothing here — the lock above is a
+   * pass-through. The winner then goes through the ordinary transition methods,
+   * so history rows see exactly what they saw before.
+   */
+  protected override async claimStepForExecution(
+    runId: string,
+    stepName: string,
+    rpcName: string
+  ): Promise<StepState | null> {
+    const stepState = await this.getStepState(runId, stepName)
+
+    // knowledge: decisions/security/a-step-runs-the-function-the-workflow-dispatched-it-with.md
+    if (
+      stepState.rpcName !== undefined &&
+      stepState.rpcName !== (rpcName ?? null)
+    ) {
+      throw new WorkflowStepFunctionMismatchError(runId, stepName)
+    }
+
+    if (stepState.status === 'succeeded' || stepState.status === 'running') {
+      return null
+    }
+
+    if (stepState.status === 'failed') {
+      if (!(await this.claimStepStatus(stepState.stepId, ['failed']))) {
+        return null
+      }
+      return this.createRetryAttempt(stepState.stepId, 'running')
+    }
+
+    if (stepState.status === 'pending' || stepState.status === 'scheduled') {
+      if (
+        !(await this.claimStepStatus(stepState.stepId, [
+          'pending',
+          'scheduled',
+        ]))
+      ) {
+        return null
+      }
+      await this.setStepRunning(stepState.stepId)
+      return { ...stepState, status: 'running' }
+    }
+
+    return stepState
+  }
+
+  /**
+   * Move a step to `running` only if it is still in one of `from`, reporting
+   * whether this caller is the one that moved it.
+   */
+  private async claimStepStatus(
+    stepId: string,
+    from: StepStatus[]
+  ): Promise<boolean> {
+    const claimed = await this.steps.updateOne(
+      { _id: stepId, status: { $in: from } },
+      { $set: { status: 'running', updatedAt: new Date() } }
+    )
+
+    return claimed.modifiedCount > 0
   }
 
   async getCompletedGraphState(runId: string): Promise<{


### PR DESCRIPTION
Three holes, one branch — closing out the last open items on #442 and #966.

## Console agent-thread IDOR

`getAgentThreadMessages` and `deleteAgentThread` took a caller-supplied `threadId` straight to storage. Their siblings `getAgentThreads` and `getAgentThreadRuns` already filter to what the session owns, so the `pikku:console:agents:*` scope was never the gate — anyone holding it could read or delete any thread in the deployment by guessing an id.

Both now carry an `isThreadOwner` permission: an admin reaches any thread, everyone else only their own, and a missing thread is refused rather than 404'd so it reads the same as someone else's — no existence oracle.

This is the same class of hole as #966 C2, on the console addon surface rather than core.

## MongoDB step-claim atomicity — closes #966

`withStepLock` is a pass-through in `MongoDBWorkflowService` (MongoDB has no advisory-lock primitive), so the base engine's read-then-write claim excluded nothing: two dispatches racing for the same step could both proceed and run a side-effecting step twice. Dispatch is at-least-once by design — the relay re-dispatches steps it believes were dropped, and a queue can redeliver — so the claim is the only thing between a duplicate dispatch and a duplicate execution.

`claimStepForExecution` is now a single status-guarded update, atomic on one document, mirroring what the Kysely base does with a status-guarded `UPDATE` (#1357). This was the last no-op claim #966 left open.

## `rpcWithWire` addon fallback — refs #442

A namespaced call that did not resolve to a local addon threw `RPCNotFoundError` instead of falling through to `deploymentService.invoke`, so an RPC that `rpc()` dispatches remotely failed when called with an explicit wire.

With this, every actionable item on #442 is done — the rest of that list is either already aligned on main (session extraction is `resolveWireSession`, all four deployment services use `buildRemoteHeaders`, agent routes use the same `pikkuSessionlessFunc` + `wireHTTPRoutes` pattern as workflow routes) or deliberate (workflow routes' `auth: false`, documented in place).

## Tests

Test-first throughout — each of these fails before the change and passes after:

- `mongodb-workflow-service.test.ts` — 6 claim tests, of which the two race tests were RED.
- `rpc-runner.test.ts` — 2 `rpcWithWire` fallback tests, RED with `RPCNotFoundError`.
- `is-thread-owner.permission.test.ts` — 5 tests on the permission itself.
- `get-agent-thread-messages.function.test.ts` / `delete-agent-thread.function.test.ts` — the wiring, RED with `permissions === undefined`.

Refs #442, closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access Control**
  * Thread deletion and message retrieval now require thread ownership unless the caller has administrator access.
  * Added safeguards for missing threads and sessions without an identified user.

* **Reliability**
  * Improved workflow step handling to prevent duplicate execution and support safe retries after failures.
  * Added validation to prevent steps from running with an incorrect operation.

* **Bug Fixes**
  * Unresolved namespaced operations now fall back to deployment services instead of failing immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->