### PR TITLE
fix(cli): a version the store kept is not a split core

### DIFF
--- a/.changeset/store-kept-core-is-not-a-split.md
+++ b/.changeset/store-kept-core-is-not-a-split.md
@@ -1,0 +1,9 @@
+---
+'@pikku/cli': patch
+---
+
+PKU717 no longer fires on a version bun or pnpm left in its store. Neither prunes
+on upgrade, so one `@pikku/core` bump leaves both copies on disk while the links
+resolve to one — and the guard reported a split on a tree that had none. The scan
+now walks in from the `@pikku/*` links, so a store copy counts only when
+something actually resolves to it.

--- a/packages/cli/src/utils/assert-single-core-version.test.ts
+++ b/packages/cli/src/utils/assert-single-core-version.test.ts
@@ -1,6 +1,12 @@
 import { describe, test, afterEach } from 'node:test'
 import assert from 'node:assert'
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { readFile } from 'node:fs/promises'
@@ -113,6 +119,87 @@ describe('assertSingleCoreVersion', () => {
   test('two distinct cores still throw PKU717 (split beats skew)', async () => {
     await assert.rejects(
       assertSingleCoreVersion(projectWithCores('0.12.51', '0.12.56'), logger),
+      /PKU717.*Multiple @pikku\/core versions/s
+    )
+  })
+
+  /**
+   * bun leaves the version it replaced in `.bun` after an upgrade, so the store
+   * holds two while the links resolve to one. That is not a split.
+   */
+  const bunProject = (linked: string, ...orphaned: string[]) => {
+    const root = mkdtempSync(path.join(tmpdir(), 'pikku-core-store-'))
+    dirs.push(root)
+    const store = path.join(root, 'node_modules', '.bun')
+
+    const place = (version: string) => {
+      const dir = path.join(
+        store,
+        `@pikku+core@${version}`,
+        'node_modules',
+        '@pikku',
+        'core'
+      )
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(
+        path.join(dir, 'package.json'),
+        JSON.stringify({ name: '@pikku/core', version })
+      )
+      return dir
+    }
+
+    for (const version of orphaned) place(version)
+    const target = place(linked)
+    const scope = path.join(root, 'node_modules', '@pikku')
+    mkdirSync(scope, { recursive: true })
+    symlinkSync(target, path.join(scope, 'core'), 'dir')
+    return root
+  }
+
+  test('a version the store kept but nothing links to is not a split', async () => {
+    const range = await cliCorePeerRange()
+    const inRange = /(\d+\.\d+\.\d+)/.exec(range)![1]!
+    await assertSingleCoreVersion(bunProject(inRange, '0.12.51'), logger)
+    assert.strictEqual(warnings.length, 0)
+  })
+
+  test('two versions the links both reach still throw PKU717', async () => {
+    const root = bunProject('0.12.56', '0.12.51')
+    // A second package resolving the older store copy is what makes it live.
+    const dependent = path.join(
+      root,
+      'node_modules',
+      '.bun',
+      '@pikku+kysely@0.13.0',
+      'node_modules',
+      '@pikku'
+    )
+    mkdirSync(path.join(dependent, 'kysely'), { recursive: true })
+    writeFileSync(
+      path.join(dependent, 'kysely', 'package.json'),
+      JSON.stringify({ name: '@pikku/kysely', version: '0.13.0' })
+    )
+    symlinkSync(
+      path.join(
+        root,
+        'node_modules',
+        '.bun',
+        '@pikku+core@0.12.51',
+        'node_modules',
+        '@pikku',
+        'core'
+      ),
+      path.join(dependent, 'core'),
+      'dir'
+    )
+    symlinkSync(
+      path.join(dependent, 'kysely'),
+      path.join(root, 'node_modules', '@pikku', 'kysely'),
+      'dir'
+    )
+
+    await assert.rejects(
+      assertSingleCoreVersion(root, logger),
       /PKU717.*Multiple @pikku\/core versions/s
     )
   })

--- a/packages/cli/src/utils/assert-single-core-version.ts
+++ b/packages/cli/src/utils/assert-single-core-version.ts
@@ -1,20 +1,68 @@
 import { readFile } from 'node:fs/promises'
-import { realpathSync } from 'node:fs'
+import { readdirSync, realpathSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { glob } from 'tinyglobby'
 import { ErrorCode } from '@pikku/inspector'
 
-// Bounded globs (no unbounded `**`) covering the real @pikku/core copies each
-// package manager keeps: hoisted root, bun (.bun), pnpm (.pnpm), and one level
-// of npm/yarn nesting (both plain and scoped dependents).
+// Bounded globs (no unbounded `**`) covering the copies reachable without a
+// content-addressed store: the hoisted root, and one level of npm/yarn nesting
+// (both plain and scoped dependents).
 const PATTERNS = [
   '@pikku/core/package.json',
-  '.bun/@pikku+core@*/node_modules/@pikku/core/package.json',
-  '.pnpm/@pikku+core@*/node_modules/@pikku/core/package.json',
   '*/node_modules/@pikku/core/package.json',
   '@*/*/node_modules/@pikku/core/package.json',
 ]
+
+/**
+ * bun and pnpm keep every version they have ever installed under `.bun`/`.pnpm`
+ * and neither prunes on upgrade, so globbing the store counts copies nothing can
+ * load: after one `@pikku/core` bump the store holds both, and the split this
+ * guard exists to catch is reported on a tree that has none. Walk in from the
+ * links instead — a store copy counts only when a live `@pikku/*` package
+ * resolves to it.
+ */
+const storeCores = (nodeModules: string): string[] => {
+  const seen = new Set<string>()
+  const cores = new Set<string>()
+  const queue: string[] = []
+
+  const real = (dir: string) => {
+    try {
+      return realpathSync(dir)
+    } catch {
+      return null
+    }
+  }
+
+  const visitScope = (scopeDir: string) => {
+    let entries: string[]
+    try {
+      entries = readdirSync(scopeDir)
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const resolved = real(path.join(scopeDir, entry))
+      if (!resolved || seen.has(resolved)) continue
+      seen.add(resolved)
+      if (entry === 'core') cores.add(path.join(resolved, 'package.json'))
+      else queue.push(resolved)
+    }
+  }
+
+  visitScope(path.join(nodeModules, '@pikku'))
+  while (queue.length > 0) {
+    const pkg = queue.pop()!
+    // A package's own dependencies sit either beside it (bun and pnpm put a
+    // package and everything it resolves into one store `node_modules`) or
+    // nested under it (npm/yarn). Every queued entry is a `@pikku/*` package, so
+    // its parent is always the scope directory.
+    visitScope(path.dirname(pkg))
+    visitScope(path.join(pkg, 'node_modules', '@pikku'))
+  }
+  return [...cores]
+}
 
 /**
  * Minimal semver range check for the shapes @pikku/cli publishes in its own
@@ -117,11 +165,14 @@ export async function assertSingleCoreVersion(
   logger: { warn: (message: string) => void }
 ): Promise<void> {
   const nodeModules = path.join(path.resolve(rootDir), 'node_modules')
-  const found = await glob(PATTERNS, {
-    cwd: nodeModules,
-    absolute: true,
-    onlyFiles: true,
-  }).catch(() => [] as string[])
+  const found = [
+    ...(await glob(PATTERNS, {
+      cwd: nodeModules,
+      absolute: true,
+      onlyFiles: true,
+    }).catch(() => [] as string[])),
+    ...storeCores(nodeModules),
+  ]
 
   // Dedupe by real path (symlinks/hoisting surface the same copy many times),
   // then map each physical copy to its version.


### PR DESCRIPTION
`PKU717` fires on any bun or pnpm workspace that has upgraded `@pikku/core` once.

Neither package manager prunes its store on upgrade, so `.bun/@pikku+core@0.12.90` stays on disk beside `0.12.93` while every link resolves to the new one. The old scan globbed `.bun/@pikku+core@*/…`, counted both, and reported a split on a tree that had none — hit while bumping fabric from 0.12.113 to 0.12.116, in both the monorepo and the starter template, and the only way out was deleting the store directory by hand.

The scan now walks in from the `@pikku/*` links: a store copy counts only when a live package resolves to it. Two versions that are both genuinely reachable still throw, which the second new test pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRGghZzh67Q1A2f5B5znkE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PKU717 dependency validation to ignore stale, unreachable package-store copies.
  * Correctly detects genuine `@pikku/core` version conflicts across reachable Bun, pnpm, hoisted, and nested installations.
  * Prevents false-positive split-version warnings caused by orphaned dependency copies.

* **Documentation**
  * Added release notes describing the improved version-scan behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->