### PR TITLE
docs(skills): say the dev seed is local only, and what belongs in a migration

### DIFF
--- a/.changeset/dev-seed-is-local-only.md
+++ b/.changeset/dev-seed-is-local-only.md
@@ -1,0 +1,5 @@
+---
+'@pikku/skills': patch
+---
+
+Say plainly that the dev seed is local only. No deploy applies it, so the test for a row is not whether it looks realistic but whether the app would be broken without it in production — a venue, a catalogue, a tenant is configuration and belongs in a migration. Names the failure it causes: a stage whose pages return 200 while its first data read throws.

--- a/packages/skills/skills/pikku-build-app/SKILL.md
+++ b/packages/skills/skills/pikku-build-app/SKILL.md
@@ -325,7 +325,9 @@ or not the note says `built`.
    for working on an empty state the test data would hide). Because reset always
    arrives at a database it just wiped, **the seed file is plain `INSERT`s** — no
    `ON CONFLICT DO NOTHING`, no `INSERT OR IGNORE`. Nothing ever applies it
-   twice, so it never has to defend itself.
+   twice, so it never has to defend itself. It is also **local only** — no deploy
+   applies it, so anything the app would be broken without in production is
+   configuration and belongs in a migration, not here.
    Do this generously and do it now: an empty app demos badly and critiques
    badly, and you cannot judge a screen's hierarchy, overflow, or truncation
    against zero rows. Seed rows each persona sees differently — with an ownership

--- a/packages/skills/skills/pikku-build-quick/SKILL.md
+++ b/packages/skills/skills/pikku-build-quick/SKILL.md
@@ -115,7 +115,9 @@ Then, in this order — it is the order codegen depends on:
 2. **Seed** — rows in `db/sqlite-dev-seed.sql`. There is no seed command:
    `bunx --bun pikku db reset` wipes, migrates and seeds in one go, and is the
    only thing that applies the file. It always starts from a wiped database, so
-   the file is plain `INSERT`s — no `ON CONFLICT DO NOTHING`. **Be generous, and
+   the file is plain `INSERT`s — no `ON CONFLICT DO NOTHING`. It is local only:
+   no deploy applies it, so anything the app cannot run without belongs in a
+   migration instead. **Be generous, and
    seed rows for both personas.** An empty app demos badly, and you cannot see a
    layout break against zero rows.
 3. **Functions** — one `pikkuFunc` per `*.function.ts`, `expose: true`. Pikku

--- a/packages/skills/skills/pikku-fabric/SKILL.md
+++ b/packages/skills/skills/pikku-fabric/SKILL.md
@@ -109,11 +109,25 @@ plain `INSERT`s** — no `INSERT OR IGNORE`, no `ON CONFLICT DO NOTHING`, no
 you find yourself reaching for an idempotent form, that's a sign the data wants
 to be a migration instead.
 
-This is **test data only**: enough rows that a fresh dev database isn't an empty
-app. It never reaches staging or production — reset refuses `NODE_ENV=production`
-and refuses a database outside the runtime directory. Anything a real environment
-needs — accounts, role grants — is provisioning, not seeding, and belongs in
-`pikku persona sync` or a migration.
+This is **local dev data only**: enough rows that a fresh dev database isn't an
+empty app. Nothing else ever runs it. A deployed stage applies `db/<engine>/*.sql`
+and stops there — reset refuses `NODE_ENV=production` and refuses a database
+outside the runtime directory, and no deploy step reaches for the seed file.
+
+So the test is not "is this row realistic?", it is **"would the app be broken
+without it in production?"** If yes, it is configuration and belongs in a
+migration, however much it looks like sample data. A venue and its rooms, a
+product catalogue, a tenant, a country list, the organization the whole
+deployment hangs off — all configuration. Accounts and role grants are
+provisioning: `pikku persona sync` or a migration. What is left over is the
+seed's job — the bookings, orders and messages a demo needs and a real
+environment starts without.
+
+Get this wrong and it hides: the app is perfect locally, where reset has just
+run, and every deployed environment comes up with empty tables. The signature is
+a stage whose pages return 200 — the shell renders fine — while its first data
+read throws `no result` or a foreign-key violation on a row the seed was
+silently supplying.
 
 A Better Auth app has a second constraint: the plugins you enable (`ban()`,
 `actor()`, …) each declare columns, and `pikku db migrate` refuses to run while


### PR DESCRIPTION
## Why

The skills said the dev seed is "test data only" and that it "never reaches staging or production" — but framed the exclusion around *"accounts, role grants — provisioning"*. Nobody reads that and thinks *"my venue and its rooms"*.

A real client app put its venue, 21 bathrooms, 23 rooms and 2 seminar rooms in `db/sqlite-dev-seed.sql`. It was perfect locally, where `pikku db reset` had just run. Every deployed stage came up with an empty `venue` table: pages returned 200 because the SSR shell rendered fine, while the first data RPC threw `no result` and the e2e reset threw a foreign-key violation on a row the seed had been silently supplying. Nothing in the prose would have caught it.

## What changed

`pikku-fabric/SKILL.md` — the "test data only" paragraph is rewritten around the test that actually discriminates:

> the test is not "is this row realistic?", it is **"would the app be broken without it in production?"**

…with examples that are recognisably *not* accounts (a venue and its rooms, a product catalogue, a tenant, a country list), and the failure signature spelled out, because this class of bug hides behind a green local machine.

`pikku-build-app` and `pikku-build-quick` get one sentence each at the seed step — that's where the habit forms.

Docs only. No behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that development seed data is local-only and is not applied during deployment.
  - Documented that production-required configuration belongs in migrations, while accounts and permissions remain provisioning tasks.
  - Added guidance for required venues, catalogues, tenants, countries, and related configuration.
  - Documented potential production symptoms when required configuration is missing, including empty pages and data-read errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->