### PR TITLE
chore: keep every pending changeset on patch

### DIFF
--- a/.changeset/fabric-deploy-apply-sync.md
+++ b/.changeset/fabric-deploy-apply-sync.md
@@ -1,5 +1,5 @@
 ---
-'@pikku/cli': minor
+'@pikku/cli': patch
 ---
 
 feat(fabric): `deploy apply --sync` waits for the deploy and fails the build when it doesn't land


### PR DESCRIPTION
`fabric-deploy-apply-sync` (from #1401) landed as `'@pikku/cli': minor`. Every other pending changeset is `patch`, so the next release would have been 0.13.0 and moved every project pin off the 0.12.x line.

Flipped to `patch`. No other non-patch changeset exists on main or on any open PR (checked #1400, #1409, #1412).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the upcoming `@pikku/cli` release classification from a minor release to a patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->