### PR TITLE
feat(console): let an embedding host supply the loading mark

### DIFF
--- a/.changeset/olive-panthers-shake.md
+++ b/.changeset/olive-panthers-shake.md
@@ -1,0 +1,16 @@
+---
+'@pikku/console': patch
+---
+
+Let an embedding host supply the loading mark.
+
+Every page-level spinner in the console was a bare Mantine `<Loader />` centred
+in the screen — 30-odd copies of the same block. A host that embeds the console
+inside its own product (Fabric) has a loading mark of its own, and a Mantine
+ring in the middle of an otherwise branded page is the one place the embedded
+screen stops looking like the rest of that product.
+
+Those sites now render `ConsoleLoading`, which shows the host's mark when there
+is one and the Mantine loader when the console stands alone. The host supplies
+it once, as `HostConsoleChrome`'s new optional `loader` prop, rather than every
+screen taking a prop for it. Nothing changes for the standalone console.

--- a/packages/console/src/components/agent-playground/AgentChatPanel.tsx
+++ b/packages/console/src/components/agent-playground/AgentChatPanel.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { Box, Center, Loader } from '@pikku/mantine/core'
+import { Box } from '@pikku/mantine/core'
 import { useAgentPlayground } from '../../context/AgentPlaygroundContext'
 import { useAgentPlaygroundSurface } from '../../context/AgentPlaygroundSurfaceContext'
 import { useAgentCredentials } from '../../hooks/useAgentCredentials'
 import { AgentChat } from '../project/AgentChat'
 import { AgentCredentialPrompt } from './AgentCredentialPrompt'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 /**
  * The conversation with the surface's agent, gated behind whatever accounts the
@@ -30,9 +31,7 @@ export const AgentChatPanel: React.FC = () => {
             onRefresh={refetchCreds}
           />
         ) : threadId != null && dbMessages === undefined ? (
-          <Center h="100%">
-            <Loader />
-          </Center>
+          <ConsoleLoading />
         ) : (
           <AgentChat key={`${agentId}-${threadId}`} />
         )}

--- a/packages/console/src/components/auth/AuthGate.tsx
+++ b/packages/console/src/components/auth/AuthGate.tsx
@@ -1,7 +1,7 @@
-import { Center, Loader } from '@pikku/mantine/core'
 import { useAuth } from '../../context/AuthContext'
 import { LoginScreen } from './LoginScreen'
 import { NotAuthorized } from './NotAuthorized'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 /**
  * The console's front door. Blocks all app UI until there is a Better Auth
@@ -20,11 +20,7 @@ export const AuthGate: React.FC<{ children: React.ReactNode }> = ({
   const { loading, user, canUseConsole } = useAuth()
 
   if (loading) {
-    return (
-      <Center h="100vh">
-        <Loader />
-      </Center>
-    )
+    return <ConsoleLoading h="100vh" />
   }
 
   if (!user) {

--- a/packages/console/src/components/knowledge/KnowledgeWorkspace.tsx
+++ b/packages/console/src/components/knowledge/KnowledgeWorkspace.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Center, Loader, Text } from '@pikku/mantine/core'
+import { Box, Center, Text } from '@pikku/mantine/core'
 import { BookOpen } from 'lucide-react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
@@ -14,6 +14,7 @@ import type { KnowledgeBrowse } from '../../hooks/useKnowledgeBrowse'
 import { findingsForNote } from '../../lib/knowledge'
 import { usePageOptionsDismiss } from '../../context/PageOptionsProvider'
 import classes from '../ui/console.module.css'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 const DOCS_HREF = 'https://pikku.dev/docs/core-features/knowledge'
 
@@ -76,9 +77,7 @@ export const KnowledgeWorkspace: React.FC<KnowledgeWorkspaceProps> = ({
   if (isLoading) {
     return (
       <ResizablePanelLayout header={header} hidePanel>
-        <Center style={{ flex: 1 }}>
-          <Loader />
-        </Center>
+        <ConsoleLoading />
       </ResizablePanelLayout>
     )
   }

--- a/packages/console/src/components/layout/TableListPage.tsx
+++ b/packages/console/src/components/layout/TableListPage.tsx
@@ -17,6 +17,7 @@ import { EmptyStatePlaceholder } from './EmptyStatePlaceholder'
 import { usePageGate } from '../../context/PageGateContext'
 import { useListSurfaceClass } from '../../context/ConsoleChromeContext'
 import classes from '../ui/console.module.css'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 interface Column<T> {
   key: string
@@ -131,9 +132,7 @@ export const TableListPage = <T,>({
   if (loading) {
     return (
       <Box className={surfaceClass}>
-        <Center h="100%">
-          <Loader />
-        </Center>
+        <ConsoleLoading />
       </Box>
     )
   }

--- a/packages/console/src/components/packages/AddonsList.tsx
+++ b/packages/console/src/components/packages/AddonsList.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react'
-import { Box, Center, Loader } from '@pikku/mantine/core'
+import { Box } from '@pikku/mantine/core'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { Package } from 'lucide-react'
@@ -17,6 +17,7 @@ import type {
   PackageMeta,
 } from './packageMeta'
 import { PAGE_SIZE, installedToPackageMeta } from './packageMeta'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 // The registry caps a page at 500 rows.
 const MAX_PAGE = 500
@@ -150,9 +151,7 @@ export const AddonsList: React.FC<{
   if (isPending) {
     return (
       <Box style={{ flex: 1, minHeight: 0 }}>
-        <Center h="100%">
-          <Loader />
-        </Center>
+        <ConsoleLoading />
       </Box>
     )
   }

--- a/packages/console/src/components/packages/ApisList.tsx
+++ b/packages/console/src/components/packages/ApisList.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react'
-import { Box, Center, Loader } from '@pikku/mantine/core'
+import { Box } from '@pikku/mantine/core'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { Globe } from 'lucide-react'
@@ -12,6 +12,7 @@ import { CommunityGallery } from './CommunityGallery'
 import { deriveNamespace } from './deriveNamespace'
 import type { InstalledAddonRow, PackageMeta } from './packageMeta'
 import { PAGE_SIZE } from './packageMeta'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 interface OpenApiEntry {
   name: string
@@ -134,9 +135,7 @@ export const ApisList: React.FC<{
   if (isPending) {
     return (
       <Box style={{ flex: 1, minHeight: 0 }}>
-        <Center h="100%">
-          <Loader />
-        </Center>
+        <ConsoleLoading />
       </Box>
     )
   }

--- a/packages/console/src/components/project/panels/AgentRuns.tsx
+++ b/packages/console/src/components/project/panels/AgentRuns.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react'
-import { Center, Loader, Stack } from '@pikku/mantine/core'
+import { Stack } from '@pikku/mantine/core'
 import { Bot, Gauge } from 'lucide-react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
@@ -7,6 +7,7 @@ import { EmptyState } from '../../ui/EmptyState'
 import { AgentRunCard, type AgentRunCardProps } from './AgentRunCard'
 import { AgentPlaygroundContext } from '../../../context/AgentPlaygroundContext'
 import { useAgentThreadRuns } from '../../../hooks/useAgentRuns'
+import { ConsoleLoading } from '../../ui/ConsoleLoading'
 
 /**
  * The runs of the conversation currently open, newest first, each carrying
@@ -35,11 +36,7 @@ export const AgentRuns: React.FC = () => {
   }
 
   if (isLoading) {
-    return (
-      <Center h="100%">
-        <Loader />
-      </Center>
-    )
+    return <ConsoleLoading />
   }
 
   const runs = (data as AgentRunCardProps['run'][] | undefined) ?? []

--- a/packages/console/src/components/project/panels/EmailPreviewPanel.tsx
+++ b/packages/console/src/components/project/panels/EmailPreviewPanel.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react'
-import { Box, Center, Loader, Alert, Text } from '@pikku/mantine/core'
+import { Box, Alert, Text } from '@pikku/mantine/core'
 import { AlertTriangle } from 'lucide-react'
 import { asI18n } from '@pikku/react'
 import { useRenderEmailPreview } from '../../../hooks/useWirings'
+import { ConsoleLoading } from '../../ui/ConsoleLoading'
 
 /**
  * Read-only rendered preview of an email template — the viewer half of the
@@ -30,11 +31,7 @@ export const EmailPreviewPanel: React.FC<{
 
   return (
     <Box>
-      {preview.isLoading ? (
-        <Center py="xl">
-          <Loader />
-        </Center>
-      ) : null}
+      {preview.isLoading ? <ConsoleLoading py="xl" /> : null}
       {preview.error ? (
         <Alert color="red" icon={<AlertTriangle size={16} />}>
           {asI18n(

--- a/packages/console/src/components/scenarios/ScenariosWorkspace.tsx
+++ b/packages/console/src/components/scenarios/ScenariosWorkspace.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Group, TextInput, Center, Loader, Text } from '@pikku/mantine/core'
+import { Group, TextInput, Center, Text } from '@pikku/mantine/core'
 import { Search } from 'lucide-react'
 import { m } from '@/i18n/messages'
 import { ListPageHeader } from '../layout/PageLayout'
@@ -14,6 +14,7 @@ import type { ScenariosBrowse } from '../../hooks/useScenariosBrowse'
 import { useScenarioPersonaEntries } from '../../hooks/useScenarioEntries'
 import { usePageOptionsDismiss } from '../../context/PageOptionsProvider'
 import { scenarioViewSelection, type ScenarioView } from './scenario-view'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 export interface ScenariosWorkspaceProps {
   /** Browse state owned by the host (see `useScenariosBrowse`). Supplying it
@@ -133,9 +134,7 @@ export const ScenariosWorkspace: React.FC<ScenariosWorkspaceProps> = ({
         hidePanel={loading}
       >
         {loading ? (
-          <Center style={{ flex: 1 }}>
-            <Loader />
-          </Center>
+          <ConsoleLoading />
         ) : selected ? (
           <FeatureDocument
             feature={selected}

--- a/packages/console/src/components/scenarios/runs/ScenarioRunDetail.tsx
+++ b/packages/console/src/components/scenarios/runs/ScenarioRunDetail.tsx
@@ -5,7 +5,6 @@ import {
   Center,
   Code,
   Group,
-  Loader,
   ScrollArea,
   Stack,
   Text,
@@ -20,6 +19,7 @@ import {
 import { ScenarioRunStatusBadge } from './ScenarioRunStatusBadge'
 import { ScenarioRunResult } from './ScenarioRunResult'
 import { runDuration, runRelativeTime } from './scenario-run-format'
+import { ConsoleLoading } from '../../ui/ConsoleLoading'
 
 type ScenarioRunDetailProps = {
   runId: string
@@ -38,11 +38,7 @@ export const ScenarioRunDetail: React.FC<ScenarioRunDetailProps> = ({
   const remove = useDeleteScenarioRun()
 
   if (isLoading) {
-    return (
-      <Center style={{ flex: 1 }}>
-        <Loader />
-      </Center>
-    )
+    return <ConsoleLoading />
   }
 
   if (!run) {

--- a/packages/console/src/components/security/SecurityReportPanel.tsx
+++ b/packages/console/src/components/security/SecurityReportPanel.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
-import { Box, Center, Loader, ScrollArea, Text } from '@pikku/mantine/core'
+import { Box, ScrollArea, Text } from '@pikku/mantine/core'
 import { ShieldCheck } from 'lucide-react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { EmptyStatePlaceholder } from '../layout/EmptyStatePlaceholder'
 import { SecurityAuditView, type SecurityLens } from './SecurityAuditView'
 import { useSecurityAudit } from '../../hooks/useSecurityAudit'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 export interface SecurityReportPanelProps {
   lens: SecurityLens
@@ -33,11 +34,7 @@ export const SecurityReportPanel: React.FC<SecurityReportPanelProps> = ({
   const { report, isLoading } = useSecurityAudit()
 
   if (isLoading) {
-    return (
-      <Center style={{ flex: 1 }}>
-        <Loader />
-      </Center>
-    )
+    return <ConsoleLoading />
   }
 
   if (!report) {

--- a/packages/console/src/components/tabs/ChannelsTab.tsx
+++ b/packages/console/src/components/tabs/ChannelsTab.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react'
-import { Center, Loader } from '@pikku/mantine/core'
 import { ChannelTabContent } from './ChannelTabContent'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 type ChannelsTabProps = { searchQuery: string; emptyHero?: React.ReactNode }
 
@@ -9,13 +9,7 @@ export const ChannelsTab: React.FC<ChannelsTabProps> = ({
   emptyHero,
 }) => {
   return (
-    <Suspense
-      fallback={
-        <Center h="100%">
-          <Loader />
-        </Center>
-      }
-    >
+    <Suspense fallback={<ConsoleLoading />}>
       <ChannelTabContent searchQuery={searchQuery} emptyHero={emptyHero} />
     </Suspense>
   )

--- a/packages/console/src/components/tabs/CliTab.tsx
+++ b/packages/console/src/components/tabs/CliTab.tsx
@@ -1,18 +1,12 @@
 import React, { Suspense } from 'react'
-import { Center, Loader } from '@pikku/mantine/core'
 import { CliTabContent } from './CliTabContent'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 type CliTabProps = { searchQuery: string }
 
 export const CliTab: React.FC<CliTabProps> = ({ searchQuery }) => {
   return (
-    <Suspense
-      fallback={
-        <Center h="100%">
-          <Loader />
-        </Center>
-      }
-    >
+    <Suspense fallback={<ConsoleLoading />}>
       <CliTabContent searchQuery={searchQuery} />
     </Suspense>
   )

--- a/packages/console/src/components/tabs/CredentialUsersTab.tsx
+++ b/packages/console/src/components/tabs/CredentialUsersTab.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { Text, Group, Badge, Center, Loader } from '@pikku/mantine/core'
+import { Text, Group, Badge } from '@pikku/mantine/core'
 import { Users, Check } from 'lucide-react'
 import { EmptyStatePlaceholder } from '../layout/EmptyStatePlaceholder'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
@@ -10,6 +10,7 @@ import { TableListPage } from '../layout/TableListPage'
 import { asI18n } from '@pikku/react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 interface CredentialMeta {
   name: string
@@ -143,11 +144,7 @@ export const CredentialUsersTab: React.FC<{ searchQuery?: string }> = ({
   )
 
   if (loading) {
-    return (
-      <Center h="100%">
-        <Loader />
-      </Center>
-    )
+    return <ConsoleLoading />
   }
 
   if (perUserCredentials.length === 0) {

--- a/packages/console/src/components/tabs/WorkflowTabContent.tsx
+++ b/packages/console/src/components/tabs/WorkflowTabContent.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { usePikkuRPC } from '../../context/PikkuRpcProvider'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
-import { Center, Loader } from '@pikku/mantine/core'
 import { GitBranch } from 'lucide-react'
 import { useConsoleNavigator } from '../../context/ConsoleNavigatorContext'
 import { EmptyStatePlaceholder } from '../layout/EmptyStatePlaceholder'
@@ -12,6 +11,7 @@ import { workflowQueryKeys } from '../../hooks/workflow-query-keys'
 import { asI18n } from '@pikku/react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 export const WorkflowTabContent: React.FC<{
   immersiveDetail?: boolean
@@ -47,11 +47,7 @@ export const WorkflowTabContent: React.FC<{
   }, [meta.workflows])
 
   if (isLoading) {
-    return (
-      <Center h="100vh">
-        <Loader />
-      </Center>
-    )
+    return <ConsoleLoading h="100vh" />
   }
 
   if (!workflow) {

--- a/packages/console/src/components/ui/ConsoleLoading.tsx
+++ b/packages/console/src/components/ui/ConsoleLoading.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, type ReactNode } from 'react'
+import { Center, Loader } from '@pikku/mantine/core'
+
+/**
+ * The mark a console screen shows while it waits.
+ *
+ * A host that embeds the console (Fabric) has a loader of its own, and a
+ * Mantine ring in the middle of its page is the one place the embedded screen
+ * stops looking like the rest of the product. The host supplies its mark once,
+ * through `HostConsoleChrome`, rather than every screen taking a prop for it.
+ */
+const ConsoleLoaderContext = createContext<ReactNode>(null)
+
+export function ConsoleLoaderProvider({
+  loader,
+  children,
+}: {
+  loader?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <ConsoleLoaderContext.Provider value={loader ?? null}>
+      {children}
+    </ConsoleLoaderContext.Provider>
+  )
+}
+
+/**
+ * A screen's waiting state: the host's mark when there is one, a centred
+ * Mantine loader when the console stands alone.
+ *
+ * `h` is the height the centre fills — `100%` inside a page that already has
+ * one, `100vh` for a gate that IS the page. `py` is for the sites that sit in a
+ * stack with no height to fill, where the mark is spaced rather than centred.
+ */
+export function ConsoleLoading({
+  h = '100%',
+  py,
+}: {
+  h?: string | number
+  py?: string | number
+}) {
+  const loader = useContext(ConsoleLoaderContext)
+  return (
+    <Center
+      h={py ? undefined : h}
+      py={py}
+      style={py ? undefined : { flex: 1, minWidth: 0, minHeight: 0 }}
+    >
+      {loader ?? <Loader />}
+    </Center>
+  )
+}

--- a/packages/console/src/components/users/UserRolesDrawer.tsx
+++ b/packages/console/src/components/users/UserRolesDrawer.tsx
@@ -2,12 +2,10 @@ import {
   Alert,
   Badge,
   Box,
-  Center,
   CloseButton,
   Divider,
   Drawer,
   Group,
-  Loader,
   Menu,
   Button,
   Stack,
@@ -27,6 +25,7 @@ import {
 import { ScopeTreeSelector } from '../scopes/ScopeTreeSelector'
 import { diffScopeSelection } from '../scopes/scope-tree'
 import { m } from '@/i18n/messages'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 type UserRolesDrawerProps = {
   opened: boolean
@@ -83,9 +82,7 @@ export const UserRolesDrawer: React.FC<UserRolesDrawerProps> = ({
       title={m.scopes_user_roles_title({ label: userLabel })}
     >
       {userRolesQuery.isLoading ? (
-        <Center py="xl">
-          <Loader />
-        </Center>
+        <ConsoleLoading py="xl" />
       ) : (
         <Stack gap="md" data-testid="user-roles-drawer">
           {mutationError && (

--- a/packages/console/src/components/virtual-users/VirtualUsersWorkspace.tsx
+++ b/packages/console/src/components/virtual-users/VirtualUsersWorkspace.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Center, Loader, Stack, Text } from '@pikku/mantine/core'
+import { Center, Stack, Text } from '@pikku/mantine/core'
 import { asI18n } from '@pikku/react'
 import { m } from '@/i18n/messages'
 import { ListPageHeader } from '../layout/PageLayout'
@@ -8,6 +8,7 @@ import { VirtualUserNavigator } from './VirtualUserNavigator'
 import { VirtualUserDocument } from './VirtualUserDocument'
 import { useVirtualUsers } from '../../hooks/useVirtualUsers'
 import { usePageOptionsDismiss } from '../../context/PageOptionsProvider'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 const EXAMPLE =
   "definePersonas({ shopper: { name: 'Shopper', disposition: 'careless', goals: [...] } })"
@@ -56,9 +57,7 @@ export const VirtualUsersWorkspace: React.FC = () => {
       hidePanel
     >
       {loading ? (
-        <Center style={{ flex: 1 }}>
-          <Loader />
-        </Center>
+        <ConsoleLoading />
       ) : selected ? (
         <VirtualUserDocument user={selected} />
       ) : (

--- a/packages/console/src/components/workflow/WorkflowGraphPanel.tsx
+++ b/packages/console/src/components/workflow/WorkflowGraphPanel.tsx
@@ -1,12 +1,5 @@
 import React, { useMemo, useCallback } from 'react'
-import {
-  Alert,
-  Box,
-  Center,
-  Loader,
-  ScrollArea,
-  Text,
-} from '@pikku/mantine/core'
+import { Alert, Box, ScrollArea, Text } from '@pikku/mantine/core'
 import { asI18n } from '@pikku/react'
 import { m } from '@/i18n/messages'
 import { GitBranch, History } from 'lucide-react'
@@ -18,6 +11,7 @@ import { EmptyStatePlaceholder } from '../layout/EmptyStatePlaceholder'
 import { ScenarioDocument } from '../scenarios/ScenarioDocument'
 import { WorkflowGraphView } from '../project/WorkflowGraphView'
 import { WorkflowTimelineDrawer } from '../project/WorkflowTimelineDrawer'
+import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 /**
  * The workflow itself — a node graph, or the scenario's own document when the
@@ -48,11 +42,7 @@ export const WorkflowGraphPanel: React.FC = () => {
   }, [baseWorkflow, runContext?.runData?.wire])
 
   if (loading) {
-    return (
-      <Center h="100%">
-        <Loader />
-      </Center>
-    )
+    return <ConsoleLoading />
   }
 
   if (!workflow) {

--- a/packages/console/src/context/ConsoleChromeContext.tsx
+++ b/packages/console/src/context/ConsoleChromeContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react'
 import type { ReactNode } from 'react'
 import classes from '../components/ui/console.module.css'
+import { ConsoleLoaderProvider } from '../components/ui/ConsoleLoading'
 
 /**
  * Who draws the chrome around a console screen.
@@ -44,17 +45,28 @@ export function useListSurfaceClass(): string {
  * console.module.css. The data attribute is not read by the console itself — it
  * is a hook for the host's own stylesheet, which may need to reach inside the
  * embedded screen.
+ *
+ * `loader` is the mark every screen inside shows while it waits, so an embedded
+ * console waits the way the rest of the host's product does.
  */
-export function HostConsoleChrome({ children }: { children: ReactNode }) {
+export function HostConsoleChrome({
+  children,
+  loader,
+}: {
+  children: ReactNode
+  loader?: ReactNode
+}) {
   return (
     <ConsoleChromeContext.Provider value="host">
-      <div
-        data-console-chrome="host"
-        className={`${classes.flexColumn} ${classes.chromeHost}`}
-        style={{ flex: 1, minWidth: 0, minHeight: 0 }}
-      >
-        {children}
-      </div>
+      <ConsoleLoaderProvider loader={loader}>
+        <div
+          data-console-chrome="host"
+          className={`${classes.flexColumn} ${classes.chromeHost}`}
+          style={{ flex: 1, minWidth: 0, minHeight: 0 }}
+        >
+          {children}
+        </div>
+      </ConsoleLoaderProvider>
     </ConsoleChromeContext.Provider>
   )
 }

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -391,6 +391,13 @@ export {
 } from './context/ConsoleChromeContext'
 export type { ConsoleChrome } from './context/ConsoleChromeContext'
 
+// A screen's waiting state. Every page-level spinner renders `ConsoleLoading`,
+// which shows the host's own mark when `HostConsoleChrome` was given one.
+export {
+  ConsoleLoading,
+  ConsoleLoaderProvider,
+} from './components/ui/ConsoleLoading'
+
 // The shell behind the console's tabbed pages. `activeTab`/`onTabChange` are
 // optional: supply them to drive tabs from a host router, omit them to keep the
 // OSS `?tab=` search-param behaviour.

--- a/packages/console/src/pages/AgentPlaygroundPage.tsx
+++ b/packages/console/src/pages/AgentPlaygroundPage.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Center, Loader } from '@pikku/mantine/core'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { asI18n } from '@pikku/react'
@@ -8,6 +7,7 @@ import { EmptyStatePlaceholder } from '../components/layout/EmptyStatePlaceholde
 import { AgentPlaygroundSurface } from '../components/agent-playground/AgentPlaygroundSurface'
 import { AgentThreePane } from '../components/agent-playground/AgentThreePane'
 import { useAgentPlaygroundState } from '../hooks/useAgentPlaygroundState'
+import { ConsoleLoading } from '../components/ui/ConsoleLoading'
 
 export const AgentPlaygroundPage: React.FC = () => {
   useLocale()
@@ -15,11 +15,7 @@ export const AgentPlaygroundPage: React.FC = () => {
     useAgentPlaygroundState()
 
   if (loading) {
-    return (
-      <Center h="100vh">
-        <Loader />
-      </Center>
-    )
+    return <ConsoleLoading h="100vh" />
   }
 
   if (!agentId || !agentData) {

--- a/packages/console/src/pages/ApisPage.tsx
+++ b/packages/console/src/pages/ApisPage.tsx
@@ -1,5 +1,4 @@
 import React, { Suspense } from 'react'
-import { Center, Loader } from '@pikku/mantine/core'
 import type { I18nString } from '@pikku/react'
 import { TabbedSurface } from '../components/console/TabbedSurface'
 import type { TabbedSurfaceTab } from '../components/console/TabbedSurface'
@@ -10,6 +9,7 @@ import { CliTab } from '../components/tabs/CliTab'
 import { GatewaysTab } from '../components/tabs/GatewaysTab'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
+import { ConsoleLoading } from '../components/ui/ConsoleLoading'
 
 type ApisPageProps = {
   httpHero?: React.ReactNode
@@ -68,13 +68,7 @@ export const ApisPage: React.FC<ApisPageProps> = ({
   ]
 
   return (
-    <Suspense
-      fallback={
-        <Center h="100vh">
-          <Loader />
-        </Center>
-      }
-    >
+    <Suspense fallback={<ConsoleLoading h="100vh" />}>
       <TabbedSurface
         controls="shell"
         tabs={tabs}

--- a/packages/console/src/pages/ChangesPage.tsx
+++ b/packages/console/src/pages/ChangesPage.tsx
@@ -5,7 +5,6 @@ import {
   Stack,
   Group,
   Badge,
-  Loader,
   Center,
   Tabs,
   TextInput,
@@ -31,6 +30,7 @@ import {
 } from '../hooks/useStateDiff'
 import { httpMethodDefs, funcWrapperDefs } from '../components/ui/badge-defs'
 import classes from '../components/ui/console.module.css'
+import { ConsoleLoading } from '../components/ui/ConsoleLoading'
 
 const CATEGORY_LABELS: Record<string, string> = {
   functions: 'Functions',
@@ -683,11 +683,7 @@ export const ChangesPage: React.FC = () => {
               docsHref="https://pikku.dev/docs"
             />
           )}
-          {activePath && isLoading && (
-            <Center p="xl">
-              <Loader />
-            </Center>
-          )}
+          {activePath && isLoading && <ConsoleLoading py="xl" />}
           {activePath && error && (
             <Center p="xl">
               <Text size="sm" c="red">

--- a/packages/console/src/pages/EmailsPage.tsx
+++ b/packages/console/src/pages/EmailsPage.tsx
@@ -9,7 +9,6 @@ import {
   Center,
   Code,
   Group,
-  Loader,
   Select,
   Stack,
   Text,
@@ -41,6 +40,7 @@ import { ListPageHeader } from '../components/layout/PageLayout'
 import { PikkuSwitch } from '../components/ui/PikkuSwitch'
 import { EmailsOverview } from './EmailsOverview'
 import classes from '../components/ui/console.module.css'
+import { ConsoleLoading } from '../components/ui/ConsoleLoading'
 
 const EMAIL_DOCS_HREF = 'https://pikku.dev/docs'
 
@@ -163,9 +163,7 @@ export const EmailsPage: React.FC<EmailsPageProps> = ({
             />
           }
         >
-          <Center h="100%">
-            <Loader />
-          </Center>
+          <ConsoleLoading />
         </ResizablePanelLayout>
       </ConsoleSurface>
     )
@@ -329,11 +327,7 @@ export const EmailsPage: React.FC<EmailsPageProps> = ({
               p="md"
             >
               <Stack gap="md" style={{ minWidth: 0 }}>
-                {preview.isLoading ? (
-                  <Center py="xl">
-                    <Loader />
-                  </Center>
-                ) : null}
+                {preview.isLoading ? <ConsoleLoading py="xl" /> : null}
                 {preview.error ? (
                   <Alert color="red" icon={<AlertTriangle size={16} />}>
                     {asI18n(

--- a/packages/console/src/pages/OverviewPage.tsx
+++ b/packages/console/src/pages/OverviewPage.tsx
@@ -1,15 +1,6 @@
 import React from 'react'
 import { useLink } from '../router'
-import {
-  Box,
-  SimpleGrid,
-  Paper,
-  Text,
-  Group,
-  Stack,
-  Center,
-  Loader,
-} from '@pikku/mantine/core'
+import { Box, SimpleGrid, Paper, Text, Group, Stack } from '@pikku/mantine/core'
 import {
   FunctionSquare,
   GitBranch,
@@ -28,6 +19,7 @@ import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { usePikkuMeta } from '../context/PikkuMetaContext'
 import { PageContainer, ListPageHeader } from '../components/layout/PageLayout'
+import { ConsoleLoading } from '../components/ui/ConsoleLoading'
 
 interface StatCardProps {
   label: I18nString
@@ -98,11 +90,7 @@ export const OverviewPage: React.FC = () => {
   const { counts, loading } = usePikkuMeta()
 
   if (loading) {
-    return (
-      <Center h="100vh">
-        <Loader />
-      </Center>
-    )
+    return <ConsoleLoading h="100vh" />
   }
 
   const stats: StatCardProps[] = [

--- a/packages/console/src/pages/PackageDetailPage.tsx
+++ b/packages/console/src/pages/PackageDetailPage.tsx
@@ -7,8 +7,6 @@ import {
   Button,
   Code,
   Group,
-  Loader,
-  Center,
   Select,
   Stack,
   Table,
@@ -61,6 +59,7 @@ import type {
   MCPResourceMeta,
   MCPPromptMeta,
 } from '@pikku/core/mcp'
+import { ConsoleLoading } from '../components/ui/ConsoleLoading'
 
 interface McpMeta {
   toolsMeta: MCPToolMeta
@@ -488,11 +487,7 @@ export const PackageDetailPage: React.FC<{
   if (source === 'api') {
     const api = apiDetail
     if (!api) {
-      return (
-        <Center h="100vh">
-          <Loader />
-        </Center>
-      )
+      return <ConsoleLoading h="100vh" />
     }
     return (
       <ResizablePanelLayout
@@ -709,11 +704,7 @@ export const PackageDetailPage: React.FC<{
   }
 
   if (isLoading || settling) {
-    return (
-      <Center h="100vh">
-        <Loader />
-      </Center>
-    )
+    return <ConsoleLoading h="100vh" />
   }
 
   if (!pkg) {

--- a/packages/console/src/pages/PersonasPage.tsx
+++ b/packages/console/src/pages/PersonasPage.tsx
@@ -1,8 +1,8 @@
 import React, { Suspense } from 'react'
-import { Center, Loader } from '@pikku/mantine/core'
 import { useLocale } from '@/i18n/config'
 import { ConsoleSurface } from '../components/console/ConsoleSurface'
 import { PersonasWorkspace } from '../components/personas/PersonasWorkspace'
+import { ConsoleLoading } from '../components/ui/ConsoleLoading'
 
 /**
  * The people a product is for, declared once with `definePersonas()`.
@@ -23,13 +23,7 @@ const PersonasPageInner: React.FC = () => {
 }
 
 export const PersonasPage: React.FC = () => (
-  <Suspense
-    fallback={
-      <Center h="100vh">
-        <Loader />
-      </Center>
-    }
-  >
+  <Suspense fallback={<ConsoleLoading h="100vh" />}>
     <PersonasPageInner />
   </Suspense>
 )

--- a/packages/console/src/pages/ScenariosPage.tsx
+++ b/packages/console/src/pages/ScenariosPage.tsx
@@ -1,5 +1,4 @@
 import React, { Suspense, useContext } from 'react'
-import { Center, Loader } from '@pikku/mantine/core'
 import { useLocale } from '@/i18n/config'
 import { ConsoleSurface } from '../components/console/ConsoleSurface'
 import { ScenariosWorkspace } from '../components/scenarios/ScenariosWorkspace'
@@ -11,6 +10,7 @@ import {
   ConsoleNavigatorCtx,
   OSSConsoleNavigator,
 } from '../context/ConsoleNavigatorContext'
+import { ConsoleLoading } from '../components/ui/ConsoleLoading'
 
 const SCENARIOS_BASE_PATH = '/scenarios'
 
@@ -52,13 +52,7 @@ export const ScenariosPage: React.FC<ScenariosPageProps> = ({ browse }) => {
   // fall back to the OSS query-param navigator when none is present.
   const hostNavigator = useContext(ConsoleNavigatorCtx)
   const page = (
-    <Suspense
-      fallback={
-        <Center h="100vh">
-          <Loader />
-        </Center>
-      }
-    >
+    <Suspense fallback={<ConsoleLoading h="100vh" />}>
       <ScenariosPageInner browse={browse} />
     </Suspense>
   )

--- a/packages/console/src/pages/VirtualUsersPage.tsx
+++ b/packages/console/src/pages/VirtualUsersPage.tsx
@@ -1,8 +1,8 @@
 import React, { Suspense } from 'react'
-import { Center, Loader } from '@pikku/mantine/core'
 import { useLocale } from '@/i18n/config'
 import { ConsoleSurface } from '../components/console/ConsoleSurface'
 import { VirtualUsersWorkspace } from '../components/virtual-users/VirtualUsersWorkspace'
+import { ConsoleLoading } from '../components/ui/ConsoleLoading'
 
 /**
  * Virtual users sit beside scenarios because they are fed by the same prose: a
@@ -20,13 +20,7 @@ const VirtualUsersPageInner: React.FC = () => {
 }
 
 export const VirtualUsersPage: React.FC = () => (
-  <Suspense
-    fallback={
-      <Center h="100vh">
-        <Loader />
-      </Center>
-    }
-  >
+  <Suspense fallback={<ConsoleLoading h="100vh" />}>
     <VirtualUsersPageInner />
   </Suspense>
 )

--- a/packages/console/src/pages/WorkflowPage.tsx
+++ b/packages/console/src/pages/WorkflowPage.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, useContext, useState } from 'react'
 import type { ReactNode } from 'react'
-import { Group, TextInput, Center, Loader } from '@pikku/mantine/core'
+import { Group, TextInput } from '@pikku/mantine/core'
 import { GitBranch, Search } from 'lucide-react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
@@ -15,6 +15,7 @@ import {
   ConsoleNavigatorCtx,
   useConsoleNavigator,
 } from '../context/ConsoleNavigatorContext'
+import { ConsoleLoading } from '../components/ui/ConsoleLoading'
 
 export type { WorkflowExtraColumn } from '../components/project/WorkflowsList'
 
@@ -111,13 +112,7 @@ export const WorkflowsPage: React.FC<{
 }) => {
   const existingNavigator = useContext(ConsoleNavigatorCtx)
   const inner = (
-    <Suspense
-      fallback={
-        <Center h="100vh">
-          <Loader />
-        </Center>
-      }
-    >
+    <Suspense fallback={<ConsoleLoading h="100vh" />}>
       <WorkflowPageInner
         onOpen={onOpen}
         headerRight={headerRight}


### PR DESCRIPTION
Every page-level spinner in `@pikku/console` was a bare Mantine `<Loader />` centred in the screen — thirty-odd copies of the same block. A host that embeds the console inside its own product (Fabric) has a loading mark of its own, and a Mantine ring in the middle of an otherwise branded page is the one place the embedded screen stops looking like the rest of that product.

Those sites now render `ConsoleLoading`, which shows the host's mark when there is one and the Mantine loader when the console stands alone. The host supplies it once, through `HostConsoleChrome`'s new optional `loader` prop, rather than every screen taking a prop for it — `HostConsoleChrome` is already the single place a host declares it owns the chrome, so there is nothing new to mount.

Nothing changes for the standalone console: with no host, `ConsoleLoading` renders exactly the `<Center><Loader /></Center>` it replaced.

Reported as pikkufabric/fabric#387 ("the sandbox addons page uses the wrong loader"), but it was never addons-specific.

### Scope

- new `components/ui/ConsoleLoading.tsx` — the context, the provider, and the component
- `HostConsoleChrome` gains an optional `loader` prop and provides it
- 30 page-level loader sites converted; the four that sit in a stack with no height to fill pass `py` instead of filling
- inline spinners (button pending states, `size=\"sm\"`/`size={12}` marks inside rows) are deliberately left alone — they are not the page waiting

`tsc --noEmit` on `packages/console` reports the same 42 pre-existing errors before and after, with only line numbers shifted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared loading experience across console pages and workspaces.
  * Hosted consoles can provide a custom branded loading indicator.
  * Loading indicators support configurable height and spacing, with a standard fallback when no custom indicator is supplied.
  * Exported the loading components for reuse.
* **Improvements**
  * Standardized loading states across authentication, pages, tabs, panels, and data views.
  * Standalone console behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->