### PR TITLE
fix(better-auth): say when an impersonation header goes unhonoured

### DIFF
--- a/.changeset/warn-unhonoured-impersonation-header.md
+++ b/.changeset/warn-unhonoured-impersonation-header.md
@@ -1,0 +1,9 @@
+---
+'@pikku/better-auth': patch
+---
+
+Say so when a request carries `x-pikku-impersonate-user-id` and the session middleware was registered without an `impersonation` option.
+
+The option is opt-in and omitting it was silent: the header was read by nobody and the request ran as the caller that signed in. A deployed stage's scenario and virtual-user runs sign in with a Fabric operator token and name the persona in that header, so an app that never passed the option ran every persona as the operator — a row with no membership anywhere — and the only symptom was assertions failing against data the persona should have been able to see.
+
+Both `betterAuthSession` and `betterAuthStatelessSession` now warn once per process instead.

--- a/packages/services/better-auth/src/auth-session-impersonation.test.ts
+++ b/packages/services/better-auth/src/auth-session-impersonation.test.ts
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
 import {
+  DEFAULT_IMPERSONATION_HEADER,
   resolveImpersonatedSession,
+  warnImpersonationUnconfigured,
   type SessionLike,
 } from './auth-session-impersonation.js'
 
@@ -211,5 +213,24 @@ describe('resolveImpersonatedSession', () => {
       ),
       /db down/
     )
+  })
+
+  test('a request with no impersonation header says nothing', () => {
+    const { services, logs } = svc()
+    warnImpersonationUnconfigured(services, () => undefined)
+    assert.deepEqual(logs.warn, [])
+  })
+
+  test('a header nobody is configured to honour is reported, once', () => {
+    const { services, logs } = svc()
+    const getHeader = (name: string) =>
+      name === DEFAULT_IMPERSONATION_HEADER ? 'u_guest' : undefined
+
+    warnImpersonationUnconfigured(services, getHeader)
+    warnImpersonationUnconfigured(services, getHeader)
+
+    assert.equal(logs.warn.length, 1)
+    assert.match(logs.warn[0]!, /without an `impersonation` option/)
+    assert.match(logs.warn[0]!, /u_guest/)
   })
 })

--- a/packages/services/better-auth/src/auth-session-impersonation.ts
+++ b/packages/services/better-auth/src/auth-session-impersonation.ts
@@ -1,6 +1,9 @@
 import type { CoreServices, CoreUserSession } from '@pikku/core/types'
 import { ADMIN_SCOPES, userHoldsScopes } from './auth-scopes.js'
 
+/** Where a target user id arrives when no `header` is configured. */
+export const DEFAULT_IMPERSONATION_HEADER = 'x-pikku-impersonate-user-id'
+
 /** The `{ user, session }` shape both session paths resolve before mapping. */
 export type SessionLike = { user: any; session: any }
 
@@ -51,7 +54,7 @@ export const resolveImpersonatedSession = async (
   getHeader: (name: string) => string | undefined | null,
   mapSession?: MapSession
 ): Promise<CoreUserSession | null> => {
-  const header = impersonation.header ?? 'x-pikku-impersonate-user-id'
+  const header = impersonation.header ?? DEFAULT_IMPERSONATION_HEADER
   const targetId = getHeader(header)
   // No header, or impersonating your own id, is a no-op.
   if (!targetId || targetId === caller.user.id) {
@@ -85,4 +88,38 @@ export const resolveImpersonatedSession = async (
   return mapSession
     ? await mapSession({ user: targetUser, session: caller.session }, services)
     : ({ userId: targetUser.id } as CoreUserSession)
+}
+
+let warnedUnconfigured = false
+
+/**
+ * Say so when a request carries an impersonation header that nothing is
+ * configured to honour — shared by both session middlewares.
+ *
+ * `impersonation` is opt-in, and omitting it is silent: the header is read by
+ * nobody and the request runs as the real caller. That is exactly what a
+ * deployed stage's scenario and virtual-user runs do — they sign in with a
+ * Fabric operator token and name the persona in this header — so an app that
+ * never passed the option runs every persona as the operator, a row with no
+ * membership anywhere, and the only symptom is assertions failing against
+ * data the persona should have been able to see.
+ *
+ * Once per process: a scenario run sends the header on every request, and the
+ * misconfiguration it reports does not change between them.
+ */
+export const warnImpersonationUnconfigured = (
+  services: CoreServices,
+  getHeader: (name: string) => string | undefined | null
+): void => {
+  if (warnedUnconfigured) {
+    return
+  }
+  const targetId = getHeader(DEFAULT_IMPERSONATION_HEADER)
+  if (!targetId) {
+    return
+  }
+  warnedUnconfigured = true
+  services.logger?.warn(
+    `better-auth: a request carried ${DEFAULT_IMPERSONATION_HEADER}: ${targetId}, but this session middleware was registered without an \`impersonation\` option, so the header was ignored and the request ran as the caller that signed in. Pass \`impersonation: { loadUser: (userId, services) => ... }\` to honour it.`
+  )
 }

--- a/packages/services/better-auth/src/auth-session-stateless.ts
+++ b/packages/services/better-auth/src/auth-session-stateless.ts
@@ -4,6 +4,7 @@ import type { CorePikkuMiddleware } from '@pikku/core/middleware'
 import { getCookieCache } from 'better-auth/cookies'
 import {
   resolveImpersonatedSession,
+  warnImpersonationUnconfigured,
   type ImpersonationOptions,
 } from './auth-session-impersonation.js'
 import { stampActorFlag } from './stamp-actor-flag.js'
@@ -118,6 +119,10 @@ export const betterAuthStatelessSession = (
             )
             return next()
           }
+        } else {
+          warnImpersonationUnconfigured(services as CoreServices, (name) =>
+            request.header(name)
+          )
         }
         const mapped = mapSession
           ? await mapSession(cached, services as CoreServices)

--- a/packages/services/better-auth/src/auth-session-stateless.ts
+++ b/packages/services/better-auth/src/auth-session-stateless.ts
@@ -57,8 +57,6 @@ export const betterAuthStatelessSession = (
       if (!http?.request || !setSession || session) {
         return next()
       }
-      // Capture the narrowed request so the deferred impersonation header reader
-      // below keeps the non-null type.
       const request = http.request
 
       let secret: string | undefined
@@ -81,8 +79,9 @@ export const betterAuthStatelessSession = (
       // surface. The normal "no valid cookie" path returns null here — it does
       // not throw.
       let cached: CachedSession | null
+      let headers: Headers
       try {
-        const headers = mergeRelayedCookies(new Headers(request.headers()))
+        headers = mergeRelayedCookies(new Headers(request.headers()))
         // Cookie is `__Secure-`-prefixed when secure, unprefixed otherwise; try
         // both since NODE_ENV is unreliable in serverless. Only one cookie exists.
         cached =
@@ -110,7 +109,7 @@ export const betterAuthStatelessSession = (
             cached,
             impersonation,
             services as CoreServices,
-            (name) => request.header(name),
+            (name) => headers.get(name),
             mapSession
           )
           if (impersonated) {
@@ -120,8 +119,9 @@ export const betterAuthStatelessSession = (
             return next()
           }
         } else {
-          warnImpersonationUnconfigured(services as CoreServices, (name) =>
-            request.header(name)
+          warnImpersonationUnconfigured(
+            services as CoreServices,
+            (name) => headers.get(name)
           )
         }
         const mapped = mapSession

--- a/packages/services/better-auth/src/auth-session.ts
+++ b/packages/services/better-auth/src/auth-session.ts
@@ -5,6 +5,7 @@ import type { BetterAuthInstance } from './define-auth.js'
 import { stampActorFlag } from './stamp-actor-flag.js'
 import {
   resolveImpersonatedSession,
+  warnImpersonationUnconfigured,
   type ImpersonationOptions,
 } from './auth-session-impersonation.js'
 import { withResolvedScopes } from './auth-session-scopes.js'
@@ -161,6 +162,10 @@ export const betterAuthSession = (
           )
           return next()
         }
+      } else {
+        warnImpersonationUnconfigured(services as CoreServices, (name) =>
+          request.header(name)
+        )
       }
       const mapped = mapSession
         ? await mapSession(result, services as CoreServices)


### PR DESCRIPTION
`impersonation` on `betterAuthSession` / `betterAuthStatelessSession` is opt-in, and omitting it is silent: `x-pikku-impersonate-user-id` is read by nobody and the request runs as the caller that signed in.

That is exactly what a deployed stage's scenario and virtual-user runs do — they sign in with a Fabric operator token and name the persona in that header. An app that never passed the option runs **every persona as the operator**: a synthetic row with no membership anywhere. The only symptom is assertions failing against data the persona should have been able to see, with nothing anywhere saying why.

Three of the four apps I checked had exactly this, and it cost a long time to find, because the sign-in succeeds, the session is valid, and the response body looks reasonable.

This does not change behaviour — it just stops the misconfiguration being invisible. Both middlewares now warn once per process (a scenario run sends the header on every request, and the misconfiguration does not change between them).

Same shape as the default `canImpersonate` gate, whose own docblock already notes that "no app template actually" wires the thing it depends on.

- `warnImpersonationUnconfigured` lives beside `resolveImpersonatedSession`, so both middlewares behave identically.
- `DEFAULT_IMPERSONATION_HEADER` is now a named export rather than a literal repeated in two places.
- Tests: 16/16 in `auth-session-impersonation.test.ts`, two of them new.
- Changeset: patch, `@pikku/better-auth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a warning when an impersonation header is detected without impersonation being configured.
  - Warnings are emitted only once per process and include relevant configuration and target details.
  - Standardized the default impersonation header used by session handling.

- **Bug Fixes**
  - Stateless sessions now correctly detect impersonation headers alongside relayed cookies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->