### PR TITLE
fix(personas): honour PIKKU_PERSONA_CREATE_MISSING again

### DIFF
--- a/.changeset/persona-create-missing-is-a-boolean.md
+++ b/.changeset/persona-create-missing-is-a-boolean.md
@@ -1,0 +1,12 @@
+---
+'@pikku/cli': patch
+---
+
+Honour `PIKKU_PERSONA_CREATE_MISSING=true` again.
+
+`variables.get` JSON-parses its value, so the flag arrived as the boolean
+`true` and never equalled the string it was compared against — every
+deployed scenario run asked the stage not to create the persona, and
+failed on the first one with `No account on this stage for ...`. The
+operator token beside it survived the same parse only because a JWT is
+not valid JSON.

--- a/packages/cli/src/utils/persona-credentials.test.ts
+++ b/packages/cli/src/utils/persona-credentials.test.ts
@@ -7,12 +7,14 @@ import {
   OPERATOR_TOKEN_VARIABLE,
   CREATE_MISSING_VARIABLE,
 } from './persona-credentials.js'
-import type { VariablesService } from '@pikku/core/services'
+import { LocalVariablesService } from '@pikku/core/services'
 
-const variablesFrom = (values: Record<string, string>): VariablesService =>
-  ({
-    get: async (name: string) => values[name],
-  }) as unknown as VariablesService
+// The real service, not a fake that hands back what it was given: `get`
+// JSON-parses, so 'true' arrives as a boolean and 'false' as one too. A stub
+// returning raw strings is more forgiving than anything this code runs
+// against, and hid a createMissing flag that could never be turned on.
+const variablesFrom = (values: Record<string, string>) =>
+  new LocalVariablesService(values)
 
 describe('resolvePersonaCredentials', () => {
   test('uses the actor secret when that is all the environment holds', async () => {
@@ -50,6 +52,15 @@ describe('resolvePersonaCredentials', () => {
       'scenario actors'
     )
     assert.equal(on.operator?.createMissing, true)
+
+    const explicitlyOff = await resolvePersonaCredentials(
+      variablesFrom({
+        [OPERATOR_TOKEN_VARIABLE]: 'operator-token',
+        [CREATE_MISSING_VARIABLE]: 'false',
+      }),
+      'scenario actors'
+    )
+    assert.equal(explicitlyOff.operator?.createMissing, false)
   })
 
   test('names both credentials, and the command, when neither is set', async () => {

--- a/packages/cli/src/utils/persona-credentials.ts
+++ b/packages/cli/src/utils/persona-credentials.ts
@@ -28,8 +28,12 @@ export const resolvePersonaCredentials = async (
 ): Promise<PersonaCredentials> => {
   const token = await variables.get(OPERATOR_TOKEN_VARIABLE)
   if (token) {
+    // `variables.get` JSON-parses, so `PIKKU_PERSONA_CREATE_MISSING=true`
+    // arrives as the boolean `true` and never equalled the string. The
+    // operator token survives the same parse only because a JWT is not
+    // valid JSON.
     const createMissing =
-      (await variables.get(CREATE_MISSING_VARIABLE)) === 'true'
+      String(await variables.get(CREATE_MISSING_VARIABLE)) === 'true'
     return { operator: { token, createMissing } }
   }
 


### PR DESCRIPTION
## What

`PIKKU_PERSONA_CREATE_MISSING=true` has never been able to turn account creation on.

`variables.get` JSON-parses its value, so `'true'` arrives as the **boolean** `true`, and `resolvePersonaCredentials` compared it against the **string** `'true'`. Every `pikku scenario run` against a deployed stage therefore sent `actAs.create: false` and failed on the very first persona:

```
[scenario] operator sign-in failed for 'admin' (404):
{"message":"No account on this stage for admin@actors.seminarhof.example"}
```

The `FABRIC_OPERATOR_TOKEN` read two lines above survives the same parse only because a JWT is not valid JSON — which is why that half kept working and hid this.

## The test that should have caught it

There was already a test asserting `createMissing` goes on for `'true'`, and it passed the whole time. It built its own `VariablesService` stub:

```ts
const variablesFrom = (values: Record<string, string>): VariablesService =>
  ({ get: async (name: string) => values[name] }) as unknown as VariablesService
```

That stub hands back the raw string, so it is more forgiving than anything this function actually runs against, and it proved the opposite of what it appeared to. It now uses the real `LocalVariablesService`, and fails without the fix. I also added the `'false'` case, which the boolean parse makes a genuinely distinct path.

## Verification

Found by running a real suite against a deployed Fabric stage. With the fix, the stage's `/auth/sign-in/fabric` resolves and creates the persona as intended — confirmed directly against the deployed endpoint:

```json
{"actAs":{"userId":"a255d3c6-1119-4cb0-8329-1bef43256d4d"}}
```

`packages/cli` tests: 4/4 pass with the fix, 1 fails without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored support for `PIKKU_PERSONA_CREATE_MISSING=true`, allowing missing persona accounts to be created as configured.
  * Ensured the setting works consistently whether its value is interpreted as a Boolean or text.
  * Preserved the expected behavior when the setting is explicitly `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->