### PR TITLE
feat(cli): pikku fabric variables set/get

### DIFF
--- a/.changeset/fabric-variables-set.md
+++ b/.changeset/fabric-variables-set.md
@@ -1,0 +1,22 @@
+---
+'@pikku/cli': patch
+'@pikku/skills': patch
+---
+
+Add `pikku fabric variables set` and `pikku fabric variables get`
+
+`secrets` was the only stage-scoped store the CLI exposed, so a value declared
+with `defineVariable` could be set locally through `.env` and not at all on a
+deployed stage — `variables.get('NAME')` compiled, ran, and answered `undefined`
+forever, with nothing saying why. The fabric API already had
+`setStageConsoleVariable` and `getStageConsoleVariable`; only the CLI surface was
+missing.
+
+`set` stores the value the way `LocalVariablesService` reads one: `JSON.parse`,
+falling back to the raw string. `--value true` is therefore the boolean on a
+stage exactly as it is from `.env`, and `--value '"true"'` is the string. `get`
+prints the stored value as JSON so the two are distinguishable, which is usually
+why you are looking.
+
+Variables are not sealed and are readable back — that is the difference from
+`secrets`, and anything that would hurt to print belongs in `secrets set`.

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -47,6 +47,8 @@ import { FabricRollback } from './functions/rollback.function.js'
 import { FabricSecretsSet } from './functions/secrets-set.function.js'
 import { FabricSecretsList } from './functions/secrets-list.function.js'
 import { FabricSecretsRotate } from './functions/secrets-rotate.function.js'
+import { FabricVariablesSet } from './functions/variables-set.function.js'
+import { FabricVariablesGet } from './functions/variables-get.function.js'
 import { FabricLogs } from './functions/logs.function.js'
 import { FabricMetrics } from './functions/metrics.function.js'
 import { FabricTrace } from './functions/trace.function.js'
@@ -293,6 +295,29 @@ export const fabricCommands = defineCLICommands({
             description: 'Confirm that existing secrets become unreadable',
             default: false,
           },
+        },
+      }),
+    },
+  },
+  variables: {
+    description: 'Manage stage-scoped variables',
+    subcommands: {
+      set: pikkuCLICommand({
+        parameters: '<name>',
+        func: FabricVariablesSet,
+        description: 'Set a stage-scoped variable',
+        options: {
+          branch: { description: 'Target branch', short: 'b' },
+          value: { description: 'Variable value, read as JSON when it parses' },
+        },
+      }),
+      get: pikkuCLICommand({
+        parameters: '<name>',
+        func: FabricVariablesGet,
+        description: 'Read a stage-scoped variable back',
+        options: {
+          branch: { description: 'Target branch', short: 'b' },
+          json: { description: 'Machine-readable output', default: false },
         },
       }),
     },

--- a/packages/cli/src/fabric/functions/variables-get.function.ts
+++ b/packages/cli/src/fabric/functions/variables-get.function.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod'
+import { pikkuSessionlessFunc } from '../../../.pikku/function/index.js'
+import { resolveApiContext } from '../lib/config.js'
+import { getFabricRPC } from '../lib/http.js'
+import { resolveStageId } from '../lib/stage.js'
+
+export const FabricVariablesGetInput = z.object({
+  name: z.string(),
+  branch: z.string(),
+  json: z.boolean().optional(),
+})
+
+export const FabricVariablesGetOutput = z.object({
+  name: z.string(),
+  exists: z.boolean(),
+  value: z.unknown(),
+})
+
+export const FabricVariablesGet = pikkuSessionlessFunc({
+  description:
+    'Read a stage-scoped variable back, so you can see the shape it was stored in rather than the shape you meant.',
+  input: FabricVariablesGetInput,
+  output: FabricVariablesGetOutput,
+  func: async (_services, { name, branch, json }) => {
+    const ctx = await resolveApiContext()
+    if (!ctx.token)
+      throw new Error('Not logged in. Run `pikku fabric login` first.')
+    if (!ctx.projectId)
+      throw new Error(
+        'No fabric project linked. Run `pikku fabric link` first.'
+      )
+
+    const rpc = getFabricRPC({ apiUrl: ctx.apiUrl, token: ctx.token })
+    const stageId = await resolveStageId(rpc, ctx.projectId, branch)
+    const { exists, value } = await rpc.invoke('getStageConsoleVariable', {
+      stageId,
+      variableId: name,
+    })
+
+    if (json) {
+      console.log(JSON.stringify({ branch, name, exists, value }, null, 2))
+    } else if (!exists) {
+      console.log(`[fabric] ${name} is not set on ${branch}`)
+    } else {
+      // `JSON.stringify` rather than the bare value, because the shape is the
+      // thing worth seeing: `true` and `"true"` print identically otherwise, and
+      // telling them apart is usually why you are looking.
+      console.log(JSON.stringify(value))
+    }
+
+    return { name, exists, value }
+  },
+})

--- a/packages/cli/src/fabric/functions/variables-set.function.ts
+++ b/packages/cli/src/fabric/functions/variables-set.function.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+import { pikkuSessionlessFunc } from '../../../.pikku/function/index.js'
+import { resolveApiContext } from '../lib/config.js'
+import { getFabricRPC } from '../lib/http.js'
+import { resolveStageId } from '../lib/stage.js'
+import { parseVariableValue } from '../lib/variable-value.js'
+
+export const FabricVariablesSetInput = z.object({
+  name: z.string(),
+  branch: z.string(),
+  value: z.string(),
+})
+
+export const FabricVariablesSetOutput = z.object({
+  name: z.string(),
+  success: z.boolean(),
+})
+
+export const FabricVariablesSet = pikkuSessionlessFunc({
+  description:
+    'Set a stage-scoped variable — the deployed counterpart of a line in .env. Not a secret: the value is stored in plain form and is readable back.',
+  input: FabricVariablesSetInput,
+  output: FabricVariablesSetOutput,
+  func: async (_services, { name, branch, value }) => {
+    const ctx = await resolveApiContext()
+    if (!ctx.token)
+      throw new Error('Not logged in. Run `pikku fabric login` first.')
+    if (!ctx.projectId)
+      throw new Error(
+        'No fabric project linked. Run `pikku fabric link` first.'
+      )
+
+    const rpc = getFabricRPC({ apiUrl: ctx.apiUrl, token: ctx.token })
+    const stageId = await resolveStageId(rpc, ctx.projectId, branch)
+
+    // Deliberately not sealed, and deliberately not prompted for. A variable is
+    // configuration — a port, a URL, a feature switch — and treating it like a
+    // secret would mean it could not be read back, which is most of the value of
+    // having it separate from `secrets` in the first place. Anything that would
+    // hurt to print belongs in `pikku fabric secrets set`.
+    const { success } = await rpc.invoke('setStageConsoleVariable', {
+      stageId,
+      variableId: name,
+      value: parseVariableValue(value),
+    })
+
+    console.log(`[fabric] ${name} set on ${branch}.`)
+    return { name, success }
+  },
+})

--- a/packages/cli/src/fabric/lib/variable-value.test.ts
+++ b/packages/cli/src/fabric/lib/variable-value.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseVariableValue } from './variable-value.js'
+
+describe('parseVariableValue', () => {
+  it('parses the JSON spellings, so a stage sees what `.env` would give', () => {
+    assert.equal(parseVariableValue('true'), true)
+    assert.equal(parseVariableValue('false'), false)
+    assert.equal(parseVariableValue('8080'), 8080)
+    assert.equal(parseVariableValue('null'), null)
+    assert.deepEqual(parseVariableValue('{"a":1}'), { a: 1 })
+    assert.deepEqual(parseVariableValue('["a","b"]'), ['a', 'b'])
+  })
+
+  it('keeps anything that is not JSON as the string it was typed as', () => {
+    assert.equal(parseVariableValue('hello'), 'hello')
+    assert.equal(
+      parseVariableValue('https://example.com'),
+      'https://example.com'
+    )
+    assert.equal(parseVariableValue(''), '')
+    // A quoted string is JSON, and unwrapping it is the point: it is how you
+    // store the four characters `true` rather than the boolean.
+    assert.equal(parseVariableValue('"true"'), 'true')
+  })
+})

--- a/packages/cli/src/fabric/lib/variable-value.ts
+++ b/packages/cli/src/fabric/lib/variable-value.ts
@@ -1,0 +1,21 @@
+/**
+ * How a `--value` typed at a shell prompt becomes the value a running stage sees.
+ *
+ * `setStageConsoleVariable` takes `unknown`, so the choice of what to store is
+ * the CLI's to make, and the only defensible answer is whatever
+ * `LocalVariablesService` would have produced from the same text in a `.env`
+ * file. That service reads `JSON.parse(raw)` and falls back to the raw string
+ * when the parse throws, so this does the same.
+ *
+ * The alternative — store every value as a string — is what makes a variable
+ * behave differently in a deploy than it does locally, and the failure it causes
+ * is silent: `DEMO_ACCESS=true` compared against the boolean `true` is simply
+ * false, and the feature it gates stays off with nothing in the log to say why.
+ */
+export const parseVariableValue = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return raw
+  }
+}

--- a/packages/skills/skills/pikku-fabric/SKILL.md
+++ b/packages/skills/skills/pikku-fabric/SKILL.md
@@ -322,7 +322,12 @@ Why it parked is the whole story, and it is `statusReason`, not `status`:
   accepts them for that deploy.
 - `needs_config` — a declared secret or variable has no value covering the
   stage. The CLI names them. `--auto-approve` will **not** force this through;
-  set the values (`pikku fabric secrets set <name>`) and re-attach.
+  set the values and re-attach — `pikku fabric secrets set <name>` for a
+  declared secret, `pikku fabric variables set <name> --value <v>` for a declared
+  variable. They are separate stores: a secret is sealed to the stage and cannot
+  be read back, a variable is stored plainly and can (`variables get`). `set`
+  reads the value as JSON when it parses, so `--value true` is the boolean on a
+  stage exactly as it is from `.env`, and `--value '"true"'` is the string.
 - `needs_attention` — the plan is red. Nothing to approve.
 
 `--sync` defaults to a 900s ceiling; `--timeout <seconds>` moves it. On timeout


### PR DESCRIPTION
## What

Adds `pikku fabric variables set <name> --value <v>` and `pikku fabric variables get <name>`.

## Why

`secrets` was the only stage-scoped store the CLI exposed. There was a `pikku fabric secrets set`; there was no `variables set`, and `pikkufabric.config.json` has no `variables` or `env` section. So a value declared with `defineVariable` was settable locally — the variables service is backed by `.env` there — and unsettable in production.

Nothing said so. `defineVariable` accepts the declaration, the CLI generates the typed `VariablesMap` entry, `variables.get('NAME')` compiles and runs, and the deployed answer is `undefined` forever. Hit this on a real deploy with a feature switch that was therefore permanently off in production, where the symptom — a permission failing closed — is identical to the switch being deliberately off.

The server side already existed: `setStageConsoleVariable` and `getStageConsoleVariable` are both in the fabric RPC map. Only the CLI surface was missing.

## Value semantics

`set` stores the value the way `LocalVariablesService` reads one: `JSON.parse`, falling back to the raw string when the parse throws.

```
pikku fabric variables set DEMO_ACCESS --value true      # boolean true
pikku fabric variables set DEMO_ACCESS --value '"true"'  # string "true"
pikku fabric variables set PORT --value 8080             # number 8080
pikku fabric variables set API_URL --value https://x.com # string
```

The alternative — store every value as a string — is what makes a variable behave differently in a deploy than it does locally, and the failure it causes is silent: `DEMO_ACCESS=true` compared against the boolean `true` is simply false, and the feature it gates stays off with nothing in the log to say why. `parseVariableValue` is its own module with unit tests for exactly this.

`get` prints the stored value through `JSON.stringify` rather than bare, because the shape is the thing worth seeing: `true` and `"true"` print identically otherwise, and telling them apart is usually why you are looking. `--json` gives the full `{branch, name, exists, value}`.

## Not secrets

A variable is deliberately not sealed and not prompted for. It is configuration — a port, a URL, a feature switch — and treating it like a secret would mean it could not be read back, which is most of the value of having it separate from `secrets` in the first place. Anything that would hurt to print belongs in `pikku fabric secrets set`.

## Skill

`pikku-fabric/SKILL.md` already told users that a declared **variable** with no value parks a deploy at `needs_config`, while offering only `secrets set` as the fix. That bullet now names both stores and the JSON value semantics.

## Test plan

- `packages/cli/src/fabric/lib/variable-value.test.ts` — new, covers the JSON spellings and the string fallback, including `'"true"'` → `'true'`.
- `packages/cli` `yarn test`: 1395 pass / 0 fail.
- `packages/cli` `yarn tsc`: clean.
- `yarn build:packages`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmhHZ4LqT828q9wWBZktzy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pikku fabric variables set` for creating or updating stage-specific variables.
  * Added `pikku fabric variables get` for retrieving variables, including optional JSON output.
  * Variable values support JSON types while preserving plain-text values when needed.
  * Added branch selection and clear handling for unset variables.

* **Documentation**
  * Clarified the distinction between readable variables and secrets, including configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->