### PR TITLE
fix(cli): say when a services factory shadows what the host passed in

### DIFF
--- a/.changeset/warn-on-shadowed-host-services.md
+++ b/.changeset/warn-on-shadowed-host-services.md
@@ -10,3 +10,16 @@ one the host configured — silently. The replacement starts empty and the first
 failure lands much later, somewhere unrelated, with nothing in the boot log
 pointing at the swap. The generated wrapper now names what it discarded and
 points at the `existingServices.x ?? new Own()` idiom the templates use.
+
+Shadowing stays available where it is deliberate, but has to be said out loud.
+`allowShadowedServices` in `pikku.config.json` lists the names that may be
+replaced without a warning:
+
+```json
+{
+  "allowShadowedServices": ["kysely"]
+}
+```
+
+Names are opted in one at a time rather than by a blanket flag, so adding a
+service later still warns until someone decides it should not.

--- a/.changeset/warn-on-shadowed-host-services.md
+++ b/.changeset/warn-on-shadowed-host-services.md
@@ -1,0 +1,12 @@
+---
+'@pikku/cli': patch
+---
+
+Warn when `createSingletonServices` returns a service the host already passed in
+
+`pikkuServices` merges `{ ...existingServices, ...createdServices }`, so a
+factory that builds its own `secrets` (or `kysely`, or `content`) wins over the
+one the host configured — silently. The replacement starts empty and the first
+failure lands much later, somewhere unrelated, with nothing in the boot log
+pointing at the swap. The generated wrapper now names what it discarded and
+points at the `existingServices.x ?? new Own()` idiom the templates use.

--- a/packages/cli/src/functions/wirings/functions/pikku-command-function-types-split.ts
+++ b/packages/cli/src/functions/wirings/functions/pikku-command-function-types-split.ts
@@ -114,7 +114,8 @@ export const pikkuFunctionTypesSplit = pikkuSessionlessFunc<
           ? `import type { ${pikkuConfigType.type} } from '${getFileImportRelativePath(setupTypesFile, pikkuConfigType.typePath, packageMappings)}'`
           : '// Config type not found, will use fallback',
         pikkuConfigType?.type,
-        `import type { RequiredSingletonServices, RequiredWireServices } from '${getFileImportRelativePath(setupTypesFile, servicesFile, packageMappings)}'`
+        `import type { RequiredSingletonServices, RequiredWireServices } from '${getFileImportRelativePath(setupTypesFile, servicesFile, packageMappings)}'`,
+        config.allowShadowedServices
       )
     )
 

--- a/packages/cli/src/functions/wirings/setup/serialize-setup-types.test.ts
+++ b/packages/cli/src/functions/wirings/setup/serialize-setup-types.test.ts
@@ -2,14 +2,15 @@ import { strict as assert } from 'assert'
 import { describe, test } from 'node:test'
 import { serializeSetupTypes } from './serialize-setup-types.js'
 
-const emit = (configTypeName?: string) =>
+const emit = (configTypeName?: string, allowShadowedServices?: string[]) =>
   serializeSetupTypes(
     '../function/pikku-function-types.gen.js',
     configTypeName
       ? `import type { ${configTypeName} } from '../../src/application-types.js'`
       : '// Config type not found, will use fallback',
     configTypeName,
-    "import type { RequiredSingletonServices, RequiredWireServices } from '../pikku-services.gen.js'"
+    "import type { RequiredSingletonServices, RequiredWireServices } from '../pikku-services.gen.js'",
+    allowShadowedServices
   )
 
 describe('serializeSetupTypes', () => {
@@ -42,6 +43,24 @@ describe('serializeSetupTypes', () => {
     assert.match(content, /const shadowed = Object\.keys\(createdServices\)\.filter\(/)
     assert.match(content, /logger\?\.warn\?\.\(/)
     assert.match(content, /discarding what the host passed in/)
+  })
+
+  test('exempts nothing when the project opts none in', () => {
+    assert.match(emit('Config'), /const allowedToShadow = new Set\(\[\]\)/)
+  })
+
+  test('exempts the services pikku.config.json opts in', () => {
+    const content = emit('Config', ['kysely', 'secrets'])
+
+    assert.match(
+      content,
+      /const allowedToShadow = new Set\(\["kysely","secrets"\]\)/
+    )
+    assert.match(content, /!allowedToShadow\.has\(name\) &&/)
+  })
+
+  test('points at the config key as the way to silence the warning', () => {
+    assert.match(emit('Config'), /allowShadowedServices\\` in pikku\.config\.json/)
   })
 
   test('registers the wire services factory on pikku state', () => {

--- a/packages/cli/src/functions/wirings/setup/serialize-setup-types.test.ts
+++ b/packages/cli/src/functions/wirings/setup/serialize-setup-types.test.ts
@@ -36,6 +36,18 @@ describe('serializeSetupTypes', () => {
     assert.match(emit(), /export type Config = any/)
   })
 
+  // A host (fabric, a test harness, an addon runner) passes services it has
+  // already configured. Returning a fresh one of the same name wins the merge
+  // silently, and the empty replacement only fails much later — so the wrapper
+  // says which names it just discarded.
+  test('warns when the factory shadows a service the host passed in', () => {
+    const content = emit('Config')
+
+    assert.match(content, /const shadowed = Object\.keys\(createdServices\)\.filter\(/)
+    assert.match(content, /logger\?\.warn\?\.\(/)
+    assert.match(content, /discarding what the host passed in/)
+  })
+
   test('registers the wire services factory on pikku state', () => {
     assert.match(
       emit('Config'),

--- a/packages/cli/src/functions/wirings/setup/serialize-setup-types.test.ts
+++ b/packages/cli/src/functions/wirings/setup/serialize-setup-types.test.ts
@@ -36,10 +36,6 @@ describe('serializeSetupTypes', () => {
     assert.match(emit(), /export type Config = any/)
   })
 
-  // A host (fabric, a test harness, an addon runner) passes services it has
-  // already configured. Returning a fresh one of the same name wins the merge
-  // silently, and the empty replacement only fails much later — so the wrapper
-  // says which names it just discarded.
   test('warns when the factory shadows a service the host passed in', () => {
     const content = emit('Config')
 

--- a/packages/cli/src/functions/wirings/setup/serialize-setup-types.ts
+++ b/packages/cli/src/functions/wirings/setup/serialize-setup-types.ts
@@ -66,6 +66,16 @@ export const pikkuServices = (
   return async (config: Config, existingServices: Partial<SingletonServices> = {}) => {
     const createdServices = await func(config, existingServices)
     const services = { ...existingServices, ...createdServices }
+    const shadowed = Object.keys(createdServices).filter(
+      (name) =>
+        (existingServices as any)[name] !== undefined &&
+        (existingServices as any)[name] !== (createdServices as any)[name]
+    )
+    if (shadowed.length > 0) {
+      ;(services as any).logger?.warn?.(
+        \`createSingletonServices returned its own \${shadowed.join(', ')}, discarding what the host passed in. A host only passes a service it has already configured — a \\\`secrets\\\` holding this deployment's values, a \\\`kysely\\\` bound to its database — so the replacement starts empty and fails later somewhere unrelated. Write \\\`existingServices.<name> ?? new Own...\\\` to take the host's when there is one and still work standalone.\`
+      )
+    }
     const authFactory = __pikkuState(null, 'package', 'authFactory')
     if (authFactory) {
       let authInstance: Promise<unknown> | undefined

--- a/packages/cli/src/functions/wirings/setup/serialize-setup-types.ts
+++ b/packages/cli/src/functions/wirings/setup/serialize-setup-types.ts
@@ -8,7 +8,8 @@ export const serializeSetupTypes = (
   functionTypesImportPath: string,
   configTypeImport: string,
   configTypeName: string | undefined,
-  requiredServicesTypeImport: string
+  requiredServicesTypeImport: string,
+  allowShadowedServices: string[] = []
 ) => {
   return `/**
  * Config and service factory definitions, declared once per application
@@ -66,14 +67,16 @@ export const pikkuServices = (
   return async (config: Config, existingServices: Partial<SingletonServices> = {}) => {
     const createdServices = await func(config, existingServices)
     const services = { ...existingServices, ...createdServices }
+    const allowedToShadow = new Set(${JSON.stringify(allowShadowedServices)})
     const shadowed = Object.keys(createdServices).filter(
       (name) =>
+        !allowedToShadow.has(name) &&
         (existingServices as any)[name] !== undefined &&
         (existingServices as any)[name] !== (createdServices as any)[name]
     )
     if (shadowed.length > 0) {
       ;(services as any).logger?.warn?.(
-        \`createSingletonServices returned its own \${shadowed.join(', ')}, discarding what the host passed in. A host only passes a service it has already configured — a \\\`secrets\\\` holding this deployment's values, a \\\`kysely\\\` bound to its database — so the replacement starts empty and fails later somewhere unrelated. Write \\\`existingServices.<name> ?? new Own...\\\` to take the host's when there is one and still work standalone.\`
+        \`createSingletonServices returned its own \${shadowed.join(', ')}, discarding what the host passed in. A host only passes a service it has already configured — a \\\`secrets\\\` holding this deployment's values, a \\\`kysely\\\` bound to its database — so the replacement starts empty and fails later somewhere unrelated. Write \\\`existingServices.<name> ?? new Own...\\\` to take the host's when there is one and still work standalone, or list the name under \\\`allowShadowedServices\\\` in pikku.config.json if replacing it is deliberate.\`
       )
     }
     const authFactory = __pikkuState(null, 'package', 'authFactory')

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -299,6 +299,13 @@ export type PikkuCLIInput = {
       }
   addonName?: string
 
+  /**
+   * Service names `createSingletonServices` is allowed to return even though
+   * the host already passed one in. Anything not listed warns at boot, because
+   * the host's instance is the configured one and the replacement starts empty.
+   */
+  allowShadowedServices?: string[]
+
   configDir: string
   tsconfig: string
 


### PR DESCRIPTION
## What

`pikkuServices` merges `{ ...existingServices, ...createdServices }`. An app whose `createSingletonServices` unconditionally builds its own `secrets` therefore discards the one the host (fabric, a test harness, an addon runner) had already loaded with that deployment's values — silently.

The generated wrapper now names what it replaced:

```
createSingletonServices returned its own secrets, discarding what the host passed in.
A host only passes a service it has already configured — a `secrets` holding this
deployment's values, a `kysely` bound to its database — so the replacement starts
empty and fails later somewhere unrelated. Write `existingServices.<name> ?? new Own...`
to take the host's when there is one and still work standalone.
```

## Why

This is not hypothetical. A deployed app booted clean — the platform's secret fetch succeeded, the log said nothing — and then every request 500'd with `Requested secret not found`, because one line in `services.ts` built a fresh empty `LocalSecretService` over the top. Nothing between the successful fetch and the failing request mentioned that the fetched service had been thrown away.

Overriding is still allowed; it is the *silence* that costs the time. The templates already use `existingServices.x ?? new Own()`, so the warning points at the idiom that is already the documented shape.

## Notes

- Identity comparison, so a factory returning the same instance it was handed (the common `config` case) does not warn.
- `logger?.warn?.` — optional at both hops, since the logger may itself be the shadowed service or absent entirely.
- Patch changeset for `@pikku/cli`.