### PR TITLE
fix(cli): derive the TanStack Start shim's API base instead of throwing

### DIFF
--- a/.changeset/tanstack-shim-derives-origin.md
+++ b/.changeset/tanstack-shim-derives-origin.md
@@ -1,0 +1,28 @@
+---
+'@pikku/cli': patch
+---
+
+Stop the TanStack Start shim throwing on every deployed page
+
+`makeApi()` read `import.meta.env.VITE_API_URL` and threw `VITE_API_URL is not
+set` when it was absent — which is what happens in a deployed bundle. Fabric
+binds `VITE_API_URL` as a runtime binding on the worker, invisible to Vite at
+build time, so the read is `undefined` and the shim threw on the first loader
+that touched it. Codegen was shipping the failure `fabric validate` now fails
+projects for.
+
+The generated shim derives the base instead:
+
+- **Browser** — `import.meta.env.VITE_API_URL` when the build inlined one,
+  otherwise `window.location.origin + '/api'`. A configured base pointing at
+  localhost while the page is served from a real origin is ignored: the browser
+  cannot reach it, so it is a stray dev value.
+- **SSR** — `PIKKU_API_URL` then `VITE_API_URL` from the environment, since
+  there is no page to derive from. This is the one path that still throws when
+  nothing is set, and it now names both variables. The environment is reached
+  through `globalThis`, so the emitted file type-checks under a browser-only
+  tsconfig with no Node types.
+
+`apiBaseUrl()` is exported alongside `makeApi()` for code that needs the base
+without an RPC client. This is the same resolution the shipping app templates
+use.

--- a/packages/cli/src/functions/runtimes/tanstack-start/serialize-tanstack-start-shim.test.ts
+++ b/packages/cli/src/functions/runtimes/tanstack-start/serialize-tanstack-start-shim.test.ts
@@ -1,0 +1,58 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import ts from 'typescript'
+import { serializeTanStackStartShim } from './serialize-tanstack-start-shim.js'
+
+const emit = () => serializeTanStackStartShim('../pikku-rpc.gen.js')
+
+describe('serializeTanStackStartShim', () => {
+  test('emits a file that parses', () => {
+    const sf = ts.createSourceFile(
+      'shim.gen.ts',
+      emit(),
+      ts.ScriptTarget.ESNext,
+      true,
+      ts.ScriptKind.TS
+    )
+    assert.deepStrictEqual(
+      (sf.parseDiagnostics ?? []).map((d) =>
+        ts.flattenDiagnosticMessageText(d.messageText, ' ')
+      ),
+      []
+    )
+  })
+
+  test('imports PikkuRPC from the path it was given', () => {
+    assert.match(emit(), /import \{ PikkuRPC \} from '\.\.\/pikku-rpc\.gen\.js'/)
+  })
+
+  test('falls back to the page origin instead of throwing in the browser', () => {
+    const content = emit()
+
+    assert.match(content, /return window\.location\.origin \+ '\/api'/)
+    assert.doesNotMatch(
+      content.split('if (import.meta.env.SSR)')[0]!,
+      /throw new Error/
+    )
+  })
+
+  test('ignores a localhost base served from a real origin', () => {
+    const content = emit()
+
+    assert.match(content, /const remote = !LOCAL_HOSTNAME\.test\(window\.location\.hostname\)/)
+    assert.match(content, /if \(configured && !\(remote && LOCAL_BASE\.test\(configured\)\)\)/)
+  })
+
+  test('reads a runtime binding during SSR, where there is no origin', () => {
+    const content = emit()
+    const ssr = content.split('if (import.meta.env.SSR)')[1]!
+
+    assert.match(ssr, /env\?\.PIKKU_API_URL \?\? env\?\.VITE_API_URL \?\? configured/)
+    assert.match(ssr, /throw new Error/)
+  })
+
+  test('reaches process through globalThis, so a browser tsconfig still builds', () => {
+    assert.match(emit(), /\(globalThis as \{ process\?: /)
+    assert.doesNotMatch(emit(), /(?<!globalThis as \{ )\bprocess\.env\b/)
+  })
+})

--- a/packages/cli/src/functions/runtimes/tanstack-start/serialize-tanstack-start-shim.ts
+++ b/packages/cli/src/functions/runtimes/tanstack-start/serialize-tanstack-start-shim.ts
@@ -3,8 +3,9 @@
  *
  * The "server function" is a Pikku function; this shim is a typed *caller* over
  * the generated RPC map (`PikkuRPC`) for use in Start loaders, actions and
- * components. The API base URL comes from `import.meta.env.VITE_API_URL` and the
- * shim throws if it is unset — never hardcode a host.
+ * components. The base URL is derived from the page origin in the browser and
+ * from a runtime binding during SSR — never hardcoded, and never taken from a
+ * build-time variable alone, which is undefined in a deployed bundle.
  *
  * @param rpcWiringsPath - import path to the file exporting the `PikkuRPC` class
  */
@@ -17,19 +18,41 @@ export const serializeTanStackStartShim = (rpcWiringsPath: string): string => {
  *
  *   loader: () => makeApi().invoke('listCards', {})
  *
- * The API base URL is read from \`import.meta.env.VITE_API_URL\`.
+ * In the browser the base URL is \`import.meta.env.VITE_API_URL\` when the build
+ * inlined one, otherwise the page's own origin + /api. During SSR it comes from
+ * \`PIKKU_API_URL\` / \`VITE_API_URL\` in the environment, since there is no page
+ * to derive it from.
  */
 import { PikkuRPC } from '${rpcWiringsPath}'
 
-export function makeApi(): PikkuRPC {
-  const serverUrl = import.meta.env.VITE_API_URL
-  if (!serverUrl) {
-    throw new Error(
-      'VITE_API_URL is not set — point it at the Pikku API base URL'
-    )
+const LOCAL_HOSTNAME = /^(localhost|127\\.0\\.0\\.1)$/
+const LOCAL_BASE = /\\/\\/(localhost|127\\.0\\.0\\.1)(:|\\/)/
+
+export function apiBaseUrl(): string {
+  const configured = import.meta.env.VITE_API_URL
+
+  if (import.meta.env.SSR) {
+    const env = (globalThis as { process?: { env?: Record<string, string | undefined> } })
+      .process?.env
+    const serverUrl = env?.PIKKU_API_URL ?? env?.VITE_API_URL ?? configured
+    if (!serverUrl) {
+      throw new Error(
+        'No API base URL during SSR — set VITE_API_URL for local dev, or bind PIKKU_API_URL on the deployed server'
+      )
+    }
+    return serverUrl
   }
+
+  const remote = !LOCAL_HOSTNAME.test(window.location.hostname)
+  if (configured && !(remote && LOCAL_BASE.test(configured))) {
+    return configured
+  }
+  return window.location.origin + '/api'
+}
+
+export function makeApi(): PikkuRPC {
   const rpc = new PikkuRPC()
-  rpc.setServerUrl(serverUrl)
+  rpc.setServerUrl(apiBaseUrl())
   return rpc
 }
 `


### PR DESCRIPTION
`makeApi()` read `import.meta.env.VITE_API_URL` and threw `VITE_API_URL is not set` when it was absent — which is what happens in every deployed bundle. Fabric binds `VITE_API_URL` as a **runtime** binding on the worker (`app-assets.service.ts`), invisible to Vite at build time, so the read is `undefined` and the first loader to call it threw.

Codegen was shipping the exact failure #1409 now fails projects for.

The generated shim derives the base instead:

- **Browser** — the inlined value when the build had one, otherwise `window.location.origin + '/api'`. A configured base pointing at localhost while the page is served from a real origin is ignored: the browser can't reach it, so it's a stray dev value.
- **SSR** — `PIKKU_API_URL` then `VITE_API_URL` from the environment, since there's no page to derive from. This is the only path that still throws, and it now names both variables. The env is reached via `globalThis`, so the emitted file type-checks under a browser-only tsconfig with no Node types.

`apiBaseUrl()` is exported alongside `makeApi()` for callers that need the base without a client. Same resolution both shipping app templates already use.

The file had no tests; it has six now, including a parse check on the emitted output.