### PR TITLE
fix(inspector): record `rpc!.invoke(...)` as an invocation

### DIFF
--- a/.changeset/rpc-invoke-non-null-receiver.md
+++ b/.changeset/rpc-invoke-non-null-receiver.md
@@ -1,0 +1,23 @@
+---
+'@pikku/inspector': patch
+---
+
+Record `rpc!.invoke(...)` as an invocation
+
+`rpc` is optional on the wire, so a caller that knows it is there writes
+`rpc!.invoke('someFunction', …)`. The inspector matched the receiver as a bare
+identifier, but a non-null assertion is a node of its own wrapping that
+identifier, so those call sites were never recorded.
+
+That is silent rather than loud. An invocation is what puts a function that is
+not `expose: true` into the runtime registry, so the target was left
+unregistered and the dispatch failed with `Function not found` — at run time,
+on a call site that type-checked.
+
+The generated virtual-user scaffold dispatches exactly this way, which meant
+`executeVirtualUserRun` was never registered: every virtual-user run sat at
+`running` forever with nothing logged, because the scaffold's own
+`.catch(() => {})` swallowed the rejection.
+
+The receiver is now unwrapped through non-null assertions and parentheses
+before it is matched.

--- a/packages/inspector/src/add/add-rpc-invocations.test.ts
+++ b/packages/inspector/src/add/add-rpc-invocations.test.ts
@@ -110,4 +110,54 @@ export const routes = { stream: { func: ref('console:streamWorkflowRun') } }
       await rm(dir, { recursive: true, force: true })
     }
   })
+
+  test('a non-null assertion on the receiver is still an invocation', async () => {
+    const { state, dir } = await inspectFiles({
+      'caller.ts': `
+declare const rpc: { invoke: (name: string, data?: unknown) => Promise<unknown> } | undefined
+export async function doWork() {
+  return rpc!.invoke('executeVirtualUserRun')
+}
+`,
+    })
+    try {
+      assert.ok(state.rpc.invokedFunctions.has('executeVirtualUserRun'))
+      const invoked = [...state.rpc.invokedFunctionsByFile.values()][0]!
+      assert.deepStrictEqual([...invoked], ['executeVirtualUserRun'])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('a parenthesised receiver is still an invocation', async () => {
+    const { state, dir } = await inspectFiles({
+      'caller.ts': `
+declare const rpc: { invoke: (name: string, data?: unknown) => Promise<unknown> } | undefined
+export async function doWork() {
+  return (rpc!).invoke('listTasks')
+}
+`,
+    })
+    try {
+      assert.ok(state.rpc.invokedFunctions.has('listTasks'))
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('invoke on some other receiver is left alone', async () => {
+    const { state, dir } = await inspectFiles({
+      'caller.ts': `
+declare const client: { invoke: (name: string, data?: unknown) => Promise<unknown> } | undefined
+export async function doWork() {
+  return client!.invoke('notAnRpc')
+}
+`,
+    })
+    try {
+      assert.ok(!state.rpc.invokedFunctions.has('notAnRpc'))
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/inspector/src/add/add-rpc-invocations.ts
+++ b/packages/inspector/src/add/add-rpc-invocations.ts
@@ -21,6 +21,26 @@ function findCastArg(
 }
 
 /**
+ * The `rpc` in `rpc.invoke(...)`, seen through whatever the author wrote to
+ * satisfy the type checker.
+ *
+ * `rpc` is optional on the wire, so a caller that knows it is there reaches for
+ * `rpc!.invoke(...)` — and a non-null assertion is a node of its own, not the
+ * identifier underneath it. Matching only the bare identifier meant those calls
+ * were never recorded as invocations, which is silent rather than loud: the
+ * target is not `expose: true`, so nothing else puts it in the registry, and
+ * the dispatch fails with "Function not found" at run time on a call site that
+ * type-checked. Parentheses are unwrapped for the same reason.
+ */
+function invocationReceiver(node: ts.Expression): ts.Expression {
+  let inner = node
+  while (ts.isNonNullExpression(inner) || ts.isParenthesizedExpression(inner)) {
+    inner = inner.expression
+  }
+  return inner
+}
+
+/**
  * Helper to extract namespace from a namespaced function reference like 'ext:hello'
  */
 function extractNamespace(functionRef: string): string | null {
@@ -80,11 +100,15 @@ export function addRPCInvocations(
     }
 
     // Check for rpc.invoke('...') calls
+    const invokeReceiver = ts.isPropertyAccessExpression(expression)
+      ? invocationReceiver(expression.expression)
+      : undefined
     if (
       ts.isPropertyAccessExpression(expression) &&
       expression.name.text === 'invoke' &&
-      ts.isIdentifier(expression.expression) &&
-      expression.expression.text === 'rpc'
+      invokeReceiver &&
+      ts.isIdentifier(invokeReceiver) &&
+      invokeReceiver.text === 'rpc'
     ) {
       // Skip PKU940 for generated files — they may contain intentional casts
       // (e.g. the paginated useInfiniteQuery hook in pikku-react-query.gen.ts).


### PR DESCRIPTION
`rpc` is optional on the wire, so a caller that knows it is there writes `rpc!.invoke('someFunction', …)`. The inspector matched the receiver as a bare identifier, but a non-null assertion is a node of its own wrapping that identifier, so those call sites were never recorded.

That is silent rather than loud. An invocation is what puts a function that is not `expose: true` into the runtime registry, so the target was left unregistered and the dispatch failed with `Function not found` — at run time, on a call site that type-checked.

### How it surfaced

The generated virtual-user scaffold dispatches exactly this way:

```ts
void rpc!
  .invoke('executeVirtualUserRun', { runId, persona, … })
  .catch(() => {})
```

So `executeVirtualUserRun` was never registered, and **every virtual-user run on every project using this scaffold sat at `running` forever with nothing logged** — the scaffold's own `.catch(() => {})` swallowed the rejection.

### The fix

The receiver is unwrapped through non-null assertions and parentheses before it is matched.

### Tests

Three cases added to the existing suite, all running through the real `inspect()`:

- `rpc!.invoke(...)` is recorded — **fails without this change**
- `(rpc!).invoke(...)` is recorded — **fails without this change**
- `client!.invoke(...)` is still ignored — negative control, passes either way

```
✔ body-level rpc.invoke() is attributed to its source file
✔ namespaced body invoke joins serviceAggregation.usedFunctions
✔ multiple invocations in one file accumulate under that file
✔ wiring-level ref() lands in invokedFunctions but NOT in the by-file map
✔ a non-null assertion on the receiver is still an invocation
✔ a parenthesised receiver is still an invocation
✔ invoke on some other receiver is left alone
ℹ pass 7  ℹ fail 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbD1Nm6beyHkCB8qujxcLw