### PR TITLE
feat: run personas against deployed stages

### DIFF
--- a/.changeset/fabric-tokens-name-their-stage.md
+++ b/.changeset/fabric-tokens-name-their-stage.md
@@ -1,5 +1,5 @@
 ---
-'@pikku/services-better-auth': minor
+'@pikku/services-better-auth': patch
 ---
 
 Let a Fabric operator token be scoped to one stage.

--- a/.changeset/fabric-tokens-name-their-stage.md
+++ b/.changeset/fabric-tokens-name-their-stage.md
@@ -1,0 +1,16 @@
+---
+'@pikku/services-better-auth': minor
+---
+
+Let a Fabric operator token be scoped to one stage.
+
+Every stage verifies against the same `FABRIC_AUTH_PUBLIC_KEY`, so a token
+carrying only an operator and a purpose is admin on all of them at once. That
+was contained while the token never left the control plane, and stops being
+contained the moment one is handed to a scenario run or CI.
+
+`fabric()` now takes `audience` — the stage's own id, `FABRIC_STAGE_ID` in a
+Fabric deploy. A token carrying `aud` is refused unless `audience` is configured
+and matches, so a stage that has not been told who it is cannot be the weak one.
+Tokens without `aud` behave exactly as before, which keeps the existing
+server-to-server callers working while the claim rolls out.

--- a/.changeset/personas-sign-in-on-deployed-stages.md
+++ b/.changeset/personas-sign-in-on-deployed-stages.md
@@ -1,5 +1,5 @@
 ---
-'@pikku/core': minor
+'@pikku/core': patch
 ---
 
 Let personas run against a deployed stage.

--- a/.changeset/personas-sign-in-on-deployed-stages.md
+++ b/.changeset/personas-sign-in-on-deployed-stages.md
@@ -1,0 +1,20 @@
+---
+'@pikku/core': minor
+---
+
+Let personas run against a deployed stage.
+
+A persona could only ever sign in through the actor plugin, which is
+passwordless and therefore a local-development mechanism — so the scenario
+suite had no way to reach staging or production, including the parts of it
+that never assert anything about a logged-in user.
+
+`HttpPersonasConfig` now takes `operator` as an alternative to `secret`. Given
+Fabric operator credentials, a persona signs in at `/auth/sign-in/fabric` and
+acts as its account through the `x-pikku-impersonate-user-id` header, which is
+gated on the umbrella `admin` scope rather than `user.role`. Nothing on the
+deployed side holds a test credential: the stage verifies operator tokens and
+cannot mint them.
+
+Provisioning stays opt-in (`createMissing`), so pointing a run at a live
+environment never quietly writes user rows into it.

--- a/.changeset/scenario-commands-reach-deployed-stages.md
+++ b/.changeset/scenario-commands-reach-deployed-stages.md
@@ -1,6 +1,6 @@
 ---
-'@pikku/cli': minor
-'@pikku/playwright': minor
+'@pikku/cli': patch
+'@pikku/playwright': patch
 ---
 
 Point `pikku scenario run`, `pikku persona`, and `pikku persona sync` at a

--- a/.changeset/scenario-commands-reach-deployed-stages.md
+++ b/.changeset/scenario-commands-reach-deployed-stages.md
@@ -1,0 +1,22 @@
+---
+'@pikku/cli': minor
+'@pikku/playwright': minor
+---
+
+Point `pikku scenario run`, `pikku persona`, and `pikku persona sync` at a
+deployed environment.
+
+Each of the three read `SCENARIO_ACTOR_SECRET` directly and failed without it,
+which meant a deployed target was unreachable no matter what credentials you
+held. They now share one resolver: `FABRIC_OPERATOR_TOKEN` for a deployed stage,
+`SCENARIO_ACTOR_SECRET` for a local `pikku dev` one, and an error naming both
+when neither is set. The operator token wins when both are present, being the
+stronger of the two.
+
+Browser runs follow the same split. `@pikku/playwright` takes `operator` as an
+alternative to `secret`, plants the operator session on the actor's context and
+sets the impersonation header on it — so a browser step and an RPC step in one
+scenario still act as one user.
+
+Set `PIKKU_PERSONA_CREATE_MISSING=true` to let a run provision persona accounts
+the target does not have. It is off by default.

--- a/packages/cli/src/functions/commands/persona-sync.test.ts
+++ b/packages/cli/src/functions/commands/persona-sync.test.ts
@@ -169,7 +169,10 @@ const run = async (data: any, personas: unknown[] = PERSONAS) =>
       logger,
       config: config(),
       getInspectorState: async () => ({ personas: { definitions: personas } }),
-      variables: { get: async () => 'impersonation-secret' },
+      variables: {
+        get: async (key: string) =>
+          key === 'SCENARIO_ACTOR_SECRET' ? 'impersonation-secret' : undefined,
+      },
     } as any,
     data,
     {} as any

--- a/packages/cli/src/functions/commands/persona-sync.ts
+++ b/packages/cli/src/functions/commands/persona-sync.ts
@@ -6,6 +6,7 @@ import type { ResolvedPersona } from '@pikku/core/services'
 import { personaEnvironmentRefusal } from '@pikku/core/persona'
 
 import { resolvePersonas } from '../../utils/resolve-personas.js'
+import { resolvePersonaCredentials } from '../../utils/persona-credentials.js'
 import { resolveEnvironment } from './environment.js'
 import { loadDeclaredRoles, openScopeServiceForRoles } from './roles-shared.js'
 
@@ -132,13 +133,10 @@ export const personaSync = pikkuSessionlessFunc<
       return
     }
 
-    const secret = await variables.get('SCENARIO_ACTOR_SECRET')
-    if (!secret) {
-      throw new Error(
-        'SCENARIO_ACTOR_SECRET is not set — a persona account cannot be created. ' +
-          'Export it in the environment running this command (never put it in pikku.config.json).'
-      )
-    }
+    const credentials = await resolvePersonaCredentials(
+      variables,
+      'a persona account'
+    )
 
     const declaredRoles = await loadDeclaredRoles(
       config.rolesMetaJsonFile,
@@ -150,7 +148,7 @@ export const personaSync = pikkuSessionlessFunc<
 
     const signedIn = createHttpPersonas({
       apiUrl: env.apiUrl,
-      secret,
+      ...credentials,
       personas: Object.fromEntries(eligible),
       signInPath: env.signInPath,
       rpcPath: env.rpcPath,

--- a/packages/cli/src/functions/commands/persona.ts
+++ b/packages/cli/src/functions/commands/persona.ts
@@ -19,6 +19,7 @@ import {
 import { getSingletonServices, setSingletonServices } from '@pikku/core/state'
 
 import { resolvePersonas } from '../../utils/resolve-personas.js'
+import { resolvePersonaCredentials } from '../../utils/persona-credentials.js'
 import { resolveEnvironment } from './environment.js'
 import { createDevAgentRunner } from './dev-agent-runner.js'
 import { formatVirtualUserReport } from './virtual-user-formatter.js'
@@ -153,13 +154,10 @@ export const personaRun = pikkuSessionlessFunc<
       throw new Error(refusal)
     }
 
-    const secret = await variables.get('SCENARIO_ACTOR_SECRET')
-    if (!secret) {
-      throw new Error(
-        'SCENARIO_ACTOR_SECRET is not set — a virtual user cannot sign in. ' +
-          'Export it in the environment running this command (never put it in pikku.config.json).'
-      )
-    }
+    const credentials = await resolvePersonaCredentials(
+      variables,
+      'a virtual user'
+    )
 
     const resolvedModel = model ?? config.scenarios?.model
     if (!resolvedModel) {
@@ -203,7 +201,7 @@ export const personaRun = pikkuSessionlessFunc<
 
     const signedIn = createHttpPersonas({
       apiUrl: env.apiUrl,
-      secret,
+      ...credentials,
       personas,
       signInPath: env.signInPath,
       rpcPath: env.rpcPath,

--- a/packages/cli/src/functions/commands/scenario-browser.ts
+++ b/packages/cli/src/functions/commands/scenario-browser.ts
@@ -13,12 +13,16 @@ import type {
   ScenarioBrowserProvider,
 } from '@pikku/core/scenario'
 import type { ResolvedPersona } from '@pikku/core/services'
+import type { OperatorSignInOptions } from '@pikku/core/persona'
 
 /** The default driver, used when a project names no other. */
 export const DEFAULT_BROWSER_DRIVER = '@pikku/playwright'
 
 export interface ScenarioBrowserDriverOptions {
-  secret: string
+  /** The actor secret, for a local `pikku dev` target. */
+  secret?: string
+  /** Fabric operator credentials, for a deployed target. */
+  operator?: OperatorSignInOptions
   actors: Record<string, ResolvedPersona>
   signInPath?: string
   capture?: ScenarioCaptureOptions
@@ -81,7 +85,10 @@ export interface ResolveScenarioBrowserProviderOptions {
   appUrl?: string
   /** Base url per app, for a product whose personas sign into more than one. */
   appUrls?: Record<string, string>
-  secret: string
+  /** The actor secret, for a local `pikku dev` target. */
+  secret?: string
+  /** Fabric operator credentials, for a deployed target. */
+  operator?: OperatorSignInOptions
   actors: Record<string, ResolvedPersona>
   signInPath?: string
   /**
@@ -127,6 +134,7 @@ export const resolveScenarioBrowserProvider = async ({
   appUrl,
   appUrls,
   secret,
+  operator,
   actors,
   signInPath,
   capture,
@@ -173,6 +181,7 @@ export const resolveScenarioBrowserProvider = async ({
   }
   const options: ScenarioBrowserDriverOptions = {
     secret,
+    operator,
     actors,
     signInPath,
     capture,

--- a/packages/cli/src/functions/commands/scenario.ts
+++ b/packages/cli/src/functions/commands/scenario.ts
@@ -35,6 +35,7 @@ import {
   scenarioBrowserLifecycle,
 } from './scenario-browser.js'
 import { resolvePersonas } from '../../utils/resolve-personas.js'
+import { resolvePersonaCredentials } from '../../utils/persona-credentials.js'
 import { spawnDevServer } from '../../server/spawn-dev-server.js'
 import { buildScenarioPlan } from './scenario-plan.js'
 import type { ScenarioPlanGroup } from './scenario-plan.js'
@@ -262,13 +263,10 @@ export const scenarioRun = pikkuSessionlessFunc<
       return
     }
 
-    const secret = await variables.get('SCENARIO_ACTOR_SECRET')
-    if (!secret) {
-      throw new Error(
-        'SCENARIO_ACTOR_SECRET is not set — scenario actors cannot sign in. ' +
-          'Export it in the environment running this command (never put it in pikku.config.json).'
-      )
-    }
+    const credentials = await resolvePersonaCredentials(
+      variables,
+      'scenario actors'
+    )
     // Every declared persona, with its address filled in. Resolved once: the
     // HTTP personas and the Playwright provider below must see the same
     // registry, and codegen resolved the same way to type `PersonaName`.
@@ -278,7 +276,7 @@ export const scenarioRun = pikkuSessionlessFunc<
     )
     const actors = createHttpPersonas({
       apiUrl: env.apiUrl,
-      secret,
+      ...credentials,
       personas: scenarioActors,
       signInPath: env.signInPath,
       rpcPath: env.rpcPath,
@@ -442,7 +440,7 @@ export const scenarioRun = pikkuSessionlessFunc<
               apiUrl: env.apiUrl,
               appUrl: env.appUrl,
               appUrls: env.appUrls,
-              secret,
+              ...credentials,
               actors: scenarioActors,
               signInPath: env.signInPath,
               capture,

--- a/packages/cli/src/utils/persona-credentials.test.ts
+++ b/packages/cli/src/utils/persona-credentials.test.ts
@@ -1,0 +1,66 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  resolvePersonaCredentials,
+  ACTOR_SECRET_VARIABLE,
+  OPERATOR_TOKEN_VARIABLE,
+  CREATE_MISSING_VARIABLE,
+} from './persona-credentials.js'
+import type { VariablesService } from '@pikku/core/services'
+
+const variablesFrom = (values: Record<string, string>): VariablesService =>
+  ({
+    get: async (name: string) => values[name],
+  }) as unknown as VariablesService
+
+describe('resolvePersonaCredentials', () => {
+  test('uses the actor secret when that is all the environment holds', async () => {
+    const credentials = await resolvePersonaCredentials(
+      variablesFrom({ [ACTOR_SECRET_VARIABLE]: 'dev-secret' }),
+      'scenario actors'
+    )
+    assert.deepEqual(credentials, { secret: 'dev-secret' })
+  })
+
+  test('prefers the operator token over the actor secret', async () => {
+    const credentials = await resolvePersonaCredentials(
+      variablesFrom({
+        [ACTOR_SECRET_VARIABLE]: 'dev-secret',
+        [OPERATOR_TOKEN_VARIABLE]: 'operator-token',
+      }),
+      'scenario actors'
+    )
+    assert.equal(credentials.secret, undefined)
+    assert.equal(credentials.operator?.token, 'operator-token')
+  })
+
+  test('leaves account creation off unless it is asked for', async () => {
+    const off = await resolvePersonaCredentials(
+      variablesFrom({ [OPERATOR_TOKEN_VARIABLE]: 'operator-token' }),
+      'scenario actors'
+    )
+    assert.equal(off.operator?.createMissing, false)
+
+    const on = await resolvePersonaCredentials(
+      variablesFrom({
+        [OPERATOR_TOKEN_VARIABLE]: 'operator-token',
+        [CREATE_MISSING_VARIABLE]: 'true',
+      }),
+      'scenario actors'
+    )
+    assert.equal(on.operator?.createMissing, true)
+  })
+
+  test('names both credentials, and the command, when neither is set', async () => {
+    await assert.rejects(
+      () => resolvePersonaCredentials(variablesFrom({}), 'a virtual user'),
+      (error: Error) => {
+        assert.match(error.message, /a virtual user cannot sign in/)
+        assert.match(error.message, new RegExp(OPERATOR_TOKEN_VARIABLE))
+        assert.match(error.message, new RegExp(ACTOR_SECRET_VARIABLE))
+        return true
+      }
+    )
+  })
+})

--- a/packages/cli/src/utils/persona-credentials.ts
+++ b/packages/cli/src/utils/persona-credentials.ts
@@ -1,0 +1,49 @@
+import type { VariablesService } from '@pikku/core/services'
+import type { HttpPersonasConfig } from '@pikku/core/persona'
+
+/** A Fabric operator token, which is what a deployed stage accepts. */
+export const OPERATOR_TOKEN_VARIABLE = 'FABRIC_OPERATOR_TOKEN'
+/** The actor plugin's passwordless secret, which only `pikku dev` serves. */
+export const ACTOR_SECRET_VARIABLE = 'SCENARIO_ACTOR_SECRET'
+/** Opt in to creating persona accounts the target does not already have. */
+export const CREATE_MISSING_VARIABLE = 'PIKKU_PERSONA_CREATE_MISSING'
+
+export type PersonaCredentials = Pick<
+  HttpPersonasConfig,
+  'secret' | 'operator'
+>
+
+/**
+ * How the personas in this run will sign in, decided by which credential the
+ * environment actually holds.
+ *
+ * An operator token wins when both are present. It is the stronger of the two —
+ * asymmetric, and it never needs an account the target would not otherwise
+ * have — so a run that could use either should not fall back to the weaker one.
+ *
+ * `what` names the thing that cannot proceed ('scenario actors', 'a virtual
+ * user'), because the same missing credential blocks several commands and the
+ * message should say which one the operator was running.
+ */
+export const resolvePersonaCredentials = async (
+  variables: VariablesService,
+  what: string
+): Promise<PersonaCredentials> => {
+  const token = await variables.get(OPERATOR_TOKEN_VARIABLE)
+  if (token) {
+    const createMissing =
+      (await variables.get(CREATE_MISSING_VARIABLE)) === 'true'
+    return { operator: { token, createMissing } }
+  }
+
+  const secret = await variables.get(ACTOR_SECRET_VARIABLE)
+  if (secret) {
+    return { secret }
+  }
+
+  throw new Error(
+    `Neither ${OPERATOR_TOKEN_VARIABLE} nor ${ACTOR_SECRET_VARIABLE} is set — ${what} cannot sign in. ` +
+      `Export ${ACTOR_SECRET_VARIABLE} against a local \`pikku dev\` target, or ` +
+      `${OPERATOR_TOKEN_VARIABLE} against a deployed one (never put either in pikku.config.json).`
+  )
+}

--- a/packages/cli/src/utils/persona-credentials.ts
+++ b/packages/cli/src/utils/persona-credentials.ts
@@ -8,10 +8,7 @@ export const ACTOR_SECRET_VARIABLE = 'SCENARIO_ACTOR_SECRET'
 /** Opt in to creating persona accounts the target does not already have. */
 export const CREATE_MISSING_VARIABLE = 'PIKKU_PERSONA_CREATE_MISSING'
 
-export type PersonaCredentials = Pick<
-  HttpPersonasConfig,
-  'secret' | 'operator'
->
+export type PersonaCredentials = Pick<HttpPersonasConfig, 'secret' | 'operator'>
 
 /**
  * How the personas in this run will sign in, decided by which credential the

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,8 +5,8 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2762 observable things**: 870 exported names, plus
-1892 members on the classes and interfaces among them, reachable
+**2766 observable things**: 872 exported names, plus
+1894 members on the classes and interfaces among them, reachable
 through 53 entry points.
 
 An entry point whose exports are mostly *exclusive* is a self-contained
@@ -22,7 +22,7 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | `./channel` | 32 | 32 | 84 |
 | `./types` | 23 | 20 | 73 |
 | `./queue` | 22 | 22 | 71 |
-| `./persona` | 32 | 32 | 47 |
+| `./persona` | 34 | 34 | 49 |
 | `./http` | 25 | 25 | 49 |
 | `./errors` | 49 | 49 | 20 |
 | `./services/local-meta` | 22 | 3 | 46 |
@@ -3905,6 +3905,7 @@ export type CorePersona = {
 export type CorePersonas = Record<string, CorePersona>
 createHttpPersonas: (config: HttpPersonasConfig) => ScenarioPersonas
 definePersonas: (_config: CorePersonas) => void
+establishOperatorSession: (fetchImpl: (input: URL | RequestInfo, init?: RequestInit | undefined) => Promise<Response>, apiUrl: string, persona: ResolvedPersona, options: OperatorSignInOptions, extraHeaders?: Record<string, string>) => Promise<OperatorSessionResult>
 export class HttpPersona implements ScenarioPersona {
   constructor(readonly name: string, private persona: ResolvedPersona, private config: HttpPersonasConfig)
   get email(): string
@@ -3928,6 +3929,10 @@ isRunnablePersona: (persona: { runnable?: boolean | undefined; account?: { provi
 export interface MailboxAllowlist {
   senders: readonly string[]
   linkOrigins?: readonly string[]
+}
+export interface OperatorSessionResult {
+  setCookies: string[]
+  userId: string
 }
 export class OperatorSignIn implements PersonaSignIn {
   constructor(private readonly apiUrl: string, private readonly options: OperatorSignInOptions)

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,8 +5,8 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2744 observable things**: 865 exported names, plus
-1879 members on the classes and interfaces among them, reachable
+**2762 observable things**: 870 exported names, plus
+1892 members on the classes and interfaces among them, reachable
 through 53 entry points.
 
 An entry point whose exports are mostly *exclusive* is a self-contained
@@ -22,9 +22,9 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | `./channel` | 32 | 32 | 84 |
 | `./types` | 23 | 20 | 73 |
 | `./queue` | 22 | 22 | 71 |
+| `./persona` | 32 | 32 | 47 |
 | `./http` | 25 | 25 | 49 |
 | `./errors` | 49 | 49 | 20 |
-| `./persona` | 27 | 27 | 34 |
 | `./services/local-meta` | 22 | 3 | 46 |
 | `./cli` | 14 | 12 | 26 |
 | `./function` | 32 | 27 | 10 |
@@ -3879,6 +3879,11 @@ validateAndBuildSystemRoleDefinitionsMeta: (definitions: SystemRoleDefinitions) 
 ## ./persona
 
 ```ts
+export class ActorSignIn implements PersonaSignIn {
+  constructor(private readonly apiUrl: string, private readonly secret: string, private readonly signInPath: string)
+  async login(jar: ScenarioCookieJar, persona: ResolvedPersona): Promise<void>
+  headers(): Record<string, string>
+}
 export type CorePersona = {
   name: string
   jobTitle?: string
@@ -3910,17 +3915,30 @@ export class HttpPersona implements ScenarioPersona {
 }
 export interface HttpPersonasConfig {
   apiUrl: string
-  secret: string
+  secret?: string
+  operator?: OperatorSignInOptions
   personas: Record<string, ResolvedPersona>
   signInPath?: string
   sessionPath?: string
   rpcPath?: string
   model?: string
 }
+IMPERSONATE_USER_ID_HEADER: "x-pikku-impersonate-user-id"
 isRunnablePersona: (persona: { runnable?: boolean | undefined; account?: { provider?: string | undefined; } | undefined; }) => boolean
 export interface MailboxAllowlist {
   senders: readonly string[]
   linkOrigins?: readonly string[]
+}
+export class OperatorSignIn implements PersonaSignIn {
+  constructor(private readonly apiUrl: string, private readonly options: OperatorSignInOptions)
+  async login(jar: ScenarioCookieJar, persona: ResolvedPersona): Promise<void>
+  headers(): Record<string, string>
+}
+export interface OperatorSignInOptions {
+  token: string | (() => string | Promise<string>)
+  createMissing?: boolean
+  adminPath?: string
+  signInPath?: string
 }
 export type PersonaAccountMeta = {
   provider?: string
@@ -3961,6 +3979,10 @@ export type PersonaMeta = {
   runnable: boolean
   app?: string
   sourceFile?: string
+}
+export interface PersonaSignIn {
+  login(jar: ScenarioCookieJar, persona: ResolvedPersona): Promise<void>
+  headers(): Record<string, string>
 }
 export type PersonasMeta = Record<string, PersonaMeta>
 postScenarioJson: <T = unknown>(url: string, { body, headers, method, fetch: send, }?: ScenarioJsonRequest) => Promise<ScenarioHttpResponse<T>>

--- a/packages/core/src/public-surface.json
+++ b/packages/core/src/public-surface.json
@@ -272,9 +272,13 @@
     "validateAndBuildSystemRoleDefinitionsMeta"
   ],
   "./persona": [
+    "ActorSignIn",
     "HttpPersona",
+    "IMPERSONATE_USER_ID_HEADER",
+    "OperatorSignIn",
     "createHttpPersonas",
     "definePersonas",
+    "establishOperatorSession",
     "isRunnablePersona",
     "personaEmail",
     "personaEmails",

--- a/packages/core/src/services/http-personas.ts
+++ b/packages/core/src/services/http-personas.ts
@@ -16,6 +16,12 @@ import {
   createCookieJar,
   type ScenarioCookieJar,
 } from '../wirings/workflow/scenario-cookie-jar.js'
+import {
+  ActorSignIn,
+  OperatorSignIn,
+  type OperatorSignInOptions,
+  type PersonaSignIn,
+} from './persona-sign-in.js'
 import { getSingletonServices } from '../pikku-state.js'
 import { AIProviderNotConfiguredError } from '../errors/errors.js'
 
@@ -30,8 +36,19 @@ export interface HttpPersonasConfig {
   /**
    * The impersonation secret. Sign-in only ever works for user rows flagged
    * `actor: true` — knowing the secret never impersonates real users.
+   *
+   * The local-development credential. A deployed stage has none, and passes
+   * {@link HttpPersonasConfig.operator} instead.
    */
-  secret: string
+  secret?: string
+  /**
+   * Fabric operator credentials, for signing personas into a DEPLOYED stage.
+   *
+   * Mutually exclusive with {@link HttpPersonasConfig.secret}: the operator
+   * path acts as the persona through an admin session rather than logging in as
+   * them, so no test credential has to exist on the target at all.
+   */
+  operator?: OperatorSignInOptions
   /** Persona id → the declaration with its address filled in. */
   personas: Record<string, ResolvedPersona>
   /** Sign-in path under apiUrl. Default: the actor plugin's `/auth/sign-in/actor`. */
@@ -49,12 +66,13 @@ export interface HttpPersonasConfig {
 }
 
 /**
- * Default HTTP-backed persona. Signs in lazily on first invoke via the Better
- * Auth actor plugin (`POST /auth/sign-in/actor` with `{ email, secret }` —
- * the plugin upserts the actor-flagged user row and mints a session whose
- * `actor` flag flows into audits/analytics). Holds the session cookies for
- * its lifetime; a 401 mid-run re-logs-in once (long health-check runs can
- * outlive a session).
+ * Default HTTP-backed persona. Signs in lazily on first invoke, holds the
+ * session cookies for its lifetime, and re-logs-in once on a 401 mid-run (long
+ * health-check runs can outlive a session).
+ *
+ * How it signs in depends on the target, and the two ways are not
+ * interchangeable — see {@link ActorSignIn} for local development and
+ * {@link OperatorSignIn} for a deployed stage.
  */
 export class HttpPersona implements ScenarioPersona {
   private jar: ScenarioCookieJar
@@ -65,6 +83,7 @@ export class HttpPersona implements ScenarioPersona {
    * established.
    */
   private signedIn = false
+  private signIn: PersonaSignIn
 
   constructor(
     readonly name: string,
@@ -72,6 +91,19 @@ export class HttpPersona implements ScenarioPersona {
     private config: HttpPersonasConfig
   ) {
     this.jar = createCookieJar(config.apiUrl)
+    if (config.operator) {
+      this.signIn = new OperatorSignIn(config.apiUrl, config.operator)
+    } else if (config.secret) {
+      this.signIn = new ActorSignIn(
+        config.apiUrl,
+        config.secret,
+        config.signInPath ?? '/auth/sign-in/actor'
+      )
+    } else {
+      throw new Error(
+        `[scenario] persona '${name}' has no way to sign in — set 'secret' for a dev target or 'operator' for a deployed one`
+      )
+    }
   }
 
   get email(): string {
@@ -161,7 +193,9 @@ export class HttpPersona implements ScenarioPersona {
       await this.login()
     }
     const sessionPath = this.config.sessionPath ?? '/auth/get-session'
-    const res = await this.jar.fetch(`${this.config.apiUrl}${sessionPath}`)
+    const res = await this.jar.fetch(`${this.config.apiUrl}${sessionPath}`, {
+      headers: this.signIn.headers(),
+    })
     if (!res.ok) {
       return null
     }
@@ -226,7 +260,10 @@ export class HttpPersona implements ScenarioPersona {
     const send = () =>
       this.jar.fetch(url, {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: {
+          'content-type': 'application/json',
+          ...this.signIn.headers(),
+        },
         body: JSON.stringify(body),
       })
 
@@ -255,7 +292,11 @@ export class HttpPersona implements ScenarioPersona {
     const rpcPath = this.config.rpcPath ?? '/rpc'
     return this.jar.fetch(`${this.config.apiUrl}${rpcPath}/${rpcName}`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json', ...extraHeaders },
+      headers: {
+        'content-type': 'application/json',
+        ...this.signIn.headers(),
+        ...extraHeaders,
+      },
       body: JSON.stringify({ data }),
     })
   }
@@ -267,29 +308,7 @@ export class HttpPersona implements ScenarioPersona {
   }
 
   private async login(): Promise<void> {
-    const signInPath = this.config.signInPath ?? '/auth/sign-in/actor'
-    const res = await this.jar.fetch(`${this.config.apiUrl}${signInPath}`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        email: this.persona.email,
-        name: this.persona.name,
-        secret: this.config.secret,
-      }),
-    })
-    if (!res.ok) {
-      const body = (await res.text().catch(() => '')).slice(0, 300)
-      throw new Error(
-        `[scenario] persona sign-in failed for '${this.name}' (${res.status}): ${body}`
-      )
-    }
-    // What proves a session was established is this response setting a cookie,
-    // not the jar being non-empty — the target may have set one earlier.
-    if (res.headers.getSetCookie().length === 0) {
-      throw new Error(
-        `[scenario] persona sign-in for '${this.name}' returned no session cookie`
-      )
-    }
+    await this.signIn.login(this.jar, this.persona)
     this.signedIn = true
   }
 }

--- a/packages/core/src/services/persona-sign-in.test.ts
+++ b/packages/core/src/services/persona-sign-in.test.ts
@@ -34,9 +34,11 @@ const startStage = async (seeded: Array<{ id: string; email: string }>) => {
 
       if (url.pathname === '/api/auth/admin/list-users') {
         const wanted = url.searchParams.get('filterValue')
-        res.writeHead(200, { 'content-type': 'application/json' }).end(
-          JSON.stringify({ users: users.filter((u) => u.email === wanted) })
-        )
+        res
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(
+            JSON.stringify({ users: users.filter((u) => u.email === wanted) })
+          )
         return
       }
 

--- a/packages/core/src/services/persona-sign-in.test.ts
+++ b/packages/core/src/services/persona-sign-in.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { createServer, type Server } from 'node:http'
 
 import { createHttpPersonas } from './http-personas.js'
+import { establishOperatorSession } from './persona-sign-in.js'
 
 const OPERATOR_TOKEN = 'operator.jwt.token'
 
@@ -30,6 +31,16 @@ const startStage = async (seeded: Array<{ id: string; email: string }>) => {
         res.setHeader('set-cookie', ['session=operator; Path=/; HttpOnly'])
         res.writeHead(200).end(JSON.stringify({ token: 'operator' }))
         return
+      }
+
+      // The admin plugin refuses an unauthenticated caller, and saying so here
+      // is the point: a handshake that dropped the operator session between
+      // sign-in and lookup would otherwise pass this stage happily.
+      if (url.pathname.startsWith('/api/auth/admin/')) {
+        if (!/(^|;\s*)session=operator(;|$)/.test(req.headers.cookie ?? '')) {
+          res.writeHead(401).end(JSON.stringify({ message: 'no session' }))
+          return
+        }
       }
 
       if (url.pathname === '/api/auth/admin/list-users') {
@@ -165,6 +176,21 @@ describe('operator persona sign-in', () => {
 
     await personas.customer!.invoke('whoami', {})
     assert.equal(minted, 1)
+  })
+
+  test('carries the operator session into the admin lookup', async () => {
+    const stage = await startStage([{ id: 'user-9', email: 'susan@acme.test' }])
+    servers.push(stage.server)
+
+    // Plain fetch keeps no cookies, which is the browser provider's situation:
+    // it plants them on a Playwright context only once this has returned.
+    const { userId } = await establishOperatorSession(
+      fetch,
+      stage.apiUrl,
+      persona('susan@acme.test'),
+      { token: OPERATOR_TOKEN }
+    )
+    assert.equal(userId, 'user-9')
   })
 
   test('a persona with neither credential is refused at construction', async () => {

--- a/packages/core/src/services/persona-sign-in.test.ts
+++ b/packages/core/src/services/persona-sign-in.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer, type Server } from 'node:http'
+
+import { createHttpPersonas } from './http-personas.js'
+
+const OPERATOR_TOKEN = 'operator.jwt.token'
+
+/**
+ * Minimal deployed stage: the fabric plugin's sign-in, the admin plugin's
+ * user endpoints, and an RPC route that reports back who it was addressed as.
+ */
+const startStage = async (seeded: Array<{ id: string; email: string }>) => {
+  const users = [...seeded]
+  let created = 0
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on('data', (c) => chunks.push(c))
+    req.on('end', () => {
+      const body = chunks.length
+        ? JSON.parse(Buffer.concat(chunks).toString())
+        : {}
+      const url = new URL(req.url ?? '/', 'http://stage.invalid')
+
+      if (url.pathname === '/api/auth/sign-in/fabric') {
+        if (body.token !== OPERATOR_TOKEN) {
+          res.writeHead(401).end(JSON.stringify({ message: 'bad token' }))
+          return
+        }
+        res.setHeader('set-cookie', ['session=operator; Path=/; HttpOnly'])
+        res.writeHead(200).end(JSON.stringify({ token: 'operator' }))
+        return
+      }
+
+      if (url.pathname === '/api/auth/admin/list-users') {
+        const wanted = url.searchParams.get('filterValue')
+        res.writeHead(200, { 'content-type': 'application/json' }).end(
+          JSON.stringify({ users: users.filter((u) => u.email === wanted) })
+        )
+        return
+      }
+
+      if (url.pathname === '/api/auth/admin/create-user') {
+        created++
+        const user = { id: `made-${created}`, email: body.email }
+        users.push(user)
+        res
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ user, sawPassword: Boolean(body.password) }))
+        return
+      }
+
+      if (url.pathname.startsWith('/api/rpc/')) {
+        res.writeHead(200, { 'content-type': 'application/json' }).end(
+          JSON.stringify({
+            actingAs: req.headers['x-pikku-impersonate-user-id'] ?? null,
+            cookie: req.headers.cookie ?? '',
+          })
+        )
+        return
+      }
+
+      res.writeHead(404).end()
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  const port = (server.address() as { port: number }).port
+  return {
+    apiUrl: `http://127.0.0.1:${port}/api`,
+    server,
+    get createdCount() {
+      return created
+    },
+  }
+}
+
+const persona = (email: string) => ({
+  id: 'customer',
+  name: 'Customer',
+  email,
+  roles: ['client'],
+  goals: [],
+  tags: [],
+  runnable: true,
+})
+
+describe('operator persona sign-in', () => {
+  const servers: Server[] = []
+  after(() => servers.forEach((s) => s.close()))
+
+  test('acts as an existing account rather than signing in as it', async () => {
+    const stage = await startStage([
+      { id: 'user-7', email: 'customer@personas.invalid' },
+    ])
+    servers.push(stage.server)
+
+    const personas = createHttpPersonas({
+      apiUrl: stage.apiUrl,
+      operator: { token: OPERATOR_TOKEN },
+      personas: { customer: persona('customer@personas.invalid') },
+    })
+
+    const result = (await personas.customer!.invoke('whoami', {})) as {
+      actingAs: string | null
+      cookie: string
+    }
+    assert.equal(result.actingAs, 'user-7')
+    assert.match(result.cookie, /session=operator/)
+    assert.equal(stage.createdCount, 0)
+  })
+
+  test('refuses a persona the stage has no account for', async () => {
+    const stage = await startStage([])
+    servers.push(stage.server)
+
+    const personas = createHttpPersonas({
+      apiUrl: stage.apiUrl,
+      operator: { token: OPERATOR_TOKEN },
+      personas: { customer: persona('ghost@personas.invalid') },
+    })
+
+    await assert.rejects(
+      () => personas.customer!.invoke('whoami', {}),
+      /no account on the target for persona 'customer'/
+    )
+    assert.equal(stage.createdCount, 0)
+  })
+
+  test('provisions the account only when told to', async () => {
+    const stage = await startStage([])
+    servers.push(stage.server)
+
+    const personas = createHttpPersonas({
+      apiUrl: stage.apiUrl,
+      operator: { token: OPERATOR_TOKEN, createMissing: true },
+      personas: { customer: persona('fresh@personas.invalid') },
+    })
+
+    const result = (await personas.customer!.invoke('whoami', {})) as {
+      actingAs: string | null
+    }
+    assert.equal(result.actingAs, 'made-1')
+    assert.equal(stage.createdCount, 1)
+  })
+
+  test('mints the operator session from a token factory', async () => {
+    const stage = await startStage([
+      { id: 'user-9', email: 'lazy@personas.invalid' },
+    ])
+    servers.push(stage.server)
+
+    let minted = 0
+    const personas = createHttpPersonas({
+      apiUrl: stage.apiUrl,
+      operator: {
+        token: () => {
+          minted++
+          return OPERATOR_TOKEN
+        },
+      },
+      personas: { customer: persona('lazy@personas.invalid') },
+    })
+
+    await personas.customer!.invoke('whoami', {})
+    assert.equal(minted, 1)
+  })
+
+  test('a persona with neither credential is refused at construction', async () => {
+    const stage = await startStage([])
+    servers.push(stage.server)
+
+    assert.throws(
+      () =>
+        createHttpPersonas({
+          apiUrl: stage.apiUrl,
+          personas: { customer: persona('nobody@personas.invalid') },
+        }),
+      /has no way to sign in/
+    )
+  })
+})

--- a/packages/core/src/services/persona-sign-in.ts
+++ b/packages/core/src/services/persona-sign-in.ts
@@ -110,6 +110,130 @@ interface AdminUser {
   email?: unknown
 }
 
+/** What an operator handshake yields: the session, and who to act as. */
+export interface OperatorSessionResult {
+  /** `Set-Cookie` values the operator sign-in returned. */
+  setCookies: string[]
+  /** The target's own id for the persona, for the impersonation header. */
+  userId: string
+}
+
+/**
+ * Establish a Fabric operator session against `apiUrl` and resolve the target's
+ * own id for `persona`, which is what the impersonation header names.
+ *
+ * Takes the fetch to use rather than making one, because the two callers need
+ * the cookies to land in different places: an HTTP persona keeps them in its
+ * jar, a browser run plants them on a Playwright context. Both need the same
+ * handshake, and it is the kind of sequence that quietly diverges once it is
+ * written twice.
+ */
+export const establishOperatorSession = async (
+  fetchImpl: typeof fetch,
+  apiUrl: string,
+  persona: ResolvedPersona,
+  options: OperatorSignInOptions,
+  extraHeaders: Record<string, string> = {}
+): Promise<OperatorSessionResult> => {
+  const signInPath = options.signInPath ?? '/auth/sign-in/fabric'
+  const token =
+    typeof options.token === 'function' ? await options.token() : options.token
+
+  const res = await fetchImpl(`${apiUrl}${signInPath}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...extraHeaders },
+    body: JSON.stringify({ token }),
+  })
+  if (!res.ok) {
+    throw await failed('operator sign-in', persona.id, res)
+  }
+  const setCookies = res.headers.getSetCookie?.() ?? []
+  if (setCookies.length === 0) {
+    throw new Error(
+      `[scenario] operator sign-in for '${persona.id}' returned no session cookie`
+    )
+  }
+
+  const userId = await resolveUserId(
+    fetchImpl,
+    apiUrl,
+    persona,
+    options,
+    extraHeaders
+  )
+  return { setCookies, userId }
+}
+
+/**
+ * The target's own id for this persona's address, since impersonation names a
+ * user id and a persona only knows an email.
+ *
+ * Looked up before creating, so a persona that already exists is never
+ * duplicated and the run reads as "act as this person" rather than "make one".
+ */
+const resolveUserId = async (
+  fetchImpl: typeof fetch,
+  apiUrl: string,
+  persona: ResolvedPersona,
+  options: OperatorSignInOptions,
+  extraHeaders: Record<string, string>
+): Promise<string> => {
+  const adminPath = options.adminPath ?? '/auth/admin'
+  const query = new URLSearchParams({
+    filterField: 'email',
+    filterValue: persona.email,
+    filterOperator: 'eq',
+    limit: '1',
+  })
+  const found = await fetchImpl(`${apiUrl}${adminPath}/list-users?${query}`, {
+    headers: { accept: 'application/json', ...extraHeaders },
+  })
+  if (!found.ok) {
+    throw await failed('persona lookup', persona.id, found)
+  }
+  const listed = (await found.json().catch(() => null)) as {
+    users?: AdminUser[]
+  } | null
+  const existing = listed?.users?.find((u) => u.email === persona.email)
+  if (existing?.id) {
+    return String(existing.id)
+  }
+
+  if (!options.createMissing) {
+    throw new Error(
+      `[scenario] no account on the target for persona '${persona.id}' (${persona.email}) — ` +
+        'provision it, or set createMissing on the operator credentials'
+    )
+  }
+
+  const created = await fetchImpl(`${apiUrl}${adminPath}/create-user`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...extraHeaders },
+    body: JSON.stringify({
+      email: persona.email,
+      name: persona.name,
+      // Never used and never returned: the run impersonates rather than signs
+      // in, so the account is reachable only by someone already holding an
+      // operator token. A derivable password would undo exactly that.
+      password: globalThis.crypto.randomUUID(),
+      ...(persona.roles[0] ? { role: persona.roles[0] } : {}),
+    }),
+  })
+  if (!created.ok) {
+    throw await failed('persona creation', persona.id, created)
+  }
+  const body = (await created.json().catch(() => null)) as {
+    user?: AdminUser
+  } | null
+  const id = body?.user?.id
+  if (!id) {
+    throw new Error(
+      `[scenario] creating persona '${persona.id}' returned no user id`
+    )
+  }
+  return String(id)
+}
+
 /**
  * Sign a persona in on a DEPLOYED stage, by having a Fabric operator act as
  * them — the path that needs no test credential to exist anywhere.
@@ -134,27 +258,13 @@ export class OperatorSignIn implements PersonaSignIn {
   ) {}
 
   async login(jar: ScenarioCookieJar, persona: ResolvedPersona): Promise<void> {
-    const signInPath = this.options.signInPath ?? '/auth/sign-in/fabric'
-    const token =
-      typeof this.options.token === 'function'
-        ? await this.options.token()
-        : this.options.token
-
-    const res = await jar.fetch(`${this.apiUrl}${signInPath}`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ token }),
-    })
-    if (!res.ok) {
-      throw await failed('operator sign-in', persona.id, res)
-    }
-    if (res.headers.getSetCookie().length === 0) {
-      throw new Error(
-        `[scenario] operator sign-in for '${persona.id}' returned no session cookie`
-      )
-    }
-
-    this.userId = await this.resolveUserId(jar, persona)
+    const { userId } = await establishOperatorSession(
+      jar.fetch,
+      this.apiUrl,
+      persona,
+      this.options
+    )
+    this.userId = userId
   }
 
   headers(): Record<string, string> {
@@ -164,72 +274,5 @@ export class OperatorSignIn implements PersonaSignIn {
       )
     }
     return { [IMPERSONATE_USER_ID_HEADER]: this.userId }
-  }
-
-  /**
-   * The target's own id for this persona's address, since impersonation names a
-   * user id and a persona only knows an email.
-   *
-   * Looked up before creating, so a persona that already exists is never
-   * duplicated and the run reads as "act as this person" rather than "make one".
-   */
-  private async resolveUserId(
-    jar: ScenarioCookieJar,
-    persona: ResolvedPersona
-  ): Promise<string> {
-    const adminPath = this.options.adminPath ?? '/auth/admin'
-    const query = new URLSearchParams({
-      filterField: 'email',
-      filterValue: persona.email,
-      filterOperator: 'eq',
-      limit: '1',
-    })
-    const found = await jar.fetch(`${this.apiUrl}${adminPath}/list-users?${query}`, {
-      headers: { accept: 'application/json' },
-    })
-    if (!found.ok) {
-      throw await failed('persona lookup', persona.id, found)
-    }
-    const listed = (await found.json().catch(() => null)) as {
-      users?: AdminUser[]
-    } | null
-    const existing = listed?.users?.find((u) => u.email === persona.email)
-    if (existing?.id) {
-      return String(existing.id)
-    }
-
-    if (!this.options.createMissing) {
-      throw new Error(
-        `[scenario] no account on the target for persona '${persona.id}' (${persona.email}) — ` +
-          'provision it, or set createMissing on the operator credentials'
-      )
-    }
-
-    const created = await jar.fetch(`${this.apiUrl}${adminPath}/create-user`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        email: persona.email,
-        name: persona.name,
-        // Never used and never returned: the run impersonates rather than signs
-        // in, so the account is reachable only by someone already holding an
-        // operator token. A derivable password would undo exactly that.
-        password: globalThis.crypto.randomUUID(),
-        ...(persona.roles[0] ? { role: persona.roles[0] } : {}),
-      }),
-    })
-    if (!created.ok) {
-      throw await failed('persona creation', persona.id, created)
-    }
-    const body = (await created.json().catch(() => null)) as {
-      user?: AdminUser
-    } | null
-    const id = body?.user?.id
-    if (!id) {
-      throw new Error(
-        `[scenario] creating persona '${persona.id}' returned no user id`
-      )
-    }
-    return String(id)
   }
 }

--- a/packages/core/src/services/persona-sign-in.ts
+++ b/packages/core/src/services/persona-sign-in.ts
@@ -1,0 +1,235 @@
+import type { ResolvedPersona } from './personas-service.js'
+import type { ScenarioCookieJar } from '../wirings/workflow/scenario-cookie-jar.js'
+
+/**
+ * The header `resolveImpersonatedSession` reads the target user id from.
+ *
+ * A wire value rather than a shared import: the reader lives in
+ * `@pikku/services-better-auth`, which depends on core, so core cannot import
+ * it back. The two agree by protocol, the way an HTTP header always does.
+ */
+export const IMPERSONATE_USER_ID_HEADER = 'x-pikku-impersonate-user-id'
+
+/**
+ * How a persona obtains a session on the target, and what every later request
+ * needs to carry to keep acting as them.
+ *
+ * Two answers exist because the two environments have opposite trust models,
+ * not because one is a fallback for the other. See {@link ActorSignIn} and
+ * {@link OperatorSignIn}.
+ */
+export interface PersonaSignIn {
+  /**
+   * Establish a session in `jar`. Throws on failure with a message naming the
+   * persona, since a run that continues unauthenticated fails later and
+   * somewhere less informative.
+   */
+  login(jar: ScenarioCookieJar, persona: ResolvedPersona): Promise<void>
+  /** Headers every request after `login` must carry. */
+  headers(): Record<string, string>
+}
+
+const failed = async (
+  what: string,
+  personaId: string,
+  res: Response
+): Promise<Error> => {
+  const body = (await res.text().catch(() => '')).slice(0, 300)
+  return new Error(
+    `[scenario] ${what} failed for '${personaId}' (${res.status}): ${body}`
+  )
+}
+
+/**
+ * Sign a persona in through the Better Auth actor plugin — the local-development
+ * path.
+ *
+ * `POST /auth/sign-in/actor` upserts an `actor: true` row and mints a session
+ * for it. Passwordless by design and refused for any row not carrying that flag,
+ * so the secret can never reach a real user's account; the plugin still declines
+ * to serve the endpoint at all outside `pikku dev`.
+ */
+export class ActorSignIn implements PersonaSignIn {
+  constructor(
+    private readonly apiUrl: string,
+    private readonly secret: string,
+    private readonly signInPath: string
+  ) {}
+
+  async login(jar: ScenarioCookieJar, persona: ResolvedPersona): Promise<void> {
+    const res = await jar.fetch(`${this.apiUrl}${this.signInPath}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        email: persona.email,
+        name: persona.name,
+        secret: this.secret,
+      }),
+    })
+    if (!res.ok) {
+      throw await failed('persona sign-in', persona.id, res)
+    }
+    // What proves a session was established is this response setting a cookie,
+    // not the jar being non-empty — the target may have set one earlier.
+    if (res.headers.getSetCookie().length === 0) {
+      throw new Error(
+        `[scenario] persona sign-in for '${persona.id}' returned no session cookie`
+      )
+    }
+  }
+
+  headers(): Record<string, string> {
+    return {}
+  }
+}
+
+export interface OperatorSignInOptions {
+  /**
+   * The short-lived RS256 operator token, or a function that mints one. Prefer
+   * the function: tokens expire, and a long run re-logs-in after a 401.
+   */
+  token: string | (() => string | Promise<string>)
+  /**
+   * Create the persona's user row when the target has no account for that
+   * address.
+   *
+   * Off by default, which is the whole point of the deployed path: a persona is
+   * meant to be a real account somebody provisioned, and a test run that
+   * silently writes users into a live database is a side effect nobody asked
+   * for. Turn it on for throwaway stages.
+   */
+  createMissing?: boolean
+  /** Admin endpoint prefix under apiUrl. Default `/auth/admin`. */
+  adminPath?: string
+  /** Fabric operator sign-in path under apiUrl. Default `/auth/sign-in/fabric`. */
+  signInPath?: string
+}
+
+interface AdminUser {
+  id?: unknown
+  email?: unknown
+}
+
+/**
+ * Sign a persona in on a DEPLOYED stage, by having a Fabric operator act as
+ * them — the path that needs no test credential to exist anywhere.
+ *
+ * `POST /auth/sign-in/fabric` verifies an RS256 token against the stage's
+ * `FABRIC_AUTH_PUBLIC_KEY` and mints a session for a synthetic operator row
+ * granted the umbrella `admin` scope. Impersonation is then a header on each
+ * request rather than a second session, and its gate is that scope — not
+ * `user.role`, which is why this works without touching the app's roles.
+ *
+ * Asymmetric throughout: the stage can verify an operator token and never mint
+ * one, so nothing in a deployed environment is worth stealing. That is the
+ * property the actor secret cannot have, and the reason these are two classes
+ * instead of one with a flag.
+ */
+export class OperatorSignIn implements PersonaSignIn {
+  private userId: string | null = null
+
+  constructor(
+    private readonly apiUrl: string,
+    private readonly options: OperatorSignInOptions
+  ) {}
+
+  async login(jar: ScenarioCookieJar, persona: ResolvedPersona): Promise<void> {
+    const signInPath = this.options.signInPath ?? '/auth/sign-in/fabric'
+    const token =
+      typeof this.options.token === 'function'
+        ? await this.options.token()
+        : this.options.token
+
+    const res = await jar.fetch(`${this.apiUrl}${signInPath}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token }),
+    })
+    if (!res.ok) {
+      throw await failed('operator sign-in', persona.id, res)
+    }
+    if (res.headers.getSetCookie().length === 0) {
+      throw new Error(
+        `[scenario] operator sign-in for '${persona.id}' returned no session cookie`
+      )
+    }
+
+    this.userId = await this.resolveUserId(jar, persona)
+  }
+
+  headers(): Record<string, string> {
+    if (!this.userId) {
+      throw new Error(
+        '[scenario] operator session has no persona to act as — login() first'
+      )
+    }
+    return { [IMPERSONATE_USER_ID_HEADER]: this.userId }
+  }
+
+  /**
+   * The target's own id for this persona's address, since impersonation names a
+   * user id and a persona only knows an email.
+   *
+   * Looked up before creating, so a persona that already exists is never
+   * duplicated and the run reads as "act as this person" rather than "make one".
+   */
+  private async resolveUserId(
+    jar: ScenarioCookieJar,
+    persona: ResolvedPersona
+  ): Promise<string> {
+    const adminPath = this.options.adminPath ?? '/auth/admin'
+    const query = new URLSearchParams({
+      filterField: 'email',
+      filterValue: persona.email,
+      filterOperator: 'eq',
+      limit: '1',
+    })
+    const found = await jar.fetch(`${this.apiUrl}${adminPath}/list-users?${query}`, {
+      headers: { accept: 'application/json' },
+    })
+    if (!found.ok) {
+      throw await failed('persona lookup', persona.id, found)
+    }
+    const listed = (await found.json().catch(() => null)) as {
+      users?: AdminUser[]
+    } | null
+    const existing = listed?.users?.find((u) => u.email === persona.email)
+    if (existing?.id) {
+      return String(existing.id)
+    }
+
+    if (!this.options.createMissing) {
+      throw new Error(
+        `[scenario] no account on the target for persona '${persona.id}' (${persona.email}) — ` +
+          'provision it, or set createMissing on the operator credentials'
+      )
+    }
+
+    const created = await jar.fetch(`${this.apiUrl}${adminPath}/create-user`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        email: persona.email,
+        name: persona.name,
+        // Never used and never returned: the run impersonates rather than signs
+        // in, so the account is reachable only by someone already holding an
+        // operator token. A derivable password would undo exactly that.
+        password: globalThis.crypto.randomUUID(),
+        ...(persona.roles[0] ? { role: persona.roles[0] } : {}),
+      }),
+    })
+    if (!created.ok) {
+      throw await failed('persona creation', persona.id, created)
+    }
+    const body = (await created.json().catch(() => null)) as {
+      user?: AdminUser
+    } | null
+    const id = body?.user?.id
+    if (!id) {
+      throw new Error(
+        `[scenario] creating persona '${persona.id}' returned no user id`
+      )
+    }
+    return String(id)
+  }
+}

--- a/packages/core/src/services/persona-sign-in.ts
+++ b/packages/core/src/services/persona-sign-in.ts
@@ -154,13 +154,19 @@ export const establishOperatorSession = async (
     )
   }
 
-  const userId = await resolveUserId(
-    fetchImpl,
-    apiUrl,
-    persona,
-    options,
-    extraHeaders
-  )
+  // The lookup runs on the session this handshake just established, and a
+  // plain `fetch` keeps no cookies — the browser path in particular hands the
+  // jar's contents to Playwright only after this returns. Forwarding them
+  // explicitly is what keeps the admin calls authenticated for every caller.
+  const session = setCookies
+    .map((raw) => raw.split(';')[0])
+    .filter((pair): pair is string => Boolean(pair))
+    .join('; ')
+
+  const userId = await resolveUserId(fetchImpl, apiUrl, persona, options, {
+    ...extraHeaders,
+    cookie: session,
+  })
   return { setCookies, userId }
 }
 

--- a/packages/core/src/wirings/persona/index.ts
+++ b/packages/core/src/wirings/persona/index.ts
@@ -46,6 +46,13 @@ export {
   type HttpPersonasConfig,
 } from '../../services/http-personas.js'
 export {
+  ActorSignIn,
+  OperatorSignIn,
+  IMPERSONATE_USER_ID_HEADER,
+  type PersonaSignIn,
+  type OperatorSignInOptions,
+} from '../../services/persona-sign-in.js'
+export {
   postScenarioJson,
   readScenarioHttpResponse,
 } from '../../services/personas-service.js'

--- a/packages/core/src/wirings/persona/index.ts
+++ b/packages/core/src/wirings/persona/index.ts
@@ -48,9 +48,11 @@ export {
 export {
   ActorSignIn,
   OperatorSignIn,
+  establishOperatorSession,
   IMPERSONATE_USER_ID_HEADER,
   type PersonaSignIn,
   type OperatorSignInOptions,
+  type OperatorSessionResult,
 } from '../../services/persona-sign-in.js'
 export {
   postScenarioJson,

--- a/packages/core/src/wirings/workflow/scenario-cookie-jar.ts
+++ b/packages/core/src/wirings/workflow/scenario-cookie-jar.ts
@@ -11,8 +11,19 @@ export const createCookieJar = (apiUrl: string): ScenarioCookieJar => {
     fetch: async (input, init) => {
       const headers = new Headers(init?.headers)
       headers.set('origin', origin)
-      const held = [...jar].map(([name, value]) => `${name}=${value}`)
+      // The caller's own cookie header wins per name: a request that already
+      // carries a session is stating which one it means, and emitting the jar's
+      // copy alongside it sends the same name twice.
       const caller = headers.get('cookie')
+      const named = new Set(
+        (caller ?? '')
+          .split(';')
+          .map((pair) => pair.split('=')[0]?.trim())
+          .filter(Boolean)
+      )
+      const held = [...jar]
+        .filter(([name]) => !named.has(name))
+        .map(([name, value]) => `${name}=${value}`)
       if (held.length > 0 || caller) {
         headers.set('cookie', [caller, ...held].filter(Boolean).join('; '))
       }

--- a/packages/playwright/src/provider.ts
+++ b/packages/playwright/src/provider.ts
@@ -2,6 +2,11 @@ import { mkdir, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { BrowserContext, Video } from '@playwright/test'
 import type { ResolvedPersona } from '@pikku/core/services'
+import {
+  establishOperatorSession,
+  IMPERSONATE_USER_ID_HEADER,
+  type OperatorSignInOptions,
+} from '@pikku/core/persona'
 import type {
   ScenarioArtifact,
   ScenarioBrowserFailure,
@@ -24,7 +29,8 @@ const VIDEO_STAGING_DIR = '.video-raw'
 export interface ActorSignInRequest {
   email: string
   name: string
-  secret: string
+  /** Absent on a deployed stage, which has no actor secret to post. */
+  secret?: string
 }
 
 /** Where the actor sign-in endpoint lives, and which origin it is called from. */
@@ -46,8 +52,18 @@ export type ActorSignIn = (
 
 export interface PlaywrightScenarioBrowserProviderOptions {
   config?: BrowserConfig
-  /** The actor impersonation secret — the same SCENARIO_ACTOR_SECRET the HTTP actors use. */
-  secret: string
+  /**
+   * The actor impersonation secret — the same SCENARIO_ACTOR_SECRET the HTTP
+   * actors use. The local-development credential; a deployed stage passes
+   * {@link PlaywrightScenarioBrowserProviderOptions.operator} instead.
+   */
+  secret?: string
+  /**
+   * Fabric operator credentials, for browsing a DEPLOYED stage as a persona.
+   * Same handshake the HTTP personas use, so a browser step and an RPC step in
+   * one scenario still act as one user.
+   */
+  operator?: OperatorSignInOptions
   /** Actor name → the persona filling it, resolved from `definePersonas()`. */
   actors: Record<string, ResolvedPersona>
   /** Sign-in path under apiUrl. Default: the actor plugin's `/auth/sign-in/actor`. */
@@ -348,7 +364,7 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
     if (this.captureContext) {
       session.capture = this.captureContext
     }
-    const signIn = this.options.signIn ?? defaultActorSignIn
+    const signIn = this.options.signIn ?? this.defaultSignIn()
     await signIn(
       session.context,
       {
@@ -363,6 +379,44 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
       }
     )
     return session
+  }
+
+  /**
+   * How a context gets its session when the project has not supplied its own
+   * `signIn`. The operator path wins when both credentials are present, for the
+   * same reason it does on the HTTP side: it is the stronger of the two.
+   */
+  private defaultSignIn(): ActorSignIn {
+    const operator = this.options.operator
+    if (!operator) {
+      return defaultActorSignIn
+    }
+    return async (context, request, target) => {
+      const persona = this.options.actors[request.name] ?? {
+        id: request.name,
+        name: request.name,
+        email: request.email,
+        roles: [],
+        goals: [],
+        tags: [],
+        runnable: true,
+      }
+      const { setCookies, userId } = await establishOperatorSession(
+        fetch,
+        target.apiUrl,
+        persona,
+        operator,
+        { origin: new URL(target.appUrl).origin }
+      )
+      await context.addCookies(
+        setCookies.map((raw: string) => parseCookie(raw, target.appUrl))
+      )
+      // The page's own API calls carry this, which is what makes the browser
+      // session act as the persona rather than as the operator.
+      await context.setExtraHTTPHeaders({
+        [IMPERSONATE_USER_ID_HEADER]: userId,
+      })
+    }
   }
 
   /**

--- a/packages/playwright/src/provider.ts
+++ b/packages/playwright/src/provider.ts
@@ -87,6 +87,36 @@ export interface PlaywrightScenarioBrowserProviderOptions {
  * `wire.browser` and `wire.scenarioStep.actor` are the same identity — a
  * browser step and an RPC step in one scenario act as one user.
  */
+/**
+ * Send the impersonation header to the product's own origins and nowhere else.
+ *
+ * `setExtraHTTPHeaders` would be one line, but it stamps every request the
+ * context makes — analytics, fonts, any third-party subresource a page pulls —
+ * and telling an unrelated host which user this run is acting as is not
+ * something a test should do. Routing is the origin-aware alternative, and
+ * `fallback` rather than `continue` so a project's own route handlers still see
+ * the request.
+ */
+const impersonateOn = async (
+  context: BrowserContext,
+  userId: string,
+  origins: string[]
+): Promise<void> => {
+  const trusted = new Set(origins.map((url) => new URL(url).origin))
+  await context.route('**/*', async (route) => {
+    const request = route.request()
+    if (!trusted.has(new URL(request.url()).origin)) {
+      return route.fallback()
+    }
+    return route.fallback({
+      headers: {
+        ...request.headers(),
+        [IMPERSONATE_USER_ID_HEADER]: userId,
+      },
+    })
+  })
+}
+
 export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvider {
   private readonly config: BrowserConfig
   private sessions = new Map<string, Promise<ActorSession>>()
@@ -364,7 +394,7 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
     if (this.captureContext) {
       session.capture = this.captureContext
     }
-    const signIn = this.options.signIn ?? this.defaultSignIn()
+    const signIn = this.options.signIn ?? this.defaultSignIn(actorConfig)
     await signIn(
       session.context,
       {
@@ -386,21 +416,12 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
    * `signIn`. The operator path wins when both credentials are present, for the
    * same reason it does on the HTTP side: it is the stronger of the two.
    */
-  private defaultSignIn(): ActorSignIn {
+  private defaultSignIn(persona: ResolvedPersona): ActorSignIn {
     const operator = this.options.operator
     if (!operator) {
       return defaultActorSignIn
     }
-    return async (context, request, target) => {
-      const persona = this.options.actors[request.name] ?? {
-        id: request.name,
-        name: request.name,
-        email: request.email,
-        roles: [],
-        goals: [],
-        tags: [],
-        runnable: true,
-      }
+    return async (context, _request, target) => {
       const { setCookies, userId } = await establishOperatorSession(
         fetch,
         target.apiUrl,
@@ -411,11 +432,7 @@ export class PlaywrightScenarioBrowserProvider implements ScenarioBrowserProvide
       await context.addCookies(
         setCookies.map((raw: string) => parseCookie(raw, target.appUrl))
       )
-      // The page's own API calls carry this, which is what makes the browser
-      // session act as the persona rather than as the operator.
-      await context.setExtraHTTPHeaders({
-        [IMPERSONATE_USER_ID_HEADER]: userId,
-      })
+      await impersonateOn(context, userId, [target.apiUrl, target.appUrl])
     }
   }
 

--- a/packages/services/better-auth/src/fabric-plugin.test.ts
+++ b/packages/services/better-auth/src/fabric-plugin.test.ts
@@ -87,13 +87,23 @@ describe('better-auth fabric plugin', () => {
     const token = signToken(privateKey, { sub: 'op-1', aud: 'stage-a' })
 
     const wrongStage = await signInFabric(
-      makeAuth({ user: [], session: [], account: [] }, publicKey, undefined, 'stage-b'),
+      makeAuth(
+        { user: [], session: [], account: [] },
+        publicKey,
+        undefined,
+        'stage-b'
+      ),
       token
     )
     assert.equal(wrongStage.status, 401)
 
     const rightStage = await signInFabric(
-      makeAuth({ user: [], session: [], account: [] }, publicKey, undefined, 'stage-a'),
+      makeAuth(
+        { user: [], session: [], account: [] },
+        publicKey,
+        undefined,
+        'stage-a'
+      ),
       token
     )
     assert.equal(rightStage.status, 200)
@@ -119,7 +129,12 @@ describe('better-auth fabric plugin', () => {
       privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
     })
     const res = await signInFabric(
-      makeAuth({ user: [], session: [], account: [] }, publicKey, undefined, 'stage-a'),
+      makeAuth(
+        { user: [], session: [], account: [] },
+        publicKey,
+        undefined,
+        'stage-a'
+      ),
       signToken(privateKey, { sub: 'op-1' })
     )
     assert.equal(res.status, 200)

--- a/packages/services/better-auth/src/fabric-plugin.test.ts
+++ b/packages/services/better-auth/src/fabric-plugin.test.ts
@@ -57,14 +57,15 @@ const makeScopeService = () => {
 const makeAuth = (
   db: Record<string, any[]>,
   key?: string,
-  scopeService?: any
+  scopeService?: any,
+  audience?: string
 ) =>
   betterAuth({
     baseURL: 'http://localhost:3000',
     secret: 'better-auth-test-secret',
     database: memoryAdapter(db),
     emailAndPassword: { enabled: true },
-    plugins: [fabric({ publicKey: key, scopeService })],
+    plugins: [fabric({ publicKey: key, scopeService, audience })],
   })
 
 const signInFabric = (auth: ReturnType<typeof makeAuth>, token: string) =>
@@ -77,6 +78,53 @@ const signInFabric = (auth: ReturnType<typeof makeAuth>, token: string) =>
   )
 
 describe('better-auth fabric plugin', () => {
+  test('a stage-scoped token only works on the stage it names', async () => {
+    const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    })
+    const token = signToken(privateKey, { sub: 'op-1', aud: 'stage-a' })
+
+    const wrongStage = await signInFabric(
+      makeAuth({ user: [], session: [], account: [] }, publicKey, undefined, 'stage-b'),
+      token
+    )
+    assert.equal(wrongStage.status, 401)
+
+    const rightStage = await signInFabric(
+      makeAuth({ user: [], session: [], account: [] }, publicKey, undefined, 'stage-a'),
+      token
+    )
+    assert.equal(rightStage.status, 200)
+  })
+
+  test('a stage that does not know its own id refuses a scoped token', async () => {
+    const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    })
+    const res = await signInFabric(
+      makeAuth({ user: [], session: [], account: [] }, publicKey),
+      signToken(privateKey, { sub: 'op-1', aud: 'stage-a' })
+    )
+    assert.equal(res.status, 401)
+  })
+
+  test('an unscoped token is still accepted, so server-to-server callers keep working', async () => {
+    const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    })
+    const res = await signInFabric(
+      makeAuth({ user: [], session: [], account: [] }, publicKey, undefined, 'stage-a'),
+      signToken(privateKey, { sub: 'op-1' })
+    )
+    assert.equal(res.status, 200)
+  })
+
   test('mints an admin session for a synthetic fabric operator row', async () => {
     const db: Record<string, any[]> = { user: [], session: [], account: [] }
     const { granted, scopeService } = makeScopeService()

--- a/packages/services/better-auth/src/fabric-plugin.ts
+++ b/packages/services/better-auth/src/fabric-plugin.ts
@@ -21,6 +21,23 @@ export interface FabricPluginOptions {
   /** Reject tokens whose `purpose` claim isn't this. Defaults to `fabric-admin`. */
   purpose?: string
   /**
+   * This stage's own identity — in Fabric deploys, `FABRIC_STAGE_ID`.
+   *
+   * Every stage verifies against the same `FABRIC_AUTH_PUBLIC_KEY`, so without
+   * an audience an operator token is admin on all of them at once. That is
+   * tolerable while the token never leaves the control plane, and not at all
+   * once one is handed to something like CI.
+   *
+   * A token carrying `aud` is therefore refused unless this is configured and
+   * matches — fail closed, so a stage that has not been told who it is cannot
+   * be the weak one. Tokens without `aud` are unaffected, which is what keeps
+   * the existing server-to-server callers working.
+   */
+  audience?:
+    | string
+    | undefined
+    | (() => string | undefined | Promise<string | undefined>)
+  /**
    * Grants the operator's synthetic row the `admin` scope on creation, which is
    * what authorizes it against the framework's `admin:*` gates. Without one the
    * operator signs in but holds nothing.
@@ -54,6 +71,7 @@ interface FabricClaims {
   sub?: unknown
   name?: unknown
   purpose?: unknown
+  aud?: unknown
   exp?: unknown
 }
 
@@ -141,6 +159,8 @@ const grantOperatorAdmin = async (
  * `resolveImpersonatedSession`'s default `canImpersonate`.
  * The token's `sub` is the operator id; the synthetic email is namespaced so it
  * can never collide with a real user, and sign-in against a real row is refused.
+ * A token naming an audience is accepted only by the stage it names — see
+ * {@link FabricPluginOptions.audience}.
  *
  * Requires a {@link FabricPluginOptions.scopeService} for the grant to land.
  * Filter `fabric: true` rows out of any end-user listing.
@@ -197,6 +217,17 @@ export const fabric = (options: FabricPluginOptions): BetterAuthPlugin => {
             throw new APIError('UNAUTHORIZED', {
               message: 'Fabric token has the wrong purpose',
             })
+          }
+          if (claims.aud !== undefined) {
+            const audience =
+              typeof options.audience === 'function'
+                ? await options.audience()
+                : options.audience
+            if (!audience || claims.aud !== audience) {
+              throw new APIError('UNAUTHORIZED', {
+                message: 'Fabric token was issued for another stage',
+              })
+            }
           }
           const fabricUserId = typeof claims.sub === 'string' ? claims.sub : ''
           if (!fabricUserId) {


### PR DESCRIPTION
## Why

`pikku scenario run`, `pikku persona`, and `pikku persona sync` could only sign a persona in one way: the dev-only `actor()` plugin, using `SCENARIO_ACTOR_SECRET`. That secret is a passwordless master key — anyone holding it can become any user — so it can never ship to a deployed stage, which meant scenarios could not run against staging or production at all.

Personas on a deployed stage are real credentialed users. This teaches the runner to reach them the way an operator would.

## What

**A persona sign-in strategy.** `packages/core/src/services/persona-sign-in.ts` factors the existing inline actor call out behind a small `PersonaSignIn` interface with two implementations:

- `ActorSignIn` — the current behaviour, unchanged, for dev targets.
- `OperatorSignIn` — exchanges a short-lived Fabric operator token at `/auth/sign-in/fabric`, resolves the persona's user id through the Better Auth admin API, and then acts as that user via pikku's existing `x-pikku-impersonate-user-id` header.

Nothing new is invented on the security side: the token exchange, the `admin:impersonate` scope, and header impersonation all already existed. This wires them together.

The key property is asymmetry — **a stage can verify an operator token but can never mint one.** So unlike the actor secret, a deployed environment holds no credential worth stealing.

**A credential resolver in the CLI.** `resolvePersonaCredentials` reads `FABRIC_OPERATOR_TOKEN` (deployed) or `SCENARIO_ACTOR_SECRET` (dev); the operator token wins when both are set, and the error names both variables. All three commands and the Playwright browser provider go through it, so a browser-driven scenario gets the same cookies plus the impersonation header on its context.

Seeding a missing persona is **opt-in** behind `createMissing` / `PIKKU_PERSONA_CREATE_MISSING` — meant for throwaway stages, not for anything you care about.

## Security fix included

`fabric()` tokens carried no `aud` claim, and every stage verifies the same public key — so one token was admin on *every stage of every tenant*. The plugin now takes an `audience` option and rejects a token whose `aud` doesn't match.

Enforcement is **fail-closed but backwards-compatible**: a token *with* an `aud` is rejected unless it matches (and rejected outright if the stage declares no audience), while an existing token *without* one is unaffected. That lets issuers start scoping tokens before every verifier is upgraded, without a flag day.

## Tests

- `persona-sign-in.test.ts` — 5 tests against an in-process stage server covering the full exchange, impersonation header propagation, the create-missing path, and both failure modes.
- `persona-credentials.test.ts` — 4 tests on precedence and the error.
- `fabric-plugin.test.ts` — 3 new: a scoped token works only on its own stage, a stage declaring no audience refuses a scoped token, an unscoped token is still accepted.

`@pikku/core` 2324 tests, 0 fail · `@pikku/services-better-auth` 142/142 · `@pikku/cli` byte-identical to the pre-change baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for signing in personas on deployed stages with Fabric operator credentials.
  - Browser, scenario, and persona commands can use operator sessions and impersonation while preserving local actor-secret authentication.
  - Added optional provisioning for missing persona accounts.
  - Added stage-scoped operator tokens with audience validation; unscoped tokens continue to work.
- **Bug Fixes**
  - Improved sign-in errors when no valid credentials are configured.
  - Prevented operator tokens from being accepted by unintended stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->