### PR TITLE
chore(cli): drop the explanatory comment from the entrypoint-guard test

### DIFF
--- a/.changeset/drop-guard-test-comment.md
+++ b/.changeset/drop-guard-test-comment.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Drop an explanatory comment from the CLI entrypoint-guard test.

--- a/packages/cli/src/functions/wirings/cli/serialize-cli-entrypoint-guard.test.ts
+++ b/packages/cli/src/functions/wirings/cli/serialize-cli-entrypoint-guard.test.ts
@@ -10,11 +10,6 @@ import { DIRECT_EXECUTION_GUARD } from './serialize-cli-entrypoint-guard.js'
  * Writes the emitted guard into a module that reports what it decided, and runs
  * it both directly and through a symlinked bin — the shape every CLI installed
  * into node_modules/.bin actually takes.
- *
- * `String(...)` because `console.log` of a bare boolean goes through
- * `util.inspect`, which wraps it in ANSI yellow whenever colour is forced — and
- * `yarn` forces it, so these assertions compared `'\x1B[33mfalse\x1B[39m'`
- * against `'false'` under the pre-push hook while passing when run by hand.
  */
 const runGuard = (): { direct: string; viaSymlink: string } => {
   const dir = mkdtempSync(join(tmpdir(), 'pikku-entry-guard-'))


### PR DESCRIPTION
Removes the explanatory comment added in #1415. The rationale belongs in that PR, not in the file.
