### PR TITLE
fix(cli): make @pikku/ws and ws optional peers resolved from the project

### DIFF
--- a/.changeset/cli-optional-websocket-peers.md
+++ b/.changeset/cli-optional-websocket-peers.md
@@ -1,0 +1,9 @@
+---
+'@pikku/cli': patch
+---
+
+Make `@pikku/ws` and `ws` optional peer dependencies instead of dependencies, and resolve them from the project rather than from the CLI.
+
+`@pikku/ws` peers on a `@pikku/core` range, so a copy sitting in the CLI's own tree gets paired with the CLI's core rather than the project's — the skew surfaced as `Cannot find module '@pikku/core/ecosystem'` from a package the project never imported. As an optional peer resolved against the project's `package.json`, there is one core in play, and a Bun project (which serves WebSockets natively through `@pikku/bun-server`) no longer installs a Node WebSocket stack it cannot use.
+
+`pikku dev` and `pikku serve` under Node now start over plain HTTP when the packages are absent, logging why, and `pikku validate` reports `websocket-deps-missing` as an error for a project that wires channels without them.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -63,6 +63,7 @@
     "@ai-sdk/openai-compatible": "^3.0.30",
     "@pikku/cli": "workspace:*",
     "@pikku/playwright": "workspace:*",
+    "@pikku/ws": "workspace:*",
     "@playwright/test": "^1.50.0",
     "@types/better-sqlite3": "^9.6.0",
     "@types/node": "^22",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,6 @@
     "@pikku/openapi-parser": "^0.12.20",
     "@pikku/schedule": "^0.12.7",
     "@pikku/skills": "^0.12.15",
-    "@pikku/ws": "^0.12.9",
     "@types/cookie": "^1.0.0",
     "@types/json-schema": "^7.0.15",
     "ai": "^7.0.66",
@@ -63,7 +62,6 @@
     "ts-json-schema-generator": "2.9.1-next.18",
     "tsx": "^4.23.12",
     "typescript": "^6.0.3",
-    "ws": "^8.21.3",
     "yaml": "^2.9.0",
     "zod": "^4.4.3",
     "zod-to-ts": "^2.1.0"
@@ -71,17 +69,21 @@
   "peerDependencies": {
     "@pikku/core": "^0.12.93",
     "@pikku/playwright": "^0.12.79",
-    "better-auth": "^1.6.0"
+    "@pikku/ws": "^0.12.9",
+    "better-auth": "^1.6.0",
+    "ws": "^8.21.3"
   },
   "devDependencies": {
     "@pikku/core": "^0.12.93",
     "@pikku/playwright": "^0.12.79",
+    "@pikku/ws": "^0.12.9",
     "@playwright/test": "^1.50.0",
     "@types/istanbul-lib-instrument": "^1.7.8",
     "@types/node": "^24.13.3",
     "@types/pg": "^8.21.0",
     "@types/semver": "^7.8.0",
-    "@types/ws": "^8"
+    "@types/ws": "^8",
+    "ws": "^8.21.3"
   },
   "files": [
     "dist",
@@ -104,7 +106,13 @@
     "@pikku/playwright": {
       "optional": true
     },
+    "@pikku/ws": {
+      "optional": true
+    },
     "better-auth": {
+      "optional": true
+    },
+    "ws": {
       "optional": true
     }
   }

--- a/packages/cli/src/functions/validate/shared-checks.ts
+++ b/packages/cli/src/functions/validate/shared-checks.ts
@@ -5,6 +5,11 @@ import { runKnowledgeValidate } from '@pikku/knowledge'
 import { runBootstrapChecks } from './bootstrap-checks.js'
 import { runPersonaChecks, type ValidateFinding } from './persona-checks.js'
 import { runScenarioFileChecks } from './scenario-file-checks.js'
+import {
+  projectWiresChannels,
+  runWebsocketDepsChecks,
+} from './websocket-deps-checks.js'
+import { resolveFromProject } from '../../utils/resolve-from-project.js'
 
 export type Finding = ValidateFinding
 
@@ -556,6 +561,21 @@ export async function runSharedProjectChecks(
 
   // ── server bootstrap ───────────────────────────────────────────────────
   findings.push(...(await runBootstrapChecks(root, rootPkg, pikkuConfig)))
+
+  findings.push(
+    ...runWebsocketDepsChecks({
+      root,
+      runtime:
+        typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined'
+          ? 'bun'
+          : 'node',
+      hasChannels: await projectWiresChannels(
+        root,
+        typeof pikkuConfig?.outDir === 'string' ? pikkuConfig.outDir : '.pikku'
+      ),
+      resolve: (specifier) => resolveFromProject(root, specifier),
+    })
+  )
 
   // ── personas, scenario files and the knowledge base ────────────────────
   findings.push(...(await runPersonaChecks(root, pikkuConfig)))

--- a/packages/cli/src/functions/validate/websocket-deps-checks.test.ts
+++ b/packages/cli/src/functions/validate/websocket-deps-checks.test.ts
@@ -1,0 +1,111 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  projectWiresChannels,
+  runWebsocketDepsChecks,
+} from './websocket-deps-checks.js'
+
+const installed = (...names: string[]) => {
+  const set = new Set(names)
+  return (specifier: string) =>
+    set.has(specifier) ? `/node_modules/${specifier}` : undefined
+}
+
+describe('websocket deps checks', () => {
+  test('says nothing when both packages resolve', () => {
+    const findings = runWebsocketDepsChecks({
+      root: '/project',
+      runtime: 'node',
+      hasChannels: true,
+      resolve: installed('@pikku/ws', 'ws'),
+    })
+    assert.deepEqual(findings, [])
+  })
+
+  test('says nothing under Bun, which serves WebSockets natively', () => {
+    const findings = runWebsocketDepsChecks({
+      root: '/project',
+      runtime: 'bun',
+      hasChannels: true,
+      resolve: installed(),
+    })
+    assert.deepEqual(findings, [])
+  })
+
+  test('says nothing when the project wires no channels', () => {
+    const findings = runWebsocketDepsChecks({
+      root: '/project',
+      runtime: 'node',
+      hasChannels: false,
+      resolve: installed(),
+    })
+    assert.deepEqual(findings, [])
+  })
+
+  test('errors when a channel-wiring Node project is missing them', () => {
+    const findings = runWebsocketDepsChecks({
+      root: '/project',
+      runtime: 'node',
+      hasChannels: true,
+      resolve: installed(),
+    })
+    assert.equal(findings.length, 1)
+    assert.equal(findings[0]!.id, 'websocket-deps-missing')
+    assert.equal(findings[0]!.severity, 'error')
+    assert.match(findings[0]!.message, /@pikku\/ws and ws/)
+  })
+
+  test('names only the package that is missing', () => {
+    const findings = runWebsocketDepsChecks({
+      root: '/project',
+      runtime: 'node',
+      hasChannels: true,
+      resolve: installed('@pikku/ws'),
+    })
+    assert.equal(findings.length, 1)
+    assert.match(findings[0]!.message, /^ws is not installed/)
+  })
+
+  test('points at the project package.json', () => {
+    const findings = runWebsocketDepsChecks({
+      root: '/project',
+      runtime: 'node',
+      hasChannels: true,
+      resolve: installed(),
+    })
+    assert.equal(findings[0]!.path, join('/project', 'package.json'))
+  })
+})
+
+describe('projectWiresChannels', () => {
+  const project = async (meta?: string) => {
+    const root = await mkdtemp(join(tmpdir(), 'pikku-ws-deps-'))
+    if (meta !== undefined) {
+      await mkdir(join(root, '.pikku', 'channel'), { recursive: true })
+      await writeFile(
+        join(root, '.pikku', 'channel', 'pikku-channels-meta.gen.json'),
+        meta
+      )
+    }
+    return root
+  }
+
+  test('is false when codegen has not run', async () => {
+    assert.equal(await projectWiresChannels(await project(), '.pikku'), false)
+  })
+
+  test('is false when no channel is wired', async () => {
+    assert.equal(
+      await projectWiresChannels(await project('{}'), '.pikku'),
+      false
+    )
+  })
+
+  test('is true when a channel is wired', async () => {
+    const root = await project('{"todos-live":{"name":"todos-live"}}')
+    assert.equal(await projectWiresChannels(root, '.pikku'), true)
+  })
+})

--- a/packages/cli/src/functions/validate/websocket-deps-checks.ts
+++ b/packages/cli/src/functions/validate/websocket-deps-checks.ts
@@ -1,0 +1,63 @@
+import { join } from 'node:path'
+import { readJsonSafe } from './shared-checks.js'
+import type { ValidateFinding } from './persona-checks.js'
+
+/**
+ * The packages the Node dev/serve path needs to speak WebSocket. Both are
+ * optional peers of `@pikku/cli`, because Bun serves WebSockets natively
+ * through `@pikku/bun-server` and a Bun project has no use for either.
+ */
+export const NODE_WEBSOCKET_PACKAGES = ['@pikku/ws', 'ws'] as const
+
+export type WebsocketDepsInput = {
+  root: string
+  /** The runtime the CLI is running on. Bun needs neither package. */
+  runtime: 'node' | 'bun'
+  /** Whether the project wires any channels. Nothing is reported when not. */
+  hasChannels: boolean
+  /** Resolves a specifier from the project. `undefined` when not installed. */
+  resolve: (specifier: string) => string | undefined
+}
+
+/**
+ * Reports the optional WebSocket peers when a Node-hosted project that wires
+ * channels is missing them.
+ *
+ * `pikku dev` / `pikku serve` under Node start over plain HTTP when the
+ * packages are absent, rather than failing: a project with no channels does not
+ * need them, and making them hard dependencies of the CLI is what put a second
+ * `@pikku/core` in the tree. That leaves a project that *does* wire channels
+ * with sockets that never connect and nothing pointing at the cause — which is
+ * this check.
+ */
+export function runWebsocketDepsChecks(
+  input: WebsocketDepsInput
+): ValidateFinding[] {
+  const { root, runtime, hasChannels, resolve } = input
+  if (runtime === 'bun' || !hasChannels) return []
+
+  const missing = NODE_WEBSOCKET_PACKAGES.filter((name) => !resolve(name))
+  if (missing.length === 0) return []
+
+  const named = missing.join(' and ')
+  return [
+    {
+      id: 'websocket-deps-missing',
+      severity: 'error',
+      message: `${named} ${missing.length > 1 ? 'are' : 'is'} not installed, but this project wires channels — \`pikku dev\` and \`pikku serve\` will start without WebSocket support and every channel connection will fail`,
+      path: join(root, 'package.json'),
+      fixHint: `Install ${NODE_WEBSOCKET_PACKAGES.join(' ')} in this project. They are optional peer dependencies of @pikku/cli so that Bun projects, which serve WebSockets natively, do not pull them in`,
+    },
+  ]
+}
+
+/** True when codegen produced at least one channel for this project. */
+export async function projectWiresChannels(
+  root: string,
+  outDir: string
+): Promise<boolean> {
+  const meta = await readJsonSafe<Record<string, unknown>>(
+    join(root, outDir, 'channel', 'pikku-channels-meta.gen.json')
+  )
+  return !!meta && Object.keys(meta).length > 0
+}

--- a/packages/cli/src/server/node-server-runner.ts
+++ b/packages/cli/src/server/node-server-runner.ts
@@ -2,15 +2,22 @@
  * Node dev server runner — `@pikku/node-http-server` + the `ws` WebSocketServer.
  * Used when the CLI runs under Node. Owns the WebSocketServer so teardown
  * (close ws then the http server) is encapsulated in the returned instance.
+ *
+ * `@pikku/ws` and `ws` are optional peers of the CLI, so they are imported
+ * dynamically and resolved from the *project* rather than from the CLI: both
+ * peer on `@pikku/core`, and a copy loaded out of the CLI's own tree is paired
+ * with the CLI's core instead of the project's. A project without them served
+ * over plain HTTP — `pikku validate` reports the missing packages.
  */
 
 import type { EventHubService } from '@pikku/core/channel'
 import type { Logger } from '@pikku/core/services'
 import { LocalEventHubService } from '@pikku/core/channel/local'
 import { PikkuNodeHTTPServer } from '@pikku/node-http-server'
-import { DEFAULT_WS_MAX_PAYLOAD, pikkuWebsocketHandler } from '@pikku/ws'
-import { WebSocketServer } from 'ws'
+import type * as PikkuWs from '@pikku/ws'
+import type * as Ws from 'ws'
 
+import { cjsInterop, importFromProject } from '../utils/resolve-from-project.js'
 import type {
   DevServerRunner,
   DevServerInstance,
@@ -18,8 +25,22 @@ import type {
   DevServerOptions,
 } from './dev-server-runner.interface.js'
 
+export const WEBSOCKET_PACKAGES_MISSING =
+  'WebSocket support is disabled: @pikku/ws and ws are not installed in this project. Install them (npm install @pikku/ws ws) to serve channels over Node.'
+
 export class NodeServerRunner implements DevServerRunner {
+  private pikkuWs?: typeof PikkuWs
+  private ws?: typeof Ws
+
+  constructor(private readonly rootDir: string) {}
+
   async createEventHub(): Promise<EventHubService<any>> {
+    this.pikkuWs = await importFromProject<typeof PikkuWs>(
+      this.rootDir,
+      '@pikku/ws'
+    )
+    const ws = await importFromProject<typeof Ws>(this.rootDir, 'ws')
+    this.ws = ws && cjsInterop(ws, 'WebSocketServer')
     return new LocalEventHubService()
   }
 
@@ -28,13 +49,22 @@ export class NodeServerRunner implements DevServerRunner {
     logger: Logger,
     options: DevServerOptions = {}
   ): DevServerInstance {
-    const wss = new WebSocketServer({
-      noServer: true,
-      maxPayload: DEFAULT_WS_MAX_PAYLOAD,
-    })
+    const { pikkuWs, ws } = this
+    if (!pikkuWs || !ws) {
+      logger.warn(WEBSOCKET_PACKAGES_MISSING)
+    }
+    const wss =
+      pikkuWs && ws
+        ? new ws.WebSocketServer({
+            noServer: true,
+            maxPayload: pikkuWs.DEFAULT_WS_MAX_PAYLOAD,
+          })
+        : undefined
     const server = new PikkuNodeHTTPServer(config, logger, {
       configureServer: (httpServer) => {
-        pikkuWebsocketHandler({ server: httpServer, wss, logger })
+        if (pikkuWs && wss) {
+          pikkuWs.pikkuWebsocketHandler({ server: httpServer, wss, logger })
+        }
       },
       contentSigningJWT: options.contentSigningJWT,
       // Read off this options object by the transport, not off `config` — so it
@@ -45,9 +75,11 @@ export class NodeServerRunner implements DevServerRunner {
       init: () => server.init(),
       start: () => server.start(),
       stop: async () => {
-        await new Promise<void>((resolve, reject) =>
-          wss.close((err) => (err ? reject(err) : resolve()))
-        )
+        if (wss) {
+          await new Promise<void>((resolve, reject) =>
+            wss.close((err) => (err ? reject(err) : resolve()))
+          )
+        }
         await server.stop()
       },
     }

--- a/packages/cli/src/services.ts
+++ b/packages/cli/src/services.ts
@@ -456,7 +456,9 @@ export const createSingletonServices: CreateSingletonServices<
     invalidateInspectorState,
     workflowService,
     bundler: isBun ? new BunBundler() : new NodeBundler(),
-    devServerRunner: isBun ? new BunServerRunner() : new NodeServerRunner(),
+    devServerRunner: isBun
+      ? new BunServerRunner()
+      : new NodeServerRunner(rootDir),
   }
 }
 

--- a/packages/cli/src/utils/resolve-from-project.test.ts
+++ b/packages/cli/src/utils/resolve-from-project.test.ts
@@ -1,0 +1,73 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type * as Ws from 'ws'
+
+import {
+  cjsInterop,
+  importFromProject,
+  resolveFromProject,
+} from './resolve-from-project.js'
+
+/** The CLI package root — a real project with `ws` installed. */
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+describe('resolveFromProject', () => {
+  test('resolves a package installed for the project', () => {
+    assert.match(resolveFromProject(projectRoot, 'ws') ?? '', /[\\/]ws[\\/]/)
+  })
+
+  test('is undefined for a package the project does not have', () => {
+    assert.equal(
+      resolveFromProject(projectRoot, '@pikku/not-a-real-package'),
+      undefined
+    )
+  })
+
+  test('is undefined for a directory that is not a project', () => {
+    assert.equal(resolveFromProject('/nowhere-at-all', 'ws'), undefined)
+  })
+})
+
+describe('importFromProject', () => {
+  test('is undefined rather than throwing when nothing resolves', async () => {
+    assert.equal(
+      await importFromProject(projectRoot, '@pikku/not-a-real-package'),
+      undefined
+    )
+  })
+})
+
+describe('cjsInterop', () => {
+  test('reaches the named exports of a CJS package imported by path', async () => {
+    const ws = await importFromProject<typeof Ws & { default?: typeof Ws }>(
+      projectRoot,
+      'ws'
+    )
+    assert.ok(ws, 'ws should resolve from the CLI package')
+
+    // The shape this interop exists for: imported by absolute path, `ws` comes
+    // back with no named exports at all. If Node ever starts reconstructing
+    // them, the interop stays correct and this assertion is what says so.
+    assert.ok('default' in ws)
+
+    const resolved = cjsInterop(ws, 'WebSocketServer')
+    assert.equal(typeof resolved.WebSocketServer, 'function')
+    const server = new resolved.WebSocketServer({ noServer: true })
+    server.close()
+  })
+
+  test('leaves a namespace that already has the export alone', () => {
+    const mod = {
+      WebSocketServer: 'named',
+      default: { WebSocketServer: 'cjs' },
+    }
+    assert.equal(cjsInterop(mod, 'WebSocketServer').WebSocketServer, 'named')
+  })
+
+  test('falls back to the namespace when there is no default either', () => {
+    const mod = { other: 1 } as { other: number; default?: { other: number } }
+    assert.equal(cjsInterop(mod, 'other').other, 1)
+  })
+})

--- a/packages/cli/src/utils/resolve-from-project.ts
+++ b/packages/cli/src/utils/resolve-from-project.ts
@@ -1,0 +1,53 @@
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+
+/**
+ * Resolves a package as the *project* would, not as the CLI would.
+ *
+ * The CLI is frequently run from somewhere that is not the project — `npx`
+ * unpacks it into `~/.npm/_npx/<hash>`, a monorepo hoists it to the workspace
+ * root — so a bare `import('pkg')` from CLI code finds the copy sitting next to
+ * the CLI. For a package that peers on `@pikku/core` that is the wrong copy:
+ * it gets paired with the CLI's core rather than the project's, and the version
+ * skew surfaces as a missing subpath export from a package the project never
+ * imported. Resolving against the project's own package.json keeps one core in
+ * play.
+ */
+export const resolveFromProject = (
+  rootDir: string,
+  specifier: string
+): string | undefined => {
+  try {
+    return createRequire(join(rootDir, 'package.json')).resolve(specifier)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Recovers a CommonJS package's exports from an import by path.
+ *
+ * Node reconstructs a CJS module's named exports only when it is imported by
+ * bare specifier. Imported by absolute path — which is the whole point of
+ * resolving from the project — the namespace carries `default` and nothing
+ * else, so a package like `ws`, which hangs `WebSocketServer` off
+ * `module.exports`, arrives with the constructor apparently missing. `probe` is
+ * the export that decides which of the two shapes came back.
+ */
+export const cjsInterop = <T>(mod: T, probe: string): T =>
+  probe in (mod as object)
+    ? mod
+    : (((mod as { default?: T }).default ?? mod) as T)
+
+/**
+ * Imports a package resolved from the project, or `undefined` when it is not
+ * installed there. Callers decide whether absence is fatal.
+ */
+export const importFromProject = async <T>(
+  rootDir: string,
+  specifier: string
+): Promise<T | undefined> => {
+  const resolved = resolveFromProject(rootDir, specifier)
+  if (!resolved) return undefined
+  return (await import(resolved)) as T
+}

--- a/packages/services/kysely-node-sqlite/src/node-sqlite-adapter.test.ts
+++ b/packages/services/kysely-node-sqlite/src/node-sqlite-adapter.test.ts
@@ -1,0 +1,74 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createNodeSqliteKysely } from './create-node-sqlite-kysely.js'
+
+interface DB {
+  widget: { id: number; name: string }
+}
+
+const withDb = async (fn: (db: ReturnType<typeof create>) => Promise<void>) => {
+  const db = create()
+  try {
+    await fn(db)
+  } finally {
+    await db.destroy()
+  }
+}
+
+const create = () =>
+  createNodeSqliteKysely<DB>({ filename: ':memory:', camelCase: false })
+
+describe('NodeSqliteDatabase', () => {
+  test('an insert reports its changes and row id', () =>
+    withDb(async (db) => {
+      await db.schema
+        .createTable('widget')
+        .addColumn('id', 'integer', (c) => c.primaryKey().autoIncrement())
+        .addColumn('name', 'text')
+        .execute()
+
+      const result = await db
+        .insertInto('widget')
+        .values({ name: 'first' })
+        .executeTakeFirstOrThrow()
+
+      assert.equal(result.numInsertedOrUpdatedRows, 1n)
+      assert.equal(result.insertId, 1n)
+    }))
+
+  test('an insert with RETURNING gives the row back', () =>
+    withDb(async (db) => {
+      await db.schema
+        .createTable('widget')
+        .addColumn('id', 'integer', (c) => c.primaryKey().autoIncrement())
+        .addColumn('name', 'text')
+        .execute()
+
+      const row = await db
+        .insertInto('widget')
+        .values({ name: 'second' })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+
+      assert.equal(row.name, 'second')
+    }))
+
+  // Kysely's SQLite introspector reads columns through a CTE over
+  // pragma_table_info, so a WITH statement that is treated as a writer reports
+  // every table as having no columns at all.
+  test('introspection sees the columns of a table', () =>
+    withDb(async (db) => {
+      await db.schema
+        .createTable('widget')
+        .addColumn('id', 'integer', (c) => c.primaryKey())
+        .addColumn('name', 'text')
+        .execute()
+
+      const [table] = await db.introspection.getTables()
+      assert.equal(table?.name, 'widget')
+      assert.deepEqual(
+        table?.columns.map((column) => column.name),
+        ['id', 'name']
+      )
+    }))
+})

--- a/packages/services/kysely-node-sqlite/src/node-sqlite-adapter.ts
+++ b/packages/services/kysely-node-sqlite/src/node-sqlite-adapter.ts
@@ -17,15 +17,39 @@ function coerce(v: unknown): SQLInputValue {
 }
 
 /**
+ * Whether a statement returns rows. node:sqlite's StatementSync has no `reader`
+ * flag (better-sqlite3, which Kysely's SqliteDialect was written against, does),
+ * so the value has to come from the SQL: a writer is run through `.run()` for
+ * its `changes`/`lastInsertRowid`, a reader through `.all()` for its rows, and
+ * getting it wrong silently drops whichever half the caller wanted.
+ *
+ * The list is wider than SELECT because Kysely's own SQLite introspector asks
+ * for columns through a CTE over `pragma_table_info`, so a statement that opens
+ * with WITH is a reader too — treating it as a writer reports every table as
+ * having no columns.
+ */
+function isReaderSql(sql: string): boolean {
+  return (
+    /^\s*(select|with|pragma|values|explain)\b/i.test(sql) ||
+    /\breturning\b/i.test(sql)
+  )
+}
+
+/**
  * Wraps node:sqlite's DatabaseSync as Kysely's SqliteDatabase. The shapes
  * are close but not identical: node:sqlite's Statement methods take
  * variadic positional params and always return bigint counters; Kysely's
  * dialect passes parameters as a ReadonlyArray and expects number|bigint.
  */
 class NodeSqliteStatement implements SqliteStatement {
-  readonly reader = true
+  readonly reader: boolean
 
-  constructor(private readonly stmt: StatementSync) {}
+  constructor(
+    private readonly stmt: StatementSync,
+    reader: boolean
+  ) {
+    this.reader = reader
+  }
 
   all(parameters: ReadonlyArray<unknown>): unknown[] {
     return this.stmt.all(...parameters.map(coerce)) as unknown[]
@@ -53,7 +77,7 @@ export class NodeSqliteDatabase implements SqliteDatabase {
   constructor(private readonly db: DatabaseSync) {}
 
   prepare(sql: string): SqliteStatement {
-    return new NodeSqliteStatement(this.db.prepare(sql))
+    return new NodeSqliteStatement(this.db.prepare(sql), isReaderSql(sql))
   }
 
   close(): void {

--- a/templates/functions/package.json
+++ b/templates/functions/package.json
@@ -31,6 +31,7 @@
     "@pikku/node-http-server": "workspace:*",
     "@pikku/schedule": "workspace:*",
     "@pikku/websocket": "^0.12.4",
+    "@pikku/ws": "^0.12.9",
     "@types/aws-lambda": "^8.10.162",
     "@types/node": "^24",
     "@types/ws": "^8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5209,11 +5209,17 @@ __metadata:
   peerDependencies:
     "@pikku/core": ^0.12.93
     "@pikku/playwright": ^0.12.79
+    "@pikku/ws": ^0.12.9
     better-auth: ^1.6.0
+    ws: ^8.21.3
   peerDependenciesMeta:
     "@pikku/playwright":
       optional: true
+    "@pikku/ws":
+      optional: true
     better-auth:
+      optional: true
+    ws:
       optional: true
   bin:
     pikku: dist/bin/pikku.js
@@ -5440,6 +5446,7 @@ __metadata:
     "@pikku/redis": "workspace:*"
     "@pikku/schema-cfworker": "workspace:*"
     "@pikku/websocket": "workspace:*"
+    "@pikku/ws": "workspace:*"
     "@playwright/test": "npm:^1.50.0"
     "@types/better-sqlite3": "npm:^9.6.0"
     "@types/node": "npm:^22"
@@ -6272,6 +6279,7 @@ __metadata:
     "@pikku/schema-cfworker": "npm:^0.12.6"
     "@pikku/templates-function-addon": "workspace:*"
     "@pikku/websocket": "npm:^0.12.4"
+    "@pikku/ws": "npm:^0.12.9"
     "@types/aws-lambda": "npm:^8.10.162"
     "@types/node": "npm:^24"
     "@types/ws": "npm:^8"
@@ -6905,7 +6913,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pikku/ws@npm:^0.12.9, @pikku/ws@workspace:packages/runtimes/ws":
+"@pikku/ws@npm:^0.12.9, @pikku/ws@workspace:*, @pikku/ws@workspace:packages/runtimes/ws":
   version: 0.0.0-use.local
   resolution: "@pikku/ws@workspace:packages/runtimes/ws"
   dependencies:


### PR DESCRIPTION
## The problem

`@pikku/ws` peers on a `@pikku/core` range and sat in `@pikku/cli`'s own dependency tree, so it got paired with the CLI's core rather than the project's. The skew surfaced as `Cannot find module '@pikku/core/ecosystem'` — thrown from a package the project never imported, which is about as far from the cause as an error can land.

The first cut of this PR removed the Node dev server entirely and hosted `pikku dev` / `pikku serve` on Bun alone. That has been reverted: it broke every Node-hosted template, and it did not even close the failure class, since `@pikku/bun-server` and `@pikku/node-http-server` are hard CLI dependencies with the identical peer-on-core shape.

## What this does instead

**`@pikku/ws` and `ws` become optional peer dependencies of `@pikku/cli`.** npm 7+ auto-installs peers but skips optional ones; yarn, pnpm and bun never auto-install them. A Bun project — which serves WebSockets natively through `@pikku/bun-server` — installs neither.

**`NodeServerRunner` imports them through the new `resolveFromProject` helper**, which resolves against the project's own `package.json` rather than using a bare specifier. `npx` unpacks the CLI into `~/.npm/_npx/<hash>`, so a bare import would find the wrong copy again; resolving from the project keeps one `@pikku/core` in play.

**Absence is not fatal.** A Node project with no channels does not need either package, so the dev/serve path starts over plain HTTP and logs why. A project that *does* wire channels would instead get sockets that never connect and nothing pointing at the cause — so `pikku validate` reports that case as `websocket-deps-missing` (severity `error`), reading the channel count out of `<outDir>/channel/pikku-channels-meta.gen.json`.

`e2e` and `templates/functions` — the two projects in this repo that host `pikku dev` under Node — declare `@pikku/ws` explicitly.

## Also here

`fix(kysely-node-sqlite): treat WITH and PRAGMA statements as readers` — `SqliteStatement.reader` was hardcoded `true`. Kysely's `SqliteDialect` was written against better-sqlite3, whose statements carry the flag; `node:sqlite`'s do not, so a plain `INSERT` never reported `changes` or `lastInsertRowid`, and Kysely's own SQLite introspector (a CTE over `pragma_table_info`) reported every table as having no columns. Found while the branch was still on the Bun path; it is a real adapter bug either way, with its own tests.

## Verification

- `packages/cli`: 1358 tests, all validate checks green including the 9 new `websocket-deps-checks` cases.
- `packages/services/kysely-node-sqlite`: 9 tests, including 3 new adapter cases.
- `templates/functions` `test:runtime dev` — the real Node `pikku dev` path — passes end to end, with `Matched channel: todos-live` in the log confirming the project-resolved WebSocket import wires up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
