### PR TITLE
fix(cli): type the shadow-exempt set so a project opting none in still compiles

### DIFF
--- a/.changeset/setup-types-empty-shadow-set.md
+++ b/.changeset/setup-types-empty-shadow-set.md
@@ -1,0 +1,13 @@
+---
+'@pikku/cli': patch
+---
+
+fix(cli): type the shadow-exempt set so a project that opts none in still compiles
+
+The shadowed-services warning emitted `new Set([])` when a project declared no
+`allowShadowedServices`, and TypeScript infers that as `Set<never>` — so the
+`allowedToShadow.has(name)` on the next line failed to compile with a `string`.
+It type-checked only for a project that had opted at least one service in, and
+no project in the repo has, so every build broke on the generated setup types.
+
+Emitted as `new Set<string>([])`.

--- a/packages/cli/src/functions/wirings/setup/serialize-setup-types.test.ts
+++ b/packages/cli/src/functions/wirings/setup/serialize-setup-types.test.ts
@@ -40,13 +40,22 @@ describe('serializeSetupTypes', () => {
   test('warns when the factory shadows a service the host passed in', () => {
     const content = emit('Config')
 
-    assert.match(content, /const shadowed = Object\.keys\(createdServices\)\.filter\(/)
+    assert.match(
+      content,
+      /const shadowed = Object\.keys\(createdServices\)\.filter\(/
+    )
     assert.match(content, /logger\?\.warn\?\.\(/)
     assert.match(content, /discarding what the host passed in/)
   })
 
   test('exempts nothing when the project opts none in', () => {
-    assert.match(emit('Config'), /const allowedToShadow = new Set\(\[\]\)/)
+    // Typed, not inferred: an empty literal infers Set<never>, and the
+    // `.has(name)` below is then a compile error in every project that opts none
+    // in — which is every project by default.
+    assert.match(
+      emit('Config'),
+      /const allowedToShadow = new Set<string>\(\[\]\)/
+    )
   })
 
   test('exempts the services pikku.config.json opts in', () => {
@@ -54,13 +63,16 @@ describe('serializeSetupTypes', () => {
 
     assert.match(
       content,
-      /const allowedToShadow = new Set\(\["kysely","secrets"\]\)/
+      /const allowedToShadow = new Set<string>\(\["kysely","secrets"\]\)/
     )
     assert.match(content, /!allowedToShadow\.has\(name\) &&/)
   })
 
   test('points at the config key as the way to silence the warning', () => {
-    assert.match(emit('Config'), /allowShadowedServices\\` in pikku\.config\.json/)
+    assert.match(
+      emit('Config'),
+      /allowShadowedServices\\` in pikku\.config\.json/
+    )
   })
 
   test('registers the wire services factory on pikku state', () => {

--- a/packages/cli/src/functions/wirings/setup/serialize-setup-types.ts
+++ b/packages/cli/src/functions/wirings/setup/serialize-setup-types.ts
@@ -67,7 +67,7 @@ export const pikkuServices = (
   return async (config: Config, existingServices: Partial<SingletonServices> = {}) => {
     const createdServices = await func(config, existingServices)
     const services = { ...existingServices, ...createdServices }
-    const allowedToShadow = new Set(${JSON.stringify(allowShadowedServices)})
+    const allowedToShadow = new Set<string>(${JSON.stringify(allowShadowedServices)})
     const shadowed = Object.keys(createdServices).filter(
       (name) =>
         !allowedToShadow.has(name) &&


### PR DESCRIPTION
main has been red since #1412 landed. The Build job fails on the CLI's own generated setup types:

```
.pikku/setup/pikku-setup-types.gen.ts(63,30): error TS2345:
  Argument of type 'string' is not assignable to parameter of type 'never'.
```

#1412 added a shadowed-services warning to the setup-types serializer. It emits
`new Set(${JSON.stringify(allowShadowedServices)})`, which for a project that
declares no `allowShadowedServices` becomes `new Set([])` — inferred as
`Set<never>`, so the `allowedToShadow.has(name)` on the next line will not
compile with a `string`.

It type-checks only for a project that has opted at least one service in, and no
project in this repo has, so every build broke.

Emitted as `new Set<string>(...)` instead.

Tests: the two serializer tests that pin the emitted `Set` were updated to
require the type argument, and fail against the old emitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated TypeScript output for empty shadow-service configurations by preserving an explicit `string` type.
  * Prevented type inference errors when no services are configured to allow shadowing.
  * Maintained existing shadowing warnings, guidance, and runtime behavior.

* **Tests**
  * Added coverage for empty and configured shadow-service sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->