### PR TITLE
feat: separate a project's three languages — identifiers, meta, and product UI

### DIFF
--- a/.changeset/meta-has-a-language-identifiers-do-not.md
+++ b/.changeset/meta-has-a-language-identifiers-do-not.md
@@ -1,5 +1,5 @@
 ---
-'@pikku/cli': minor
+'@pikku/cli': patch
 ---
 
 `pikku.config.json` takes a `locale`, naming the language the project's meta is
@@ -9,9 +9,14 @@ Meta is the human-readable prose authored inside the code rather than in a
 message catalogue: `description` on functions and steps, `name`/`title` on
 features and scenarios, step `template` strings, role and persona descriptions.
 It is also the one part of a project the Pikku Console renders back to a human,
-which is the entire reason the field exists — a team whose working language is
-German should be able to read their own Console in German without anything else
-about the project changing.
+which is what the field is for — a team whose working language is German should
+be able to read their own Console in German without anything else about the
+project changing.
+
+This release is the groundwork: the field is read, validated and canonicalized,
+and the skills explain which of a project's three languages it is. Nothing
+consumes it yet, so setting it does not change what the Console renders — that
+comes with the reader.
 
 It defaults to `en`, is validated as a BCP-47 tag through
 `Intl.getCanonicalLocales` (so `de_DE` fails at the line that is wrong rather

--- a/.changeset/meta-has-a-language-identifiers-do-not.md
+++ b/.changeset/meta-has-a-language-identifiers-do-not.md
@@ -1,0 +1,26 @@
+---
+'@pikku/cli': minor
+---
+
+`pikku.config.json` takes a `locale`, naming the language the project's meta is
+written in.
+
+Meta is the human-readable prose authored inside the code rather than in a
+message catalogue: `description` on functions and steps, `name`/`title` on
+features and scenarios, step `template` strings, role and persona descriptions.
+It is also the one part of a project the Pikku Console renders back to a human,
+which is the entire reason the field exists — a team whose working language is
+German should be able to read their own Console in German without anything else
+about the project changing.
+
+It defaults to `en`, is validated as a BCP-47 tag through
+`Intl.getCanonicalLocales` (so `de_DE` fails at the line that is wrong rather
+than degrading to "some language" three layers down), and comes back
+canonicalized so `EN-gb` and `en-GB` are one value downstream.
+
+Two things it deliberately does not do, because collapsing them is the bug this
+came from. It never renames anything — identifiers, files, database tables and
+columns stay English whatever it says. And it is not the product's UI language:
+what the app says to its users lives in `messages/<locale>.json`, with
+`active.json`'s `defaultLocale` deciding what a first-time visitor is served,
+while `baseLocale` names the message source and stays `en`.

--- a/.changeset/skills-name-the-three-languages.md
+++ b/.changeset/skills-name-the-three-languages.md
@@ -1,5 +1,5 @@
 ---
-'@pikku/skills': minor
+'@pikku/skills': patch
 ---
 
 Skills now name the three languages a project has, and refuse to let them

--- a/.changeset/skills-name-the-three-languages.md
+++ b/.changeset/skills-name-the-three-languages.md
@@ -1,0 +1,24 @@
+---
+'@pikku/skills': minor
+---
+
+Skills now name the three languages a project has, and refuse to let them
+collapse into one.
+
+An agent building a doctor's portal for a German practice read "the entire UI is
+German" as an instruction about the codebase. It shipped
+`project.inlang/settings.json` with `baseLocale: "de"` and no `en.json` — which
+broke `--add-locale` permanently — alongside RPC functions `getUebersicht` and
+`getPatientendetail`, components `Zeitstrahl` and `AufmerksamkeitStreifen`, and
+database tables `vorgang` and `ereignis`. Nothing in the skills had ever told it
+these were three separate decisions, so it made one.
+
+`pikku-concepts` now carries the canonical statement — identifiers are always
+English and no setting changes that; meta (`description`, `title`, `template`)
+follows `locale` in `pikku.config.json`; the product's UI language lives in the
+message catalogue with `defaultLocale`, never in `baseLocale`. `pikku-build-app`
+§1a asks the question and writes the answer into the config; `pikku-scenario`
+splits step identifiers from step prose and admits where the English-only
+reporter frame still shows through; `pikku-i18n` states why `baseLocale` stays
+`en` and what to set instead. `pikku-build-quick`, `pikku-build-platform`,
+`pikku-feature` and `pikku-fabric` carry the short form.

--- a/.changeset/validate-flags-a-repointed-base-locale.md
+++ b/.changeset/validate-flags-a-repointed-base-locale.md
@@ -1,0 +1,18 @@
+---
+'@pikku/cli': patch
+---
+
+`pikku fabric validate` warns when an app's `baseLocale` is not `en`.
+
+`baseLocale` names the message source, not the language the app is served in,
+and pointing it at the product's language looks like it works — the app does
+come up in that language. What it actually does is leave the project without an
+English catalogue to add a second language from, permanently, because repointing
+it later re-authors every key.
+
+New finding `app-base-locale-not-english-<app>` (warn) says so and names the
+setting that was wanted instead: `baseLocale: "en"` with the language in
+`locales`, and `defaultLocale` in `active.json` deciding what a first-time
+visitor opens in. Where the app is already keyed in the other language the hint
+adds that this is a re-key rather than a rename, since that is the part someone
+otherwise discovers halfway through.

--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -2495,7 +2495,10 @@ describe('deployed frontend API base (live validate.function)', () => {
       const f = result.findings.find(
         (f) => f.id === 'frontend-localhost-url-web'
       )
-      assert.ok(f, `expected the bare-URL finding, got: ${ids(result.findings)}`)
+      assert.ok(
+        f,
+        `expected the bare-URL finding, got: ${ids(result.findings)}`
+      )
       assert.strictEqual(f!.severity, 'error')
       assert.match(f!.message, /src\/lib\/api\.ts/)
     } finally {
@@ -2539,7 +2542,10 @@ describe('deployed frontend API base (live validate.function)', () => {
       const f = result.findings.find(
         (f) => f.id === 'frontend-api-base-not-derived-web'
       )
-      assert.ok(f, `expected the derivation finding, got: ${ids(result.findings)}`)
+      assert.ok(
+        f,
+        `expected the derivation finding, got: ${ids(result.findings)}`
+      )
       assert.strictEqual(f!.severity, 'error')
       assert.match(f!.message, /VITE_API_URL/)
     } finally {
@@ -2581,7 +2587,10 @@ describe('deployed frontend API base (live validate.function)', () => {
       const f = result.findings.find(
         (f) => f.id === 'frontend-api-base-not-derived-web'
       )
-      assert.ok(f, `expected the derivation finding, got: ${ids(result.findings)}`)
+      assert.ok(
+        f,
+        `expected the derivation finding, got: ${ids(result.findings)}`
+      )
       assert.match(f!.message, /NEXT_PUBLIC_API_BASE/)
     } finally {
       await rm(tmp, { recursive: true, force: true })
@@ -2648,10 +2657,13 @@ describe('scenario steps vs the message catalogue (live validate.function)', () 
       type: 'module',
       dependencies: { react: '^19.0.0' },
     })
-    await writeJson(join(root, 'apps', 'web', 'project.inlang', 'settings.json'), {
-      baseLocale: 'en',
-      locales: ['en', 'de'],
-    })
+    await writeJson(
+      join(root, 'apps', 'web', 'project.inlang', 'settings.json'),
+      {
+        baseLocale: 'en',
+        locales: ['en', 'de'],
+      }
+    )
     await writeJson(join(root, 'apps', 'web', 'messages', 'en.json'), messages)
   }
 
@@ -2762,6 +2774,80 @@ describe('scenario steps vs the message catalogue (live validate.function)', () 
         [],
         `expected no finding, got: ${ids(result.findings)}`
       )
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('an app whose baseLocale is not English (live validate.function)', () => {
+  const writeInlangApp = async (
+    root: string,
+    settings: Record<string, unknown>,
+    catalogueLocale: string
+  ) => {
+    const app = join(root, 'apps', 'web')
+    await mkdir(join(app, 'project.inlang'), { recursive: true })
+    await mkdir(join(app, 'messages'), { recursive: true })
+    await writeJson(join(app, 'package.json'), {
+      name: '@project/web',
+      type: 'module',
+      dependencies: { react: '^19.0.0' },
+    })
+    await writeJson(join(app, 'project.inlang', 'settings.json'), settings)
+    await writeJson(join(app, 'messages', `${catalogueLocale}.json`), {
+      jobs_apply_fullname: 'Full Name',
+    })
+  }
+
+  const baseLocaleFindings = (findings: Array<{ id: string }>) =>
+    findings.filter((f) => f.id.startsWith('app-base-locale-not-english-'))
+
+  test('baseLocale "de" → warn pointing at defaultLocale instead', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await writeInlangApp(tmp, { baseLocale: 'de', locales: ['de'] }, 'de')
+      const result = await runValidate(tmp, { skipTypecheck: true })
+      const [finding] = baseLocaleFindings(result.findings)
+      assert.ok(finding, 'expected an app-base-locale-not-english finding')
+      assert.strictEqual(finding!.id, 'app-base-locale-not-english-web')
+      assert.strictEqual(finding!.severity, 'warn')
+      // The fix has to name the setting that actually serves a language, or
+      // the reader repoints baseLocale again and lands back here.
+      assert.match(finding!.fixHint, /"defaultLocale": "de"/)
+      assert.match(finding!.fixHint, /"baseLocale": "en"/)
+      // A project already keyed in German is a re-key, not a rename, and the
+      // hint has to say so before someone tries it as a one-line edit.
+      assert.match(finding!.fixHint, /re-key, not a rename/)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('baseLocale "en" with a second locale → no finding', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await writeInlangApp(
+        tmp,
+        { baseLocale: 'en', locales: ['en', 'de'] },
+        'en'
+      )
+      const result = await runValidate(tmp, { skipTypecheck: true })
+      assert.deepStrictEqual(baseLocaleFindings(result.findings), [])
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('an omitted baseLocale defaults to en and does not warn', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await writeInlangApp(tmp, { locales: ['en'] }, 'en')
+      const result = await runValidate(tmp, { skipTypecheck: true })
+      assert.deepStrictEqual(baseLocaleFindings(result.findings), [])
     } finally {
       await rm(tmp, { recursive: true, force: true })
     }

--- a/packages/cli/src/fabric/functions/validate.function.ts
+++ b/packages/cli/src/fabric/functions/validate.function.ts
@@ -1779,12 +1779,47 @@ export async function runValidate(
       for (const ent of await readdir(appsRoot, { withFileTypes: true })) {
         if (!ent.isDirectory()) continue
         const appPath = join(appsRoot, ent.name)
-        const settings = await readJsonSafe<{ baseLocale?: string }>(
-          join(appPath, 'project.inlang', 'settings.json')
-        )
+        const settingsPath = join(appPath, 'project.inlang', 'settings.json')
+        const settings = await readJsonSafe<{
+          baseLocale?: string
+          locales?: unknown
+        }>(settingsPath)
         if (!settings) continue
+
+        // `baseLocale` names the message SOURCE — the catalogue every other
+        // locale is cloned from and translated against — not the language the
+        // app is served in. Pointing it at the product's language looks right,
+        // because the app does come up in that language, and quietly makes the
+        // project single-language forever: there is no en.json to add a locale
+        // from, and repointing it later re-authors every key. The setting that
+        // decides what a first-time visitor opens in is active.json's
+        // defaultLocale, which is a separate file for exactly this reason.
+        const baseLocale = settings.baseLocale ?? 'en'
+        if (baseLocale !== 'en') {
+          const declared = Array.isArray(settings.locales)
+            ? settings.locales.filter((l): l is string => typeof l === 'string')
+            : []
+          w(
+            `app-base-locale-not-english-${ent.name}`,
+            `apps/${ent.name}/project.inlang/settings.json sets baseLocale to "${baseLocale}" — that names the message source, not the language the app is served in, so this app has no English catalogue to add a second language from`,
+            settingsPath,
+            lines(
+              'Serving the app in a language is a different setting from authoring the messages in one:',
+              `  1. settings.json: { "baseLocale": "en", "locales": ["en", "${baseLocale}"] }`,
+              `  2. src/i18n/active.json: { "defaultLocale": "${baseLocale}" }  (or: fabric i18n --default-locale ${baseLocale})`,
+              `Keys and their English values stay in messages/en.json; messages/${baseLocale}.json holds the ${baseLocale} values.`,
+              ...(declared.length && !declared.includes('en')
+                ? [
+                    `Note this is a re-key, not a rename: messages/${baseLocale}.json is currently the source, so its keys have to survive the move.`,
+                  ]
+                : []),
+              'Identifiers are unaffected either way — functions, components, types, tables and columns are English in every project.'
+            )
+          )
+        }
+
         const catalogue = await readJsonSafe<Record<string, unknown>>(
-          join(appPath, 'messages', `${settings.baseLocale ?? 'en'}.json`)
+          join(appPath, 'messages', `${baseLocale}.json`)
         )
         if (!catalogue) continue
         for (const [key, value] of Object.entries(catalogue)) {

--- a/packages/cli/src/utils/pikku-cli-config.test.ts
+++ b/packages/cli/src/utils/pikku-cli-config.test.ts
@@ -5,9 +5,11 @@ import { join } from 'node:path'
 import { after, describe, test } from 'node:test'
 import { rmSync } from 'node:fs'
 import {
+  DEFAULT_LOCALE,
   PikkuCLIConfigError,
   assertSchemaDirectoriesAreDistinct,
   getPikkuCLIConfig,
+  normalizeLocale,
   tryGetPikkuCLIConfig,
 } from './pikku-cli-config.js'
 
@@ -162,6 +164,45 @@ describe('getPikkuCLIConfig', () => {
     )
   })
 
+  test('locale defaults to English when the config does not name one', async () => {
+    const root = await writeConfig()
+
+    const config = await getPikkuCLIConfig(
+      silentLogger,
+      join(root, 'pikku.config.json'),
+      []
+    )
+
+    assert.equal(config.locale, DEFAULT_LOCALE)
+  })
+
+  test('a declared locale survives the load, canonicalized', async () => {
+    const root = await writeConfig({ locale: 'de-de' })
+
+    const config = await getPikkuCLIConfig(
+      silentLogger,
+      join(root, 'pikku.config.json'),
+      []
+    )
+
+    assert.equal(config.locale, 'de-DE')
+  })
+
+  test('a locale that is not a language tag names itself in the error', async () => {
+    const root = await writeConfig({ locale: 'de_DE' })
+
+    await assert.rejects(
+      () =>
+        getPikkuCLIConfig(silentLogger, join(root, 'pikku.config.json'), []),
+      (error: unknown) => {
+        assert.ok(error instanceof PikkuCLIConfigError)
+        assert.match(error.message, /locale in pikku\.config\.json/)
+        assert.match(error.message, /"de_DE"/)
+        return true
+      }
+    )
+  })
+
   test('a scenario schema directory equal to the app one is rejected', async () => {
     // The scenario write owns its directory: it emits register.gen.ts and prunes
     // every schema file its own required-set does not name. Sharing the app's
@@ -203,6 +244,39 @@ describe('assertSchemaDirectoriesAreDistinct', () => {
           scenarioSchemaDirectory: '/app/.pikku/scenarios/../schemas',
         }),
       PikkuCLIConfigError
+    )
+  })
+})
+
+describe('normalizeLocale', () => {
+  test('an absent locale is English rather than an error', () => {
+    assert.equal(normalizeLocale(undefined), DEFAULT_LOCALE)
+    assert.equal(normalizeLocale(null), DEFAULT_LOCALE)
+  })
+
+  test('canonicalizes so one language is one value downstream', () => {
+    assert.equal(normalizeLocale('en'), 'en')
+    assert.equal(normalizeLocale(' de '), 'de')
+    assert.equal(normalizeLocale('pt-br'), 'pt-BR')
+    assert.equal(normalizeLocale('EN-gb'), 'en-GB')
+  })
+
+  test('rejects the POSIX underscore people reach for', () => {
+    assert.throws(() => normalizeLocale('de_DE'), PikkuCLIConfigError)
+  })
+
+  test('rejects what is not a tag at all', () => {
+    assert.throws(() => normalizeLocale(''), PikkuCLIConfigError)
+    assert.throws(() => normalizeLocale('   '), PikkuCLIConfigError)
+    assert.throws(() => normalizeLocale('German, please'), PikkuCLIConfigError)
+    assert.throws(() => normalizeLocale(42), PikkuCLIConfigError)
+    assert.throws(() => normalizeLocale(['de']), PikkuCLIConfigError)
+  })
+
+  test('the error points at the two settings it is not', () => {
+    assert.throws(
+      () => normalizeLocale('de_DE'),
+      /Identifiers stay English regardless.*defaultLocale in active\.json/s
     )
   })
 })

--- a/packages/cli/src/utils/pikku-cli-config.ts
+++ b/packages/cli/src/utils/pikku-cli-config.ts
@@ -118,6 +118,49 @@ export const assertSchemaDirectoriesAreDistinct = (
   }
 }
 
+/**
+ * The `locale` a project gets when its config does not name one.
+ *
+ * English, and it stays English for almost every project — the field changes
+ * what the Console reads back to a human, not who the product is for.
+ */
+export const DEFAULT_LOCALE = 'en'
+
+/**
+ * `locale` is handed on to codegen and the Console as a language tag, so a
+ * value they cannot interpret is worse than none: it degrades quietly to "some
+ * language" a long way from the line that is wrong. `Intl.getCanonicalLocales`
+ * is the BCP-47 grammar Node already ships, and it catches the mistake people
+ * actually make — `de_DE` with a POSIX underscore where BCP-47 wants `de-DE`.
+ *
+ * It returns the canonical spelling rather than what was typed, so `EN-gb` and
+ * `en-GB` are one value downstream instead of two that never compare equal.
+ */
+export const normalizeLocale = (locale: unknown): string => {
+  if (locale === undefined || locale === null) {
+    return DEFAULT_LOCALE
+  }
+
+  if (typeof locale === 'string') {
+    try {
+      const [canonical] = Intl.getCanonicalLocales(locale.trim())
+      if (canonical) {
+        return canonical
+      }
+    } catch {
+      // Falls through to the shared error below — the reader needs the same
+      // explanation whether the tag was malformed or the wrong type entirely.
+    }
+  }
+
+  throw new PikkuCLIConfigError(
+    `locale in pikku.config.json is not a language tag: ${JSON.stringify(locale)}. ` +
+      `Use a BCP-47 code — "en", "de", "pt-BR" — with a hyphen rather than an underscore. ` +
+      `It sets the language of the meta the Console renders back to your team (function and step descriptions, feature and scenario names). ` +
+      `Identifiers stay English regardless, and the language the app speaks to its users is defaultLocale in active.json, not this.`
+  )
+}
+
 const _getPikkuCLIConfig = async (
   logger: CLILogger,
   configFile: string | undefined = undefined,
@@ -1125,6 +1168,8 @@ const _getPikkuCLIConfig = async (
     if (!isAbsolute(result.tsconfig)) {
       result.tsconfig = join(result.rootDir, result.tsconfig)
     }
+
+    result.locale = normalizeLocale(result.locale)
 
     assertSchemaDirectoriesAreDistinct(result)
 

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -306,6 +306,32 @@ export type PikkuCLIInput = {
    */
   allowShadowedServices?: string[]
 
+  /**
+   * The language the project's **meta** is authored in — the human-readable
+   * prose that lives inside the code rather than in a message catalogue:
+   * `description` on functions and steps, `name`/`title` on features and
+   * scenarios, step `template` strings, role and persona descriptions.
+   * A BCP-47 tag; defaults to `en`.
+   *
+   * It exists for the Pikku Console. That meta is the one part of a project
+   * the Console renders back to a human, so a team whose working language is
+   * German should be able to read their own Console in German without anything
+   * else about the project changing.
+   *
+   * Two things it deliberately does not do:
+   *
+   * - **It never renames anything.** Identifiers — functions, components,
+   *   types, variables, files, database tables and columns — are English
+   *   whatever this is set to. `locale: "de"` buys a German `description`, not
+   *   a `getUebersicht` or a `vorgang` table.
+   * - **It is not the product's UI language.** What the app says to its users
+   *   lives in `messages/<locale>.json`, and which language a first-time
+   *   visitor is served is `active.json`'s `defaultLocale`. `baseLocale` in
+   *   `project.inlang/settings.json` names the message *source* and stays
+   *   `en`, or `--add-locale` has no English catalogue to translate from.
+   */
+  locale?: string
+
   configDir: string
   tsconfig: string
 

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -316,7 +316,9 @@ export type PikkuCLIInput = {
    * It exists for the Pikku Console. That meta is the one part of a project
    * the Console renders back to a human, so a team whose working language is
    * German should be able to read their own Console in German without anything
-   * else about the project changing.
+   * else about the project changing. Nothing reads it yet, so setting it does
+   * not change what the Console renders — this is the field the reader will
+   * come to.
    *
    * Two things it deliberately does not do:
    *

--- a/packages/skills/skills/pikku-build-app/SKILL.md
+++ b/packages/skills/skills/pikku-build-app/SKILL.md
@@ -28,7 +28,10 @@ project shaped so `pikku fabric init` later adopts it with zero rework.
 ## Agent Operating Procedure
 
 1. Discover before editing. Run `pikku info functions --verbose --silent` and
-   read `AGENTS.md` before your first change.
+   read `AGENTS.md` before your first change. Read `locale` in
+   `pikku.config.json` too: it is the language every `description`, `title` and
+   step `template` you write must be in (§1a). Identifiers stay English whatever
+   it says.
 2. Make the smallest source change that satisfies the task. Keep generated files
    generated — never hand-edit `.pikku/`, `*.gen.*`, or the SDK.
 3. Validate with the narrowest relevant command, then `pikku all` when functions,
@@ -72,9 +75,67 @@ in one message. Then stop; do not interview the user.
   Neutral (fine for an internal tool, but say so out loud); a direction in words;
   a reference (brand guide, screenshots, a site whose register they want); or
   their own design agent/prompt, whose output you take as the direction.
+- **What language should the app speak, and what language does the team work
+  in?** Two answers, not one — see §1a, which is where they go. Ask only if the
+  request is not obviously English; a brief written in English about an English
+  product answers both.
 
 Skip anything you can decide yourself. If nobody answers, assume one app with
 paths, the roles implied by the request, Neutral, English — and say so.
+
+## 1a. Three languages, and you must not collapse them
+
+A brief saying "the entire UI is German" is about **one** of these. Getting this
+wrong has already shipped a project that can never add a second language, so
+settle all three explicitly before you write code.
+
+| Axis            | What it covers                                                                                                                       | Where it goes                                                                     |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **Identifiers** | Function, component, type, variable and file names. Database tables and columns. Commit messages.                                    | Nowhere — **always English**, no setting, not negotiable                          |
+| **Meta**        | `description` on functions and steps, `name`/`title` on features and scenarios, step `template`, role and persona descriptions        | `locale` in `pikku.config.json`, default `en`                                     |
+| **Product UI**  | Every string the app shows a user                                                                                                    | `messages/<locale>.json`, and `defaultLocale` for what a first-time visitor opens in |
+
+**Identifiers are English.** The product's market does not change this and
+neither does `locale`. Identifiers are the surface the generated `#pikku/*`
+clients, `pikku info`, the typed RPC map and the Kysely types all bind to, and
+unlike a string an identifier cannot be translated later — renaming one is a
+migration. A German practice management tool gets `getWorklist`, `case`,
+`event`, not `getUebersicht`, `vorgang`, `ereignis`.
+
+**Meta follows `locale`.** Write the team's answer into `pikku.config.json` in
+this phase, before there is any meta to be wrong:
+
+```json
+{ "locale": "de" }
+```
+
+It exists for the Pikku Console. Meta is the one part of a project the Console
+renders back to a human, so a team working in German reads their own functions,
+features and scenario reports in German. Default `en` and do not ask when the
+project is obviously English. **On every later run, read this field first and
+author descriptions, titles and step templates in it** — a project whose
+`locale` you ignored reports half in one language and half in another.
+
+**Product UI is the message catalogue.** `messages/<locale>.json` via
+`pikku-i18n`, with `defaultLocale` deciding what a visitor opens in.
+`baseLocale` in `project.inlang/settings.json` **stays `en`**: it names the
+message source, the catalogue every other language is cloned from, so a project
+that repoints it has nothing to translate from and `--add-locale` is broken
+forever.
+
+A German medical portal, correctly:
+
+```jsonc
+// project.inlang/settings.json
+{ "baseLocale": "en", "locales": ["en", "de"] }
+// apps/app/src/i18n/active.json   (or: fabric i18n --default-locale de)
+{ "defaultLocale": "de" }
+// pikku.config.json
+{ "locale": "de" }
+```
+
+Record the two non-obvious answers as a `decisions/` note in §2 — neither is
+discoverable from code, and the next agent will otherwise re-derive them wrong.
 
 ---
 

--- a/packages/skills/skills/pikku-build-platform/SKILL.md
+++ b/packages/skills/skills/pikku-build-platform/SKILL.md
@@ -154,6 +154,13 @@ icons, hardcoded `marginLeft`, a nav that opens on the wrong side.
 Adding a language means adding a locale file. If it means touching components,
 that is the finding.
 
+`baseLocale` stays `en` through all of this — it names the message source that
+every added locale is cloned from, so three locales is `locales: ["en", …]` and
+never a repointed base. Shipping locales is also not a reason for anything in
+the code to stop being English: identifiers are English in every project, and
+the language of `description`/`title`/`template` is `locale` in
+`pikku.config.json`. See `pikku-build-app` §1a.
+
 ### Emails — `pikku-emails`
 
 Templates in `emails/`, rendered and sent through the injected `email` service,

--- a/packages/skills/skills/pikku-build-quick/SKILL.md
+++ b/packages/skills/skills/pikku-build-quick/SKILL.md
@@ -52,6 +52,15 @@ it — one kind of person, or several?** Everything else you decide yourself.
 Do not ask about design, deployment, or scope. This is the quick mode; the
 defaults are the point.
 
+Do not ask about language either — take the defaults and note them in §6.
+Identifiers are English in every project, whatever the product's market;
+`locale` in `pikku.config.json` (the language of `description`/`title`/step
+`template`, which the Console renders) stays `en` unless the user already told
+you otherwise. If the request says the app's UI is not English, that is the
+message catalogue only: add the locale and set `defaultLocale`, and leave
+`baseLocale` at `en`. `pikku-build-app` §1a has the three axes in full; getting
+them confused is how a project ends up unable to add a second language.
+
 ## 2. Personas — 60 seconds, not optional
 
 `packages/functions/src/personas.ts` ships with a `visitor`. Add one persona per

--- a/packages/skills/skills/pikku-concepts/SKILL.md
+++ b/packages/skills/skills/pikku-concepts/SKILL.md
@@ -138,7 +138,9 @@ Services can be destructured inline in the `func` signature (e.g. `async ({ logg
 
 ```typescript
 pikkuFunc({
-  // Identity and documentation
+  // Identity and documentation — prose, so it follows `locale` in
+  // pikku.config.json (default `en`). The identifier does not; see
+  // "What Language You Write In".
   title?: string,           // Human-readable name
   description?: string,     // What the function does
   version?: number,         // Contract version (see pikku-versioning)
@@ -320,6 +322,94 @@ src/
     ├── pikku-fetch.gen.ts
     └── pikku-bootstrap.gen.ts
 ```
+
+## What Language You Write In
+
+Three different things in a Pikku project have a human language, and they are
+**not** the same language. Collapsing them is the mistake this section exists to
+prevent, and it has already shipped in a real product — the failure is at the
+bottom.
+
+| Axis            | What it covers                                                                                                                                                    | What decides it                                                                                             |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Identifiers** | Function, component, type, variable and file names. Database tables and columns. Branch names and commit messages.                                                | Nothing. **Always English.** There is no setting.                                                           |
+| **Meta**        | The prose authored _inside_ the code: `description` on functions and steps, `name`/`title` on features and scenarios, step `template`, role/persona descriptions. | `locale` in `pikku.config.json`. Defaults to `en`.                                                          |
+| **Product UI**  | Every string the app shows a user.                                                                                                                                | `messages/<locale>.json`, with `active.json`'s `defaultLocale` choosing what a first-time visitor opens in. |
+
+### Identifiers are English, and nothing changes that
+
+Not the product's market, not the team's working language, and **not `locale`**.
+A German medical practice, an Arabic marketplace and a Japanese logistics tool
+all get `getOverview`, `AttentionStripe`, `case`, `event`.
+
+This is not linguistic preference, it is mechanics. Identifiers are the surface
+every other tool binds to: the generated `#pikku/*` clients, `pikku info` and
+`pikku meta`, the RPC map a scenario's `actor.invoke` is typed over, the
+generated SQL types, every skill and every agent that ever picks the project up.
+A `vorgang` table types as `Vorgang` in Kysely and reads as noise to everyone who
+did not name it, and unlike a string it cannot be translated later — renaming an
+identifier is a migration, not an edit.
+
+### Meta follows `locale`, and that is what the field is for
+
+```json
+{ "locale": "de" }
+```
+
+Meta is the one part of a project the **Pikku Console** renders back to a human.
+A team reviewing their own functions, features and scenario reports in the
+Console is reading meta and nothing else, so a team whose working language is
+German should be able to read their Console in German. That is the entire reason
+the field exists.
+
+Read it before you author meta, and write descriptions, titles and templates in
+it. Absent, it is `en`. It is a BCP-47 tag (`en`, `de`, `pt-BR` — a hyphen, not
+an underscore), and the CLI rejects anything else by name.
+
+`locale` is **not** licence to rename anything. `locale: "de"` buys a German
+`description: 'Zeigt die Arbeitsliste'` on a function still called
+`getWorklist`.
+
+### Product UI language lives in the catalogue, and only there
+
+What the app says to its users is a translation concern, not a code concern. It
+belongs in `messages/<locale>.json`; `pikku-i18n` owns the details. The one rule
+worth repeating here: **`baseLocale` in `project.inlang/settings.json` stays
+`en`.** It names the message _source_ — the catalogue every other language is
+cloned from and translated against — so a project that sets it to anything else
+has no English catalogue to translate from and can never gain a second language
+without re-authoring every key.
+
+### The failure this comes from
+
+An agent was asked to build a doctor's portal for a German practice. The brief
+said "the entire UI is German, no English strings visible anywhere". The agent
+read one sentence about the product's users as an instruction about the
+codebase, and produced:
+
+- `project.inlang/settings.json` with `baseLocale: "de"` and `locales: ["de"]`,
+  no `en.json` at all — which silently broke `--add-locale` forever
+- RPC functions `getUebersicht` and `getPatientendetail`
+- React components `Zeitstrahl` and `AufmerksamkeitStreifen`
+- database tables `vorgang` and `ereignis`, with German columns
+
+Every one of those is wrong, and the brief was satisfied by none of them: a
+German UI needs German _messages_. What that project actually wanted was three
+settings, each on its own axis:
+
+```jsonc
+// project.inlang/settings.json — the message source stays English
+{ "baseLocale": "en", "locales": ["en", "de"] }
+
+// apps/app/src/i18n/active.json — what a first-time visitor opens in
+{ "defaultLocale": "de" }
+
+// pikku.config.json — the language the team reads their Console in
+{ "locale": "de" }
+```
+
+Identifiers stay English throughout. When a brief tells you the product speaks a
+language, it is telling you about axis three and nothing else.
 
 ## Environment Variables
 

--- a/packages/skills/skills/pikku-fabric/SKILL.md
+++ b/packages/skills/skills/pikku-fabric/SKILL.md
@@ -411,6 +411,7 @@ These apply in every Fabric app:
 - **No hand-editing `.pikku/db/schema.gen.ts`** — write a migration and re-run `pikku db migrate`.
 - **One runtime unit per file** — never define multiple functions/workflows in a single source file.
 - **Workflow steps don't need manual wiring** — `pikkuSessionlessFunc` step functions in `*.steps.ts` files are auto-discovered by codegen.
+- **Identifiers are English** — functions, components, types, files, database tables and columns, in every app whatever market it serves. The team's language is `locale` in `pikku.config.json` and reaches `description`/`title`/`template` only; the app's language is the message catalogue, where `baseLocale` stays `en` and `defaultLocale` decides what a visitor opens in. `pikku fabric validate` warns (`app-base-locale-not-english-<app>`) when an app repoints its base.
 
 ## Converting an existing app to Fabric format
 
@@ -426,7 +427,7 @@ Fix every `error` and `warn` in the output before continuing. Then:
 2. **Replace route handlers with pikkuFuncs**: extract business logic into `pikkuFunc`/`pikkuSessionlessFunc`, add `wireHTTP` or `expose: true` for transport.
 3. **Replace DI/IoC with pikkuServices**: move service construction to `createSingletonServices` in `services.ts`.
 4. **Replace `process.env` calls**: plain config becomes `defineVariable` + `variables.get()`, anything sensitive becomes `defineSecret` + `secrets.getSecret()`.
-5. **Add `pikku.config.json`** at project root with `srcDirectories`, `outDir`, and `clientFiles`.
+5. **Add `pikku.config.json`** at project root with `srcDirectories`, `outDir`, and `clientFiles` — plus `locale` if the team does not work in English, which is the language every `description`, `title` and step `template` is then authored in.
 6. **Add `pikkufabric.config.json`** at project root with `projectId`, `production.domain`, and `frontends` (production is always `main`, so there is no `production.branch`).
 7. **Run `pikku all`** — verify codegen succeeds and there are no type errors.
 8. **Run `pikku fabric validate`** once more to confirm no structural issues remain.

--- a/packages/skills/skills/pikku-feature/SKILL.md
+++ b/packages/skills/skills/pikku-feature/SKILL.md
@@ -41,6 +41,13 @@ schemas (`yarn pikku meta functions get <id>`) or workflow steps
 **Capability rule:** do not introduce new wires of a type whose
 `capabilities.<type>` is `false` unless the user explicitly asked for it.
 
+**Language rule:** read `locale` in `pikku.config.json` (default `en`). It is
+the language of every `description`, `title` and step `template` you author —
+the meta the Pikku Console renders back to the team. It renames nothing:
+functions, components, types, files, tables and columns are English in every
+project, and what the app says to its users is the message catalogue. See
+`pikku-concepts` → _What Language You Write In_.
+
 ## Stage 2 — State intent in plain English (BEFORE writing code)
 
 Before touching any files, give the user one paragraph stating exactly what

--- a/packages/skills/skills/pikku-i18n/SKILL.md
+++ b/packages/skills/skills/pikku-i18n/SKILL.md
@@ -11,9 +11,80 @@ installGroups: [client, fabric]
 Use this skill as an execution checklist, not reference material.
 
 1. Every user-facing string in a frontend is a message. Never hardcode display text — add a key to `messages/en.json` and render `m.the__key()`. This holds even when the app ships only English; the messages are the seam a second language slots into later.
-2. One `messages/<locale>.json` per language at the app root (NOT under `src/`), declared in `project.inlang/settings.json`. English (`en`) is `baseLocale` and the only locale until someone adds another.
+2. One `messages/<locale>.json` per language at the app root (NOT under `src/`), declared in `project.inlang/settings.json`. English (`en`) is `baseLocale` and the only locale until someone adds another. **`baseLocale` stays `en` whatever language the product speaks** — see [The product's language is not the code's language](#the-products-language-is-not-the-codes-language), which is the first thing to read if the brief says the app is not in English.
 3. Messages compile to typed ESM functions in `src/paraglide/` (generated, self-gitignored — never edit or commit it). The Vite plugin compiles during `dev`/`build` with HMR on message edits; run the CLI compile only when you need `tsc` before Vite has ever run.
 4. Validate with the app's own `tsc` then its `build`. The deploy pipeline compiles Paraglide and runs each frontend's `tsc` before building it — an i18n mistake blocks the deploy.
+
+## The product's language is not the code's language
+
+A brief that says "the entire UI is German, no English strings visible anywhere"
+is a statement about **one** of three separate things, and reading it as a
+statement about the codebase is the single most expensive mistake available in
+this skill. Three axes:
+
+| Axis            | What it covers                                                                                          | What sets it                                                    |
+| --------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| **Identifiers** | Function, component, type and file names; database tables and columns                                   | Nothing — always English, no setting                            |
+| **Meta**        | `description` / `name` / `title` / `template` authored inside the code, which the Pikku Console renders | `locale` in `pikku.config.json`, default `en`                   |
+| **Product UI**  | Every string the app shows a user                                                                       | `messages/<locale>.json` + `defaultLocale` — **this axis only** |
+
+A non-English product moves the third row and nothing else.
+
+### `baseLocale` stays `en`
+
+`baseLocale` in `project.inlang/settings.json` does not mean "the language the
+app is in". It names the message **source** — the catalogue every other locale is
+cloned from and translated against. Setting it to the product's language looks
+like it works, because the app does come up in that language, and then:
+
+- there is no `en.json`, so `--add-locale` has no catalogue to translate from
+- the app can never gain a second language without re-authoring every key
+- a message missing from a locale falls back to a catalogue nobody wrote
+
+The setting that actually decides what a first-time visitor sees is
+`defaultLocale`, held in `apps/app/src/i18n/active.json` in the Fabric app
+template and read by `src/i18n/config.ts`. It is deliberately a separate file
+from `settings.json` for exactly this reason — the source language and the
+served language are different questions.
+
+So a German medical portal is **three** settings, not one:
+
+```jsonc
+// project.inlang/settings.json — the source catalogue is English
+{ "baseLocale": "en", "locales": ["en", "de"] }
+
+// apps/app/src/i18n/active.json — what a visitor opens in
+{ "defaultLocale": "de" }
+
+// pikku.config.json — the language the team reads their Console in
+{ "locale": "de" }
+```
+
+In the Fabric template both of the first two have a command, so you rarely edit
+them by hand:
+
+```sh
+fabric i18n --add-locale de       # adds "de" to locales, seeds messages/de.json from en.json
+fabric i18n --default-locale de   # writes active.json — the app now OPENS in German
+```
+
+### The failure this is written from
+
+A real build, from this template. The brief said the UI was German; the agent
+set `baseLocale: "de"` with `locales: ["de"]` and no `en.json`, then carried the
+same reading into the code — RPC functions `getUebersicht` and
+`getPatientendetail`, components `Zeitstrahl` and `AufmerksamkeitStreifen`,
+helpers `datumDeutsch` and `voraussichtlichFertig`, database tables `vorgang`
+and `ereignis` with German columns.
+
+The German UI it was asked for needed none of that. It needed German **values**
+in a catalogue whose keys and source stayed English. What it got instead was a
+project that cannot add a second language and cannot be picked up by anyone who
+does not read German.
+
+If you find a project in this state, say so plainly rather than working around
+it: `baseLocale` cannot be repointed without re-keying every message, so it is a
+migration someone has to agree to, not a fix to slip in.
 
 ## The moving parts (starter-template layout)
 
@@ -109,9 +180,10 @@ The gate catches _invalid_ messages but not _inlined_ strings. The `@pikku/manti
 ## Adding a second language
 
 1. `messages/fr.json` mirroring `en.json`'s keys (translate the values, keep `{param}` names identical).
-2. Add `"fr"` to `locales` in `project.inlang/settings.json`.
+2. Add `"fr"` to `locales` in `project.inlang/settings.json`. **Leave `baseLocale` at `en`** — step 1 only works because there is an English catalogue to mirror.
 3. Recompile (restart/`vite dev` or the CLI compile). A locale file missing keys falls back to the base locale per message.
 4. Content is reachable via the `/<lang>` URL prefix (`detectLocale` already resolves it); the base locale needs no prefix. Expose the switcher via `useLocale().setLocale`.
+5. Only if the app should **open** in the new language rather than merely offer it: set `defaultLocale` (`active.json` / `fabric i18n --default-locale fr`). Adding a locale and changing the default are different asks — do the second only when asked.
 
 ## i18n debug mode (find inlined strings)
 
@@ -137,6 +209,9 @@ The wrapper alternative — a module that walks the namespace and pipes each mes
 ## What NOT to do
 
 - Don't hardcode display strings "just for now" — the message is the work.
+- Don't set `baseLocale` to anything but `en`, whatever language the product speaks. It names the source catalogue, and a project without one can never add a language. Set `defaultLocale` instead.
+- Don't let a non-English UI reach the identifiers. Functions, components, types, files, tables and columns are English in every project; the product's language lives in `messages/*.json` and nowhere else.
+- Don't translate message **keys**. `auth__login__title` stays English in `de.json`; only the value changes.
 - Don't edit or commit anything under `src/paraglide/` — it's regenerated; change `messages/*.json` instead.
 - **Don't wrap `m`.** No re-export module, no branding layer, no resolver. Components import `m` from `../paraglide/messages.js` and call it. `@pikku/react`'s `I18nString` is declared as `string & { readonly __brand: 'LocalizedString' }` — deliberately identical to Paraglide's own `LocalizedString` — so `m.some__key()` satisfies the `@pikku/mantine` `I18nNode` gate natively. A wrapper adds nothing and costs per-message tree-shaking.
 

--- a/packages/skills/skills/pikku-scenario/SKILL.md
+++ b/packages/skills/skills/pikku-scenario/SKILL.md
@@ -356,6 +356,56 @@ const order = await scenario.do(
 
 Reach for a `pikkuScenarioStep` on the non-browser side only when one intent genuinely spans several RPCs, or when the step asserts something the RPC result alone does not say.
 
+### What language the prose is in
+
+A scenario carries two kinds of text, and they do not share a language.
+
+**Identifiers are English.** The exported const (`buysAnApple`,
+`credentialFeature`), the step's `name` — which is its `pikkuFuncId`, the typed
+string the generated step map is keyed by — the file name, and every helper in
+`*.browser.ts`. These bind to generated code and to `pikku scenario list`; they
+are English in every project regardless of who the product is for or what
+language the team speaks. There is no setting that changes this.
+
+**Prose follows `locale` in `pikku.config.json`** (default `en`). That is a
+step's `description` and `template`, a feature's `name` and `description`, a
+scenario's `title`, and the positional step names passed to
+`scenario.given/when/then`. Read the field before you write any of them.
+
+This split is the same one the feature table already states — _the export
+identifier is the feature's id; `name` is the human-readable label_ — applied to
+language. The report is the deliverable, and it is read by the team; the
+identifier is an API, and it is read by the toolchain.
+
+```typescript
+// pikku.config.json: { "locale": "de" }
+export const buysAnApple = pikkuScenarioStep<{ qty: number }, { orderId: string }>({
+  name: 'buysAnApple',          // identifier — English, always
+  description: 'kauft einen Apfel',  // prose — follows locale
+  template: 'kauft {qty} Äpfel',     // prose — follows locale
+  actor: true,
+  default: async (_services, { qty }, { actor }) =>
+    await actor.invoke('placeOrder', { qty }),
+})
+```
+
+Note what does **not** change: `placeOrder` is still `placeOrder`, and the file
+is still `apple.scenario.ts`.
+
+A product with a non-English UI is not on its own a reason to set `locale` — that
+is the app's language, not the team's. Ask, or leave it `en`.
+
+**Where a non-`en` `locale` still shows English, today.** The reporter composes a
+sentence as `<Keyword> the <actor> <template>` (`composeStepProse`), and both the
+keyword and the article `the` are English literals. The Console translates the
+Given/When/Then keywords into its own UI language; the CLI reporter does not, and
+nothing translates `the`. So `locale: "de"` gives you German step prose inside an
+English frame — `Given the shopper kauft 1 Äpfel`. Write templates that read
+acceptably in that frame rather than trying to defeat it. A second gap: where a
+function or scenario declares no `title`, the Console falls back to splitting the
+**identifier** into an English-looking label (`toEnglishName`), so under a
+non-`en` `locale` meta is worth authoring rather than leaving to the fallback.
+
 ### `then` bindings are witnesses, not alternatives
 
 This is the one place the surface bindings do **not** behave like a switch, and it is the part worth reading twice.
@@ -783,6 +833,7 @@ Services are plain objects — a Pikku function is pure business logic, so a moc
 | Assuming a clean database                           | There is no state reset — it may be a staging server. Scope what you create.                                                |
 | `sleep()` before asserting                          | Use `expectEventually`.                                                                                                     |
 | A step named `clicksAddToBasket` / `opensThePage`   | That is an action, not an intent. Name the step for what the actor wanted; put the clicking in a utility.                   |
+| A step named `kauftEinenApfel` / a `vorgang` table   | Identifiers are English in every project. The German belongs in `description` / `template`, and only when `pikku.config.json` sets `locale`.  |
 | A browser step that assumes it is already on a page | It can then only run mid-flow. Arrive first — check the URL, navigate if needed.                                            |
 | `getByLabel('Full Name')` in a translated app        | Passes only in the base locale, and a copy edit breaks it as an unexplained timeout. Locate by message key.                 |
 | A `browser` binding guarding `if (!browser)`        | The binding guarantees it. The guard hides the real error, which is a missing actor (`PKU677`).                             |


### PR DESCRIPTION
## Three languages, not one

A Pikku project has three separate human-language decisions, and until now
nothing in the repo said so. An agent that met one of them assumed it had met
all three.

| Axis | What it covers | What sets it |
| --- | --- | --- |
| **Identifiers** | Function, component, type, variable and file names. Database tables and columns. Commit messages. | **Nothing — always English.** There is no setting, and this PR does not add one. |
| **Meta** | The prose authored *inside* the code: `description` on functions and steps, `name`/`title` on features and scenarios, step `template`, role and persona descriptions. | **New:** `locale` in `pikku.config.json`, default `en`. |
| **Product UI** | Every string the app shows a user. | `messages/<locale>.json`, with `active.json`'s `defaultLocale` choosing what a first-time visitor opens in. `baseLocale` stays `en`. |

## The failure this comes from

A real build, via the fabric template. The brief for a German medical practice
said *"the entire UI is German, no English strings visible anywhere"*. The agent
read one sentence about the product's users as an instruction about the
codebase and produced:

- `project.inlang/settings.json` with `baseLocale: "de"`, `locales: ["de"]`, and
  no `en.json` at all — so `fabric i18n --add-locale` has no catalogue to
  translate from, permanently. The app can never gain a second language without
  re-authoring every message key.
- RPC functions `getUebersicht`, `getPatientendetail`
- React components `Zeitstrahl`, `AufmerksamkeitStreifen`
- helpers `datumDeutsch`, `voraussichtlichFertig`
- scenario steps `arbeitslisteZeigtPatient`, `filterZeigtNurStatus`
- database tables `vorgang`, `ereignis` with German columns

The German UI it was asked for needed none of that. It needed German *values* in
a catalogue whose keys and source stayed English. What that project actually
wanted was three settings, one per axis:

```jsonc
// project.inlang/settings.json — the message source stays English
{ "baseLocale": "en", "locales": ["en", "de"] }
// apps/app/src/i18n/active.json — what a visitor opens in
{ "defaultLocale": "de" }
// pikku.config.json — the language the team reads their Console in
{ "locale": "de" }
```

It is partly the framework's fault for never asking, and the template's own
`i18n/config.ts` already documented the correct model in a comment that nothing
else in the toolchain repeated.

## What the config field does

`locale` on `PikkuCLIInput`, defaulting to `en`, validated through
`Intl.getCanonicalLocales` — Node's own BCP-47 grammar, which catches the
mistake people actually make (`de_DE` with a POSIX underscore) and returns the
canonical spelling so `EN-gb` and `en-GB` are one value downstream rather than
two that never compare equal.

**It exists for the Console.** Meta is the one part of a project the Pikku
Console renders back to a human — `ScenarioSection`, `FeatureDocument`,
`LadderStep`, `PersonaDetail` and `FunctionsListPanel` all pass it through
`asI18n()` untouched while translating their own chrome — so a team whose
working language is German should be able to read their own Console in German
without anything else about the project changing. That rationale is in the doc
comment, because a field whose purpose is unstated gets read as whatever the
reader already had in mind.

## What the skills now enforce

- **`pikku-concepts`** — new *What Language You Write In*: the canonical
  three-axis statement, the identifiers rule, and the German-portal failure told
  in full. It loads first in every Pikku task, which is why it holds the primary
  copy.
- **`pikku-build-app`** — a language question in §1, and a new **§1a** at the
  requirements-gathering point that settles all three axes and writes `locale`
  into `pikku.config.json` *before there is any meta to be wrong*. Default `en`
  without asking when the project is obviously English. The Agent Operating
  Procedure now says to read the field on every subsequent run.
- **`pikku-scenario`** — new *What language the prose is in*: the step's `name`
  is a `pikkuFuncId` the generated step map is keyed by and is English; its
  `description`/`template` follow `locale`. Plus a red-flag row.
- **`pikku-i18n`** — new *The product's language is not the code's language*:
  why `baseLocale` stays `en`, what `defaultLocale` is for, the German portal
  worked correctly, and three new *What NOT to do* bullets. A project already in
  the broken state is called out as a re-key someone has to agree to, not a fix
  to slip in.
- **`pikku-build-quick`**, **`pikku-build-platform`**, **`pikku-feature`**,
  **`pikku-fabric`** — the short form, at each one's own naming or
  requirements moment.

## The mechanical check

`pikku fabric validate` already walked every `apps/*/project.inlang/settings.json`
to read `baseLocale` (it needs the base catalogue to spot scenario steps that
hardcode copy). It read the value and never questioned it. New finding
**`app-base-locale-not-english-<app>`** (warn) does, naming `defaultLocale` as
the setting that was actually wanted and showing both edits. No new CLI surface.

## Design caveat, stated plainly

**A field called `locale` risks being read as the app's UI language** — which is
precisely the confusion that caused the original bug, so it deserves saying out
loud rather than burying. `metaLocale` would read less ambiguously against the
i18n concepts already in the template (`baseLocale`, `defaultLocale`,
`supportedLocales`), and I would mildly prefer it. I kept `locale` because that
is what was asked for, and mitigated three ways: the doc comment spends more of
its length on what the field is *not* than on what it is; the validation error
does the same, so even the failure path teaches the distinction; and every skill
that mentions it states the three axes rather than the one. Happy to rename in
review — it is a one-line change plus the prose.

## Two things in the framing that turned out not to match this repo

- **There is no `prompt.md` here.** Nothing in this tree is served at
  `pikkufabric.com/prompt.md`; `find . -name "prompt.md"` returns nothing, and
  the fabric repo has no such route either. The build instructions an agent
  actually loads are the skills in `packages/skills/skills/`, so that is where
  all of this went.
- **The fabric app template is not in this repo.** `--add-locale`,
  `--default-locale`, `apps/app/src/i18n/active.json` and the `i18n/config.ts`
  comment all live in a `starter-template` repo cloned at runtime by
  `packages/create`. The only `active.json` in this tree is the *theme*
  selector (`packages/mantine-theme/active.json`, shaped `{ "id": … }`) — worth
  knowing, since the two are easy to confuse. The skills here describe the
  template's mechanism accurately; no template file is changed by this PR.

## A limitation this PR does not fix

`composeStepProse` frames every scenario sentence in English —
`` const subject = actor ? `the ${actor}` : '' `` plus a capitalised Given/When/
Then. The Console translates the keywords into its own UI language; the CLI
reporter does not, and nothing translates `the`. So `locale: "de"` today gives
German step prose inside an English frame: `Given the shopper kauft 1 Äpfel`.
The `pikku-scenario` skill says this outright rather than letting an author
discover it. Related: where meta is absent the Console falls back to
`toEnglishName()`, which camelCase-splits the *identifier* into an
English-looking label — so under a non-`en` locale, meta is worth authoring
rather than left to the fallback.

## Verification

Run from the worktree. `packages/cli` tests use the package's own runner.

```
$ node --no-memory-protection-keys --import tsx --test src/utils/pikku-cli-config.test.ts
  ✔ locale defaults to English when the config does not name one
  ✔ a declared locale survives the load, canonicalized
  ✔ a locale that is not a language tag names itself in the error
  ✔ an absent locale is English rather than an error
  ✔ canonicalizes so one language is one value downstream
  ✔ rejects the POSIX underscore people reach for
  ✔ rejects what is not a tag at all
  ✔ the error points at the two settings it is not
ℹ tests 20
ℹ pass 20
ℹ fail 0
```

8 new tests (3 through the loader, 5 on `normalizeLocale`), covering the
default, canonicalization, and the validation error.

Type check, diffed against an untouched `origin/main` worktree sharing the same
`node_modules`:

```
$ tsc --noEmit -p packages/cli/tsconfig.json   # both trees, output sorted and diffed
identical to baseline (284 pre-existing errors, 0 new)
```

Full `packages/cli` suite, same comparison: **962 pass / 34 fail** on this
branch against **954 pass / 34 fail** on `origin/main` — the 8 added tests all
pass and the failure count is unchanged.

**Honest gap:** the 34 pre-existing failures, and the three new
`app-base-locale-not-english` tests in `validate.function.test.ts`, come from
the same environment limitation — a fresh worktree has no generated+built
`packages/cli/dist/.pikku/*/index.js`, so `#pikku/function` cannot resolve and
the file aborts before any test runs. It fails identically on untouched
`origin/main`. **Those three tests are written but I could not execute them**,
and I am not claiming them green. `tsc` does parse and type-check the body of
`validate.function.ts` (its only error is the unresolvable generated import, in
both trees), so the new block type-checks — but it has not been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
