### PR TITLE
fix(cli): make the entrypoint-guard tests colour-independent

### DIFF
--- a/.changeset/entrypoint-guard-test-color.md
+++ b/.changeset/entrypoint-guard-test-color.md
@@ -1,0 +1,17 @@
+---
+'@pikku/cli': patch
+---
+
+Stop the CLI entrypoint-guard tests failing whenever colour is forced.
+
+The two assertions ran the emitted guard in a child process and compared its
+stdout against `'true'` / `'false'`. The fixture logged the bare boolean, so
+`console.log` sent it through `util.inspect`, which wraps a boolean in ANSI
+yellow as soon as colour is forced. `yarn` forces it — so the tests passed when
+run by hand and failed inside the pre-push hook, comparing
+`'\x1B[33mfalse\x1B[39m'` against `'false'`, which left `main` unpushable
+without `--no-verify`.
+
+The fixture now logs `String(isDirectExecution)`. Strings are not colourised,
+and the assertions are about what the guard resolved to, never about how Node
+formats it.

--- a/packages/cli/src/functions/wirings/cli/serialize-cli-entrypoint-guard.test.ts
+++ b/packages/cli/src/functions/wirings/cli/serialize-cli-entrypoint-guard.test.ts
@@ -10,13 +10,18 @@ import { DIRECT_EXECUTION_GUARD } from './serialize-cli-entrypoint-guard.js'
  * Writes the emitted guard into a module that reports what it decided, and runs
  * it both directly and through a symlinked bin — the shape every CLI installed
  * into node_modules/.bin actually takes.
+ *
+ * `String(...)` because `console.log` of a bare boolean goes through
+ * `util.inspect`, which wraps it in ANSI yellow whenever colour is forced — and
+ * `yarn` forces it, so these assertions compared `'\x1B[33mfalse\x1B[39m'`
+ * against `'false'` under the pre-push hook while passing when run by hand.
  */
 const runGuard = (): { direct: string; viaSymlink: string } => {
   const dir = mkdtempSync(join(tmpdir(), 'pikku-entry-guard-'))
   const entry = join(dir, 'entry.mjs')
   writeFileSync(
     entry,
-    `${DIRECT_EXECUTION_GUARD}\nconsole.log(isDirectExecution)\n`
+    `${DIRECT_EXECUTION_GUARD}\nconsole.log(String(isDirectExecution))\n`
   )
 
   const binDir = join(dir, 'bin')
@@ -45,7 +50,7 @@ describe('DIRECT_EXECUTION_GUARD', () => {
     const lib = join(dir, 'lib.mjs')
     writeFileSync(
       lib,
-      `${DIRECT_EXECUTION_GUARD}\nconsole.log(isDirectExecution)\n`
+      `${DIRECT_EXECUTION_GUARD}\nconsole.log(String(isDirectExecution))\n`
     )
     const main = join(dir, 'main.mjs')
     writeFileSync(main, `await import('./lib.mjs')\n`)


### PR DESCRIPTION
## Problem

`packages/cli/src/functions/wirings/cli/serialize-cli-entrypoint-guard.test.ts` runs the emitted `DIRECT_EXECUTION_GUARD` in a child process and compares its stdout against `'true'` / `'false'`.

The fixture logged the bare boolean:

```js
console.log(isDirectExecution)
```

`console.log` of a non-string goes through `util.inspect`, which wraps a boolean in ANSI yellow as soon as colour is forced. `yarn` forces it. So:

- run the file directly -> passes
- run it under `yarn test` (which the husky **pre-push** hook does) -> fails, comparing `'\x1B[33mfalse\x1B[39m'` against `'false'`

Both assertions in the file were affected, which is why `main` could not be pushed to without `--no-verify`.

Reproduction:

```console
$ FORCE_COLOR=1 node -e "console.log(false); console.log(String(false))" | cat -v
^[[33mfalse^[[39m
false
```

## Fix

Log `String(isDirectExecution)`. Strings are never colourised, and these assertions are about what the guard resolved to - never about how Node formats it.

## Verification

`FORCE_COLOR=1 npx tsx --test src/functions/wirings/cli/serialize-cli-entrypoint-guard.test.ts` -> 3 pass / 0 fail. The full `yarn test` across the monorepo is now green (it had exactly these two failures), and this branch pushed with the pre-push hook enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI entrypoint guard tests that could fail in environments with forced terminal colors.
  * Ensured boolean output is consistently reported as plain text, allowing test results to match expected values.

* **Release**
  * Prepared a patch release for the CLI package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->