### PR TITLE
fix(cli): gate the generated getAgentThreads behind auth

### DIFF
--- a/.changeset/agent-threads-gate.md
+++ b/.changeset/agent-threads-gate.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Gate the generated `getAgentThreads` behind `auth: true`. It lists the caller's own threads, so an anonymous caller could only ever get an empty array back — but it was the one exposed agent function with neither a permission nor a session requirement, so every scaffolded project shipped a PKU574 warning.

--- a/packages/cli/src/functions/wirings/agent/serialize-public-agent.ts
+++ b/packages/cli/src/functions/wirings/agent/serialize-public-agent.ts
@@ -153,7 +153,7 @@ export const getAgentThreads = pikkuSessionlessFunc({
   description:
     'Returns the caller\\'s AI agent threads from storage. Accepts optional filters: agentName, resourceId, limit, and offset for pagination.',
   expose: true,
-  auth: false,
+  auth: true,
   func: async ({ agentRunService }, input, { session }) => {
     // \`owners\` is an authorization constraint derived from the session, never
     // from input — \`resourceId\` remains a caller-supplied filter within it.

--- a/packages/cli/src/functions/wirings/scaffold-dispatchers-decline-to-gate.test.ts
+++ b/packages/cli/src/functions/wirings/scaffold-dispatchers-decline-to-gate.test.ts
@@ -9,8 +9,19 @@ import { serializeVirtualUserFunctions } from './virtual-user/serialize-virtual-
 
 const leaf = (name: string) => `#pikku/${name}`
 
+const declarations = (output: string) =>
+  output.split(/\n(?=export const |wire[A-Z])/)
+
+const isExposed = (declaration: string) =>
+  /^\s*expose: true,?$/m.test(declaration)
+
 const authFields = (output: string) =>
   output.match(/^\s*auth: (true|false),?$/gm)?.map((line) => line.trim()) ?? []
+
+const forwardedAuthFields = (output: string) =>
+  declarations(output)
+    .filter((declaration) => !isExposed(declaration))
+    .flatMap(authFields)
 
 describe('the scaffold dispatchers decline to gate', () => {
   const dispatchers: Array<[string, string]> = [
@@ -22,7 +33,7 @@ describe('the scaffold dispatchers decline to gate', () => {
 
   for (const [name, output] of dispatchers) {
     test(name, () => {
-      const fields = authFields(output)
+      const fields = forwardedAuthFields(output)
       assert.notEqual(
         fields.length,
         0,
@@ -33,6 +44,28 @@ describe('the scaffold dispatchers decline to gate', () => {
         ['auth: false,'],
         `${name} gates the call itself instead of leaving it to the function it forwards to`
       )
+    })
+  }
+})
+
+describe('the exposed scaffold functions gate themselves', () => {
+  const surfaces: Array<[string, string]> = [
+    ['public agent', serializePublicAgent(leaf).functions],
+  ]
+
+  for (const [name, output] of surfaces) {
+    const exposed = declarations(output).filter(isExposed)
+
+    test(name, () => {
+      assert.notEqual(exposed.length, 0, `${name} exposes no function at all`)
+      for (const declaration of exposed) {
+        const funcName = declaration.match(/export const (\w+)/)?.[1]
+        assert.ok(
+          /^\s*auth: true,?$/m.test(declaration) ||
+            /^\s*permissions: /m.test(declaration),
+          `${funcName} is exposed with neither a session requirement nor a permission, so PKU574 fires on every project that scaffolds it`
+        )
+      }
     })
   }
 })


### PR DESCRIPTION
`getAgentThreads` lists the caller's own threads — `threadOwnerConstraint` derives `owners` from the session, and `KyselyAgentRunService.listThreads` fails closed on an empty constraint, so an anonymous caller could only ever get `[]` back. Not a leak, but it was the one exposed agent function with neither a permission nor a session requirement, so **PKU574 fired in every scaffolded project** and an anonymous caller got a silent empty list instead of a 401.

Its three siblings (`getAgentThreadMessages`, `getAgentThreadRuns`, `deleteAgentThread`) gate on `permissions: { owner: isThreadOwner }`. This one has no `threadId` to check ownership against, so `auth: true` — the remedy the PKU574 message itself offers — is the gate that fits.

It is reachable only through the generic `POST /rpc/:rpcName`; it is not in `agentRoutes`, so no HTTP wiring changes.

## Verification

Against `templates/starter-template` in the fabric repo, with the CLI built from this branch:

- before: `[PKU574] 1 exposed sessionless function carries no permission and no addon gate … getAgentThreads`
- after: no PKU574
- regenerated `agent.gen.ts` typechecks (`tsc --noEmit`, exit 0)
- `packages/cli` typechecks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRGghZzh67Q1A2f5B5znkE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Accessing agent threads now requires authentication.
  * Existing session-based ownership protections and caller-supplied filters remain in place.
* **Documentation**
  * Added release documentation describing the authentication requirement for generated agent-thread retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->