### PR TITLE
feat(nav-dock): let the dock's size be a preference

### DIFF
--- a/.changeset/nav-dock-size-preference.md
+++ b/.changeset/nav-dock-size-preference.md
@@ -1,0 +1,29 @@
+---
+'@pikku/console': patch
+---
+
+feat(nav-dock): let the dock's size be a preference
+
+The dock sized itself entirely from the window. One measured tile drove
+everything — the glyph, its stroke weight, the gap, the capsule's thickness, the
+inset it reserves — and that tile was whatever fitted the shorter window edge,
+capped at 54px. On a large display that cap is the only thing in force, so the
+dock is the same physical size on a 13" laptop and a 32" monitor, which means it
+reads as comfortable on one and tiny on the other. Density is not something the
+window can answer; it depends on how far away the person is sitting.
+
+`useDockPrefs` now carries a `scale` percent alongside `side` and
+`alwaysVisible`, persisted per browser as `nav-dock-scale` and defaulting to
+100. It moves the whole tile band rather than overriding the fit: the loop still
+shrinks the row until it fits the window, so asking for 160% on a narrow laptop
+gets you the largest tile that will actually hold the full row instead of a
+clipped one. The reserved edge inset follows the measured tile as it always has,
+so a larger dock takes the space it needs and the page stops where it starts.
+
+The control is a slider, because the answer is a comfortable size rather than
+one of four named ones. `FlyoutRow` grows a `slider` variant for it — a row that
+draws a track under its label, reports the live value as its hint, and stays
+open while you drag, since a menu that closed on release would hide the thing
+being sized at the moment you want to look at it. It is a plain element rather
+than a `Menu.Item` so the pointer and the arrow keys reach the slider instead of
+the menu's roving focus.

--- a/packages/console/messages/en.json
+++ b/packages/console/messages/en.json
@@ -635,6 +635,7 @@
   "nav_language": "Language",
   "nav_dock": "Dock",
   "nav_dock_always_visible": "Always visible",
+  "nav_dock_size": "Size",
   "nav_dock_bottom": "Bottom",
   "nav_dock_top": "Top",
   "nav_dock_left": "Left",

--- a/packages/console/src/components/nav-dock/ConsoleNavDock.tsx
+++ b/packages/console/src/components/nav-dock/ConsoleNavDock.tsx
@@ -15,6 +15,7 @@ import {
   Palette,
   PanelBottom,
   Pin,
+  Scaling,
   RefreshCw,
   Search,
   Share,
@@ -30,7 +31,14 @@ import {
   promptInstall,
   subscribeInstallPrompt,
 } from '../../lib/installPrompt'
-import { DOCK_SIDES, useDockPrefs, type DockSide } from './useDockPrefs'
+import {
+  DOCK_SCALE_MAX,
+  DOCK_SCALE_MIN,
+  DOCK_SCALE_STEP,
+  DOCK_SIDES,
+  useDockPrefs,
+  type DockSide,
+} from './useDockPrefs'
 import { useLocation, useNavigate } from '../../router'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
 import { useOptionalAuth } from '../../context/AuthContext'
@@ -234,6 +242,19 @@ export function ConsoleNavDock({
             label: m.nav_dock_always_visible(),
             checked: dock.alwaysVisible,
             onSelect: () => dock.setAlwaysVisible(!dock.alwaysVisible),
+          },
+          {
+            key: 'scale',
+            Icon: Scaling,
+            label: m.nav_dock_size(),
+            slider: {
+              value: dock.scale,
+              min: DOCK_SCALE_MIN,
+              max: DOCK_SCALE_MAX,
+              step: DOCK_SCALE_STEP,
+              format: (value: number) => `${value}%`,
+              onChange: dock.setScale,
+            },
           },
           ...DOCK_SIDES.map((side) => ({
             key: `side-${side}`,

--- a/packages/console/src/components/nav-dock/DockFlyout.tsx
+++ b/packages/console/src/components/nav-dock/DockFlyout.tsx
@@ -1,4 +1,4 @@
-import { Menu } from '@pikku/mantine/core'
+import { Menu, Slider } from '@pikku/mantine/core'
 import { m } from '@/i18n/messages'
 import type { DockMenu, DockTile, FlyoutRow } from './model'
 import classes from './NavDock.module.css'
@@ -117,6 +117,35 @@ function Row({
           ))}
         </Menu.Sub.Dropdown>
       </Menu.Sub>
+    )
+  }
+
+  /* A range, not a set of alternatives. A div rather than a Menu.Item because a
+     menu item swallows the pointer and the arrow keys the slider needs — and
+     closing the menu on release would put the thing you are sizing out of sight
+     exactly when you want to see it. */
+  if (row.slider) {
+    const { value, min, max, step, format, onChange } = row.slider
+    return (
+      <div
+        className={classes.fiSlider}
+        onKeyDown={(e) => e.stopPropagation()}
+        data-testid={`flyout-slider-${row.key}`}
+      >
+        <div className={classes.fiSliderHead}>
+          <Body row={{ ...row, hint: format ? format(value) : String(value) }} />
+        </div>
+        <Slider
+          value={value}
+          min={min}
+          max={max}
+          step={step}
+          onChange={onChange}
+          label={null}
+          size="sm"
+          aria-label={row.label}
+        />
+      </div>
     )
   }
 

--- a/packages/console/src/components/nav-dock/NavDock.module.css
+++ b/packages/console/src/components/nav-dock/NavDock.module.css
@@ -859,6 +859,32 @@
   fill: transparent;
 }
 
+/* A range row. Same insets as an item so the label column still lines up down
+   the menu, with the track hanging under it rather than beside it — a track
+   squeezed into the end slot is too short to aim with. */
+.fiSlider {
+  width: 100%;
+  padding: 5px 10px 12px;
+  color: var(--app-text-dim);
+  font-size: 13px;
+}
+
+.fiSliderHead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 34px;
+}
+
+.fiSliderHead > svg {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  stroke-width: calc(2 * var(--pf-stitch-weight, 1));
+  fill: transparent;
+}
+
 /* ---------- which edge the dock sits on ---------- */
 
 /* Four sides, one geometry with the axis swapped — so what follows only

--- a/packages/console/src/components/nav-dock/NavDock.tsx
+++ b/packages/console/src/components/nav-dock/NavDock.tsx
@@ -110,7 +110,7 @@ export function NavDock({
   /* Read here rather than taken as props: the menu that changes them is a tile
      inside the dock, so an app threading them through would only get a chance
      to disagree with the dock about where it is. */
-  const { side, alwaysVisible, setAlwaysVisible } = useDockPrefs()
+  const { side, alwaysVisible, setAlwaysVisible, scale } = useDockPrefs()
   const vertical = isVerticalDock(side)
   const [hovering, setHovering] = useState(false)
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null)
@@ -192,12 +192,17 @@ export function NavDock({
     // reads as a different object, not the same one on another edge.
     const avail = Math.min(window.innerWidth, window.innerHeight) - 26
     const measure = () => (vertical ? el.scrollHeight : el.scrollWidth)
-    let t = TILE_MAX
+    // The user's scale moves the whole band, ceiling and floor together: it is
+    // the size they asked for, and the loop below still takes it back down to
+    // whatever the window can actually hold.
+    const max = Math.round(TILE_MAX * (scale / 100))
+    const min = Math.min(Math.round(TILE_MIN * (scale / 100)), max)
+    let t = max
     applyTile(el, t)
-    for (let i = 0; i < 5 && t > TILE_MIN; i++) {
+    for (let i = 0; i < 5 && t > min; i++) {
       const need = measure()
       if (need <= avail) break
-      t = Math.max(TILE_MIN, Math.floor(t * (avail / need)))
+      t = Math.max(min, Math.floor(t * (avail / need)))
       applyTile(el, t)
     }
     reserve(alwaysVisible ? t : null)
@@ -206,7 +211,7 @@ export function NavDock({
     // whole contextual zone collapses into one.
     if (over && contextual.length) setCondensed(true)
     setOverflow(over)
-  }, [contextual.length, vertical, alwaysVisible, reserve])
+  }, [contextual.length, vertical, alwaysVisible, reserve, scale])
 
   useLayoutEffect(() => {
     fit()

--- a/packages/console/src/components/nav-dock/model.ts
+++ b/packages/console/src/components/nav-dock/model.ts
@@ -45,6 +45,19 @@ export interface FlyoutRow {
   /** Whether the setting is one of a set of alternatives (a radio) or a switch
    *  of its own (a checkbox) — which is what a screen reader announces. */
   exclusive?: boolean
+  /** A continuous setting rather than a choice between named ones: the row
+   *  draws a slider under its label and reports the live value as its hint. It
+   *  never closes the menu — you are dragging towards an answer, not picking
+   *  one. */
+  slider?: {
+    value: number
+    min: number
+    max: number
+    step: number
+    /** How the live value reads in the row's hint (e.g. `120%`). */
+    format?: (value: number) => string
+    onChange: (value: number) => void
+  }
   /** Child rows, drawn as a submenu. A row with children has no action of its
    *  own — opening it IS the action — so `onSelect` is ignored. */
   rows?: FlyoutRow[]

--- a/packages/console/src/components/nav-dock/useDockPrefs.ts
+++ b/packages/console/src/components/nav-dock/useDockPrefs.ts
@@ -7,6 +7,11 @@ export const DOCK_SIDES: DockSide[] = ['bottom', 'top', 'left', 'right']
 export const isVerticalDock = (side: DockSide) =>
   side === 'left' || side === 'right'
 
+/** Percent of the dock's natural size. */
+export const DOCK_SCALE_MIN = 70
+export const DOCK_SCALE_MAX = 160
+export const DOCK_SCALE_STEP = 5
+
 /**
  * How the user wants the dock to behave, persisted per browser.
  *
@@ -29,5 +34,13 @@ export function useDockPrefs() {
     defaultValue: true,
     getInitialValueInEffect: false,
   })
-  return { side, setSide, alwaysVisible, setAlwaysVisible }
+  /* A ceiling, not an override: the fit still shrinks the row to whatever the
+     window can hold, so asking for 160% on a narrow laptop simply gets you the
+     largest tile that fits. */
+  const [scale, setScale] = useLocalStorage({
+    key: 'nav-dock-scale',
+    defaultValue: 100,
+    getInitialValueInEffect: false,
+  })
+  return { side, setSide, alwaysVisible, setAlwaysVisible, scale, setScale }
 }

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -80,6 +80,9 @@ export { DockFlyout } from './components/nav-dock/DockFlyout'
 // such an app replaces wholesale. Without this the app's only way to reach them
 // is to restate the storage keys and hope they never change.
 export {
+  DOCK_SCALE_MAX,
+  DOCK_SCALE_MIN,
+  DOCK_SCALE_STEP,
   DOCK_SIDES,
   isVerticalDock,
   useDockPrefs,


### PR DESCRIPTION
## Why

The dock sizes itself entirely from the window. One measured tile drives everything — the glyph, its stroke weight, the gap, the capsule's thickness, the edge inset it reserves — and that tile is whatever fits the shorter window edge, capped at `TILE_MAX` (54px).

On any large display the cap is the only thing in force, so the dock ends up the same physical size on a 13" laptop and a 32" monitor. It reads as comfortable on one and tiny on the other. How dense the row should be isn't something the window can answer; it depends on how far away the person is sitting.

## What

- `useDockPrefs` carries a `scale` percent alongside `side` and `alwaysVisible`, persisted per browser as `nav-dock-scale`, default 100, band 70–160 in steps of 5.
- The fit loop scales the whole tile band (`TILE_MAX * scale`, with a matching floor) rather than overriding the clamp. The loop still shrinks the row until it fits, so asking for 160% on a narrow laptop gets you the largest tile that actually holds the full row instead of a clipped one. The reserved edge inset follows the measured tile as it always has.
- `FlyoutRow` grows a `slider` variant, rendered by `DockFlyout`: a track under the label, the live value as the row's hint, no close on release. It's a plain element rather than a `Menu.Item` so the pointer and the arrow keys reach the slider instead of the menu's roving focus.
- `ConsoleNavDock` gets a **Size** row in its Dock section.
- `DOCK_SCALE_MIN`/`MAX`/`STEP` are exported next to `DOCK_SIDES`, so an app that replaces `ConsoleNavDock` wholesale can offer the same control from its own account tile.

## Notes

- Only `messages/en.json` gains `nav_dock_size` — `de`/`ar`/`zh` carry no `nav_dock` keys at all today, so adding one there would be the odd key out.
- A slider was the right shape here rather than named steps (Small/Default/Large): the answer is a comfortable size, not one of four labels. That's why the model addition was worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)