### PR TITLE
fix(core): a missing session is 401, not 403

### DIFF
--- a/.changeset/missing-session-is-401.md
+++ b/.changeset/missing-session-is-401.md
@@ -1,0 +1,11 @@
+---
+'@pikku/core': patch
+---
+
+Answer 401, not 403, when a function requires a session and no session exists.
+
+`MissingSessionError` has been in the error table at 401 since forever and was never thrown — the runner threw `ForbiddenError('Authentication required')` instead, so "you are not signed in" and "you are signed in but not allowed" both came back 403. The two mean opposite things to a client: the first is worth retrying after re-authenticating, the second never is.
+
+That made pikku's own recovery unreachable. `HttpPersona` re-logs-in once on a 401 mid-run, for exactly the case its comment describes — a long run outliving its session. Against a stage using `betterAuthStatelessSession`, the signed cookie cache expires on the app's `cookieCache.maxAge` (5 minutes is the common setting), and from that moment every RPC in the run failed with 403 "Authentication required" while the retry watched for a 401 that could never arrive. A 32-minute scenario run failed everything after its first five minutes.
+
+Permission and scope denials are untouched and stay 403.

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -29,7 +29,7 @@ import type { CorePikkuFunctionConfig } from './functions.types.js'
 import { parseVersionedId } from '../version.js'
 import type { SessionService } from '../services/user-session-service.js'
 import { PikkuSessionService } from '../services/user-session-service.js'
-import { ForbiddenError, ReadonlySessionError } from '../errors/errors.js'
+import { MissingSessionError, ReadonlySessionError } from '../errors/errors.js'
 import { verifyScopes } from '../scopes.js'
 import {
   PikkuCredentialWireService,
@@ -329,7 +329,7 @@ export const runPikkuFunc = async <In = any, Out = any>(
         resolveAddonAuth(packageName, addonInstance?.namespace)
       ) {
         if (!session) {
-          throw new ForbiddenError('Authentication required')
+          throw new MissingSessionError('Authentication required')
         }
       }
     } else {
@@ -339,7 +339,7 @@ export const runPikkuFunc = async <In = any, Out = any>(
         )
       }
       if (!session) {
-        throw new ForbiddenError('Authentication required')
+        throw new MissingSessionError('Authentication required')
       }
     }
 

--- a/packages/core/src/wirings/addon/addon-auth-tags.test.ts
+++ b/packages/core/src/wirings/addon/addon-auth-tags.test.ts
@@ -7,7 +7,7 @@ import {
   addTagMiddleware,
   clearMiddlewareCache,
 } from '../../middleware-runner.js'
-import { ForbiddenError } from '../../errors/errors.js'
+import { ForbiddenError, MissingSessionError } from '../../errors/errors.js'
 import { resolveAddonAuth, resolveAddonTags, wireAddon } from './wire-addon.js'
 
 const ADDON_PACKAGE = '@addon/console'
@@ -114,7 +114,7 @@ describe('wireAddon auth on direct wirings', () => {
 
     await assert.rejects(
       () => callOverDirectWiring('credentialGet'),
-      ForbiddenError
+      MissingSessionError
     )
   })
 
@@ -141,7 +141,7 @@ describe('wireAddon auth on direct wirings', () => {
 
     await assert.rejects(
       () => callOverDirectWiring('credentialGet', { auth: true }),
-      ForbiddenError
+      MissingSessionError
     )
   })
 
@@ -161,7 +161,7 @@ describe('wireAddon auth on direct wirings', () => {
     ]) {
       await assert.rejects(
         () => callOverDirectWiring('credentialGet', { wireType }),
-        ForbiddenError,
+        MissingSessionError,
         `${wireType} should have been gated`
       )
     }

--- a/packages/core/src/wirings/agent/agent-authorization.test.ts
+++ b/packages/core/src/wirings/agent/agent-authorization.test.ts
@@ -8,7 +8,11 @@ import {
 } from '../../pikku-state.js'
 import { assertAgentAuthorized } from './agent-prepare.js'
 import { clearPermissionsCache } from '../../permissions.js'
-import { ForbiddenError, MissingScopeError } from '../../errors/errors.js'
+import {
+  ForbiddenError,
+  MissingScopeError,
+  MissingSessionError,
+} from '../../errors/errors.js'
 import type { CoreAgent } from './agent.types.js'
 import type { CoreUserSession } from '../../types/core.types.js'
 
@@ -73,7 +77,7 @@ describe('assertAgentAuthorized', () => {
     await assertAgentAuthorized(agent, {}, null)
   })
 
-  test('throws ForbiddenError when auth is explicitly true and no session exists', async () => {
+  test('throws MissingSessionError when auth is explicitly true and no session exists', async () => {
     const agent = addAgent('needs-session', { auth: true })
     await assert.rejects(
       () =>
@@ -82,7 +86,7 @@ describe('assertAgentAuthorized', () => {
           { sessionService: sessionService(undefined) },
           null
         ),
-      ForbiddenError
+      MissingSessionError
     )
   })
 

--- a/packages/core/src/wirings/agent/agent-prepare.ts
+++ b/packages/core/src/wirings/agent/agent-prepare.ts
@@ -22,7 +22,7 @@ import {
   type PermissionWire,
 } from '../../permissions.js'
 import { AIProviderNotConfiguredError } from '../../errors/errors.js'
-import { ForbiddenError } from '../../errors/errors.js'
+import { ForbiddenError, MissingSessionError } from '../../errors/errors.js'
 import { verifyScopes } from '../../scopes.js'
 import { pikkuState, getSingletonServices } from '../../pikku-state.js'
 import { createMiddlewareSessionWireProps } from '../../services/user-session-service.js'
@@ -315,7 +315,7 @@ export async function assertAgentAuthorized(
     : undefined
 
   if (agent.auth === true && !session) {
-    throw new ForbiddenError('Authentication required')
+    throw new MissingSessionError('Authentication required')
   }
 
   verifyScopes(agent.scopes, session)

--- a/packages/core/src/wirings/gateway/gateway-authorization.test.ts
+++ b/packages/core/src/wirings/gateway/gateway-authorization.test.ts
@@ -280,7 +280,7 @@ describe('gateway handler authorization', () => {
 
       const response = await postMessage('/webhooks/declared-session')
 
-      assert.equal(response.status, 403)
+      assert.equal(response.status, 401)
       assert.deepEqual(
         calls,
         [],
@@ -339,7 +339,7 @@ describe('gateway handler authorization', () => {
 
       const response = await postMessage('/webhooks/gw-auth')
 
-      assert.equal(response.status, 403)
+      assert.equal(response.status, 401)
       assert.deepEqual(calls, [], 'auth: true must require a session')
     })
 
@@ -365,7 +365,7 @@ describe('gateway handler authorization', () => {
 
       const response = await postMessage('/webhooks/handler-auth')
 
-      assert.equal(response.status, 403)
+      assert.equal(response.status, 401)
       assert.deepEqual(calls, [], 'auth: true must require a session')
     })
 

--- a/packages/core/src/wirings/http/http-runner-addon-ref.test.ts
+++ b/packages/core/src/wirings/http/http-runner-addon-ref.test.ts
@@ -233,6 +233,6 @@ describe('http routes wired with ref() to an addon function', () => {
 
     const response = await fetch(new ParamsRequest('/addon/greet', 'get'))
 
-    assert.strictEqual(response.status, 403)
+    assert.strictEqual(response.status, 401)
   })
 })


### PR DESCRIPTION
## Problem

`MissingSessionError` has sat in the error table at **401** since forever and was never thrown. The function runner threw `ForbiddenError('Authentication required')` instead, so "you are not signed in" and "you are signed in but not allowed" both came back **403**.

Those mean opposite things to a client. The first is worth retrying after re-authenticating; the second never is.

That made pikku's own recovery unreachable. `HttpPersona.invokeRaw` re-logs-in exactly once on a 401 mid-run — for precisely the case its comment describes, a long run outliving its session:

```ts
// packages/core/src/services/http-personas.ts
if (res.status === 401 && !retried) {
  // Session expired mid-run — re-login once and retry.
}
```

Against a stage using `betterAuthStatelessSession`, the signed cookie cache expires on the app's `session.cookieCache.maxAge` (5 minutes is the common setting). From that moment every RPC in the run failed with `403 Authentication required` while the retry watched for a 401 that could never arrive. A 32-minute scenario run failed everything after its first five minutes.

## Fix

Throw `MissingSessionError` at the three sites that mean "no session at all":

- `function-runner.ts` — both the sessionless-with-auth gate and the session-required gate
- `agent-prepare.ts` — `agent.auth === true && !session`

Permission and scope denials are untouched and stay 403.

## Verification

`packages/core` suite green. The assertions that changed are only the ones asserting a status for a *missing session*; the permission-denied, scope-gate and global-deny assertions in the same files still assert 403, which is what makes the change targeted rather than a blanket 403→401 sweep:

- `gateway-authorization.test.ts` — 3 missing-session cases → 401; perm-deny / scope-gate / global-deny left at 403
- `http-runner-addon-ref.test.ts` — 1 case → 401
- `addon-auth-tags.test.ts` — 3 cases → `MissingSessionError`; the tag-middleware `ForbiddenError('nope')` case unchanged
- `agent-authorization.test.ts` — renamed and retargeted to `MissingSessionError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Missing authentication now returns HTTP 401 instead of 403, enabling automatic re-authentication when sessions expire.
  - Authorization and permission denials continue to return HTTP 403.
  - Authentication handling is now consistent across HTTP, gateway, agent, addon, and direct function calls.
  - Improved CLI entrypoint checks to reliably report direct versus imported execution, including when terminal colors are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->