### PR TITLE
feat(virtual-user): show what a schedule runs against what its persona declares

### DIFF
--- a/.changeset/inputs-mark-a-value-that-changed.md
+++ b/.changeset/inputs-mark-a-value-that-changed.md
@@ -1,0 +1,9 @@
+---
+'@pikku/mantine': patch
+---
+
+Add `original` to the inputs, marking a value that no longer matches the one it came from. Pass what a field started as and it borders itself orange once it differs — a runtime row against what the repository declares, a form field against what it held when it loaded, a setting against its seeded default. All the same comparison, so nothing about where the other value came from reaches the component.
+
+On every control that carries a value, so wiring `original` through is never a question of whether this particular input supports it, and `modifiedStyles` is exported for anything doing its own rendering. Toggles read `checked` and hide the input they would otherwise be drawn on, so `Switch` marks its track and `Radio` its circle. `FileInput` is left out: its value is a `File`, and every `File` compares equal.
+
+These are the package's first runtime wrappers on inputs — the other overrides are type-only casts — so they forward refs explicitly. A control given no `original`, or styling its own input with a `styles` function, behaves exactly as Mantine's does.

--- a/.changeset/schedules-carry-what-personas-declare.md
+++ b/.changeset/schedules-carry-what-personas-declare.md
@@ -1,0 +1,7 @@
+---
+'@pikku/cli': patch
+---
+
+Send what a persona currently declares alongside the schedule row that is actually running it. A cadence is enabled once and then outlives the declaration it was written from: someone edits `personas.ts`, redeploys, and the row keeps running last month's goals and disposition with nothing anywhere to say so. `listVirtualUserSchedules` now resolves each row's persona out of `personaConfigs` and returns its goals and disposition as `declared`, so the difference is readable rather than inferred.
+
+Which fields differ is deliberately not computed here. It is a question about how to render two values, and a codegen step that answered it would fix the answer for every client — including the ones that want to show both sides rather than a flag.

--- a/packages/cli/src/functions/wirings/virtual-user/serialize-virtual-user-functions.ts
+++ b/packages/cli/src/functions/wirings/virtual-user/serialize-virtual-user-functions.ts
@@ -214,6 +214,19 @@ const virtualUserScheduleFields = {
   nextRunAt: z.string(),
   lastRunId: z.string().nullable(),
   lastRunAt: z.string().nullable(),
+  /**
+   * What \`definePersonas()\` says about this persona now, alongside what the
+   * row is actually running.
+   *
+   * A schedule is turned on once and then outlives the declaration it was
+   * written from: someone edits \`personas.ts\`, redeploys, and the row keeps
+   * running last month's goals with nothing anywhere to say so. Both sides
+   * cross the wire so that difference is readable rather than inferred.
+   */
+  declared: z.object({
+    disposition: Disposition,
+    goals: z.array(z.string()),
+  }),
 }
 
 export const SetVirtualUserScheduleOutput = z.object(virtualUserScheduleFields)
@@ -534,27 +547,38 @@ export const getVirtualUserRunSteps = pikkuFunc({
  * what every other call here takes; the engine's own duration also accepts
  * \`'30m'\`, which nothing on this side ever writes.
  */
-const serializeSchedule = (schedule: VirtualUserScheduleRecord) => ({
-  persona: schedule.persona,
-  enabled: schedule.enabled,
-  disposition: schedule.disposition,
-  goals: schedule.goals,
-  budget: schedule.budget
-    ? {
-        steps: schedule.budget.steps,
-        mutations: schedule.budget.mutations,
-        durationMs:
-          typeof schedule.budget.duration === 'number'
-            ? schedule.budget.duration
-            : undefined,
-      }
-    : null,
-  minIntervalMs: schedule.minIntervalMs,
-  maxIntervalMs: schedule.maxIntervalMs,
-  nextRunAt: schedule.nextRunAt.toISOString(),
-  lastRunId: schedule.lastRunId,
-  lastRunAt: schedule.lastRunAt ? schedule.lastRunAt.toISOString() : null,
-})
+const serializeSchedule = (schedule: VirtualUserScheduleRecord) => {
+  const persona = personaConfigs[
+    schedule.persona as keyof typeof personaConfigs
+  ] as { goals?: string[]; disposition?: string } | undefined
+  const declared = {
+    disposition: (persona?.disposition ??
+      'realistic') as VirtualUserDisposition,
+    goals: persona?.goals ?? [],
+  }
+  return {
+    persona: schedule.persona,
+    enabled: schedule.enabled,
+    disposition: schedule.disposition,
+    goals: schedule.goals,
+    budget: schedule.budget
+      ? {
+          steps: schedule.budget.steps,
+          mutations: schedule.budget.mutations,
+          durationMs:
+            typeof schedule.budget.duration === 'number'
+              ? schedule.budget.duration
+              : undefined,
+        }
+      : null,
+    minIntervalMs: schedule.minIntervalMs,
+    maxIntervalMs: schedule.maxIntervalMs,
+    nextRunAt: schedule.nextRunAt.toISOString(),
+    lastRunId: schedule.lastRunId,
+    lastRunAt: schedule.lastRunAt ? schedule.lastRunAt.toISOString() : null,
+    declared,
+  }
+}
 
 export const setVirtualUserSchedule = pikkuFunc({
   tags: ['pikku'],

--- a/packages/cli/src/functions/wirings/virtual-user/virtual-user-functions.test.ts
+++ b/packages/cli/src/functions/wirings/virtual-user/virtual-user-functions.test.ts
@@ -74,6 +74,22 @@ describe('serializeVirtualUserFunctions', () => {
     assert.match(setFn, /scopes: \['virtualUser:schedule'\]/)
   })
 
+  // A schedule is enabled once and then outlives the declaration it was written
+  // from, so both sides have to travel for anyone to see they have parted ways.
+  test('a schedule carries what the persona currently declares', () => {
+    const setFn = out.slice(out.indexOf('const serializeSchedule'))
+    assert.match(setFn, /declared,/)
+    assert.match(setFn, /personaConfigs\[/)
+    assert.match(schemas, /declared: z\.object\(\{/)
+  })
+
+  // Which fields differ is a question about how to render two values, and the
+  // answer belongs where they are rendered — not baked into the payload.
+  test('the difference is left for the client to work out', () => {
+    assert.doesNotMatch(out, /drifted/)
+    assert.doesNotMatch(schemas, /drifted/)
+  })
+
   // A codegen step does not get to decide that an app starts spending model
   // budget; the project wires the tick when it means it.
   test('the tick is emitted unwired, with no scaffolded cron behind it', () => {

--- a/packages/frontend/mantine/src/core/index.ts
+++ b/packages/frontend/mantine/src/core/index.ts
@@ -11,8 +11,9 @@
 // raw strings fail to compile. Pass text through `t()` / `asI18n()`.
 
 export * from '@mantine/core'
-import { createElement } from 'react'
+import { createElement, forwardRef } from 'react'
 import type { CSSProperties } from 'react'
+import { modifiedStyles } from './original.js'
 
 import {
   // polymorphic (children)
@@ -290,69 +291,124 @@ export const Notification = MantineNotification as OverrideFactory<
 >
 
 // ── Plain: inputs (label / placeholder / description, plus extras) ────────────
-export const TextInput = MantineTextInput as OverrideFactory<
+
+/**
+ * An input's value alongside the one it started as. See {@link modifiedStyles}
+ * — the two may be a runtime row against its declaration, or simply a field
+ * against what it held when the form loaded.
+ *
+ * On every control that carries a value, so that wiring `original` through is
+ * never a question of whether this particular input supports it. A control
+ * without an `original` behaves exactly as Mantine's does.
+ *
+ * Controlled fields only: the comparison reads the value off props, so a field
+ * left uncontrolled with `defaultValue` has nothing to compare and stays
+ * unmarked.
+ */
+type Original = { original?: unknown }
+
+/**
+ * A caller's own `styles` wins. Mantine also accepts a function there, which
+ * cannot be merged into without calling it with a theme this layer does not
+ * have — so a call styling its input by hand keeps its own border and simply
+ * does not get the mark.
+ *
+ * `from` and `part` differ per control: a toggle's value is `checked`, and it
+ * hides the input it would otherwise be drawn on, painting a track or a circle
+ * instead. Bordering the hidden element marks nothing visible.
+ */
+const withOriginal = (
+  Component: any,
+  from: 'value' | 'checked' = 'value',
+  part = 'input'
+) =>
+  forwardRef<any, any>(({ original, styles, ...props }, ref) => {
+    const modified = modifiedStyles(props[from], original, part)
+    const merged =
+      !modified.styles || typeof styles === 'function'
+        ? styles
+        : {
+            ...styles,
+            [part]: { ...(styles as any)?.[part], ...modified.styles[part] },
+          }
+    return createElement(Component, { ...props, ref, styles: merged })
+  })
+
+export const TextInput = withOriginal(MantineTextInput) as OverrideFactory<
   TextInputFactory,
-  Input
+  Input & Original
 >
-export const PasswordInput = MantinePasswordInput as OverrideFactory<
-  PasswordInputFactory,
-  Input
->
-export const Textarea = MantineTextarea as OverrideFactory<
+export const PasswordInput = withOriginal(
+  MantinePasswordInput
+) as OverrideFactory<PasswordInputFactory, Original & Input>
+export const Textarea = withOriginal(MantineTextarea) as OverrideFactory<
   TextareaFactory,
-  Input
+  Input & Original
 >
-export const JsonInput = MantineJsonInput as OverrideFactory<
+export const JsonInput = withOriginal(MantineJsonInput) as OverrideFactory<
   JsonInputFactory,
-  Input
+  Original & Input
 >
-export const NativeSelect = MantineNativeSelect as OverrideFactory<
-  NativeSelectFactory,
-  Input
->
-export const NumberInput = MantineNumberInput as OverrideFactory<
+export const NativeSelect = withOriginal(
+  MantineNativeSelect
+) as OverrideFactory<NativeSelectFactory, Original & Input>
+export const NumberInput = withOriginal(MantineNumberInput) as OverrideFactory<
   NumberInputFactory,
-  Input & { prefix?: I18nString; suffix?: I18nString }
+  Input & Original & { prefix?: I18nString; suffix?: I18nString }
 >
-export const Select = MantineSelect as OverrideFactory<
+export const Select = withOriginal(MantineSelect) as OverrideFactory<
   SelectFactory,
-  Input & { nothingFoundMessage?: I18nNode }
+  Input & Original & { nothingFoundMessage?: I18nNode }
 >
-export const MultiSelect = MantineMultiSelect as OverrideFactory<
+export const MultiSelect = withOriginal(MantineMultiSelect) as OverrideFactory<
   MultiSelectFactory,
-  Input & { nothingFoundMessage?: I18nNode }
+  Input & Original & { nothingFoundMessage?: I18nNode }
 >
-export const Autocomplete = MantineAutocomplete as OverrideFactory<
+export const Autocomplete = withOriginal(
+  MantineAutocomplete
+) as OverrideFactory<
   AutocompleteFactory,
-  Input & { nothingFoundMessage?: I18nNode }
+  Original & Input & { nothingFoundMessage?: I18nNode }
 >
-export const TagsInput = MantineTagsInput as OverrideFactory<
+export const TagsInput = withOriginal(MantineTagsInput) as OverrideFactory<
   TagsInputFactory,
-  Input & { nothingFoundMessage?: I18nNode }
+  Input & Original & { nothingFoundMessage?: I18nNode }
 >
-export const ColorInput = MantineColorInput as OverrideFactory<
+export const ColorInput = withOriginal(MantineColorInput) as OverrideFactory<
   ColorInputFactory,
-  Input & { swatchesLabel?: I18nString }
+  Original & Input & { swatchesLabel?: I18nString }
 >
 export const FileInput = MantineFileInput as OverrideFactory<
   FileInputFactory,
   { label?: I18nNode; placeholder?: I18nNode; description?: I18nNode }
 >
-export const PinInput = MantinePinInput as OverrideFactory<
+export const PinInput = withOriginal(MantinePinInput) as OverrideFactory<
   PinInputFactory,
-  { placeholder?: I18nString }
+  Original & { placeholder?: I18nString }
 >
-export const Checkbox = MantineCheckbox as OverrideFactory<
+export const Checkbox = withOriginal(
+  MantineCheckbox,
+  'checked',
+  'input'
+) as OverrideFactory<
   CheckboxFactory,
-  { label?: I18nNode; description?: I18nNode }
+  Original & { label?: I18nNode; description?: I18nNode }
 >
-export const Switch = MantineSwitch as OverrideFactory<
+export const Switch = withOriginal(
+  MantineSwitch,
+  'checked',
+  'track'
+) as OverrideFactory<
   SwitchFactory,
-  { label?: I18nNode; description?: I18nNode }
+  Original & { label?: I18nNode; description?: I18nNode }
 >
-export const Radio = MantineRadio as OverrideFactory<
+export const Radio = withOriginal(
+  MantineRadio,
+  'checked',
+  'radio'
+) as OverrideFactory<
   RadioFactory,
-  { label?: I18nNode; description?: I18nNode }
+  Original & { label?: I18nNode; description?: I18nNode }
 >
 // PillsInput is an Input wrapper (label/description/error live on the root); its
 // `.Field` static carries the placeholder. Gate both via a composed factory.
@@ -451,3 +507,5 @@ export const Input = MantineInput as unknown as WithStatics<
     Placeholder: OverrideFactory<{ props: InputPlaceholderProps }, Children>
   }
 >
+
+export { modifiedStyles } from './original.js'

--- a/packages/frontend/mantine/src/core/original.ts
+++ b/packages/frontend/mantine/src/core/original.ts
@@ -1,0 +1,47 @@
+/**
+ * Marks an input whose value no longer matches the one it came from.
+ *
+ * Deliberately says nothing about where the other value came from, because the
+ * comparison is the same one either way. A row edited at runtime against what
+ * the repository declares; a form field against what it held when it loaded; a
+ * setting against the default it was seeded with. In every case there are two
+ * values, the second is the one being rendered, and without a mark nobody can
+ * tell by looking which fields were touched.
+ *
+ * That makes it worth wiring `original` through even where a form is not being
+ * edited yet: pass what the value started as and every subsequent keystroke
+ * marks itself, with no dirty-tracking state and nothing asked of the server.
+ *
+ * `undefined` means no comparison was asked for, so a field whose original
+ * value is genuinely absent cannot be marked — pass `null` for that.
+ *
+ * Deliberately a plain function rather than a hook: there is no state and
+ * nothing to subscribe to, so a hook would only add a rule about where it may
+ * be called. Components that take an `original` run it themselves; anything
+ * else can call it and spread the result.
+ *
+ * Orange rather than red. A value that differs from the one it came from is not
+ * an error — someone probably meant it — it is a thing to notice before
+ * assuming what is on screen is what was there.
+ */
+export const modifiedStyles = (
+  value: unknown,
+  original: unknown,
+  /**
+   * Which part Mantine actually draws the border on. `input` for anything that
+   * holds text; a toggle hides its input and paints elsewhere.
+   */
+  key: string = 'input'
+): { styles?: Record<string, { borderColor: string }> } => {
+  if (original === undefined) return {}
+  // Structural rather than referential: the values being compared are small —
+  // a string, a number, a list of goals — and a caller holding an equal array
+  // from a different render is the normal case, not the exception.
+  const same =
+    Object.is(value, original) ||
+    JSON.stringify(value ?? null) === JSON.stringify(original ?? null)
+  if (same) return {}
+  return {
+    styles: { [key]: { borderColor: 'var(--mantine-color-orange-filled)' } },
+  }
+}


### PR DESCRIPTION
A virtual user's cadence is enabled once and then outlives the declaration it was written from. Someone edits `personas.ts`, redeploys, and the row keeps running last month's goals with nothing on screen to say the code in front of them is not what is running.

## The payload carries both sides

`listVirtualUserSchedules` now returns a `declared` snapshot — goals and disposition resolved out of `personaConfigs` — alongside the row as it actually stands.

Which fields differ is left uncomputed on purpose. That is a question about how to render two values, and answering it in codegen would fix the answer for every client, including the ones that want to show both sides rather than a flag. A test asserts the payload stays free of a computed diff so a later change has to make that decision deliberately.

## The rendering half is `original`

`@pikku/mantine`'s inputs take an `original` and border themselves orange once the value differs from it. The component is told nothing about declarations: it is the same comparison whether the other value is a declaration, a form's load-time state, or a seeded default.

That makes it worth wiring through on forms that are not diffing against a server at all — pass what a field started as and every keystroke marks itself, with no dirty-tracking state and no round-trip.

Orange rather than red: a value that differs is not an error, it is a thing to notice before assuming what is on screen is what was there.

## Notes on the wrapping

- On **every** value-carrying control, not a chosen few, so passing `original` is never a question of whether this particular input supports it.
- Toggles read `checked` rather than `value`, and hide the input they would otherwise be bordered on — `Switch` marks its `track`, `Radio` its `radio`.
- `FileInput` is excluded: its value is a `File`, and every `File` compares equal under a structural check.
- These are the package's **first runtime wrappers on inputs** — the other ~44 overrides are type-only casts, which keep component identity and cannot drop a ref. So these forward refs explicitly.
- A control given no `original` behaves exactly as Mantine's does. A caller styling its own input with a `styles` *function* keeps its border and simply does not get the mark, since merging into it would mean calling it with a theme this layer does not have.
- `modifiedStyles` is exported for anything rendering its own controls.

## Not in this PR

The console schedule UI that consumes both. Nothing calls `setVirtualUserSchedule` from a UI today; this is the surface it needs first.

## Verification

- `packages/cli` — 30 tests pass, including two new ones covering `declared` and the absence of a computed diff.
- `packages/frontend/mantine` — type test (`tsconfig.test-d.json`) clean, so the i18n gate still bites on all 15 wrapped controls, and 25 theme tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input controls can now highlight when their current value differs from an original value.
  * Added support across text, selection, numeric, color, checkbox, switch, and radio controls.
  * Added a reusable styling helper for custom modified-field indicators.
  * Virtual-user schedules now include each persona’s currently declared goals and disposition.

* **Bug Fixes**
  * Improved visibility into differences between configured persona declarations and running schedule values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->