### PR TITLE
feat(console): put a persona on a clock, against what it declares

### DIFF
--- a/.changeset/console-turns-a-persona-loose-on-a-clock.md
+++ b/.changeset/console-turns-a-persona-loose-on-a-clock.md
@@ -1,0 +1,10 @@
+---
+'@pikku/console': patch
+'@pikku/addon-console': patch
+---
+
+Let the console decide which personas keep using the application on their own. The Virtual Users screen gains a cadence section: a switch that turns a persona loose, its disposition, goals and interval, and when it is next due.
+
+Every field is shown against what the persona currently declares and marks itself orange where the two have parted ways. A cadence is enabled once and then outlives the declaration it was written from — someone edits `personas.ts`, redeploys, and the row keeps running last month's goals with nothing anywhere to say so. The declarations are already in the meta the console loads, so the pairing is done on the client and the server is never asked for a second copy that could disagree with the first.
+
+Reading cadences needs only a wired `virtualUserScheduleStore`; changing one dispatches the project's own scaffolded `setVirtualUserSchedule`, so the rules about undeclared and acted-upon personas are enforced in one place rather than copied here. Changing a cadence has its own scope, separate from running: starting a run spends money once with a caller present to see it, and a schedule spends it repeatedly with nobody there.

--- a/.changeset/inputs-mark-a-value-that-changed.md
+++ b/.changeset/inputs-mark-a-value-that-changed.md
@@ -1,0 +1,9 @@
+---
+'@pikku/mantine': patch
+---
+
+Add `original` to the inputs, marking a value that no longer matches the one it came from. Pass what a field started as and it borders itself orange once it differs — a runtime row against what the repository declares, a form field against what it held when it loaded, a setting against its seeded default. All the same comparison, so nothing about where the other value came from reaches the component.
+
+On every control that carries a value, so wiring `original` through is never a question of whether this particular input supports it, and `modifiedStyles` is exported for anything doing its own rendering. Toggles read `checked` and hide the input they would otherwise be drawn on, so `Switch` marks its track and `Radio` its circle. `FileInput` is left out: its value is a `File`, and every `File` compares equal.
+
+These are the package's first runtime wrappers on inputs — the other overrides are type-only casts — so they forward refs explicitly. A control given no `original`, or styling its own input with a `styles` function, behaves exactly as Mantine's does.

--- a/.changeset/schedules-carry-what-personas-declare.md
+++ b/.changeset/schedules-carry-what-personas-declare.md
@@ -1,0 +1,7 @@
+---
+'@pikku/cli': patch
+---
+
+Send what a persona currently declares alongside the schedule row that is actually running it. A cadence is enabled once and then outlives the declaration it was written from: someone edits `personas.ts`, redeploys, and the row keeps running last month's goals and disposition with nothing anywhere to say so. `listVirtualUserSchedules` now resolves each row's persona out of `personaConfigs` and returns its goals and disposition as `declared`, so the difference is readable rather than inferred.
+
+Which fields differ is deliberately not computed here. It is a question about how to render two values, and a codegen step that answered it would fix the answer for every client — including the ones that want to show both sides rather than a flag.

--- a/packages/addon/pikku-console/src/functions/get-virtual-user-schedules.function.ts
+++ b/packages/addon/pikku-console/src/functions/get-virtual-user-schedules.function.ts
@@ -1,0 +1,34 @@
+import { pikkuFunc } from '#pikku/addon/function'
+
+/**
+ * Which personas are on a clock, and when each is next due.
+ *
+ * Read off the host's own `virtualUserScheduleStore` rather than through the
+ * scaffolded RPC, so a project that wired the store sees its cadences whether
+ * or not it turned `scaffold.virtualUser` on — the same reasoning as
+ * `getVirtualUserRuns`, and the reason both are readable while neither can be
+ * changed from here without the scaffold.
+ *
+ * Returns rows and nothing else. What each persona *declares* is already in the
+ * meta the console loads, so pairing the two is the client's to do — sending a
+ * second copy of the declarations down here would only give it two answers that
+ * can disagree.
+ */
+export const getVirtualUserSchedules = pikkuFunc<void, any[]>({
+  title: 'Get Virtual User Schedules',
+  description:
+    'Returns the recorded virtual user cadences: which personas are enabled, how often they run, and when each is next due.',
+  expose: true,
+  scopes: ['pikku:console:virtualUsers:read'],
+  func: async ({ virtualUserScheduleStore }) => {
+    if (!virtualUserScheduleStore) {
+      return []
+    }
+    const schedules = await virtualUserScheduleStore.list()
+    return schedules.map((schedule) => ({
+      ...schedule,
+      nextRunAt: schedule.nextRunAt.toISOString(),
+      lastRunAt: schedule.lastRunAt ? schedule.lastRunAt.toISOString() : null,
+    }))
+  },
+})

--- a/packages/addon/pikku-console/src/functions/set-virtual-user-schedule.function.ts
+++ b/packages/addon/pikku-console/src/functions/set-virtual-user-schedule.function.ts
@@ -1,0 +1,42 @@
+import { pikkuFunc } from '#pikku/addon/function'
+
+/**
+ * Changes how often a persona uses the application on its own.
+ *
+ * Dispatches the project's own scaffolded `setVirtualUserSchedule` rather than
+ * writing the row here: that function refuses an undeclared persona and one
+ * declared as acted upon, and a second copy of those rules in the console would
+ * eventually disagree with the first. So reading a cadence needs only the
+ * store, while changing one needs the scaffold — and the absence is reported as
+ * the missing scaffold it is.
+ *
+ * SECURITY: its own scope, and the most powerful one on this screen. Starting a
+ * run spends money once with a caller present to see it; writing a schedule
+ * spends it repeatedly with nobody there.
+ */
+export const setVirtualUserSchedule = pikkuFunc<
+  {
+    persona: string
+    enabled?: boolean
+    disposition?: string
+    goals?: string[]
+    minIntervalMs?: number
+    maxIntervalMs?: number
+  },
+  unknown
+>({
+  title: 'Set a Virtual User Schedule',
+  description:
+    'Says how often a declared persona should use this application on its own. Every field left out keeps what it already had.',
+  expose: true,
+  scopes: ['pikku:console:virtualUsers:schedule'],
+  func: async ({ metaService }, input, { rpc }) => {
+    const rpcs = await metaService?.getRpcMeta()
+    if (!rpcs?.setVirtualUserSchedule) {
+      throw new Error(
+        'This application has no setVirtualUserSchedule function — turn on `scaffold.virtualUser` in pikku.config.json and run `pikku all` to generate it.'
+      )
+    }
+    return await rpc!.exposed('setVirtualUserSchedule', input)
+  },
+})

--- a/packages/addon/pikku-console/src/scopes.ts
+++ b/packages/addon/pikku-console/src/scopes.ts
@@ -111,6 +111,10 @@ defineScope({
               run: {
                 description: 'Turn a persona loose on this application',
               },
+              schedule: {
+                description:
+                  'Decide which personas keep using this application on their own',
+              },
             },
           },
           db: {

--- a/packages/cli/src/functions/wirings/virtual-user/serialize-virtual-user-functions.ts
+++ b/packages/cli/src/functions/wirings/virtual-user/serialize-virtual-user-functions.ts
@@ -214,6 +214,19 @@ const virtualUserScheduleFields = {
   nextRunAt: z.string(),
   lastRunId: z.string().nullable(),
   lastRunAt: z.string().nullable(),
+  /**
+   * What \`definePersonas()\` says about this persona now, alongside what the
+   * row is actually running.
+   *
+   * A schedule is turned on once and then outlives the declaration it was
+   * written from: someone edits \`personas.ts\`, redeploys, and the row keeps
+   * running last month's goals with nothing anywhere to say so. Both sides
+   * cross the wire so that difference is readable rather than inferred.
+   */
+  declared: z.object({
+    disposition: Disposition,
+    goals: z.array(z.string()),
+  }),
 }
 
 export const SetVirtualUserScheduleOutput = z.object(virtualUserScheduleFields)
@@ -534,27 +547,38 @@ export const getVirtualUserRunSteps = pikkuFunc({
  * what every other call here takes; the engine's own duration also accepts
  * \`'30m'\`, which nothing on this side ever writes.
  */
-const serializeSchedule = (schedule: VirtualUserScheduleRecord) => ({
-  persona: schedule.persona,
-  enabled: schedule.enabled,
-  disposition: schedule.disposition,
-  goals: schedule.goals,
-  budget: schedule.budget
-    ? {
-        steps: schedule.budget.steps,
-        mutations: schedule.budget.mutations,
-        durationMs:
-          typeof schedule.budget.duration === 'number'
-            ? schedule.budget.duration
-            : undefined,
-      }
-    : null,
-  minIntervalMs: schedule.minIntervalMs,
-  maxIntervalMs: schedule.maxIntervalMs,
-  nextRunAt: schedule.nextRunAt.toISOString(),
-  lastRunId: schedule.lastRunId,
-  lastRunAt: schedule.lastRunAt ? schedule.lastRunAt.toISOString() : null,
-})
+const serializeSchedule = (schedule: VirtualUserScheduleRecord) => {
+  const persona = personaConfigs[
+    schedule.persona as keyof typeof personaConfigs
+  ] as { goals?: string[]; disposition?: string } | undefined
+  const declared = {
+    disposition: (persona?.disposition ??
+      'realistic') as VirtualUserDisposition,
+    goals: persona?.goals ?? [],
+  }
+  return {
+    persona: schedule.persona,
+    enabled: schedule.enabled,
+    disposition: schedule.disposition,
+    goals: schedule.goals,
+    budget: schedule.budget
+      ? {
+          steps: schedule.budget.steps,
+          mutations: schedule.budget.mutations,
+          durationMs:
+            typeof schedule.budget.duration === 'number'
+              ? schedule.budget.duration
+              : undefined,
+        }
+      : null,
+    minIntervalMs: schedule.minIntervalMs,
+    maxIntervalMs: schedule.maxIntervalMs,
+    nextRunAt: schedule.nextRunAt.toISOString(),
+    lastRunId: schedule.lastRunId,
+    lastRunAt: schedule.lastRunAt ? schedule.lastRunAt.toISOString() : null,
+    declared,
+  }
+}
 
 export const setVirtualUserSchedule = pikkuFunc({
   tags: ['pikku'],

--- a/packages/cli/src/functions/wirings/virtual-user/virtual-user-functions.test.ts
+++ b/packages/cli/src/functions/wirings/virtual-user/virtual-user-functions.test.ts
@@ -74,6 +74,22 @@ describe('serializeVirtualUserFunctions', () => {
     assert.match(setFn, /scopes: \['virtualUser:schedule'\]/)
   })
 
+  // A schedule is enabled once and then outlives the declaration it was written
+  // from, so both sides have to travel for anyone to see they have parted ways.
+  test('a schedule carries what the persona currently declares', () => {
+    const setFn = out.slice(out.indexOf('const serializeSchedule'))
+    assert.match(setFn, /declared,/)
+    assert.match(setFn, /personaConfigs\[/)
+    assert.match(schemas, /declared: z\.object\(\{/)
+  })
+
+  // Which fields differ is a question about how to render two values, and the
+  // answer belongs where they are rendered — not baked into the payload.
+  test('the difference is left for the client to work out', () => {
+    assert.doesNotMatch(out, /drifted/)
+    assert.doesNotMatch(schemas, /drifted/)
+  })
+
   // A codegen step does not get to decide that an app starts spending model
   // budget; the project wires the tick when it means it.
   test('the tick is emitted unwired, with no scaffolded cron behind it', () => {

--- a/packages/console/messages/en.json
+++ b/packages/console/messages/en.json
@@ -1067,5 +1067,15 @@
   "virtual_users_runs_none": "Nobody has run this user yet.",
   "virtual_users_runs_intent": "{title} · {status}",
   "virtual_users_runs_seed": "{disposition} · seed {seed}",
-  "virtual_users_runs_start": "Run now"
+  "virtual_users_runs_start": "Run now",
+  "virtual_users_schedule": "On their own",
+  "virtual_users_schedule_enabled": "Keep using the app",
+  "virtual_users_schedule_note": "Turned on here, never in code — a persona put on a clock spends model budget every time it runs, with nobody watching. Fields that no longer match what this persona declares are marked.",
+  "virtual_users_schedule_disposition": "Disposition",
+  "virtual_users_schedule_goals": "Goals",
+  "virtual_users_schedule_min_hours": "At least every (hours)",
+  "virtual_users_schedule_max_hours": "At most every (hours)",
+  "virtual_users_schedule_next": "Next run around {when}",
+  "virtual_users_schedule_off": "Not running on its own.",
+  "virtual_users_schedule_save": "Save cadence"
 }

--- a/packages/console/src/components/virtual-users/VirtualUserDocument.tsx
+++ b/packages/console/src/components/virtual-users/VirtualUserDocument.tsx
@@ -15,6 +15,7 @@ import { m } from '@/i18n/messages'
 import type { VirtualUserDisposition } from '@pikku/core/virtual-user'
 import type { VirtualUserDoc } from './virtual-user-model'
 import { VirtualUserRuns } from './VirtualUserRuns'
+import { VirtualUserSchedule } from './VirtualUserSchedule'
 import styles from './virtual-users.module.css'
 
 /** One line saying what this disposition is, in a person's terms. */
@@ -623,6 +624,12 @@ export const VirtualUserDocument: React.FC<VirtualUserDocumentProps> = ({
             </Text>
           )}
         </Section>
+
+        <VirtualUserSchedule
+          persona={user.id}
+          declaredDisposition={user.disposition}
+          declaredGoals={user.goals}
+        />
 
         <VirtualUserRuns persona={user.id} />
 

--- a/packages/console/src/components/virtual-users/VirtualUserSchedule.tsx
+++ b/packages/console/src/components/virtual-users/VirtualUserSchedule.tsx
@@ -1,0 +1,205 @@
+import React from 'react'
+import {
+  Button,
+  Group,
+  NumberInput,
+  Select,
+  Stack,
+  Switch,
+  TagsInput,
+  Text,
+} from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+import { m } from '@/i18n/messages'
+import type { VirtualUserDisposition } from '@pikku/core/virtual-user'
+import {
+  useSetVirtualUserSchedule,
+  useVirtualUserSchedules,
+} from '../../hooks/useVirtualUserSchedules'
+import styles from './virtual-users.module.css'
+
+const HOUR_MS = 3_600_000
+
+const DISPOSITIONS: VirtualUserDisposition[] = [
+  'realistic',
+  'careless',
+  'newcomer',
+  'stale',
+  'auditor',
+  'adversarial',
+  'accountable',
+]
+
+/**
+ * What a persona does when nobody is watching, and whether that is still what
+ * the repository says they do.
+ *
+ * A cadence is enabled once and then outlives the declaration it was written
+ * from: someone edits `personas.ts`, redeploys, and the row keeps running last
+ * month's goals. So every field is shown against what this persona currently
+ * declares, and marks itself where the two have parted ways.
+ *
+ * `original` is the declaration rather than the row's own saved value. Both are
+ * true comparisons, but only one is a question this screen exists to answer —
+ * whether the code in front of you is what is running. That a field has unsaved
+ * edits is already said by the save button appearing.
+ *
+ * The intervals carry no `original`: nothing declares a cadence in code, and
+ * there is deliberately nowhere to. A persona's timing is an operational choice
+ * about how much to spend, made where it can be changed without a deploy.
+ */
+export const VirtualUserSchedule: React.FC<{
+  persona: string
+  declaredDisposition: VirtualUserDisposition
+  declaredGoals: string[]
+}> = ({ persona, declaredDisposition, declaredGoals }) => {
+  const { data, error } = useVirtualUserSchedules()
+  const save = useSetVirtualUserSchedule(persona)
+  const row = (data ?? []).find((schedule) => schedule.persona === persona)
+
+  const saved = React.useMemo(
+    () => ({
+      disposition: (row?.disposition ??
+        declaredDisposition) as VirtualUserDisposition,
+      goals: row?.goals ?? declaredGoals,
+      minHours: (row?.minIntervalMs ?? 6 * HOUR_MS) / HOUR_MS,
+      maxHours: (row?.maxIntervalMs ?? 24 * HOUR_MS) / HOUR_MS,
+    }),
+    [row, declaredDisposition, declaredGoals]
+  )
+  const [draft, setDraft] = React.useState(saved)
+  const dirty =
+    draft.disposition !== saved.disposition ||
+    draft.goals.join(' ') !== saved.goals.join(' ') ||
+    draft.minHours !== saved.minHours ||
+    draft.maxHours !== saved.maxHours
+  // A cadence changed from the CLI, or by anyone else on this console, arrives
+  // as a new row on the next read. Rebasing the draft on it would take the
+  // field out from under whoever is mid-edit, so the draft only follows the
+  // saved values while there is nothing to lose.
+  React.useEffect(() => {
+    if (!dirty) setDraft(saved)
+  }, [saved])
+
+  return (
+    <Stack gap="sm" data-testid="virtual-user-schedule">
+      <Group justify="space-between" align="center">
+        <Text
+          size="xs"
+          fw={600}
+          tt="uppercase"
+          c="dimmed"
+          className={styles.sectionTitle}
+          style={{ letterSpacing: '0.06em' }}
+        >
+          {m.virtual_users_schedule()}
+        </Text>
+        <Switch
+          size="sm"
+          checked={row?.enabled ?? false}
+          disabled={save.isPending}
+          onChange={(event) =>
+            save.mutate({ enabled: event.currentTarget.checked })
+          }
+          label={m.virtual_users_schedule_enabled()}
+          data-testid="virtual-user-schedule-enabled"
+        />
+      </Group>
+
+      <Text size="xs" c="dimmed" style={{ maxWidth: '68ch' }}>
+        {m.virtual_users_schedule_note()}
+      </Text>
+
+      {error && (
+        <Text size="xs" c="red">
+          {asI18n(error instanceof Error ? error.message : String(error))}
+        </Text>
+      )}
+      {save.error && (
+        <Text size="xs" c="red">
+          {asI18n(
+            save.error instanceof Error
+              ? save.error.message
+              : String(save.error)
+          )}
+        </Text>
+      )}
+
+      <Select
+        size="xs"
+        label={m.virtual_users_schedule_disposition()}
+        data={DISPOSITIONS}
+        value={draft.disposition}
+        original={declaredDisposition}
+        onChange={(value) =>
+          setDraft((current) => ({
+            ...current,
+            disposition: (value ??
+              declaredDisposition) as VirtualUserDisposition,
+          }))
+        }
+        data-testid="virtual-user-schedule-disposition"
+      />
+
+      <TagsInput
+        size="xs"
+        label={m.virtual_users_schedule_goals()}
+        value={draft.goals}
+        original={declaredGoals}
+        onChange={(goals) => setDraft((current) => ({ ...current, goals }))}
+        data-testid="virtual-user-schedule-goals"
+      />
+
+      <Group grow align="start">
+        <NumberInput
+          size="xs"
+          min={1}
+          label={m.virtual_users_schedule_min_hours()}
+          value={draft.minHours}
+          onChange={(value) =>
+            setDraft((current) => ({ ...current, minHours: Number(value) }))
+          }
+          data-testid="virtual-user-schedule-min"
+        />
+        <NumberInput
+          size="xs"
+          min={1}
+          label={m.virtual_users_schedule_max_hours()}
+          value={draft.maxHours}
+          onChange={(value) =>
+            setDraft((current) => ({ ...current, maxHours: Number(value) }))
+          }
+          data-testid="virtual-user-schedule-max"
+        />
+      </Group>
+
+      <Group justify="space-between" align="center">
+        <Text size="xs" c="dimmed">
+          {row?.enabled
+            ? m.virtual_users_schedule_next({
+                when: new Date(row.nextRunAt).toLocaleString(),
+              })
+            : m.virtual_users_schedule_off()}
+        </Text>
+        {dirty && (
+          <Button
+            size="compact-xs"
+            variant="light"
+            loading={save.isPending}
+            onClick={() =>
+              save.mutate({
+                disposition: draft.disposition,
+                goals: draft.goals,
+                minIntervalMs: draft.minHours * HOUR_MS,
+                maxIntervalMs: draft.maxHours * HOUR_MS,
+              })
+            }
+            data-testid="virtual-user-schedule-save"
+          >
+            {m.virtual_users_schedule_save()}
+          </Button>
+        )}
+      </Group>
+    </Stack>
+  )
+}

--- a/packages/console/src/components/virtual-users/VirtualUsersWorkspace.tsx
+++ b/packages/console/src/components/virtual-users/VirtualUsersWorkspace.tsx
@@ -13,10 +13,19 @@ const EXAMPLE =
   "definePersonas({ shopper: { name: 'Shopper', disposition: 'careless', goals: [...] } })"
 
 /**
- * The virtual users reading surface: who is declared, and what each one would
- * do if it were run. Deliberately not a run view — a run happens against a real
- * stage, over real auth, from the CLI or from Fabric, and pretending otherwise
- * here would put a button on something that spends money.
+ * The virtual users screen: who is declared, what each one would do if it were
+ * run, what happened when they were, and whether any of them keeps going on its
+ * own.
+ *
+ * The reading half is built from declarations alone and needs nothing wired.
+ * The rest needs a store, and says so rather than failing: an application with
+ * no `virtualUserRunStore` has no runs, and one with no
+ * `virtualUserScheduleStore` has no cadences, which are true answers.
+ *
+ * Both of the controls here spend money, which is why neither is a plain
+ * button. Running acts once, with whoever clicked it watching. A cadence keeps
+ * acting with nobody there, so it is off until somebody turns it on and every
+ * field is shown against what the persona declares.
  */
 export const VirtualUsersWorkspace: React.FC = () => {
   const { users, selected, setSelectedId, loading } = useVirtualUsers()

--- a/packages/console/src/hooks/useVirtualUserSchedules.ts
+++ b/packages/console/src/hooks/useVirtualUserSchedules.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { usePikkuRPC } from '../context/PikkuRpcProvider'
+
+export interface VirtualUserScheduleRow {
+  persona: string
+  enabled: boolean
+  disposition: string
+  goals: string[]
+  minIntervalMs: number
+  maxIntervalMs: number
+  nextRunAt: string
+  lastRunId: string | null
+  lastRunAt: string | null
+}
+
+/**
+ * Which personas keep using this application on their own.
+ *
+ * One read for every persona rather than one per row: an application has as
+ * many cadences as it has personas, the rail shows all of them, and a request
+ * per selection would re-ask for rows already in hand.
+ *
+ * An application that wired no `virtualUserScheduleStore` answers with an empty
+ * list rather than an error — it has no cadences, which is a true answer.
+ */
+export function useVirtualUserSchedules() {
+  const rpc = usePikkuRPC()
+
+  return useQuery({
+    queryKey: ['virtual-user-schedules'],
+    queryFn: async () =>
+      (await rpc.invoke(
+        'console:getVirtualUserSchedules'
+      )) as VirtualUserScheduleRow[],
+  })
+}
+
+/**
+ * Changes one persona's cadence.
+ *
+ * A partial write: every field left out keeps whatever the row already had, so
+ * a toggle sends `enabled` and nothing else and cannot quietly overwrite goals
+ * somebody set from the CLI between this page loading and the click.
+ */
+export function useSetVirtualUserSchedule(persona: string) {
+  const rpc = usePikkuRPC()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input: {
+      enabled?: boolean
+      disposition?: string
+      goals?: string[]
+      minIntervalMs?: number
+      maxIntervalMs?: number
+    }) =>
+      await rpc.invoke('console:setVirtualUserSchedule', { persona, ...input }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ['virtual-user-schedules'] }),
+  })
+}

--- a/packages/frontend/mantine/package.json
+++ b/packages/frontend/mantine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pikku/mantine",
   "version": "0.12.10",
-  "description": "Mantine components with i18n-tightened types for Pikku — zero runtime added",
+  "description": "Mantine components with i18n-tightened types for Pikku",
   "author": "yasser.fadl@gmail.com",
   "license": "MIT",
   "type": "module",
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "tsc": "tsc",
-    "test": "tsc -p tsconfig.test-d.json && node --test src/theme/theme-contract.test.ts",
+    "test": "tsc -p tsconfig.test-d.json && node --test src/theme/theme-contract.test.ts && tsx --test src/core/original.test.ts",
     "build:esm": "tsc -b && echo '{\"type\": \"module\"}' > dist/esm/package.json",
     "build:cjs": "tsc -b tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json",
     "build": "yarn build:esm && yarn build:cjs",
@@ -41,6 +41,7 @@
     "@types/react": "^19",
     "react": "^19",
     "react-dom": "^19",
+    "tsx": "^4.23.12",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/frontend/mantine/src/core/index.ts
+++ b/packages/frontend/mantine/src/core/index.ts
@@ -11,8 +11,9 @@
 // raw strings fail to compile. Pass text through `t()` / `asI18n()`.
 
 export * from '@mantine/core'
-import { createElement } from 'react'
+import { createElement, forwardRef } from 'react'
 import type { CSSProperties } from 'react'
+import { modifiedStyles } from './original.js'
 
 import {
   // polymorphic (children)
@@ -290,69 +291,124 @@ export const Notification = MantineNotification as OverrideFactory<
 >
 
 // ── Plain: inputs (label / placeholder / description, plus extras) ────────────
-export const TextInput = MantineTextInput as OverrideFactory<
+
+/**
+ * An input's value alongside the one it started as. See {@link modifiedStyles}
+ * — the two may be a runtime row against its declaration, or simply a field
+ * against what it held when the form loaded.
+ *
+ * On every control that carries a value, so that wiring `original` through is
+ * never a question of whether this particular input supports it. A control
+ * without an `original` behaves exactly as Mantine's does.
+ *
+ * Controlled fields only: the comparison reads the value off props, so a field
+ * left uncontrolled with `defaultValue` has nothing to compare and stays
+ * unmarked.
+ */
+type Original = { original?: unknown }
+
+/**
+ * A caller's own `styles` wins. Mantine also accepts a function there, which
+ * cannot be merged into without calling it with a theme this layer does not
+ * have — so a call styling its input by hand keeps its own border and simply
+ * does not get the mark.
+ *
+ * `from` and `part` differ per control: a toggle's value is `checked`, and it
+ * hides the input it would otherwise be drawn on, painting a track or a circle
+ * instead. Bordering the hidden element marks nothing visible.
+ */
+const withOriginal = (
+  Component: any,
+  from: 'value' | 'checked' = 'value',
+  part = 'input'
+) =>
+  forwardRef<any, any>(({ original, styles, ...props }, ref) => {
+    const modified = modifiedStyles(props[from], original, part)
+    const merged =
+      !modified.styles || typeof styles === 'function'
+        ? styles
+        : {
+            ...styles,
+            [part]: { ...(styles as any)?.[part], ...modified.styles[part] },
+          }
+    return createElement(Component, { ...props, ref, styles: merged })
+  })
+
+export const TextInput = withOriginal(MantineTextInput) as OverrideFactory<
   TextInputFactory,
-  Input
+  Input & Original
 >
-export const PasswordInput = MantinePasswordInput as OverrideFactory<
-  PasswordInputFactory,
-  Input
->
-export const Textarea = MantineTextarea as OverrideFactory<
+export const PasswordInput = withOriginal(
+  MantinePasswordInput
+) as OverrideFactory<PasswordInputFactory, Original & Input>
+export const Textarea = withOriginal(MantineTextarea) as OverrideFactory<
   TextareaFactory,
-  Input
+  Input & Original
 >
-export const JsonInput = MantineJsonInput as OverrideFactory<
+export const JsonInput = withOriginal(MantineJsonInput) as OverrideFactory<
   JsonInputFactory,
-  Input
+  Original & Input
 >
-export const NativeSelect = MantineNativeSelect as OverrideFactory<
-  NativeSelectFactory,
-  Input
->
-export const NumberInput = MantineNumberInput as OverrideFactory<
+export const NativeSelect = withOriginal(
+  MantineNativeSelect
+) as OverrideFactory<NativeSelectFactory, Original & Input>
+export const NumberInput = withOriginal(MantineNumberInput) as OverrideFactory<
   NumberInputFactory,
-  Input & { prefix?: I18nString; suffix?: I18nString }
+  Input & Original & { prefix?: I18nString; suffix?: I18nString }
 >
-export const Select = MantineSelect as OverrideFactory<
+export const Select = withOriginal(MantineSelect) as OverrideFactory<
   SelectFactory,
-  Input & { nothingFoundMessage?: I18nNode }
+  Input & Original & { nothingFoundMessage?: I18nNode }
 >
-export const MultiSelect = MantineMultiSelect as OverrideFactory<
+export const MultiSelect = withOriginal(MantineMultiSelect) as OverrideFactory<
   MultiSelectFactory,
-  Input & { nothingFoundMessage?: I18nNode }
+  Input & Original & { nothingFoundMessage?: I18nNode }
 >
-export const Autocomplete = MantineAutocomplete as OverrideFactory<
+export const Autocomplete = withOriginal(
+  MantineAutocomplete
+) as OverrideFactory<
   AutocompleteFactory,
-  Input & { nothingFoundMessage?: I18nNode }
+  Original & Input & { nothingFoundMessage?: I18nNode }
 >
-export const TagsInput = MantineTagsInput as OverrideFactory<
+export const TagsInput = withOriginal(MantineTagsInput) as OverrideFactory<
   TagsInputFactory,
-  Input & { nothingFoundMessage?: I18nNode }
+  Input & Original & { nothingFoundMessage?: I18nNode }
 >
-export const ColorInput = MantineColorInput as OverrideFactory<
+export const ColorInput = withOriginal(MantineColorInput) as OverrideFactory<
   ColorInputFactory,
-  Input & { swatchesLabel?: I18nString }
+  Original & Input & { swatchesLabel?: I18nString }
 >
 export const FileInput = MantineFileInput as OverrideFactory<
   FileInputFactory,
   { label?: I18nNode; placeholder?: I18nNode; description?: I18nNode }
 >
-export const PinInput = MantinePinInput as OverrideFactory<
+export const PinInput = withOriginal(MantinePinInput) as OverrideFactory<
   PinInputFactory,
-  { placeholder?: I18nString }
+  Original & { placeholder?: I18nString }
 >
-export const Checkbox = MantineCheckbox as OverrideFactory<
+export const Checkbox = withOriginal(
+  MantineCheckbox,
+  'checked',
+  'input'
+) as OverrideFactory<
   CheckboxFactory,
-  { label?: I18nNode; description?: I18nNode }
+  Original & { label?: I18nNode; description?: I18nNode }
 >
-export const Switch = MantineSwitch as OverrideFactory<
+export const Switch = withOriginal(
+  MantineSwitch,
+  'checked',
+  'track'
+) as OverrideFactory<
   SwitchFactory,
-  { label?: I18nNode; description?: I18nNode }
+  Original & { label?: I18nNode; description?: I18nNode }
 >
-export const Radio = MantineRadio as OverrideFactory<
+export const Radio = withOriginal(
+  MantineRadio,
+  'checked',
+  'radio'
+) as OverrideFactory<
   RadioFactory,
-  { label?: I18nNode; description?: I18nNode }
+  Original & { label?: I18nNode; description?: I18nNode }
 >
 // PillsInput is an Input wrapper (label/description/error live on the root); its
 // `.Field` static carries the placeholder. Gate both via a composed factory.
@@ -451,3 +507,5 @@ export const Input = MantineInput as unknown as WithStatics<
     Placeholder: OverrideFactory<{ props: InputPlaceholderProps }, Children>
   }
 >
+
+export { modifiedStyles } from './original.js'

--- a/packages/frontend/mantine/src/core/original.test.ts
+++ b/packages/frontend/mantine/src/core/original.test.ts
@@ -1,0 +1,49 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { modifiedStyles } from './original.js'
+
+const marked = (result: ReturnType<typeof modifiedStyles>) => !!result.styles
+
+test('a value matching the one it came from is not marked', () => {
+  assert.equal(marked(modifiedStyles('realistic', 'realistic')), false)
+  assert.equal(marked(modifiedStyles(6, 6)), false)
+})
+
+test('a value that has parted ways is marked', () => {
+  assert.equal(marked(modifiedStyles('careless', 'realistic')), true)
+})
+
+// The values being compared are rebuilt every render — a goals array arrives as
+// a new reference each time and is still the same list. A referential check
+// would mark every field on a screen that had changed nothing.
+test('equal lists from different renders are the same value', () => {
+  assert.equal(marked(modifiedStyles(['a', 'b'], ['a', 'b'])), false)
+  assert.equal(marked(modifiedStyles(['a', 'b'], ['b', 'a'])), true)
+})
+
+// `undefined` is how a caller says there is nothing to compare against, which
+// every control without an `original` relies on to behave as Mantine's does.
+test('no original means no comparison, whatever the value is', () => {
+  assert.equal(marked(modifiedStyles('anything', undefined)), false)
+  assert.equal(marked(modifiedStyles(undefined, undefined)), false)
+})
+
+// So a field whose original value is genuinely absent can still be marked once
+// something is typed into it.
+test('null is an original, so an absent value can still be marked', () => {
+  assert.equal(marked(modifiedStyles('typed', null)), true)
+  assert.equal(marked(modifiedStyles(null, null)), false)
+})
+
+// A toggle hides the input it would otherwise be bordered on, so the part being
+// styled travels with the value rather than being fixed here.
+test('the marked part is the caller choice', () => {
+  assert.deepEqual(Object.keys(modifiedStyles(true, false).styles!), ['input'])
+  assert.deepEqual(Object.keys(modifiedStyles(true, false, 'track').styles!), [
+    'track',
+  ])
+})
+
+test('NaN counts as unchanged against itself', () => {
+  assert.equal(marked(modifiedStyles(Number.NaN, Number.NaN)), false)
+})

--- a/packages/frontend/mantine/src/core/original.ts
+++ b/packages/frontend/mantine/src/core/original.ts
@@ -1,0 +1,47 @@
+/**
+ * Marks an input whose value no longer matches the one it came from.
+ *
+ * Deliberately says nothing about where the other value came from, because the
+ * comparison is the same one either way. A row edited at runtime against what
+ * the repository declares; a form field against what it held when it loaded; a
+ * setting against the default it was seeded with. In every case there are two
+ * values, the second is the one being rendered, and without a mark nobody can
+ * tell by looking which fields were touched.
+ *
+ * That makes it worth wiring `original` through even where a form is not being
+ * edited yet: pass what the value started as and every subsequent keystroke
+ * marks itself, with no dirty-tracking state and nothing asked of the server.
+ *
+ * `undefined` means no comparison was asked for, so a field whose original
+ * value is genuinely absent cannot be marked — pass `null` for that.
+ *
+ * Deliberately a plain function rather than a hook: there is no state and
+ * nothing to subscribe to, so a hook would only add a rule about where it may
+ * be called. Components that take an `original` run it themselves; anything
+ * else can call it and spread the result.
+ *
+ * Orange rather than red. A value that differs from the one it came from is not
+ * an error — someone probably meant it — it is a thing to notice before
+ * assuming what is on screen is what was there.
+ */
+export const modifiedStyles = (
+  value: unknown,
+  original: unknown,
+  /**
+   * Which part Mantine actually draws the border on. `input` for anything that
+   * holds text; a toggle hides its input and paints elsewhere.
+   */
+  key: string = 'input'
+): { styles?: Record<string, { borderColor: string }> } => {
+  if (original === undefined) return {}
+  // Structural rather than referential: the values being compared are small —
+  // a string, a number, a list of goals — and a caller holding an equal array
+  // from a different render is the normal case, not the exception.
+  const same =
+    Object.is(value, original) ||
+    JSON.stringify(value ?? null) === JSON.stringify(original ?? null)
+  if (same) return {}
+  return {
+    styles: { [key]: { borderColor: 'var(--mantine-color-orange-filled)' } },
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5742,6 +5742,7 @@ __metadata:
     "@types/react": "npm:^19"
     react: "npm:^19"
     react-dom: "npm:^19"
+    tsx: "npm:^4.23.12"
     typescript: "npm:^6.0.3"
   peerDependencies:
     "@mantine/core": ^9.2.1


### PR DESCRIPTION
Stacked on #1445 — review that one first; this PR's diff is the console half.

The Virtual Users screen could say who is declared and what happened when somebody ran them, but not whether anybody keeps running. That last part is the one that cannot be read off the repository: a cadence is turned on once and then outlives the declaration it was written from, so someone edits `personas.ts`, redeploys, and the row keeps running last month's goals with nothing anywhere to say so.

## What it shows

A cadence section on each persona: a switch that turns them loose, their disposition, goals and interval, and when they are next due.

Every field carries `original` set to what the persona **currently declares**, and marks itself orange where the two have parted ways. The declarations are already in the meta this console loads, so the pairing happens on the client — asking the server for a second copy would only give the screen two answers that can disagree. (This is why the `declared` field added in #1445 is for an app's *own* clients, not for the console.)

`original` is the declaration rather than the row's own saved value. Both are true comparisons, but only one is the question this screen exists to answer: whether the code in front of you is what is running. That a field has unsaved edits is already said by the save button appearing.

## Deliberate omissions

- **Intervals carry no `original`.** Nothing in code sets a cadence and there is nowhere for it to. How often to spend money is an operational choice, made where it can be changed without a deploy — the same reason the switch is the only way to start one.
- **The draft does not rebase on a newer row while it is dirty**, so a cadence changed from the CLI mid-edit does not take the field out from under whoever is typing.
- **The toggle sends `enabled` and nothing else.** A partial write, so it cannot quietly overwrite goals somebody set from the CLI between this page loading and the click.

## Server side

Two addon functions. Reading needs only a wired `virtualUserScheduleStore`, matching how runs are read, so a project sees its cadences whether or not `scaffold.virtualUser` is on. Writing dispatches the project's own scaffolded `setVirtualUserSchedule`, so the refusals for an undeclared or acted-upon persona stay in one place rather than being copied into the console.

New scope `pikku:console:virtualUsers:schedule`, separate from `:run`, for the reason the scaffold gives it one: a run spends money once with somebody watching, and a schedule spends it repeatedly with nobody there.

## Also

Corrects `VirtualUsersWorkspace`'s docblock, which still said the screen was "deliberately not a run view — … would put a button on something that spends money" after the run list landed underneath it. The principle it was defending is real and still holds, so the replacement says what it actually is rather than dropping it.

## Verification

`packages/console` typecheck goes 120 → 18 errors once `@pikku/core` is built, and none of the 18 are in the new files — all are pre-existing (an ungenerated RPC map, unbuilt `@pikku/fetch`, missing paraglide output). Confirmed the new components are genuinely checked rather than degraded to `any` by planting a bogus prop and watching it error.

Not verified in a browser. The orange marking is exercised by the unit tests in #1445, but nobody has looked at this screen against a live app with a drifted row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)