### PR TITLE
ci: give the live-model AI e2e job a budget it can finish in

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,12 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    timeout-minutes: 15
+    # Nine live-model scenarios plus a browser run, and setup eats ~3 of the
+    # budget. At 15 the step was cancelled mid-run every time, which marks the
+    # whole Release run "cancelled" even though `release` does not need this
+    # job — so a green release was unreadable. The inner cap is what still
+    # catches a genuine hang.
+    timeout-minutes: 30
     needs: [e2e, e2e-agent, verifiers, templates]
     if: ${{ github.repository_owner == 'pikkujs' }}
     steps:
@@ -137,6 +142,7 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/e2e-codegen
       - name: Run live-model AI e2e tests
+        timeout-minutes: 22
         run: yarn test:e2e:ai-live
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
`E2E AI (live)` has been cancelled at its 15-minute cap on every recent Release run — the last one died at 15:03, mid test step, after setup had already taken ~3 minutes. Nine live-model scenario files plus a browser run do not fit in what's left.

The job is not in `release`'s `needs`, so publishing was never blocked. What it blocked was *reading the result*: a single cancelled job marks the whole workflow run "cancelled", so every release looked broken and "is main green?" had to be answered job by job.

- job `timeout-minutes`: 15 → 30
- new step-level `timeout-minutes: 22`, so a genuine hang still fails fast rather than spending the full 30

No package changes, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRGghZzh67Q1A2f5B5znkE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the end-to-end live testing time limits to reduce failures from long-running test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->