### PR TITLE
fix(core): queue a workflow step that names another workflow

### DIFF
--- a/.changeset/queue-child-workflow-steps.md
+++ b/.changeset/queue-child-workflow-steps.md
@@ -1,0 +1,9 @@
+---
+'@pikku/core': patch
+---
+
+Queue a workflow step that names another workflow, instead of running it inside its parent.
+
+`dispatchStep` decided by reading `workflowQueued` off `rpc` meta, but `addWorkflow` never registers there, so a child workflow could never be queued. It always took the inline path: the parent started the child with `inline: true` and then sat in an unbounded `awaitRunEnd` poll, holding its run lock and that lock's connection until the child ended — and the child, being inline, ran its own `sleep` as a real in-process wait rather than a suspension. A parent whose child polled for fifteen minutes held two lock connections for fifteen minutes, and enough of them exhausted the lock pool and stalled every other run behind it.
+
+A step naming a workflow now queues whenever a queue service exists, reaching the `ChildWorkflowStartedException` path that already unwinds the parent and resumes it when the child completes. An inline parent still runs its children inline.

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
@@ -192,8 +192,11 @@ describe('pikku-workflow-service run-level inline', () => {
 
 describe('pikku-workflow-service per-function step dispatch', () => {
   class TestWorkflowService extends InMemoryWorkflowService {
-    public callDispatchStep(rpcName: string) {
-      return this.dispatchStep('run-1', 'step-1', rpcName, {})
+    public callDispatchStep(rpcName: string, runId = 'run-1') {
+      return this.dispatchStep(runId, 'step-1', rpcName, {})
+    }
+    public markInline(runId: string) {
+      this.registerInlineRun(runId)
     }
   }
 
@@ -247,6 +250,72 @@ describe('pikku-workflow-service per-function step dispatch', () => {
     assert.equal(dispatched, true, 'workflowQueued step should dispatch')
     assert.equal(queued, true, 'workflowQueued step should queue')
     cleanup('queuedStep')
+  })
+
+  const setupWorkflow = (name: string) => {
+    pikkuState(null, 'workflows', 'meta')[name] = {
+      name,
+      pikkuFuncId: name,
+      graphHash: 'hash',
+    } as any
+  }
+
+  const cleanupWorkflow = (name: string) => {
+    delete pikkuState(null, 'workflows', 'meta')[name]
+  }
+
+  test('a step naming a workflow queues even though it is unmarked', async () => {
+    const ws = new TestWorkflowService()
+    let queued = false
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: { error() {}, info() {}, warn() {}, debug() {} },
+      queueService: {
+        add: async () => {
+          queued = true
+        },
+      },
+    } as any)
+
+    setupWorkflow('childWorkflowStep')
+    const dispatched = await ws.callDispatchStep('childWorkflowStep')
+    assert.equal(dispatched, true, 'a child workflow should dispatch')
+    assert.equal(queued, true, 'a child workflow should queue')
+    cleanupWorkflow('childWorkflowStep')
+  })
+
+  test('a step naming a workflow stays inline when the parent run is inline', async () => {
+    const ws = new TestWorkflowService()
+    let queued = false
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: { error() {}, info() {}, warn() {}, debug() {} },
+      queueService: {
+        add: async () => {
+          queued = true
+        },
+      },
+    } as any)
+
+    setupWorkflow('childOfInlineParent')
+    ws.markInline('inline-parent')
+    const dispatched = await ws.callDispatchStep(
+      'childOfInlineParent',
+      'inline-parent'
+    )
+    assert.equal(dispatched, false, 'an inline parent keeps its child inline')
+    assert.equal(queued, false, 'an inline parent queues nothing')
+    cleanupWorkflow('childOfInlineParent')
+  })
+
+  test('a step naming a workflow stays inline when there is no queueService', async () => {
+    const ws = new TestWorkflowService()
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: { error() {}, info() {}, warn() {}, debug() {} },
+    } as any)
+
+    setupWorkflow('childWorkflowNoQueue')
+    const dispatched = await ws.callDispatchStep('childWorkflowNoQueue')
+    assert.equal(dispatched, false, 'no queue leaves the child inline')
+    cleanupWorkflow('childWorkflowNoQueue')
   })
 
   test('workflowQueued: true step throws when no queueService is configured', async () => {

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -761,10 +761,8 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepOptions?: WorkflowStepOptions,
     fromStepName?: string
   ): Promise<boolean> {
-    const target = stepDispatchTarget(
-      rpcName,
-      stepName,
-      await this.isInline(runId)
+    const target = await stepDispatchTarget(rpcName, stepName, () =>
+      this.isInline(runId)
     )
     if (target === 'inline') {
       return false

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -83,6 +83,7 @@ import {
   jobGroupFor,
   orchestratorQueueName,
   resolveWorkflowConfig,
+  stepDispatchTarget,
   stepJobOptions,
   stepWorkerQueueName,
 } from './workflow-queue-routing.js'
@@ -760,18 +761,13 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepOptions?: WorkflowStepOptions,
     fromStepName?: string
   ): Promise<boolean> {
-    const functionsMeta = pikkuState(null, 'function', 'meta')
-    const rpcFuncId = pikkuState(null, 'rpc', 'meta')[rpcName]
-    const rpcMeta =
-      typeof rpcFuncId === 'string' ? functionsMeta[rpcFuncId] : undefined
-    const forceQueue = rpcMeta?.workflowQueued === true
-    if (!forceQueue) {
+    const target = stepDispatchTarget(
+      rpcName,
+      stepName,
+      await this.isInline(runId)
+    )
+    if (target === 'inline') {
       return false
-    }
-    if (!getSingletonServices()?.queueService) {
-      throw new Error(
-        `Workflow step '${stepName}' (function '${rpcName}') is marked 'workflowQueued: true' but no queue service is configured.`
-      )
     }
     try {
       await getSingletonServices()!.queueService!.add(

--- a/packages/core/src/wirings/workflow/workflow-child-run-session.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-child-run-session.test.ts
@@ -87,3 +87,82 @@ describe('a child workflow inherits the parent run wire pikkuUserId', () => {
     assert.ok(wire.parentRunId, 'the child must name the run that started it')
   })
 })
+
+/**
+ * Queuing a child workflow is only worth anything if the parent comes back with
+ * the child's output. The routing tests assert which way a step goes; this
+ * asserts what the parent is left holding once the child it queued has ended.
+ */
+describe('a queued child workflow hands its output back to the parent step', () => {
+  const CHILD_OUTPUT = { invoiceId: 'inv-42' }
+
+  const setup = async () => {
+    resetPikkuState()
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: silentLogger,
+      queueService: { add: async () => {} },
+    } as any)
+    registerChildWorkflow('childFlow')
+    pikkuState(null, 'function', 'functions').set('childFlow', {
+      func: async () => CHILD_OUTPUT,
+    } as any)
+
+    const ws = new InMemoryWorkflowService()
+    const parentRunId = await ws.createRun('parentFlow', {}, false, '', {
+      type: 'test',
+    })
+    const step = await ws.insertStepState(
+      parentRunId,
+      'callChild',
+      'childFlow',
+      {}
+    )
+    const stepId = (step as any).stepId ?? (step as any).id
+    assert.ok(stepId, 'the parent step must have an id to hand back to')
+    return { ws, parentRunId, stepId }
+  }
+
+  const childRunIdOf = async (ws: InMemoryWorkflowService) => {
+    for (const id of (ws as any).runs?.keys?.() ?? []) {
+      const run = await ws.getRun(id)
+      if (run?.workflow === 'childFlow') return run.id
+    }
+    throw new Error('no child run was started')
+  }
+
+  test('the parent step carries the child output once the child completes', async () => {
+    const { ws, parentRunId, stepId } = await setup()
+
+    // The step worker that picked the queued job off runs this; it starts the
+    // child and unwinds the parent rather than waiting on it.
+    await (ws as any).executeWorkflowStepInner(
+      parentRunId,
+      'callChild',
+      'childFlow',
+      {},
+      {}
+    )
+
+    const childRunId = await childRunIdOf(ws)
+    const childRun = await ws.getRun(childRunId)
+    assert.equal(
+      childRun?.wire?.parentStepId,
+      stepId,
+      'the child must name the step it has to hand its output back to'
+    )
+
+    await ws.updateRunStatus(childRunId, 'completed', CHILD_OUTPUT)
+    await (ws as any).onChildWorkflowCompleted(
+      await ws.getRun(childRunId),
+      CHILD_OUTPUT
+    )
+
+    const steps = await ws.getRunSteps(parentRunId)
+    const callChild = steps.find((s: any) => s.stepName === 'callChild')
+    assert.deepEqual(
+      callChild?.result,
+      CHILD_OUTPUT,
+      'the parent step must end up holding what the child returned'
+    )
+  })
+})

--- a/packages/core/src/wirings/workflow/workflow-queue-routing.ts
+++ b/packages/core/src/wirings/workflow/workflow-queue-routing.ts
@@ -76,12 +76,16 @@ export const stepWorkerQueueName = (
  *
  * Throws only for a step that asked for the queue by name and has none, which
  * is a deployment missing a service rather than a routing choice.
+ *
+ * `parentIsInline` is a thunk because resolving it can read the run store, and
+ * every step dispatch would pay for that — only a step that names a workflow
+ * and has a queue to reach ever asks.
  */
-export const stepDispatchTarget = (
+export const stepDispatchTarget = async (
   rpcName: string,
   stepName: string,
-  parentIsInline: boolean
-): 'queue' | 'inline' => {
+  parentIsInline: () => Promise<boolean>
+): Promise<'queue' | 'inline'> => {
   const rpcFuncId = pikkuState(null, 'rpc', 'meta')[rpcName]
   const rpcMeta =
     typeof rpcFuncId === 'string'
@@ -98,7 +102,10 @@ export const stepDispatchTarget = (
   }
   const isWorkflow =
     pikkuState(null, 'workflows', 'meta')[rpcName] !== undefined
-  return isWorkflow && hasQueue && !parentIsInline ? 'queue' : 'inline'
+  if (!isWorkflow || !hasQueue) {
+    return 'inline'
+  }
+  return (await parentIsInline()) ? 'inline' : 'queue'
 }
 
 export const jobGroupFor = (

--- a/packages/core/src/wirings/workflow/workflow-queue-routing.ts
+++ b/packages/core/src/wirings/workflow/workflow-queue-routing.ts
@@ -64,6 +64,43 @@ export const stepWorkerQueueName = (
     resolveWorkflowConfig().stepWorkerQueueName
   )
 
+/**
+ * How a step reaches its worker: on the queue, or here in the orchestrator.
+ *
+ * A step naming a workflow queues whenever a queue exists, even unmarked. Run
+ * here, it holds the parent's run lock — and its lock connection — until the
+ * child ends, and marks the child inline so the child's own `sleep` degrades
+ * from a suspension into a real in-process wait. Workflows cannot opt in
+ * through `workflowQueued`: that flag is read off `rpc` meta, and `addWorkflow`
+ * never registers there.
+ *
+ * Throws only for a step that asked for the queue by name and has none, which
+ * is a deployment missing a service rather than a routing choice.
+ */
+export const stepDispatchTarget = (
+  rpcName: string,
+  stepName: string,
+  parentIsInline: boolean
+): 'queue' | 'inline' => {
+  const rpcFuncId = pikkuState(null, 'rpc', 'meta')[rpcName]
+  const rpcMeta =
+    typeof rpcFuncId === 'string'
+      ? pikkuState(null, 'function', 'meta')[rpcFuncId]
+      : undefined
+  const hasQueue = getSingletonServices()?.queueService !== undefined
+  if (rpcMeta?.workflowQueued === true) {
+    if (!hasQueue) {
+      throw new Error(
+        `Workflow step '${stepName}' (function '${rpcName}') is marked 'workflowQueued: true' but no queue service is configured.`
+      )
+    }
+    return 'queue'
+  }
+  const isWorkflow =
+    pikkuState(null, 'workflows', 'meta')[rpcName] !== undefined
+  return isWorkflow && hasQueue && !parentIsInline ? 'queue' : 'inline'
+}
+
 export const jobGroupFor = (
   strategy: WorkflowQueueStrategy,
   id?: string


### PR DESCRIPTION
## The bug

`dispatchStep` decides whether a step goes to the queue by reading `workflowQueued` off `rpc` meta:

```ts
const rpcFuncId = pikkuState(null, 'rpc', 'meta')[rpcName]
```

`addWorkflow` registers a workflow into `workflows` meta and the function registry, never into `rpc` meta. So for a step naming another workflow the lookup always misses, `forceQueue` is always false, and a child workflow can never be queued.

It therefore always took the inline path in `rpcStep`: `startWorkflow(..., { inline: true })` followed by `awaitRunEnd`, an unbounded `while (true)` poll with no timeout — all of it inside the parent's `withRunLock`. Two consequences:

- the parent holds its run lock, and that lock's database connection, until the child ends
- the child is registered inline, so its own `workflow.sleep` stops being a durable suspension and becomes a real in-process `setTimeout`

A parent whose child polls for fifteen minutes holds two lock connections for fifteen minutes. Enough concurrent runs and the lock pool is exhausted; every other run then blocks on `pg_advisory_lock`, times out, is redelivered, and the engine stops moving while every part of it still looks healthy.

Observed on a deployment with a 16-connection lock pool: 16 advisory locks held, every session idle on `SELECT pg_advisory_lock($1)`, the shared orchestrator consumer pinned at `num_ack_pending == max_ack_pending` with a backlog climbing past 450, and 39 runs stuck — 29 parents blocked on 24 children marked `inline = true`.

## The fix

A step naming a workflow now queues whenever a queue service exists, even unmarked. That reaches `executeWorkflowStepInner`, which already starts the child with `inline: false` and throws `ChildWorkflowStartedException` — the parent acks and unwinds, and `onChildWorkflowCompleted` resumes it when the child finishes. The non-blocking path was already there; it was simply unreachable.

An inline parent still runs its children inline, and a deployment with no queue service is unchanged.

The decision moves into `stepDispatchTarget` in `workflow-queue-routing.ts`, beside the other routing helpers — `pikku-workflow-service.ts` was one line under the repo's 2000-line module cap.

## Tests

Three new cases in `pikku-workflow-service.test.ts`: a workflow step queues while unmarked; stays inline when the parent run is inline; stays inline with no queue service. Existing `workflowQueued` cases unchanged.

`packages/core`: 2322 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX8tyDtWHyDfij52MjDr7f