### PR TITLE
fix(cli): hint the command that sets what the deploy is actually missing

### DIFF
--- a/.changeset/lucky-pans-shave.md
+++ b/.changeset/lucky-pans-shave.md
@@ -1,0 +1,12 @@
+---
+'@pikku/cli': patch
+---
+
+Point a config-blocked deploy at the command that sets what is actually missing
+
+A deploy blocked on `needs_config` printed one hint — "Set the values with
+`pikku fabric secrets set <name>`" — whether what was missing was a secret or a
+variable. Secrets and variables are set by two different commands, so anyone
+blocked on a variable was sent to a command that refuses their value. The hint
+now follows what is missing and names it, so the values can be found without
+reading the deployment status by hand.

--- a/packages/cli/src/fabric/functions/deploy.function.ts
+++ b/packages/cli/src/fabric/functions/deploy.function.ts
@@ -8,6 +8,7 @@ import { added, changed, removed, dim, table } from '../lib/output.js'
 import {
   blockedReason,
   blockedSummary,
+  missingConfigHints,
   changesAreEmpty,
   classifyStatus,
   describeDeployment,
@@ -506,7 +507,12 @@ export const renderDeployApply = (_s: unknown, result: ApplyOutput): void => {
         )
       )
     } else if (reason === 'needs_config') {
-      console.log(dim('Set the values with `pikku fabric secrets set <name>`.'))
+      for (const hint of missingConfigHints(
+        result.missingSecrets,
+        result.missingVariables
+      )) {
+        console.log(dim(hint))
+      }
     }
     return
   }

--- a/packages/cli/src/fabric/lib/deployment.test.ts
+++ b/packages/cli/src/fabric/lib/deployment.test.ts
@@ -6,6 +6,7 @@ import {
   describeDeployment,
   destructiveMigrations,
   isApprovable,
+  missingConfigHints,
   stateLabel,
   waitForDeployment,
   type DeploymentStatus,
@@ -128,6 +129,56 @@ describe('blocked reasons', () => {
       'needs attention'
     )
     assert.strictEqual(stateLabel('active', null), 'live')
+  })
+})
+
+describe('missingConfigHints', () => {
+  test('a missing secret names the secrets command', () => {
+    assert.deepEqual(missingConfigHints([{ name: 'GRAPH_PASSWORD' }], []), [
+      'Set the secret with `pikku fabric secrets set <name>`: GRAPH_PASSWORD.',
+    ])
+  })
+
+  test('a missing variable names the variables command, not the secrets one', () => {
+    const [hint, ...rest] = missingConfigHints([], [{ name: 'GRAPH_URI' }])
+    assert.equal(rest.length, 0)
+    assert.ok(!hint!.includes('secrets set'), hint)
+    assert.ok(hint!.includes('variables set'), hint)
+    assert.ok(hint!.includes('GRAPH_URI'), hint)
+  })
+
+  test('both missing gets both hints, secrets first', () => {
+    const hints = missingConfigHints(
+      [{ name: 'GRAPH_PASSWORD' }],
+      [{ name: 'GRAPH_URI' }, { name: 'GRAPH_USER' }]
+    )
+    assert.equal(hints.length, 2)
+    assert.ok(hints[0]!.includes('secrets set'))
+    assert.ok(hints[1]!.includes('GRAPH_URI, GRAPH_USER'))
+  })
+
+  test('several of a kind are pluralised', () => {
+    assert.ok(
+      missingConfigHints([{ name: 'A' }, { name: 'B' }], [])[0]!.includes(
+        'Set the secrets'
+      )
+    )
+    assert.ok(
+      missingConfigHints([], [{ name: 'A' }, { name: 'B' }])[0]!.includes(
+        'Set the variables'
+      )
+    )
+  })
+
+  test('blocked on config with neither list still names both commands', () => {
+    for (const hints of [
+      missingConfigHints([], []),
+      missingConfigHints(undefined, undefined),
+    ]) {
+      assert.equal(hints.length, 1)
+      assert.ok(hints[0]!.includes('secrets set'), hints[0])
+      assert.ok(hints[0]!.includes('variables set'), hints[0])
+    }
   })
 })
 

--- a/packages/cli/src/fabric/lib/deployment.ts
+++ b/packages/cli/src/fabric/lib/deployment.ts
@@ -71,6 +71,40 @@ export function blockedSummary(reason: BlockedReason): string {
   }
 }
 
+/**
+ * What to tell someone whose deploy is blocked on config they have not set.
+ *
+ * Secrets and variables go missing in the same way and are set by two different
+ * commands: `pikku fabric secrets set` seals a value the stage can never read
+ * back, `pikku fabric variables set` writes one it can. Naming one command for
+ * both sends anyone blocked on the other kind to a command that refuses their
+ * value, which reads as the command being broken rather than as the wrong one.
+ */
+export function missingConfigHints(
+  missingSecrets: readonly { name: string }[] | undefined,
+  missingVariables: readonly { name: string }[] | undefined
+): string[] {
+  const secrets = missingSecrets ?? []
+  const variables = missingVariables ?? []
+  const hints: string[] = []
+  if (secrets.length > 0) {
+    hints.push(
+      `Set the secret${secrets.length > 1 ? 's' : ''} with \`pikku fabric secrets set <name>\`: ${secrets.map((s) => s.name).join(', ')}.`
+    )
+  }
+  if (variables.length > 0) {
+    hints.push(
+      `Set the variable${variables.length > 1 ? 's' : ''} with \`pikku fabric variables set <name> <value>\`: ${variables.map((v) => v.name).join(', ')}.`
+    )
+  }
+  if (hints.length === 0) {
+    hints.push(
+      'Set the missing values with `pikku fabric secrets set <name>` or `pikku fabric variables set <name> <value>`.'
+    )
+  }
+  return hints
+}
+
 export interface DeploymentStatus {
   status: string
   statusReason: string | null


### PR DESCRIPTION
A deploy blocked on `needs_config` printed a single hint regardless of what was missing:

```
Set the values with `pikku fabric secrets set <name>`.
```

Secrets and variables are set by two different commands, so anyone blocked on a missing variable was pointed at a command that refuses their value — which reads as the command being broken rather than as the wrong command.

`missingConfigHints` reads the `missingSecrets` / `missingVariables` lists the deployment status already carries and names both the command and the values:

```
Set the secret with `pikku fabric secrets set <name>`: GRAPH_PASSWORD.
Set the variables with `pikku fabric variables set <name> <value>`: GRAPH_URI, GRAPH_USER.
```

When the status says `needs_config` but carries neither list, a single hint still names both commands rather than saying nothing.

## Notes

This branch predates `pikku fabric variables set` (#1464). Its original copy said variables could only be set in the console, which was true when it was written and is not any more — the hint now names the command. Five tests in `deployment.test.ts` cover the secret-only, variable-only, both, plural, and neither cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deploy guidance when configuration is missing.
  - Clearly distinguishes missing secrets from missing variables.
  - Provides the appropriate command and affected configuration names, with correct singular and plural wording.
  - Includes a fallback message when specific missing configuration details are unavailable.

- **Tests**
  - Added coverage for hint ordering, wording, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->