### PR TITLE
fix(cli): apply globalHTTPPrefix to synthesized RPC and agent routes

### DIFF
--- a/.changeset/global-http-prefix-on-synthesized-routes.md
+++ b/.changeset/global-http-prefix-on-synthesized-routes.md
@@ -1,0 +1,11 @@
+---
+'@pikku/cli': patch
+---
+
+Apply `globalHTTPPrefix` to the RPC and agent routes the deploy analyzer synthesizes.
+
+Every `wireHTTP` route already carries the prefix — the generator bakes it in, so `rpcCaller` is wired at `<prefix>/rpc/:rpcName` and the generated client posts to `` `${globalHTTPPrefix}/rpc/${rpcName}` ``. The per-function routes `analyzeDeployment` builds did not: an exposed function's unit was published at `/rpc/getMe` regardless of the prefix.
+
+On a deployed stage that made the whole exposed RPC surface unreachable. `<prefix>/rpc/getMe` — what every client sends — matched no function unit, so it fell through to the `rpcCaller` catch-all, which carries only its own implementation; and `/rpc/getMe`, where the unit actually sat, is outside the prefix the gateway serves the API under, so it reached the frontend instead. Projects without `globalHTTPPrefix` were unaffected, which is why this survived: the two paths are the same string when the prefix is empty.
+
+Also applies to `/remote/rpc/<name>` and the four `/rpc/agent/<name>` routes.

--- a/packages/cli/src/deploy/analyzer/analyzer.test.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.test.ts
@@ -375,3 +375,72 @@ describe('analyzeDeployment - agent identifier', () => {
     assert.equal(manifest.agents[0].unitName, 'agent-kanban-agent')
   })
 })
+
+function stateWithExposedFunctionAndAgent(): InspectorState {
+  return {
+    functions: {
+      meta: {
+        getMe: { pikkuFuncId: 'getMe', name: 'getMe', expose: true },
+      },
+    },
+    http: { meta: {} },
+    agents: {
+      agentsMeta: {
+        helper: { name: 'helper', model: 'x', tools: [], tags: [] },
+      },
+    },
+    mcpEndpoints: { toolsMeta: {}, resourcesMeta: {}, promptsMeta: {} },
+    channels: { meta: {} },
+    queueWorkers: { meta: {} },
+    scheduledTasks: { meta: {} },
+    workflows: { graphMeta: {} },
+    secrets: { definitions: [] },
+    variables: { definitions: [] },
+  } as unknown as InspectorState
+}
+
+const routesOf = (
+  manifest: ReturnType<typeof analyzeDeployment>,
+  unit: string
+) =>
+  (manifest.units.find((u) => u.name === unit)?.handlers ?? [])
+    .flatMap((h) => ('routes' in h ? h.routes : []))
+    .map((r) => r.route)
+
+describe('analyzeDeployment - globalHTTPPrefix', () => {
+  test('prefixes the synthesized RPC route', () => {
+    const manifest = analyzeDeployment(stateWithExposedFunctionAndAgent(), {
+      projectId: 'test',
+      globalHTTPPrefix: '/api',
+    })
+    assert.deepEqual(routesOf(manifest, 'get-me'), ['/api/rpc/getMe'])
+  })
+
+  test('prefixes the synthesized agent routes', () => {
+    const manifest = analyzeDeployment(stateWithExposedFunctionAndAgent(), {
+      projectId: 'test',
+      globalHTTPPrefix: '/api',
+    })
+    assert.deepEqual(routesOf(manifest, 'agent-helper'), [
+      '/api/rpc/agent/helper',
+      '/api/rpc/agent/helper/stream',
+      '/api/rpc/agent/helper/approve',
+      '/api/rpc/agent/helper/resume',
+    ])
+  })
+
+  test('a trailing slash on the prefix does not double up', () => {
+    const manifest = analyzeDeployment(stateWithExposedFunctionAndAgent(), {
+      projectId: 'test',
+      globalHTTPPrefix: '/api/',
+    })
+    assert.deepEqual(routesOf(manifest, 'get-me'), ['/api/rpc/getMe'])
+  })
+
+  test('no prefix leaves the routes as they were', () => {
+    const manifest = analyzeDeployment(stateWithExposedFunctionAndAgent(), {
+      projectId: 'test',
+    })
+    assert.deepEqual(routesOf(manifest, 'get-me'), ['/rpc/getMe'])
+  })
+})

--- a/packages/cli/src/deploy/analyzer/analyzer.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.ts
@@ -71,6 +71,7 @@ export interface AnalyzerOptions {
    * Queues created via explicit `wireQueue(...)` user code are unaffected.
    */
   workflowQueues?: boolean
+  globalHTTPPrefix?: string
 }
 
 export function analyzeDeployment(
@@ -80,6 +81,8 @@ export function analyzeDeployment(
   const serverlessIncompatible = new Set(options.serverlessIncompatible ?? [])
   const defaultTarget = options.defaultTarget ?? 'serverless'
   const workflowQueues = options.workflowQueues ?? true
+  const httpPrefix = (options.globalHTTPPrefix ?? '').replace(/\/+$/, '')
+  const prefixed = (route: string) => `${httpPrefix}${route}`
   const units: DeploymentUnit[] = []
   const queues: QueueDefinition[] = []
   const scheduledTasks: ScheduledTaskDefinition[] = []
@@ -174,7 +177,7 @@ export function analyzeDeployment(
       const funcName = funcMeta.name ?? funcId
       const rpcRoute = {
         method: 'post',
-        route: `/rpc/${funcName}`,
+        route: prefixed(`/rpc/${funcName}`),
         pikkuFuncId: funcId,
       }
       const fetchHandler = handlers.find(
@@ -191,7 +194,7 @@ export function analyzeDeployment(
       const funcName = funcMeta.name ?? funcId
       const remoteRoute = {
         method: 'post',
-        route: `/remote/rpc/${funcName}`,
+        route: prefixed(`/remote/rpc/${funcName}`),
         pikkuFuncId: funcId,
       }
       const fetchHandler = handlers.find(
@@ -250,22 +253,22 @@ export function analyzeDeployment(
     const agentRoutes = [
       {
         method: 'post',
-        route: `/rpc/agent/${agentName}`,
+        route: prefixed(`/rpc/agent/${agentName}`),
         pikkuFuncId: `agentRun:${agentName}`,
       },
       {
         method: 'post',
-        route: `/rpc/agent/${agentName}/stream`,
+        route: prefixed(`/rpc/agent/${agentName}/stream`),
         pikkuFuncId: `agentStream:${agentName}`,
       },
       {
         method: 'post',
-        route: `/rpc/agent/${agentName}/approve`,
+        route: prefixed(`/rpc/agent/${agentName}/approve`),
         pikkuFuncId: `agentApprove:${agentName}`,
       },
       {
         method: 'post',
-        route: `/rpc/agent/${agentName}/resume`,
+        route: prefixed(`/rpc/agent/${agentName}/resume`),
         pikkuFuncId: `agentResume:${agentName}`,
       },
     ]

--- a/packages/cli/src/deploy/build-pipeline.ts
+++ b/packages/cli/src/deploy/build-pipeline.ts
@@ -101,6 +101,7 @@ export async function runBuildPipeline(options: {
   inspectorState: InspectorState
   serverlessIncompatible?: string[]
   defaultTarget?: 'serverless' | 'server'
+  globalHTTPPrefix?: string
   getEntryContext: (
     unitDir: string,
     pikkuDir: string,
@@ -134,6 +135,7 @@ export async function runBuildPipeline(options: {
     projectId,
     serverlessIncompatible: options.serverlessIncompatible,
     defaultTarget: options.defaultTarget,
+    globalHTTPPrefix: options.globalHTTPPrefix,
     workflowQueues,
   })
 

--- a/packages/cli/src/functions/commands/deploy-apply.ts
+++ b/packages/cli/src/functions/commands/deploy-apply.ts
@@ -313,6 +313,7 @@ export const deployApply = pikkuSessionlessFunc<
       inspectorState,
       serverlessIncompatible: config.deploy?.serverlessIncompatible,
       defaultTarget: config.deploy?.defaultTarget,
+      globalHTTPPrefix: config.globalHTTPPrefix,
       getEntryContext,
       outDir: config.outDir,
       debugArtifacts: data?.debugArtifacts ?? false,

--- a/packages/cli/src/functions/commands/deploy-plan.ts
+++ b/packages/cli/src/functions/commands/deploy-plan.ts
@@ -79,6 +79,7 @@ export const deployPlan = pikkuSessionlessFunc<
       inspectorState,
       serverlessIncompatible: config.deploy?.serverlessIncompatible,
       defaultTarget: config.deploy?.defaultTarget,
+      globalHTTPPrefix: config.globalHTTPPrefix,
       getEntryContext,
       outDir: config.outDir,
       debugArtifacts: data?.debugArtifacts ?? false,


### PR DESCRIPTION
## Problem

`globalHTTPPrefix` from `pikku.config.json` is honoured almost everywhere:

- the generator bakes it into every `wireHTTP` scaffold it emits (rpc-public, agent, auth)
- the generated client uses it — `serialize-rpc-wrapper.ts` emits `` `${globalHTTPPrefix}/rpc/${rpcName}` ``

But the **deploy analyzer synthesizes its own routes**, and those never saw the prefix. So for a project with `"globalHTTPPrefix": "/api"`, the deployment manifest wires each exposed function's unit at `/rpc/getMe` while the client calls `/api/rpc/getMe`.

The result on a real deployment:

- `/api/rpc/getMe` matches no function unit, so it falls through to the `rpcCaller` catch-all — a unit that bundles only `rpcCaller`, not the target function
- `/rpc/getMe` sits outside the prefix entirely and never reaches the API at all — on an SSR deployment it hits the frontend and returns the app's HTML 404

Every exposed RPC on the stage 404s. Projects with no prefix were unaffected, because the prefixed and unprefixed strings are identical when the prefix is empty — which is why this went unnoticed.

## Fix

Thread `globalHTTPPrefix` from config through `deploy-plan` / `deploy-apply` → `build-pipeline` → `analyzer`, and apply it to the six routes the analyzer synthesizes:

- `/rpc/:funcName` and `/remote/rpc/:funcName`
- the four agent routes: `/rpc/agent/:agentName`, `.../stream`, `.../approve`, `.../resume`

A trailing slash on the configured prefix is stripped so it cannot double up.

## Verification

New `describe('analyzeDeployment - globalHTTPPrefix')` in `analyzer.test.ts` with four cases — prefixes the RPC route, prefixes the four agent routes, a trailing slash does not double up, and no prefix still yields `/rpc/getMe`. 24 pass / 0 fail.

## Known gap, not fixed here

`serialize-events-scaffold.ts` and `serialize-workflow-routes.ts` also ignore `globalHTTPPrefix`, so `/events/:topic` and `/workflow/:workflowName/*` are wired unprefixed while the generated client calls `${globalHTTPPrefix}/workflow/...`. Same root cause, different files — flagging rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
