### PR TITLE
fix(core): name the key a secret lookup could not find

### DIFF
--- a/.changeset/secret-not-found-names-key.md
+++ b/.changeset/secret-not-found-names-key.md
@@ -1,0 +1,15 @@
+---
+'@pikku/core': patch
+'@pikku/better-auth': patch
+'@pikku/kysely': patch
+'@pikku/redis': patch
+'@pikku/mongodb': patch
+---
+
+Name the missing key when a secret is not found.
+
+Every `SecretService` threw a bare `Requested secret not found`. In a deployed
+runtime the stack is minified, so the message was the only evidence there was —
+and it identified neither the key nor the service. Each implementation now names
+the key it looked for; the better-auth middlewares that skip on an absent secret
+match the prefix through one shared predicate instead of the whole string.

--- a/packages/core/src/services/local-secrets.test.ts
+++ b/packages/core/src/services/local-secrets.test.ts
@@ -22,7 +22,7 @@ describe('LocalSecretService', () => {
     const vars = new LocalVariablesService({})
     const service = new LocalSecretService(vars)
     await assert.rejects(() => service.getSecret('MISSING'), {
-      message: 'Requested secret not found',
+      message: 'Requested secret not found: MISSING',
     })
   })
 
@@ -44,7 +44,7 @@ describe('LocalSecretService', () => {
     const vars = new LocalVariablesService({})
     const service = new LocalSecretService(vars)
     await assert.rejects(() => service.getSecret('MISSING'), {
-      message: 'Requested secret not found',
+      message: 'Requested secret not found: MISSING',
     })
   })
 

--- a/packages/core/src/services/local-secrets.ts
+++ b/packages/core/src/services/local-secrets.ts
@@ -32,7 +32,7 @@ export class LocalSecretService implements SecretService {
     if (value) {
       return createSecretValue(this.parseSecret<T>(value))
     }
-    throw new Error('Requested secret not found')
+    throw new Error(`Requested secret not found: ${key}`)
   }
 
   public async setSecret(key: string, value: unknown): Promise<void> {

--- a/packages/core/src/services/secret-service.ts
+++ b/packages/core/src/services/secret-service.ts
@@ -4,7 +4,9 @@ import type { SecretValue } from '../classification/secret-value.js'
 export type SecretValues<T> = { [K in keyof T]: SecretValue<T[K]> }
 
 export interface SecretService {
-  /** Throws if the secret is not found. Unwrap the result with `.reveal()`. */
+  /** Throws `Requested secret not found: <key>` if the secret is not found —
+   *  naming the key, because the caller's stack is minified in every deployed
+   *  runtime and an unnamed one says nothing. Unwrap the result with `.reveal()`. */
   getSecret<T = string>(key: string): Promise<SecretValue<T>>
   /** Answers for any key, including a disallowed one — it must not throw. */
   hasSecret(key: string): Promise<boolean>

--- a/packages/core/src/services/secret-service.ts
+++ b/packages/core/src/services/secret-service.ts
@@ -4,9 +4,6 @@ import type { SecretValue } from '../classification/secret-value.js'
 export type SecretValues<T> = { [K in keyof T]: SecretValue<T[K]> }
 
 export interface SecretService {
-  /** Throws `Requested secret not found: <key>` if the secret is not found —
-   *  naming the key, because the caller's stack is minified in every deployed
-   *  runtime and an unnamed one says nothing. Unwrap the result with `.reveal()`. */
   getSecret<T = string>(key: string): Promise<SecretValue<T>>
   /** Answers for any key, including a disallowed one — it must not throw. */
   hasSecret(key: string): Promise<boolean>

--- a/packages/core/src/testing/service-tests/secret-service-tests.ts
+++ b/packages/core/src/testing/service-tests/secret-service-tests.ts
@@ -44,7 +44,7 @@ export const defineSecretServiceTests = (
     test('getSecret throws for missing key', async () => {
       const service = await factory({ key: kek })
       await assert.rejects(() => service.getSecret('nonexistent'), {
-        message: 'Requested secret not found',
+        message: 'Requested secret not found: nonexistent',
       })
     })
 

--- a/packages/services/better-auth/src/auth-session-stateless.ts
+++ b/packages/services/better-auth/src/auth-session-stateless.ts
@@ -9,6 +9,7 @@ import {
 import { stampActorFlag } from './stamp-actor-flag.js'
 import { withResolvedScopes } from './auth-session-scopes.js'
 import { mergeRelayedCookies } from './cross-site-cookies.js'
+import { isSecretNotFound } from './secret-not-found.js'
 
 type CachedSession = { session: any; user: any }
 
@@ -66,7 +67,7 @@ export const betterAuthStatelessSession = (
           await (services as any).secrets?.getSecret(secretId)
         )?.reveal()
       } catch (e: any) {
-        if (e?.message !== 'Requested secret not found') throw e
+        if (!isSecretNotFound(e)) throw e
         services.logger?.error(
           `betterAuthStatelessSession: secret '${secretId}' not found — session middleware skipped. Ensure ${secretId} is configured.`
         )

--- a/packages/services/better-auth/src/auth-session-store.test.ts
+++ b/packages/services/better-auth/src/auth-session-store.test.ts
@@ -45,7 +45,7 @@ async function run(opts: {
     secrets: {
       getSecret: async () => {
         if (opts.secretMissing) {
-          throw new Error('Requested secret not found')
+          throw new Error('Requested secret not found: BETTER_AUTH_SECRET')
         }
         return { reveal: () => SECRET }
       },

--- a/packages/services/better-auth/src/auth-session-store.ts
+++ b/packages/services/better-auth/src/auth-session-store.ts
@@ -10,6 +10,7 @@ import { stampActorFlag } from './stamp-actor-flag.js'
 import { withResolvedScopes } from './auth-session-scopes.js'
 import { verifySessionCredential } from './session-credential.js'
 import type { SessionStore } from './session-store.js'
+import { isSecretNotFound } from './secret-not-found.js'
 
 type StoredSession = { session: any; user: any }
 
@@ -112,7 +113,7 @@ export const betterAuthStoreSession = (
           await (services as any).secrets?.getSecret(secretId)
         )?.reveal()
       } catch (e: any) {
-        if (e?.message !== 'Requested secret not found') {
+        if (!isSecretNotFound(e)) {
           throw e
         }
         services.logger?.error(

--- a/packages/services/better-auth/src/credential-oauth-providers.ts
+++ b/packages/services/better-auth/src/credential-oauth-providers.ts
@@ -1,5 +1,6 @@
 import type { SecretValue } from '@pikku/core/classification'
 import type { OAuth2CredentialConfig } from '@pikku/core/secret'
+import { isSecretNotFound } from './secret-not-found.js'
 
 export type CredentialOAuth2Configs = Record<
   string,
@@ -85,7 +86,7 @@ export const credentialOAuthProviders = async (
           ).reveal()
         } catch (e: any) {
           // Not configured yet — skip this provider, don't take down all of auth.
-          if (e?.message === 'Requested secret not found') {
+          if (isSecretNotFound(e)) {
             logger?.warn(
               `OAuth2 credential '${providerId}' skipped — app secret '${config.appCredentialSecretId}' is not configured.`
             )

--- a/packages/services/better-auth/src/secret-not-found.test.ts
+++ b/packages/services/better-auth/src/secret-not-found.test.ts
@@ -5,10 +5,6 @@ import { LocalSecretService, LocalVariablesService } from '@pikku/core/services'
 import { isSecretNotFound } from './secret-not-found.js'
 
 describe('isSecretNotFound', () => {
-  // The contract is the message prefix, so the one test that matters is against
-  // a real SecretService rather than a hand-written Error: if an implementation
-  // changes its wording, this fails where the auth callers would otherwise
-  // start swallowing genuine failures as "absent".
   test('matches what a SecretService throws for a key it does not hold', async () => {
     const secrets = new LocalSecretService(new LocalVariablesService({}))
 
@@ -21,8 +17,6 @@ describe('isSecretNotFound', () => {
     assert.equal(isSecretNotFound(new Error('connect ECONNREFUSED')), false)
   })
 
-  // Every caller receives `unknown` from a catch, so the guard has to survive
-  // whatever was thrown — including the things that are not errors at all.
   test('does not match a non-error throw', () => {
     for (const thrown of [
       null,

--- a/packages/services/better-auth/src/secret-not-found.test.ts
+++ b/packages/services/better-auth/src/secret-not-found.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { LocalSecretService, LocalVariablesService } from '@pikku/core/services'
+
+import { isSecretNotFound } from './secret-not-found.js'
+
+describe('isSecretNotFound', () => {
+  // The contract is the message prefix, so the one test that matters is against
+  // a real SecretService rather than a hand-written Error: if an implementation
+  // changes its wording, this fails where the auth callers would otherwise
+  // start swallowing genuine failures as "absent".
+  test('matches what a SecretService throws for a key it does not hold', async () => {
+    const secrets = new LocalSecretService(new LocalVariablesService({}))
+
+    const error = await secrets.getSecret('MISSING').catch((e) => e)
+
+    assert.equal(isSecretNotFound(error), true)
+  })
+
+  test('does not match an unrelated failure', () => {
+    assert.equal(isSecretNotFound(new Error('connect ECONNREFUSED')), false)
+  })
+
+  // Every caller receives `unknown` from a catch, so the guard has to survive
+  // whatever was thrown — including the things that are not errors at all.
+  test('does not match a non-error throw', () => {
+    for (const thrown of [
+      null,
+      undefined,
+      'Requested secret not found',
+      42,
+      {},
+    ]) {
+      assert.equal(isSecretNotFound(thrown), false)
+    }
+  })
+})

--- a/packages/services/better-auth/src/secret-not-found.ts
+++ b/packages/services/better-auth/src/secret-not-found.ts
@@ -1,13 +1,3 @@
-/**
- * Whether a thrown error is a `SecretService` reporting an absent key.
- *
- * Matched on the message prefix rather than the whole message: every
- * implementation names the key it could not find, which is the difference
- * between a diagnosable boot failure and a sentence that says nothing. There is
- * no error class to test against — `SecretService` is an interface any host may
- * implement, so the message is the whole contract (see the shared conformance
- * suite in `@pikku/core/testing`).
- */
 export const isSecretNotFound = (e: unknown): boolean =>
   typeof (e as { message?: unknown } | null)?.message === 'string' &&
   (e as { message: string }).message.startsWith('Requested secret not found')

--- a/packages/services/better-auth/src/secret-not-found.ts
+++ b/packages/services/better-auth/src/secret-not-found.ts
@@ -1,0 +1,13 @@
+/**
+ * Whether a thrown error is a `SecretService` reporting an absent key.
+ *
+ * Matched on the message prefix rather than the whole message: every
+ * implementation names the key it could not find, which is the difference
+ * between a diagnosable boot failure and a sentence that says nothing. There is
+ * no error class to test against — `SecretService` is an interface any host may
+ * implement, so the message is the whole contract (see the shared conformance
+ * suite in `@pikku/core/testing`).
+ */
+export const isSecretNotFound = (e: unknown): boolean =>
+  typeof (e as { message?: unknown } | null)?.message === 'string' &&
+  (e as { message: string }).message.startsWith('Requested secret not found')

--- a/packages/services/kysely/src/kysely-secret-service.ts
+++ b/packages/services/kysely/src/kysely-secret-service.ts
@@ -121,7 +121,7 @@ export class KyselySecretService implements SecretService {
       .where('key', '=', key)
       .executeTakeFirst()
 
-    if (!row) throw new Error('Requested secret not found')
+    if (!row) throw new Error(`Requested secret not found: ${key}`)
 
     const kek = await this.getKEK(row.keyVersion)
     const result = await envelopeDecrypt<T>(kek, row.ciphertext, row.wrappedDek)

--- a/packages/services/mongodb/src/mongodb-secret-service.ts
+++ b/packages/services/mongodb/src/mongodb-secret-service.ts
@@ -128,7 +128,7 @@ export class MongoDBSecretService implements SecretService {
 
   async getSecret<T = string>(key: string): Promise<SecretValue<T>> {
     const row = await this.secrets.findOne({ _id: key })
-    if (!row) throw new Error('Requested secret not found')
+    if (!row) throw new Error(`Requested secret not found: ${key}`)
 
     const kek = await this.getKEK(row.keyVersion)
     const result = await envelopeDecrypt<T>(kek, row.ciphertext, row.wrappedDek)

--- a/packages/services/redis/src/redis-secret-service.ts
+++ b/packages/services/redis/src/redis-secret-service.ts
@@ -96,7 +96,7 @@ export class RedisSecretService implements SecretService {
 
   async getSecret<T = string>(key: string): Promise<SecretValue<T>> {
     const data = await this.redis.hgetall(this.secretKey(key))
-    if (!data.ciphertext) throw new Error('Requested secret not found')
+    if (!data.ciphertext) throw new Error(`Requested secret not found: ${key}`)
 
     const kek = await this.getKEK(Number(data.key_version))
     return createSecretValue(


### PR DESCRIPTION
Every `SecretService` threw a bare `Requested secret not found`. Deployed runtimes minify the stack, so that sentence was the entire evidence a reader had: it named neither the key nor the service. A stage whose auth secret never arrived looked identical to one asking for a secret it never declared — this cost hours of bisecting a deployed Worker that could only say those four words.

Each implementation (`LocalSecretService`, `KyselySecretService`, `RedisSecretService`, `MongoSecretService`) now names the key it looked for. The shared conformance suite in `@pikku/core/testing` pins that, so a new implementation cannot regress to the anonymous message.

The three better-auth middlewares that treat an absent secret as "feature off" compared the whole message, which the added key breaks. They move to one shared prefix predicate (`isSecretNotFound`) rather than three copies of a string that now carries a variable.

Patch changeset covering `@pikku/core`, `@pikku/better-auth`, `@pikku/kysely`, `@pikku/redis`, `@pikku/mongodb`.

Local: `@pikku/core` secret tests, full `@pikku/better-auth` (144) and `@pikku/kysely` (280) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing-secret errors now include the requested key, making configuration issues easier to identify.
  * Authentication middleware continues gracefully when configured secrets are absent, including errors that provide the key name.
  * Secret handling behavior is consistent across supported storage services.

* **Documentation**
  * Clarified the expected missing-secret error format and secret value handling guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->