### PR TITLE
fix: stop `pikku all` failing on a diagnostic its own codegen went on to fix

### DIFF
--- a/.changeset/pikku-all-generate-before-validate.md
+++ b/.changeset/pikku-all-generate-before-validate.md
@@ -1,0 +1,12 @@
+---
+'@pikku/inspector': patch
+'@pikku/cli': patch
+---
+
+Stop `pikku all` failing on a diagnostic its own codegen went on to fix.
+
+The run inspects several times, because generating the scaffold, the leaf indexes and the type files each changes the source graph the next inspection reads. Every full inspection re-runs every validator, so the newest pass is the complete one — but the logger accumulated diagnostics across all of them, and the build gate failed the run if any pass had ever recorded a critical.
+
+A project whose system roles grant a scaffold-declared scope (`virtualUser:*`) therefore could not build from clean: the pass taken before the scaffold existed raised PKU124, the pass taken after was clean, and the run failed anyway. Same for PKU951 on a scaffold-declared secret.
+
+Validation diagnostics are now scoped to the pass that recorded them, so a later pass supersedes an earlier one. Diagnostics reported outside a validation pass — by a generator or a command — are untouched, and a fault every pass reports still fails the run.

--- a/packages/cli/src/services/cli-logger-forwarder.service.ts
+++ b/packages/cli/src/services/cli-logger-forwarder.service.ts
@@ -106,6 +106,16 @@ export class CLILoggerForwarder implements Logger {
     this.diagnostic({ severity: 'critical', code, message })
   }
 
+  // Both delegate: the underlying logger owns the diagnostic list, so a pass
+  // opened here has to be opened there or the superseded pass is never dropped.
+  beginValidationPass() {
+    ;(this.logger as any).beginValidationPass?.()
+  }
+
+  endValidationPass() {
+    ;(this.logger as any).endValidationPass?.()
+  }
+
   hasCriticalErrors(): boolean {
     // The underlying logger (CLILogger) tracks critical errors
     return (this.logger as any).hasCriticalErrors?.() ?? false

--- a/packages/cli/src/services/cli-logger-validation-pass.test.ts
+++ b/packages/cli/src/services/cli-logger-validation-pass.test.ts
@@ -1,0 +1,70 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import { ErrorCode } from '@pikku/inspector'
+import { CLILogger } from './cli-logger.service.js'
+
+/**
+ * `pikku all` inspects several times in one run, because generating the
+ * scaffold, the leaf indexes and the type files each changes the source graph
+ * the next inspection reads. Every full inspection re-runs every validator, so
+ * only the newest pass describes the project as it now stands.
+ */
+const silent = () => new CLILogger({ silent: true })
+
+describe('CLILogger — validation passes supersede one another', () => {
+  test('a later pass replaces what an earlier one recorded', () => {
+    const logger = silent()
+
+    logger.beginValidationPass()
+    logger.critical(
+      ErrorCode.INVALID_VALUE,
+      "System role 'admin' grants scope 'virtualUser:*' which is not declared"
+    )
+    logger.endValidationPass()
+    assert.equal(logger.hasCriticalErrors(), true)
+
+    logger.beginValidationPass()
+    logger.endValidationPass()
+    assert.equal(
+      logger.hasCriticalErrors(),
+      false,
+      'the scaffold now exists, so the complaint about it missing is stale'
+    )
+  })
+
+  test('a genuine failure still fails when every pass reports it', () => {
+    const logger = silent()
+
+    for (const _ of [1, 2, 3]) {
+      logger.beginValidationPass()
+      logger.critical(ErrorCode.INVALID_VALUE, 'genuinely undeclared scope')
+      logger.endValidationPass()
+    }
+
+    assert.equal(logger.hasCriticalErrors(), true)
+    assert.equal(logger.hasBlockingDiagnostics(), true)
+  })
+
+  test('diagnostics recorded outside a pass are never discarded', () => {
+    const logger = silent()
+
+    logger.critical(ErrorCode.INVALID_VALUE, 'reported by a generator')
+    logger.beginValidationPass()
+    logger.endValidationPass()
+
+    assert.equal(
+      logger.hasCriticalErrors(),
+      true,
+      'only validation diagnostics are superseded'
+    )
+  })
+
+  test('an unclosed pass is still counted', () => {
+    const logger = silent()
+
+    logger.beginValidationPass()
+    logger.critical(ErrorCode.INVALID_VALUE, 'thrown out of mid-pass')
+
+    assert.equal(logger.hasCriticalErrors(), true)
+  })
+})

--- a/packages/cli/src/services/cli-logger.service.ts
+++ b/packages/cli/src/services/cli-logger.service.ts
@@ -31,6 +31,11 @@ export class CLILogger implements Logger {
   private silent: boolean
   private level: LogLevel = LogLevel.info // default to info level
   private diagnostics: CodedDiagnostic[] = []
+  // Diagnostics recorded by the validation pass currently open, tracked apart
+  // from the rest so a superseded pass can be dropped without touching what a
+  // generator or a command reported outside one.
+  private validationDiagnostics: CodedDiagnostic[] = []
+  private inValidationPass = false
   // Severities that should fail the build. Critical always blocks; error/warn
   // are opt-in via --fail-on-error / --fail-on-warn.
   private failOn: Set<DiagnosticSeverity> = new Set<DiagnosticSeverity>([
@@ -226,7 +231,11 @@ export class CLILogger implements Logger {
   diagnostic({ severity, code, message }: CodedDiagnostic) {
     const url = `${BASE_ERROR_URL}/${code.toLowerCase()}`
     const formattedMessage = `[${code}] ${message}\n  → ${url}`
-    this.diagnostics.push({ severity, code, message })
+    if (this.inValidationPass) {
+      this.validationDiagnostics.push({ severity, code, message })
+    } else {
+      this.diagnostics.push({ severity, code, message })
+    }
     // critical → bold red, error → red, warn → yellow. Always printed so the
     // issue surfaces even when it doesn't fail the build.
     this.emit(severity, formattedMessage, undefined, code)
@@ -244,8 +253,37 @@ export class CLILogger implements Logger {
     this.failOn = new Set<DiagnosticSeverity>(['critical', ...severities])
   }
 
+  /**
+   * Opens a validation pass, discarding what the previous one recorded.
+   *
+   * `pikku all` inspects several times over — generating the scaffold, the leaf
+   * indexes and the type files each changes the source graph the next
+   * inspection reads. Every full inspection re-runs every validator against
+   * that graph, so the newest pass is the complete one and the ones before it
+   * described input this run had not finished building yet. Keeping them made a
+   * project whose roles reference scaffold-declared scopes fail on the pass
+   * taken before its scaffold existed, while the pass taken after was clean.
+   */
+  beginValidationPass() {
+    this.validationDiagnostics = []
+    this.inValidationPass = true
+  }
+
+  /** Closes the pass opened by `beginValidationPass`. */
+  endValidationPass() {
+    this.inValidationPass = false
+  }
+
+  /**
+   * Everything recorded outside a validation pass, plus the newest pass — which
+   * is the only one that still describes the source graph as it now stands.
+   */
+  private trackedDiagnostics(): CodedDiagnostic[] {
+    return [...this.diagnostics, ...this.validationDiagnostics]
+  }
+
   hasCriticalErrors(): boolean {
-    return this.diagnostics.some((d) => d.severity === 'critical')
+    return this.trackedDiagnostics().some((d) => d.severity === 'critical')
   }
 
   /**
@@ -253,14 +291,13 @@ export class CLILogger implements Logger {
    * build (default: critical only).
    */
   hasBlockingDiagnostics(): boolean {
-    return this.diagnostics.some((d) => this.failOn.has(d.severity))
+    return this.trackedDiagnostics().some((d) => this.failOn.has(d.severity))
   }
 
   /** Distinct severities among tracked diagnostics that would fail the build. */
   blockingSeverities(): DiagnosticSeverity[] {
-    return [...this.failOn].filter((s) =>
-      this.diagnostics.some((d) => d.severity === s)
-    )
+    const tracked = this.trackedDiagnostics()
+    return [...this.failOn].filter((s) => tracked.some((d) => d.severity === s))
   }
 
   logLogo() {

--- a/packages/cli/src/services/inspect-validation-pass.test.ts
+++ b/packages/cli/src/services/inspect-validation-pass.test.ts
@@ -1,0 +1,80 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { inspect } from '@pikku/inspector'
+import { CLILogger } from './cli-logger.service.js'
+
+/**
+ * The real inspector against the real logger, reproducing what `pikku all` does
+ * to a project on a build machine: inspect, generate the scaffold that declares
+ * the scopes, inspect again.
+ *
+ * The first pass is looking at a source graph the run has not finished building
+ * yet, so it is wrong by construction — the scaffold it is complaining about is
+ * written by the very next step. Only the pass after that describes the project
+ * as it now stands.
+ */
+const ROLES = [
+  "import { defineSystemRole } from '@pikku/core/role'",
+  'defineSystemRole({',
+  "  admin: { scopes: ['virtualUser:*'] },",
+  '})',
+].join('\n')
+
+const SCAFFOLD = [
+  "import { defineScope } from '@pikku/core/scope'",
+  'defineScope({',
+  '  virtualUser: { scopes: { run: {}, read: {} } },',
+  '})',
+].join('\n')
+
+describe('pikku all — a scaffold generated mid-run clears its own complaint', () => {
+  test('the pass taken after the scaffold exists is the one that counts', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'pikku-validation-pass-'))
+    const rolesFile = join(rootDir, 'roles.ts')
+    const scaffoldFile = join(rootDir, 'virtual-user.gen.ts')
+    const logger = new CLILogger({ silent: true })
+
+    try {
+      await writeFile(rolesFile, ROLES)
+      await inspect(logger, [rolesFile], { rootDir })
+      assert.equal(
+        logger.hasCriticalErrors(),
+        true,
+        'virtualUser:* is genuinely undeclared while the scaffold is missing'
+      )
+
+      await writeFile(scaffoldFile, SCAFFOLD)
+      await inspect(logger, [rolesFile, scaffoldFile], { rootDir })
+      assert.equal(
+        logger.hasCriticalErrors(),
+        false,
+        'the scaffold now declares virtualUser, so the run must not fail on it'
+      )
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  test('a scope nothing ever declares still fails the run', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'pikku-validation-pass-bad-'))
+    const rolesFile = join(rootDir, 'roles.ts')
+    const logger = new CLILogger({ silent: true })
+
+    try {
+      await writeFile(rolesFile, ROLES)
+      await inspect(logger, [rolesFile], { rootDir })
+      await inspect(logger, [rolesFile], { rootDir })
+
+      assert.equal(
+        logger.hasCriticalErrors(),
+        true,
+        're-inspecting must not launder a real failure'
+      )
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -493,6 +493,10 @@ export const inspect = async (
   )
 
   if (!options.setupOnly) {
+    // Everything below re-derives from the state this pass just built, so it
+    // supersedes whatever an earlier pass concluded about a source graph the
+    // run has since finished generating into.
+    logger.beginValidationPass?.()
     const startAggregate = performance.now()
     // Apply the inspected auth handler service set before aggregation so it
     // flows into requiredServices (the generated handler's own func is opaque).
@@ -542,6 +546,7 @@ export const inspect = async (
     validateScopeReferences(logger, state)
     validateSystemRoleScopes(logger, state)
     validatePersonaRoles(logger, state)
+    logger.endValidationPass?.()
   }
 
   state.program = program

--- a/packages/inspector/src/types.ts
+++ b/packages/inspector/src/types.ts
@@ -366,6 +366,24 @@ export interface InspectorLogger {
   /** Sugar for `diagnostic({ severity: 'critical', code, message })`. */
   critical: (code: ErrorCode, message: string) => void
   hasCriticalErrors: () => boolean
+  /**
+   * Opens a validation pass, discarding whatever a previous one recorded.
+   *
+   * A single `pikku all` inspects several times, because generating the
+   * scaffold, the leaf indexes and the type files each changes the source graph
+   * the next inspection reads. The validators are pure functions of that graph
+   * and every full inspection re-runs all of them, so the newest pass is always
+   * the complete one and the ones before it are strictly superseded.
+   *
+   * Without this the diagnostics accumulated instead, and a run failed on a
+   * complaint about its own half-built input: a project whose roles reference
+   * scaffold-declared scopes was reported as failing even though the pass that
+   * ran once the scaffold existed was clean. Optional so a host supplying its
+   * own logger keeps working — one that omits it simply never discards.
+   */
+  beginValidationPass?: () => void
+  /** Closes the pass opened by `beginValidationPass`. */
+  endValidationPass?: () => void
 }
 
 export type AddWiring = (


### PR DESCRIPTION
## The bug

`pikku all` inspects several times in one run. Generating the scaffold, the leaf indexes and the type files each changes the source graph the next inspection reads, so the workflow deliberately re-inspects after each. Every full inspection re-runs every validator against the graph as it now stands — the newest pass is always the complete one, and the ones before it described input the run had not finished building yet.

`CLILogger` accumulated diagnostics across all of them, and `pikku-command-summary.ts` fails the run if `hasBlockingDiagnostics()` was ever true.

So a project whose system roles grant a scaffold-declared scope cannot build from clean:

```
[PKU124] System role 'admin' grants scope 'virtualUser:*' which is not declared.
• Type file or scaffolds first created, inspecting again…
<clean>
✖ inspection failed
```

The scaffold that declares `virtualUser` is written by the very next step. The pass that complained about it missing was right about a graph that no longer exists; the pass after it is clean; the run fails anyway. Same shape for PKU951 on a scaffold-declared `BETTER_AUTH_SECRET`.

There is no project-side workaround: `defineScope` is only importable from the generated `.pikku/scopes/` barrel, which the build also wipes.

## The fix

Validation diagnostics are scoped to the pass that recorded them. `inspect()` opens a pass before the validator block and closes it after, and the logger drops the previous pass's diagnostics when a new one opens.

The scoping is deliberately narrow:

- Only the validator block is inside a pass. Anything a generator or a command reports lands in the un-scoped list and is never discarded.
- `setupOnly` inspections skip the validator block entirely, so they neither open a pass nor clear one.
- A fault that every pass reports still fails the run — the newest pass reports it too.
- The hooks are optional on `InspectorLogger`, so a third-party logger keeps today's behaviour.

## Tests

`cli-logger-validation-pass.test.ts` covers the logger contract: a later pass replaces an earlier one; a genuine failure reported by every pass still fails; diagnostics outside a pass survive; an unclosed pass is still counted.

`inspect-validation-pass.test.ts` drives the real `inspect()` against the real `CLILogger` and reproduces the build machine's sequence — inspect a roles file that grants `virtualUser:*`, assert it fails, write the scaffold, inspect again, assert it passes. Reverting the two `inspector.ts` hooks fails that test and only that test.

Full inspector suite: 732/732.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbD1Nm6beyHkCB8qujxcLw
