### PR TITLE
fix(inspector,cli): refuse better-auth's admin() plugin and point at ban()

### DIFF
--- a/.changeset/reject-better-auth-admin-plugin.md
+++ b/.changeset/reject-better-auth-admin-plugin.md
@@ -1,0 +1,30 @@
+---
+'@pikku/inspector': patch
+'@pikku/cli': patch
+---
+
+Refuse better-auth's `admin()` plugin, and point at `ban()`.
+
+`admin()` authorizes its endpoints against a `user.role` column while pikku
+authorizes on scopes, so wiring it means running two authorization models and
+projecting one onto the other — coarsely, since any single `admin:users:*` scope
+has to project to `role='admin'` and thereby unlocks every one of its endpoints
+underneath. Pikku dropped that projection when user management moved to
+`@pikku/addon-admin`'s scoped RPCs, so nothing reads the column any more.
+
+The inspector now throws when `admin()` appears in a `betterAuth({ plugins })`
+array, naming the replacement:
+
+```ts
+import { ban } from '@pikku/better-auth'
+betterAuth({ plugins: [ban()] })
+```
+
+`ban()` keeps the one capability `admin()` had that pikku cannot supply from
+outside better-auth: the `banned`/`banReason`/`banExpires` columns and the
+session hook that refuses a banned user a session.
+
+`pikku validate` reports the same thing without a prebuild, and additionally
+warns about the quieter half of the migration — an app that dropped `admin()`
+and never wired `ban()`, which keeps its ban columns and its ban UI while
+silently enforcing nothing.

--- a/packages/cli/src/functions/validate/auth-plugin-checks.test.ts
+++ b/packages/cli/src/functions/validate/auth-plugin-checks.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, test } from 'node:test'
+import { runAuthPluginChecks } from './auth-plugin-checks.js'
+
+const makeTmp = async () => mkdtemp(join(tmpdir(), 'pikku-auth-plugin-checks-'))
+
+const config = { srcDirectories: ['packages/functions/src'] }
+
+const writeSource = async (
+  root: string,
+  name: string,
+  contents: string
+): Promise<void> => {
+  const dir = join(root, 'packages', 'functions', 'src')
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, name), contents, 'utf8')
+}
+
+const AUTH_WITH_BAN = [
+  "import { pikkuBetterAuth, ban } from '@pikku/better-auth'",
+  "import { betterAuth } from 'better-auth'",
+  'export const auth = pikkuBetterAuth(() =>',
+  '  betterAuth({ plugins: [ban()] })',
+  ')',
+].join('\n')
+
+const AUTH_WITH_ADMIN = [
+  "import { pikkuBetterAuth } from '@pikku/better-auth'",
+  "import { betterAuth } from 'better-auth'",
+  "import { admin, bearer } from 'better-auth/plugins'",
+  'export const auth = pikkuBetterAuth(() =>',
+  '  betterAuth({ plugins: [bearer(), admin()] })',
+  ')',
+].join('\n')
+
+const AUTH_WITHOUT_BAN = [
+  "import { pikkuBetterAuth } from '@pikku/better-auth'",
+  "import { betterAuth } from 'better-auth'",
+  "import { bearer } from 'better-auth/plugins'",
+  'export const auth = pikkuBetterAuth(() =>',
+  '  betterAuth({ plugins: [bearer()] })',
+  ')',
+].join('\n')
+
+describe('runAuthPluginChecks', () => {
+  test('errors when better-auth admin() is wired', async () => {
+    const root = await makeTmp()
+    try {
+      await writeSource(root, 'auth.ts', AUTH_WITH_ADMIN)
+      const findings = await runAuthPluginChecks(root, config)
+      const admin = findings.find((f) => f.id === 'better-auth-admin-plugin')
+      assert.ok(admin, 'admin() must be reported')
+      assert.equal(admin.severity, 'error')
+      assert.match(admin.fixHint, /ban\(\)/)
+      assert.match(admin.path, /auth\.ts$/)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('warns when better-auth is configured with no ban()', async () => {
+    const root = await makeTmp()
+    try {
+      await writeSource(root, 'auth.ts', AUTH_WITHOUT_BAN)
+      const findings = await runAuthPluginChecks(root, config)
+      const missing = findings.find((f) => f.id === 'better-auth-no-ban-plugin')
+      assert.ok(missing, 'a missing ban() must be reported')
+      assert.equal(missing.severity, 'warn')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('is silent when ban() is wired', async () => {
+    const root = await makeTmp()
+    try {
+      await writeSource(root, 'auth.ts', AUTH_WITH_BAN)
+      assert.deepEqual(await runAuthPluginChecks(root, config), [])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('reports admin() only, not a missing ban(), when both apply', async () => {
+    const root = await makeTmp()
+    try {
+      await writeSource(root, 'auth.ts', AUTH_WITH_ADMIN)
+      const ids = (await runAuthPluginChecks(root, config)).map((f) => f.id)
+      assert.deepEqual(ids, ['better-auth-admin-plugin'])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('ignores a local helper named admin', async () => {
+    const root = await makeTmp()
+    try {
+      await writeSource(
+        root,
+        'auth.ts',
+        [
+          "import { pikkuBetterAuth, ban } from '@pikku/better-auth'",
+          "import { betterAuth } from 'better-auth'",
+          "import { admin } from './my-helpers.js'",
+          'export const auth = pikkuBetterAuth(() =>',
+          '  betterAuth({ plugins: [ban()] })',
+          ')',
+          'admin()',
+        ].join('\n')
+      )
+      assert.deepEqual(await runAuthPluginChecks(root, config), [])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('says nothing about an app that does not configure better-auth', async () => {
+    const root = await makeTmp()
+    try {
+      await writeSource(root, 'todo.function.ts', 'export const noop = 1')
+      assert.deepEqual(await runAuthPluginChecks(root, config), [])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/functions/validate/auth-plugin-checks.ts
+++ b/packages/cli/src/functions/validate/auth-plugin-checks.ts
@@ -1,0 +1,140 @@
+import { existsSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { ValidateFinding } from './persona-checks.js'
+
+export type AuthPluginCheckConfig = {
+  srcDirectories?: unknown
+}
+
+const lines = (...parts: string[]): string => parts.join('\n')
+
+/** Local rather than imported from shared-checks, which imports this module. */
+const readTextSafe = async (path: string): Promise<string | null> => {
+  if (!existsSync(path)) return null
+  try {
+    return await readFile(path, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+const stringArray = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === 'string')
+    : []
+
+/**
+ * Source files under one directory, generated files included — better-auth is
+ * routinely configured in a file the auth scaffold wrote.
+ */
+const listSourceFiles = async (dir: string): Promise<string[]> => {
+  if (!existsSync(dir)) return []
+  try {
+    return (await readdir(dir, { recursive: true }))
+      .filter(
+        (f): f is string =>
+          typeof f === 'string' &&
+          (f.endsWith('.ts') || f.endsWith('.tsx')) &&
+          !f.includes('node_modules')
+      )
+      .map((f) => join(dir, f))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Files importing `admin` out of better-auth's plugin entrypoint.
+ *
+ * Matched on the import rather than on a bare `admin(` call, which collides
+ * with any local helper of that name. The import is also what a project has to
+ * remove, so it points at the line that needs editing.
+ */
+const importsAdminPlugin = (text: string): boolean =>
+  /import\s*\{[^}]*\badmin\b[^}]*\}\s*from\s*['"]better-auth\/plugins['"]/.test(
+    text
+  )
+
+const wiresBanPlugin = (text: string): boolean =>
+  /@pikku\/better-auth/.test(text) && /\bban\s*\(/.test(text)
+
+/**
+ * Whether better-auth is configured the way pikku supports.
+ *
+ * Pikku authorizes on scopes, so better-auth's `admin()` — which authorizes its
+ * endpoints against a `user.role` column — is unsupported: wiring it means
+ * running two authorization models and projecting one onto the other. The
+ * inspector refuses it outright at prebuild; this reports the same thing
+ * without one, and additionally catches the quieter half of the migration, an
+ * app that dropped `admin()` and never wired `ban()`, which keeps its ban
+ * columns and its ban UI while silently enforcing nothing.
+ */
+export const runAuthPluginChecks = async (
+  root: string,
+  config: AuthPluginCheckConfig | null
+): Promise<ValidateFinding[]> => {
+  const findings: ValidateFinding[] = []
+
+  const srcDirectories = stringArray(config?.srcDirectories)
+  const searchDirs = srcDirectories.length
+    ? srcDirectories
+    : [join('packages', 'functions', 'src')]
+  const sourceFiles = (
+    await Promise.all(searchDirs.map((dir) => listSourceFiles(join(root, dir))))
+  ).flat()
+
+  let bansAnywhere = false
+  const adminFiles: string[] = []
+  for (const file of sourceFiles) {
+    const text = await readTextSafe(file)
+    if (!text) continue
+    if (importsAdminPlugin(text)) adminFiles.push(file)
+    if (wiresBanPlugin(text)) bansAnywhere = true
+  }
+
+  for (const file of adminFiles) {
+    findings.push({
+      id: 'better-auth-admin-plugin',
+      severity: 'error',
+      message:
+        "better-auth's admin() plugin is not supported — it authorizes against a user.role column while pikku authorizes on scopes, so one has to be projected onto the other",
+      path: file,
+      fixHint: lines(
+        'Replace it with ban(), which keeps the one capability admin() had that',
+        'pikku cannot supply from outside better-auth — refusing a banned user a',
+        'session:',
+        "  import { ban } from '@pikku/better-auth'",
+        '  betterAuth({ plugins: [ban()] })',
+        'User management is already scoped RPCs in @pikku/addon-admin: list,',
+        'create, ban, remove, revoke sessions and set password.'
+      ),
+    })
+  }
+
+  if (!bansAnywhere && adminFiles.length === 0) {
+    const configuresAuth = sourceFiles.length > 0
+    if (configuresAuth) {
+      for (const file of sourceFiles) {
+        const text = await readTextSafe(file)
+        if (!text || !/\bpikkuBetterAuth\s*\(/.test(text)) continue
+        findings.push({
+          id: 'better-auth-no-ban-plugin',
+          severity: 'warn',
+          message:
+            'better-auth is configured without ban() — the banned/banReason/banExpires columns do not exist, so banning a user through @pikku/addon-admin has nothing to write and nothing refuses their next sign-in',
+          path: file,
+          fixHint: lines(
+            "  import { ban } from '@pikku/better-auth'",
+            '  betterAuth({ plugins: [ban()] })',
+            'Wire it wherever the rest of your plugins are, then run',
+            '`pikku db migrate` to add the columns.'
+          ),
+        })
+        break
+      }
+    }
+  }
+
+  return findings
+}

--- a/packages/cli/src/functions/validate/shared-checks.ts
+++ b/packages/cli/src/functions/validate/shared-checks.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { runKnowledgeValidate } from '@pikku/knowledge'
 import { runBootstrapChecks } from './bootstrap-checks.js'
 import { runPersonaChecks, type ValidateFinding } from './persona-checks.js'
+import { runAuthPluginChecks } from './auth-plugin-checks.js'
 import { runScenarioFileChecks } from './scenario-file-checks.js'
 
 export type Finding = ValidateFinding
@@ -559,6 +560,7 @@ export async function runSharedProjectChecks(
 
   // ── personas, scenario files and the knowledge base ────────────────────
   findings.push(...(await runPersonaChecks(root, pikkuConfig)))
+  findings.push(...(await runAuthPluginChecks(root, pikkuConfig)))
 
   const srcDirectories = Array.isArray(pikkuConfig?.srcDirectories)
     ? pikkuConfig.srcDirectories.filter(

--- a/packages/inspector/src/add/add-auth.test.ts
+++ b/packages/inspector/src/add/add-auth.test.ts
@@ -217,6 +217,40 @@ describe('addAuth inspector', () => {
     }
   })
 
+  test('refuses better-auth admin() and points at ban()', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'pikku-add-auth-admin-'))
+    const file = join(rootDir, 'auth.ts')
+
+    await writeFile(
+      file,
+      [
+        "import { pikkuBetterAuth } from '@pikku/better-auth'",
+        "import { betterAuth } from 'better-auth'",
+        "import { admin, bearer } from 'better-auth/plugins'",
+        'export const auth = pikkuBetterAuth(() =>',
+        '  betterAuth({',
+        '    plugins: [bearer(), admin()],',
+        '  })',
+        ')',
+      ].join('\n')
+    )
+
+    const criticals: Array<{ code: ErrorCode; message: string }> = []
+    try {
+      await assert.rejects(
+        () => inspect(makeLogger(criticals), [file], { rootDir }),
+        (error: Error) => {
+          assert.match(error.message, /admin\(\) plugin is not supported/)
+          assert.match(error.message, /ban\(\)/)
+          assert.match(error.message, /@pikku\/addon-admin/)
+          return true
+        }
+      )
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
   test('records no plugins when the plugins array is absent', async () => {
     const rootDir = await mkdtemp(join(tmpdir(), 'pikku-add-auth-noplugins-'))
     const file = join(rootDir, 'auth.ts')

--- a/packages/inspector/src/add/add-auth.ts
+++ b/packages/inspector/src/add/add-auth.ts
@@ -129,6 +129,40 @@ const isInsideGlobalMiddlewareRegistration = (node: ts.Node): boolean => {
 }
 
 /**
+ * Refusal for better-auth's `admin()`, which pikku does not support.
+ *
+ * `admin()` authorizes its endpoints against a `user.role` column, so wiring it
+ * means running a second authorization model alongside pikku's scopes and
+ * keeping one projected onto the other — coarsely, since any single
+ * `admin:users:*` scope has to project to `role='admin'` and thereby unlocks
+ * every one of its endpoints underneath. Pikku dropped that projection: user
+ * management is `@pikku/addon-admin`'s scoped RPCs, and the one capability
+ * `admin()` had that nothing else did — refusing a session to a banned user —
+ * is `ban()`.
+ *
+ * Thrown rather than warned because the failure it prevents is silent. An app
+ * that drops `admin()` without wiring `ban()` keeps its ban columns and its ban
+ * UI, and simply stops enforcing bans.
+ */
+const UNSUPPORTED_ADMIN_PLUGIN = (sourceFile: string): string =>
+  `better-auth's admin() plugin is not supported by pikku (${sourceFile}).
+
+It authorizes against a 'user.role' column, while pikku authorizes on scopes —
+wiring both means one has to be projected onto the other, and the projection is
+coarser than the scopes it stands in for.
+
+Use ban() instead:
+
+  import { ban } from '@pikku/better-auth'
+  betterAuth({ plugins: [ban()] })
+
+ban() keeps the part of admin() that pikku cannot supply from outside
+better-auth — the banned/banReason/banExpires columns and the session hook that
+refuses a banned user a session. Everything else admin() offered is already
+scoped RPCs in @pikku/addon-admin: list, create, ban, remove, revoke sessions
+and set password.`
+
+/**
  * Detects `pikkuBetterAuth((services) => betterAuth({...}))` calls.
  *
  * `pikkuBetterAuth` is pure: it wraps a factory that returns a configured better-auth
@@ -306,6 +340,9 @@ export const addAuth: AddWiring = (logger, node, _checker, state) => {
     if (plugins) {
       for (const el of plugins.elements) {
         const id = readPluginId(el)
+        if (id === 'admin') {
+          throw new Error(UNSUPPORTED_ADMIN_PLUGIN(sourceFile))
+        }
         if (id && !state.auth.plugins.includes(id)) {
           state.auth.plugins.push(id)
         }


### PR DESCRIPTION
Stacked on #1400 — review that first; this PR's diff is the six files below.

## Why

better-auth's `admin()` plugin authorizes its ~15 endpoints against a `user.role` column. Pikku authorizes on scopes. Wiring both means running two authorization models and projecting one onto the other, and the projection is necessarily coarser than the thing it stands for: any single `admin:users:*` scope has to project to `role='admin'`, which unlocks *every* admin endpoint at the better-auth layer regardless of which scope the user actually holds.

That projection (`projectedAdminRole` / `syncProjectedAdminRole`) is gone from main — #1310 moved user management to `@pikku/addon-admin`'s scoped RPCs and added a `ban()` plugin carrying the ban half of `admin()`. Nothing reads the role column any more. But nothing in the toolchain *says* so, and the question has now been re-derived from scratch in three separate sessions. This adds the guard that states the answer once.

## What

**`@pikku/inspector`** throws when `admin` appears in a `betterAuth({ plugins: [...] })` array, naming `ban()` from `@pikku/better-auth` as the replacement and `@pikku/addon-admin` for the rest of what `admin()` used to provide.

A throw rather than a warning, because the failure it prevents is silent: an app that drops `admin()` without wiring `ban()` keeps its `banned`/`banReason`/`banExpires` columns and its ban UI, and simply stops enforcing bans at session creation. Nothing errors; bans just have no effect.

**`pikku validate`** reports the same finding without needing a prebuild (`better-auth-admin-plugin`, error), plus a separate warning for that quieter half — an app that configures better-auth and wires neither plugin (`better-auth-no-ban-plugin`, warn). Detection keys on the *import* from `better-auth/plugins`, not a bare `admin(` call, which collides with local helpers.

Migrations need no work: `better-auth-schema.ts` calls better-auth's own `getMigrations(config)`, which merges plugin schema declarations, so `ban()`'s columns are created and `role` / `session.impersonatedBy` stop being generated. A stale `role` column is left on existing databases and is harmless.

## Tests

TDD, both halves. 6 new validate tests and 1 new inspector test; the inspector test was confirmed red before the throw went in.

- `@pikku/inspector` — 717/717
- `@pikku/cli` — 1268/1268
- `tsc` clean in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)