### PR TITLE
fix(changeset): name the package, not its directory

### DIFF
--- a/.changeset/fabric-tokens-name-their-stage.md
+++ b/.changeset/fabric-tokens-name-their-stage.md
@@ -1,5 +1,5 @@
 ---
-'@pikku/services-better-auth': patch
+'@pikku/better-auth': patch
 ---
 
 Let a Fabric operator token be scoped to one stage.


### PR DESCRIPTION
The better-auth changeset from #1402 said `@pikku/services-better-auth` — that is
the path under `packages/`, not the package. It publishes as `@pikku/better-auth`.

`changeset version` refuses a changeset naming a package that isn't in the
workspace, so the Release job for `09aff0282` died at
`Create Release Pull Request or Publish` with:

```
Error: Found changeset fabric-tokens-name-their-stage for package @pikku/services-better-auth which is not in the workspace
```

No version PR was opened and nothing from #1402 can publish until this lands.
One word; the changeset body is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented support for stage-scoped Fabric operator tokens.
  - Added guidance for configuring and validating token audiences.
  - Clarified that tokens without an `aud` claim remain compatible.
- **Maintenance**
  - Updated the release change record to target the correct authentication package for the patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->