### PR TITLE
fix(cli): the virtual user scaffold typechecks in a real app

### DIFF
--- a/.changeset/the-virtual-user-scaffold-typechecks-in-a-real-app.md
+++ b/.changeset/the-virtual-user-scaffold-typechecks-in-a-real-app.md
@@ -1,0 +1,20 @@
+---
+'@pikku/cli': patch
+---
+
+Make the virtual user scaffold typecheck in the project it is generated into.
+
+Three shapes in `virtual-user.gen.ts` were written against what the scaffold
+knows rather than what an application actually has, and every one of them was
+an error the moment a real project turned `scaffold.virtualUser` on:
+
+- `startVirtualUserRun` asked for `config: { nodeEnv?: string }`. An
+  application's `Config` is its own interface and need not declare `nodeEnv` at
+  all — and a target type whose properties are all optional shares none with
+  such a config, so TypeScript rejected the whole call. It takes `unknown` and
+  reads `nodeEnv` off it.
+- It also asked for `rpc.invoke(name: string, …)`. A project's generated
+  `invoke` is generic over its own map's keys and `string` is not one of them.
+  The parameter now names the one function the scaffold dispatches.
+- `listVirtualUserSchedules` passed `input: null`, which is not one of the two
+  things an input may be. The field is omitted.

--- a/.changeset/the-virtual-user-scaffold-typechecks-in-a-real-app.md
+++ b/.changeset/the-virtual-user-scaffold-typechecks-in-a-real-app.md
@@ -18,3 +18,11 @@ an error the moment a real project turned `scaffold.virtualUser` on:
   The parameter now names the one function the scaffold dispatches.
 - `listVirtualUserSchedules` passed `input: null`, which is not one of the two
   things an input may be. The field is omitted.
+
+It also signed in at the wrong door. `createPersonas` was called without a
+sign-in or RPC path, so a run against an application that mounts auth anywhere
+but the root — `/api/auth` is the usual place — signed in against a 404 and
+spent its whole budget reasoning about why every call failed. It now reads
+`SCENARIO_SIGN_IN_PATH` and `SCENARIO_RPC_PATH`, the same two variables a
+scenario run reads, because a virtual user goes through exactly the doors a
+scenario does.

--- a/packages/cli/src/functions/wirings/virtual-user/serialize-virtual-user-functions.ts
+++ b/packages/cli/src/functions/wirings/virtual-user/serialize-virtual-user-functions.ts
@@ -362,9 +362,16 @@ const serializeRun = (run: VirtualUserRunRecord) => ({
 const startVirtualUserRun = async (
   services: {
     virtualUserRunStore?: VirtualUserRunStore
-    config: { nodeEnv?: string }
+    // \`unknown\` because an application's Config is its own interface and need
+    // not declare nodeEnv at all. A structural \`{ nodeEnv?: string }\` shares no
+    // property with such a config and TypeScript rejects the whole call.
+    config: unknown
   },
-  rpc: { invoke: (name: string, data: any) => Promise<unknown> },
+  // Named literally rather than as \`string\`: a project's generated rpc.invoke
+  // is generic over its own map's keys, and \`string\` is not one of them.
+  rpc: {
+    invoke: (name: 'executeVirtualUserRun', data: any) => Promise<unknown>
+  },
   input: {
     persona: string
     disposition?: string
@@ -406,7 +413,7 @@ const startVirtualUserRun = async (
   // does wrong, which is not a thing to do to real customers' data. Checked
   // against the effective disposition, so the override cannot smuggle one in.
   if (
-    config.nodeEnv === 'production' &&
+    (config as { nodeEnv?: string } | undefined)?.nodeEnv === 'production' &&
     disposition !== PRODUCTION_DISPOSITION
   ) {
     throw new Error(
@@ -645,7 +652,6 @@ export const listVirtualUserSchedules = pikkuFunc({
     'Which personas are on a clock, how often they run, and when each is next due.',
   expose: true,
   scopes: ['virtualUser:read'],
-  input: null,
   output: ListVirtualUserSchedulesOutput,
   func: async ({ virtualUserScheduleStore }) => {
     if (!virtualUserScheduleStore) {

--- a/packages/cli/src/functions/wirings/virtual-user/serialize-virtual-user-functions.ts
+++ b/packages/cli/src/functions/wirings/virtual-user/serialize-virtual-user-functions.ts
@@ -314,6 +314,16 @@ const SECRET_VARIABLE = 'SCENARIO_ACTOR_SECRET'
 const MODEL_VARIABLE = 'VIRTUAL_USER_MODEL'
 
 /**
+ * The same two variables a scenario run reads, because a virtual user signs in
+ * and calls through exactly the doors a scenario does. An app that mounts auth
+ * somewhere other than the root — \`/api/auth\` is the common one — has no other
+ * way to say so, and without them the run signs in against a 404 and spends its
+ * whole budget thinking about why nothing works.
+ */
+const SIGN_IN_PATH_VARIABLE = 'SCENARIO_SIGN_IN_PATH'
+const RPC_PATH_VARIABLE = 'SCENARIO_RPC_PATH'
+
+/**
  * One run on the wire. Findings and intents are free-form by design — the
  * engine records what it noticed, not a fixed row shape — so they cross as the
  * schema's open objects rather than being narrowed to whatever kinds exist
@@ -798,7 +808,13 @@ export const executeVirtualUserRun = pikkuSessionlessFunc({
         agentsMeta: await metaService.getAgentsMeta(),
       })
 
-      const signedIn = createPersonas({ apiUrl, secret, model })
+      const signedIn = createPersonas({
+        apiUrl,
+        secret,
+        model,
+        signInPath: (await variables.get(SIGN_IN_PATH_VARIABLE)) ?? undefined,
+        rpcPath: (await variables.get(RPC_PATH_VARIABLE)) ?? undefined,
+      })
       const target = signedIn[personaId as keyof typeof signedIn]
       if (!target) {
         throw new Error(\`Persona "\${personaId}" cannot sign in\`)

--- a/packages/cli/src/functions/wirings/virtual-user/virtual-user-functions.test.ts
+++ b/packages/cli/src/functions/wirings/virtual-user/virtual-user-functions.test.ts
@@ -173,7 +173,7 @@ describe('serializeVirtualUserFunctions', () => {
   })
 
   test('refuses every disposition but the accountable one in production', () => {
-    assert.match(out, /config\.nodeEnv === 'production'/)
+    assert.match(out, /nodeEnv === 'production'/)
     assert.match(out, /disposition !== PRODUCTION_DISPOSITION/)
   })
 
@@ -206,6 +206,16 @@ describe('serializeVirtualUserFunctions', () => {
     )
     const execute = out.slice(out.indexOf('executeVirtualUserRun ='))
     assert.doesNotMatch(execute, /expose: true/)
+  })
+
+  // An app that mounts auth somewhere other than the root has no other way to
+  // say so, and the run would otherwise sign in against a 404 and spend its
+  // whole budget wondering why every call fails.
+  test('signs in and calls through the paths a scenario run uses', () => {
+    assert.match(out, /SCENARIO_SIGN_IN_PATH/)
+    assert.match(out, /SCENARIO_RPC_PATH/)
+    assert.match(out, /signInPath:/)
+    assert.match(out, /rpcPath:/)
   })
 
   test('imports the generated personas rather than declaring any', () => {


### PR DESCRIPTION
Turning `scaffold.virtualUser` on in an application and running `tsc` produces three errors, all in the generated `virtual-user.gen.ts` and none of them the app's fault.

- `startVirtualUserRun` asked for `config: { nodeEnv?: string }`. An application's `Config` is its own interface and need not declare `nodeEnv` at all — and a target type whose properties are all optional shares none with such a config, so TypeScript rejected the whole call rather than the one field. It takes `unknown` and reads `nodeEnv` off it.
- It also asked for `rpc.invoke(name: string, …)`. A project's generated `invoke` is generic over its own map's keys, and `string` is not one of them. The parameter now names the one function the scaffold dispatches.
- `listVirtualUserSchedules` passed `input: null`, which is neither a schema nor absent.

Verified by hand-applying the same three edits to a real project's generated scaffold: its error count drops from 67 to 64, its pre-existing baseline, with nothing left in `virtual-user.gen.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated virtual user scaffolds so they typecheck correctly in real projects.
  - Virtual user sign-in and RPC requests now honor configurable scenario paths.
  - Improved compatibility with different configuration shapes.
  - Corrected generated schedule and run invocation definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->