### PR TITLE
fix(cli): fail validate when a scenario step hardcodes catalogue copy

### DIFF
--- a/.changeset/scenario-hardcoded-copy.md
+++ b/.changeset/scenario-hardcoded-copy.md
@@ -1,0 +1,12 @@
+---
+'@pikku/cli': patch
+'@pikku/skills': patch
+---
+
+Fail `pikku fabric validate` when a scenario step hardcodes a string the message catalogue already owns.
+
+A browser step that says `getByLabel('Full Name')` passes only while the app happens to render the base locale, and any copy edit turns it into a selector timeout that points at the wizard rather than at the rename that caused it. Validate now reads each `apps/<app>/messages/<baseLocale>.json` and errors on any string in a `*.steps.ts` / `*.scenario.ts` that is verbatim a catalogue value, naming the key to use.
+
+It scans every literal rather than only the ones sitting in a `getBy*` call, because copy passed to a project helper — `pick('Where would you like to work?', …)` — reaches the DOM just the same. Comments are stripped first, since the prose around a step quotes the copy it is explaining. A project with no inlang app is not scanned, and a string the catalogue does not own (a test id, a fixture filename) is left alone.
+
+The `pikku-scenario` skill gains the corresponding rule, including typing the lookup off the catalogue JSON rather than the generated Paraglide output, so a renamed key is a compile error instead of a run-time timeout.

--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -2633,3 +2633,137 @@ describe('deployed frontend API base (live validate.function)', () => {
     }
   })
 })
+
+describe('scenario steps vs the message catalogue (live validate.function)', () => {
+  const writeCatalogue = async (
+    root: string,
+    messages: Record<string, string>
+  ) => {
+    await mkdir(join(root, 'apps', 'web', 'project.inlang'), {
+      recursive: true,
+    })
+    await mkdir(join(root, 'apps', 'web', 'messages'), { recursive: true })
+    await writeJson(join(root, 'apps', 'web', 'package.json'), {
+      name: '@project/web',
+      type: 'module',
+      dependencies: { react: '^19.0.0' },
+    })
+    await writeJson(join(root, 'apps', 'web', 'project.inlang', 'settings.json'), {
+      baseLocale: 'en',
+      locales: ['en', 'de'],
+    })
+    await writeJson(join(root, 'apps', 'web', 'messages', 'en.json'), messages)
+  }
+
+  const writeSteps = async (root: string, source: string) => {
+    const dir = join(root, 'packages', 'functions', 'tests', 'scenarios')
+    await mkdir(dir, { recursive: true })
+    await writeFile(join(dir, 'application.steps.ts'), source, 'utf8')
+  }
+
+  const hardcoded = (findings: Array<{ id: string }>) =>
+    findings.filter((f) => f.id.startsWith('scenario-hardcoded-copy-'))
+
+  const ids = (findings: Array<{ id: string }>) =>
+    JSON.stringify(findings.map((f) => f.id))
+
+  test('a locator repeating catalogue copy → error naming the key', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await writeCatalogue(tmp, { jobs_apply_fullname: 'Full Name' })
+      await writeSteps(tmp, `await page.getByLabel('Full Name').fill(name)\n`)
+      const result = await runValidate(tmp, { skipTypecheck: true })
+      const [finding] = hardcoded(result.findings)
+      assert.ok(finding, `expected a finding, got: ${ids(result.findings)}`)
+      assert.strictEqual(finding!.severity, 'error')
+      assert.match(finding!.fixHint, /jobs_apply_fullname/)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('copy passed to a project helper is caught too', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await writeCatalogue(tmp, {
+        jobs_worklocation: 'Where would you like to work?',
+      })
+      await writeSteps(
+        tmp,
+        `await pick('Where would you like to work?', 'Berlin')\n`
+      )
+      const result = await runValidate(tmp, { skipTypecheck: true })
+      assert.ok(
+        hardcoded(result.findings).length === 1,
+        `expected a finding, got: ${ids(result.findings)}`
+      )
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('copy quoted in a comment is not a locator', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await writeCatalogue(tmp, { common_yes: 'Yes' })
+      await writeSteps(
+        tmp,
+        [
+          `/**`,
+          ` * A dozen selects each offer "Yes", so the lookup is scoped.`,
+          ` */`,
+          `// the "Yes" option is ambiguous page-wide`,
+          `await scoped.getByRole('option', { name: yesLabel }).click()`,
+          ``,
+        ].join('\n')
+      )
+      const result = await runValidate(tmp, { skipTypecheck: true })
+      assert.deepStrictEqual(
+        hardcoded(result.findings),
+        [],
+        `expected no finding, got: ${ids(result.findings)}`
+      )
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('a string the catalogue does not own is left alone', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await writeCatalogue(tmp, { jobs_apply_fullname: 'Full Name' })
+      await writeSteps(
+        tmp,
+        `await page.getByText('favicon-16x16.png').waitFor()\n`
+      )
+      const result = await runValidate(tmp, { skipTypecheck: true })
+      assert.deepStrictEqual(
+        hardcoded(result.findings),
+        [],
+        `expected no finding, got: ${ids(result.findings)}`
+      )
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('a project with no inlang app is not scanned', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await writeSteps(tmp, `await page.getByLabel('Full Name').fill(name)\n`)
+      const result = await runValidate(tmp, { skipTypecheck: true })
+      assert.deepStrictEqual(
+        hardcoded(result.findings),
+        [],
+        `expected no finding, got: ${ids(result.findings)}`
+      )
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/fabric/functions/validate.function.ts
+++ b/packages/cli/src/fabric/functions/validate.function.ts
@@ -1761,6 +1761,76 @@ export async function runValidate(
     }
   }
 
+  // ── scenario steps must locate by i18n key, not rendered copy ──────────
+  // A browser step that says getByLabel('Full Name') passes only while the app
+  // happens to render the base locale, and a copy edit breaks it as a timeout
+  // on a selector — the failure points at the wizard rather than at the rename
+  // that caused it. Any literal in a step file that is verbatim a value in the
+  // base catalogue is that mistake: the catalogue already holds the string
+  // under a key the test can read. Comments are stripped first, because the
+  // prose around a step quotes the copy it is explaining.
+  {
+    const relFile = (p: string): string =>
+      p.slice(root.length + 1).replace(/\\/g, '/')
+
+    const keysByValue = new Map<string, string[]>()
+    const appsRoot = join(root, 'apps')
+    if (existsSync(appsRoot)) {
+      for (const ent of await readdir(appsRoot, { withFileTypes: true })) {
+        if (!ent.isDirectory()) continue
+        const appPath = join(appsRoot, ent.name)
+        const settings = await readJsonSafe<{ baseLocale?: string }>(
+          join(appPath, 'project.inlang', 'settings.json')
+        )
+        if (!settings) continue
+        const catalogue = await readJsonSafe<Record<string, unknown>>(
+          join(appPath, 'messages', `${settings.baseLocale ?? 'en'}.json`)
+        )
+        if (!catalogue) continue
+        for (const [key, value] of Object.entries(catalogue)) {
+          if (typeof value !== 'string' || value.trim().length < 2) continue
+          const owners = keysByValue.get(value) ?? []
+          owners.push(key)
+          keysByValue.set(value, owners)
+        }
+      }
+    }
+
+    if (keysByValue.size > 0) {
+      const STRING_LITERAL =
+        /(?<![A-Za-z0-9_$])(['"])((?:[^\\\n]|\\.){2,200}?)\1/g
+      for (const file of await walkSourceFiles(root)) {
+        if (!/\.(steps|scenario)\.tsx?$/.test(file)) continue
+        const text = await readTextSafe(file)
+        if (!text) continue
+        const code = text
+          .replace(/\/\*[\s\S]*?\*\//g, '')
+          .replace(/(^|[^:'"`\\])\/\/[^\n]*/g, '$1')
+        const hits: string[] = []
+        for (const match of code.matchAll(STRING_LITERAL)) {
+          const literal = match[2]
+          if (!literal) continue
+          const keys = keysByValue.get(literal)
+          if (keys) hits.push(`"${literal}" → ${keys.join(' | ')}`)
+        }
+        if (hits.length === 0) continue
+        e(
+          `scenario-hardcoded-copy-${relFile(file).replace(/[^a-z0-9]/gi, '-')}`,
+          `${relFile(file)} hardcodes ${hits.length} string(s) the message catalogue already owns — the step passes only while the app renders the base locale, and a copy edit breaks it as an unexplained selector timeout`,
+          file,
+          lines(
+            'Read each string from the catalogue instead of repeating it:',
+            ...hits.slice(0, 10).map((h) => `  - ${h}`),
+            ...(hits.length > 10 ? [`  …and ${hits.length - 10} more`] : []),
+            'Type the lookup off the catalogue so a renamed key is a compile error:',
+            "  import type messages from '<app>/messages/<baseLocale>.json'",
+            '  export type MessageKey = keyof typeof messages'
+          )
+        )
+      }
+    }
+  }
+
   // ── packages/theme + packages/components ──────────────────────────────
   const designDocUrl = 'https://pikkufabric.dev/docs/design'
   const designSeverity = hasMantineFrontend ? w : info

--- a/packages/skills/skills/pikku-scenario/SKILL.md
+++ b/packages/skills/skills/pikku-scenario/SKILL.md
@@ -534,6 +534,32 @@ export const opensTheCart = pikkuScenarioStep<
 - `pikku scenario run <env> --no-browser` **skips** scenarios containing browser steps and reports them as skipped — it does not fail them. That is how a machine with no browser stays green.
 - Playwright auto-waits; do not wrap `page.click` in `expectEventually`.
 
+#### Locate by message key, never by rendered copy
+
+If the app is translated, **no step may contain a user-visible string.** `getByLabel('Full Name')` passes only while the browser happens to render the base locale, and any copy edit turns it into a selector timeout that points at the wizard rather than at the rename that caused it — the test looks broken where it is merely stale.
+
+The message catalogue already holds the string under a key. Read it from there. Type the lookup off the catalogue JSON so a renamed or misspelled key is a **compile** error rather than a run-time timeout:
+
+```typescript
+// tests/scenarios/i18n.ts
+import type messages from '../../../../apps/web/messages/en.json'
+
+export type MessageKey = keyof typeof messages
+
+export const t = (key: MessageKey, locale = baseLocale): string => { /* … */ }
+```
+
+```typescript
+await page.getByLabel(t('jobs_apply_fullname')).fill(identity.name)
+await page.getByRole('button', { name: t('jobs_apply_submit'), exact: true }).click()
+```
+
+- Type off `messages/<baseLocale>.json`, **not** the generated Paraglide output — `i18n/paraglide/` is build output, so typing against it makes the tests unbuildable until the app has been built. The JSON is the tracked source.
+- Fall back to the base locale for a key a locale has not translated. That is what Paraglide does at run time, so a helper that throws instead would disagree with the screen the test is looking at.
+- This is not only about locators. A copy literal passed to a **project helper** (`pick('Where would you like to work?', …)`) reaches the DOM the same way, and so does a pane name quoted back in a failure message. `pikku fabric validate` scans every string in a `*.steps.ts` / `*.scenario.ts` against the base catalogue and errors on any verbatim match, wherever it sits.
+- A regex locator (`{ name: /^Next$/i }`) hides the literal but not the problem. `{ name: t('key'), exact: true }` is both stricter and locale-correct.
+- Strings the catalogue does not own — a test id, a fixture filename, a seeded value — stay literal. The catalogue is the test for whether something is copy.
+
 ## Configuration
 
 Personas, actors and environments live in `pikku.config.json`:
@@ -758,6 +784,7 @@ Services are plain objects — a Pikku function is pure business logic, so a moc
 | `sleep()` before asserting                          | Use `expectEventually`.                                                                                                     |
 | A step named `clicksAddToBasket` / `opensThePage`   | That is an action, not an intent. Name the step for what the actor wanted; put the clicking in a utility.                   |
 | A browser step that assumes it is already on a page | It can then only run mid-flow. Arrive first — check the URL, navigate if needed.                                            |
+| `getByLabel('Full Name')` in a translated app        | Passes only in the base locale, and a copy edit breaks it as an unexplained timeout. Locate by message key.                 |
 | A `browser` binding guarding `if (!browser)`        | The binding guarantees it. The guard hides the real error, which is a missing actor (`PKU677`).                             |
 | A step with a `func:` instead of a surface binding  | There is no `func` on a step. Bodies live under `default` / `browser` / `cli`; a step with none throws at load.             |
 | `expectEventually` in a `pikkuWorkflowFunc`         | `PKU675` — scenario-only.                                                                                                   |


### PR DESCRIPTION
## The bug this catches

heygermany's scenario suite located elements by rendered English:

```ts
await page.getByLabel('Full Name', { exact: false }).fill(identity.name)
await pick('Where would you like to work in Germany?', 'Berlin')
```

The app ships 11 locales. Those steps pass only while the browser happens to render `en`, and any copy edit turns them into a selector timeout that points at the wizard rather than at the rename that caused it — the test looks broken where it is merely stale.

A sweep of that suite against its own catalogue found **18** such literals.

## The check

`pikku fabric validate` reads each `apps/<app>/messages/<baseLocale>.json` (locale taken from `project.inlang/settings.json`) and errors on any string in a `*.steps.ts` / `*.scenario.ts` that is verbatim a catalogue value, naming the key to use.

Two deliberate choices:

- **Every literal, not just the ones inside a `getBy*` call.** The literal that actually broke heygermany was the first argument to a project helper (`pick(...)`), which reaches the DOM exactly the same way. So does a pane name quoted back in a failure message. Restricting the scan to Playwright locator positions would have missed the real bug.
- **Comments are stripped first.** The prose around a step quotes the copy it is explaining (`a dozen selects each offer "Yes"`). Without stripping, that JSDoc was the majority of the hits.

A project with no inlang app is not scanned, and a string the catalogue does not own — a test id, a fixture filename like `favicon-16x16.png` — is left alone. The catalogue is the test for whether something is copy.

## Skill

`pikku-scenario` gains the rule, including the part that is easy to get wrong: type the lookup off `messages/<baseLocale>.json`, **not** the generated Paraglide output. `i18n/paraglide/` is build output, so typing against it makes the tests unbuildable until the app has been built. Typing off the tracked JSON makes a renamed key a compile error instead of a run-time timeout:

```ts
import type messages from '../../../../apps/web/messages/en.json'
export type MessageKey = keyof typeof messages
```

The skill also notes falling back to the base locale for an untranslated key — that is what Paraglide does at run time, so a helper that throws instead would disagree with the screen the test is looking at.

## Tests

Five new cases in `validate.function.test.ts`: a locator repeating catalogue copy, copy passed to a project helper, copy quoted only in a comment, a string the catalogue does not own, and a project with no inlang app. Full CLI suite: 109/109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)