### PR TITLE
fix(cli): release the inspector ts.Program between refreshes

### DIFF
--- a/.changeset/lucky-pans-shave.md
+++ b/.changeset/lucky-pans-shave.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Release the inspector's ts.Program between refreshes so `pikku dev` stops ratcheting memory

--- a/packages/cli/src/services.ts
+++ b/packages/cli/src/services.ts
@@ -233,6 +233,16 @@ export const createSingletonServices: CreateSingletonServices<
   let inspectorInvalidated = false
 
   /**
+   * Drop the `ts.Program` an inspection leaves on the state. Its only reader is
+   * the next inspection, which takes it back as `oldProgram` for incremental
+   * reuse — so keeping it pins a whole program's source files and ASTs live for
+   * the life of the process, which in `pikku dev` is its largest allocation.
+   */
+  const releaseProgram = (state: { program?: unknown } | undefined) => {
+    if (state) state.program = undefined
+  }
+
+  /**
    * `unfiltered` is for commands that RUN the project rather than generate from
    * it. The CLI filters narrow what gets written out, which is meaningless to a
    * runner and actively wrong for one: `--tags` on `pikku scenario run` selects
@@ -390,6 +400,8 @@ export const createSingletonServices: CreateSingletonServices<
       logger.debug(`Inspector took ${Date.now() - inspectStart}ms`)
       inspectedTsGeneration = tsGenerationAtInspect
       inspectorInvalidated = false
+
+      releaseProgram(unfilteredState)
 
       if (
         'diagnostics' in unfilteredState &&

--- a/packages/cli/src/services.ts
+++ b/packages/cli/src/services.ts
@@ -232,12 +232,6 @@ export const createSingletonServices: CreateSingletonServices<
   let inspectedTsGeneration: number | undefined
   let inspectorInvalidated = false
 
-  /**
-   * Drop the `ts.Program` an inspection leaves on the state. Its only reader is
-   * the next inspection, which takes it back as `oldProgram` for incremental
-   * reuse — so keeping it pins a whole program's source files and ASTs live for
-   * the life of the process, which in `pikku dev` is its largest allocation.
-   */
   const releaseProgram = (state: { program?: unknown } | undefined) => {
     if (state) state.program = undefined
   }


### PR DESCRIPTION
## What

The inspector stashes its `ts.Program` on the state (`inspector.ts`), and the only thing that ever reads it is the *next* inspection, which passes it back as `oldProgram` for incremental reuse (`services.ts`). This releases it once the inspection is done.

## Why

Holding the program pins a whole program's source files and ASTs live for the lifetime of the process. In `pikku dev` that's the single largest allocation, and it never comes back.

Measured on a 26-file project:

| runtime / config | RSS after 5-8 passes | trend |
|---|---|---|
| bun, before | 1330MB | still climbing |
| bun, after | 1134MB | still climbing |
| node `--max-old-space-size=768`, before | 835MB | flat |
| node `--max-old-space-size=768`, after | **747MB** | flat |

On a 13-file project, `oldProgram` chaining retains ~190MB of extra *live* heap after a forced GC (409MB vs 220MB) — so this is retention, not just deferred collection.

Downstream, Fabric's build sandboxes see `pikku dev` holding a median **2367MB** inside a 6144MB cgroup — 6x the next-largest process — which starves the `tsc` spawns sharing the box and gets them OOM-killed.

## Cost

Incremental reuse buys ~5% on a re-inspection. That is not worth a permanent second copy of the program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRGghZzh67Q1A2f5B5znkE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed excessive memory growth during `pikku dev` sessions by releasing inspection data between refreshes.
  * Improved long-running development sessions by preventing stale TypeScript data from being retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->