### PR TITLE
fix(cli): one codegen pass per change in dev, and make watch actually watch

### DIFF
--- a/.changeset/dev-double-codegen.md
+++ b/.changeset/dev-double-codegen.md
@@ -1,0 +1,12 @@
+---
+'@pikku/cli': patch
+---
+
+Run one codegen pass per file change in `pikku dev`, not two
+
+`configWatcher` watched the source directories and rebuilt the file watcher on
+every change, whose `ready` handler immediately ran a full codegen — while the
+old watcher's own `change` handler ran another. Each pass holds a whole
+`ts.Program`, so the two overlapping passes doubled peak RSS and could OOM a
+memory-capped sandbox. There is now a single long-lived watcher, and changes
+arriving mid-pass coalesce into exactly one follow-up run.

--- a/.changeset/watch-never-ran.md
+++ b/.changeset/watch-never-ran.md
@@ -1,0 +1,11 @@
+---
+'@pikku/cli': patch
+---
+
+Keep `pikku watch` alive so it actually watches, and run one codegen pass per change
+
+The command registered its chokidar handlers and returned, so the process exited
+before `ready` ever fired and nothing was ever regenerated. It now stays alive the
+way `pikku dev` does, and uses the same single-watcher, in-flight-coalescing shape,
+so a change during a pass schedules exactly one more run instead of overlapping two
+`ts.Program`s.

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -423,7 +423,6 @@ export const dev = pikkuSessionlessFunc<
 
     logger.info(serverReadyLine(hostname, resolvedPort))
 
-    let configWatcher: FSWatcher | undefined
     let watcher: FSWatcher | undefined
 
     process.once('SIGINT', async () => {
@@ -431,7 +430,6 @@ export const dev = pikkuSessionlessFunc<
       try {
         await lifecycle?.beforeStop?.(resolvedServices)
         await stopSingletonServices()
-        await configWatcher?.close()
         await watcher?.close()
         await pikkuServer.stop()
         await lifecycle?.afterStop?.(resolvedServices)
@@ -450,81 +448,91 @@ export const dev = pikkuSessionlessFunc<
     if (enableWatch) {
       const genIgnore = /\.gen\.tsx?$/
 
-      configWatcher = chokidar.watch(watchDirectories, {
+      logger.info(
+        `• Watching directories: \n  - ${watchDirectories.join('\n  - ')}`
+      )
+      watcher = chokidar.watch(watchDirectories, {
         ignoreInitial: true,
         ignored: genIgnore,
       })
 
-      const generatorWatcher = () => {
-        watcher?.close()
+      watcher.on('ready', async () => {
+        const handle = async () => {
+          try {
+            const start = Date.now()
+            invalidateInspectorState()
+            await runAllWithCommandState()
+            workflowService.wireQueueWorkers()
+            wireAgentScorerQueueWorkers()
+            // Pull the regenerated meta + JSON schemas into the running
+            // process so new/changed functions are callable without a
+            // restart (the hot-reloader registers their implementations).
+            await reloadGeneratedMeta({
+              pikkuDir,
+              logger,
+              schemaService: resolvedServices.schema,
+            })
+            // Re-import recently changed files now that the fresh meta is
+            // in state: wire* calls skip routes whose meta doesn't exist,
+            // so a NEW route in a changed wiring file only registers on
+            // this post-codegen pass (the reloader's instant pass ran too
+            // early to see it).
+            await devReloader?.reimportPending()
+            // reimportPending only re-runs wire* for changed/added files, so a
+            // DELETED *.addon.ts leaves its wireAddon entry stranded in the
+            // live registry. Prune it against the inspection runAllWithCommandState
+            // already produced this pass — a plain read (no refresh) reuses that
+            // fresh post-change cache. Forcing refresh=true here re-inspected the
+            // whole project a SECOND time: the codegen writes after that inspection
+            // bump the ts-write generation, so refresh treats the cache as stale.
+            const { rpc } = await getInspectorState()
+            reconcileAddonRegistry(rpc.wireAddonDeclarations.keys(), logger)
+            logger.info({
+              message: `✓ Generated in ${Date.now() - start}ms`,
+              type: 'timing',
+            })
+          } catch (err) {
+            logger.error(`Error running watch: ${err}`)
+          }
+        }
 
-        logger.info(
-          `• Watching directories: \n  - ${watchDirectories.join('\n  - ')}`
-        )
-        watcher = chokidar.watch(watchDirectories, {
-          ignoreInitial: true,
-          ignored: genIgnore,
-        })
+        // A codegen pass holds a whole ts.Program, so two overlapping passes
+        // double the peak RSS — enough to OOM a sandbox. Coalesce instead:
+        // changes arriving mid-pass schedule exactly one more run after it.
+        let inFlight: Promise<void> | undefined
+        let queued = false
 
-        watcher.on('ready', async () => {
-          const handle = async () => {
+        const runHandle = async (): Promise<void> => {
+          if (inFlight) {
+            queued = true
+            return
+          }
+          do {
+            queued = false
+            inFlight = handle()
             try {
-              const start = Date.now()
-              invalidateInspectorState()
-              await runAllWithCommandState()
-              workflowService.wireQueueWorkers()
-              wireAgentScorerQueueWorkers()
-              // Pull the regenerated meta + JSON schemas into the running
-              // process so new/changed functions are callable without a
-              // restart (the hot-reloader registers their implementations).
-              await reloadGeneratedMeta({
-                pikkuDir,
-                logger,
-                schemaService: resolvedServices.schema,
-              })
-              // Re-import recently changed files now that the fresh meta is
-              // in state: wire* calls skip routes whose meta doesn't exist,
-              // so a NEW route in a changed wiring file only registers on
-              // this post-codegen pass (the reloader's instant pass ran too
-              // early to see it).
-              await devReloader?.reimportPending()
-              // reimportPending only re-runs wire* for changed/added files, so a
-              // DELETED *.addon.ts leaves its wireAddon entry stranded in the
-              // live registry. Prune it against the inspection runAllWithCommandState
-              // already produced this pass — a plain read (no refresh) reuses that
-              // fresh post-change cache. Forcing refresh=true here re-inspected the
-              // whole project a SECOND time: the codegen writes after that inspection
-              // bump the ts-write generation, so refresh treats the cache as stale.
-              const { rpc } = await getInspectorState()
-              reconcileAddonRegistry(rpc.wireAddonDeclarations.keys(), logger)
-              logger.info({
-                message: `✓ Generated in ${Date.now() - start}ms`,
-                type: 'timing',
-              })
-            } catch (err) {
-              logger.error(`Error running watch: ${err}`)
+              await inFlight
+            } finally {
+              inFlight = undefined
             }
+          } while (queued)
+        }
+
+        await runHandle()
+
+        let timeout: ReturnType<typeof setTimeout> | undefined
+
+        const deduped = (_file: string) => {
+          if (timeout) {
+            clearTimeout(timeout)
           }
+          timeout = setTimeout(runHandle, 10)
+        }
 
-          await handle()
-
-          let timeout: ReturnType<typeof setTimeout> | undefined
-
-          const deduped = (_file: string) => {
-            if (timeout) {
-              clearTimeout(timeout)
-            }
-            timeout = setTimeout(handle, 10)
-          }
-
-          watcher?.on('change', deduped)
-          watcher?.on('add', deduped)
-          watcher?.on('unlink', deduped)
-        })
-      }
-
-      configWatcher.on('ready', generatorWatcher)
-      configWatcher.on('change', generatorWatcher)
+        watcher?.on('change', deduped)
+        watcher?.on('add', deduped)
+        watcher?.on('unlink', deduped)
+      })
     }
 
     await new Promise(() => {})

--- a/packages/cli/src/functions/commands/watch.ts
+++ b/packages/cli/src/functions/commands/watch.ts
@@ -22,58 +22,77 @@ export const watch = pikkuSessionlessFunc<{ hmr?: boolean }, void>({
       })
     }
 
-    const configWatcher = chokidar.watch(watchDirectories, {
+    const watcher = chokidar.watch(watchDirectories, {
       ignoreInitial: true,
       ignored: /.*\.gen\.tsx?/,
     })
 
-    let watcher = new chokidar.FSWatcher({})
+    logger.info(
+      `• Watching directories: \n  - ${watchDirectories.join('\n  - ')}`
+    )
 
-    const generatorWatcher = () => {
-      watcher.close()
+    watcher.on('ready', async () => {
+      const handle = async () => {
+        try {
+          const start = Date.now()
+          invalidateInspectorState()
+          await rpc.invoke('all')
+          logger.info({
+            message: `✓ Generated in ${Date.now() - start}ms`,
+            type: 'timing',
+          })
+        } catch (err) {
+          console.error(err)
+          logger.error('Error running watch')
+        }
+      }
 
-      logger.info(
-        `• Watching directories: \n  - ${watchDirectories.join('\n  - ')}`
-      )
-      watcher = chokidar.watch(watchDirectories, {
-        ignoreInitial: true,
-        ignored: /.*\.gen\.ts/,
-      })
+      // A codegen pass holds a whole ts.Program, so two overlapping passes double
+      // the peak RSS. Coalesce instead: changes arriving mid-pass schedule exactly
+      // one more run after it.
+      let inFlight: Promise<void> | undefined
+      let queued = false
 
-      watcher.on('ready', async () => {
-        const handle = async () => {
+      const runHandle = async (): Promise<void> => {
+        if (inFlight) {
+          queued = true
+          return
+        }
+        do {
+          queued = false
+          inFlight = handle()
           try {
-            const start = Date.now()
-            invalidateInspectorState()
-            await rpc.invoke('all')
-            logger.info({
-              message: `✓ Generated in ${Date.now() - start}ms`,
-              type: 'timing',
-            })
-          } catch (err) {
-            console.error(err)
-            logger.error('Error running watch')
+            await inFlight
+          } finally {
+            inFlight = undefined
           }
+        } while (queued)
+      }
+
+      await runHandle()
+
+      let timeout: ReturnType<typeof setTimeout> | undefined
+
+      const deduped = (_file: string) => {
+        if (timeout) {
+          clearTimeout(timeout)
         }
+        timeout = setTimeout(runHandle, 1000)
+      }
 
-        await handle()
+      watcher.on('change', deduped)
+      watcher.on('add', deduped)
+      watcher.on('unlink', deduped)
+    })
 
-        let timeout: ReturnType<typeof setTimeout> | undefined
+    process.once('SIGINT', async () => {
+      await watcher.close()
+      process.exit(0)
+    })
 
-        const deduped = (_file: string) => {
-          if (timeout) {
-            clearTimeout(timeout)
-          }
-          timeout = setTimeout(handle, 1000)
-        }
-
-        watcher.on('change', deduped)
-        watcher.on('add', deduped)
-        watcher.on('unlink', deduped)
-      })
-    }
-
-    configWatcher.on('ready', generatorWatcher)
-    configWatcher.on('change', generatorWatcher)
+    // Without this the command returns the moment the handlers are registered and
+    // the process exits, taking the watcher with it — chokidar's `ready` never
+    // fires, so `pikku watch` regenerated nothing at all.
+    await new Promise(() => {})
   },
 })


### PR DESCRIPTION
Two fixes to the file-watching commands, both aimed at peak memory during codegen.

## `pikku dev` ran two codegen passes per change

`configWatcher` watched the source directories (not a config file) and rebuilt the real file watcher on every change. The new watcher's `ready` handler then ran a full codegen while the old watcher's `change` handler ran another.

Each pass holds a whole `ts.Program`, so the two overlapping passes roughly doubled peak RSS — enough to OOM a memory-capped container.

There is now a single long-lived watcher, and changes arriving mid-pass coalesce into exactly one follow-up run.

Measured on `templates/functions`, 20 edits 3s apart, against `main` at 0.12.112:

| | before | after |
|---|---|---|
| codegen passes per edit | 2 | 1 |
| mean peak RSS | 975MB | 748MB |
| codegen wall time | 4102ms | 1881ms |
| max single-pass peak | 1820MB | 1814MB |
| idle floor | 121MB | 109MB |

Pass count is exact — counted from `Generated in` lines after a single edit. The RSS figures are single runs and directional only. The max is unchanged by design: one `ts.Program` still costs ~1.8GB, which is a separate problem.

## `pikku watch` never watched anything

Found while applying the same fix to `watch.ts`. The command registered its chokidar handlers and returned, so the process exited before chokidar's `ready` ever fired — it regenerated nothing at all. Confirmed against unmodified `main`: 75s in a template, zero `Generated in` lines, process already gone.

It now holds open the way `dev` does, and closes its watcher on SIGINT. With that in place it had the same double-codegen shape, so it gets the same single-watcher coalescing treatment.

Verified after the fix: 1 boot pass, then exactly 1 pass per edit.

## Testing

- `tsc --noEmit` clean on `packages/cli`
- `npm run build` clean
- Manual A/B on `templates/functions` as above, for both commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `dev` and `watch` reliability by preventing overlapping code generation runs.
  * Reduced memory usage during rapid file changes, helping avoid out-of-memory failures.
  * Ensured `watch` remains active and performs an initial generation pass.
  * Changes detected during generation are now consolidated into a single follow-up run.
  * Improved handling of file additions, changes, and deletions while watching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->