### PR TITLE
fix(console): the nav dock starts on the right in RTL

### DIFF
--- a/.changeset/rtl-dock-starts-on-the-right.md
+++ b/.changeset/rtl-dock-starts-on-the-right.md
@@ -1,0 +1,7 @@
+---
+'@pikku/console': patch
+---
+
+Start the nav dock on the right edge in an RTL locale. The dock's default side was `bottom` for everyone, which puts the identity tile — the anchor the rest of the row is read from — at the far end from where an Arabic or Hebrew reader's eye starts. `defaultDockSide()` reads `document.documentElement.dir`, so it is the layout direction that decides, not the locale list. It remains only a default: the dock's own menu moves it, and a stored `nav-dock-side` always wins.
+
+Hosts that mirror direction onto `<html dir>` from an effect will hand this `ltr` on a cold load — set the attribute during render if the first paint matters.

--- a/packages/console/src/components/nav-dock/useDockPrefs.test.ts
+++ b/packages/console/src/components/nav-dock/useDockPrefs.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { defaultDockSide } from './useDockPrefs.js'
+
+const withDocumentDir = (dir: string | undefined) => {
+  const g = globalThis as { document?: unknown }
+  if (dir === undefined) {
+    delete g.document
+    return
+  }
+  g.document = { documentElement: { dir } }
+}
+
+afterEach(() => withDocumentDir(undefined))
+
+describe('defaultDockSide', () => {
+  test('an RTL page starts the dock on the right', () => {
+    withDocumentDir('rtl')
+    assert.equal(defaultDockSide(), 'right')
+  })
+
+  test('an LTR page keeps the bottom dock', () => {
+    withDocumentDir('ltr')
+    assert.equal(defaultDockSide(), 'bottom')
+  })
+
+  test('a page that never set dir keeps the bottom dock', () => {
+    withDocumentDir('')
+    assert.equal(defaultDockSide(), 'bottom')
+  })
+
+  test('rendering without a document does not throw', () => {
+    withDocumentDir(undefined)
+    assert.equal(defaultDockSide(), 'bottom')
+  })
+})

--- a/packages/console/src/components/nav-dock/useDockPrefs.ts
+++ b/packages/console/src/components/nav-dock/useDockPrefs.ts
@@ -7,6 +7,20 @@ export const DOCK_SIDES: DockSide[] = ['bottom', 'top', 'left', 'right']
 export const isVerticalDock = (side: DockSide) =>
   side === 'left' || side === 'right'
 
+/**
+ * Where the dock starts before anyone has moved it.
+ *
+ * An RTL reader's whole layout runs right-to-left, and a bottom dock puts the
+ * identity tile — the anchor everything else is read from — at the far end of
+ * the row from where their eye starts. The right edge is that same anchor on
+ * the side the page is already read from. It is only a default: the dock's own
+ * menu moves it, and once moved the stored side wins forever.
+ */
+export function defaultDockSide(): DockSide {
+  if (typeof document === 'undefined') return 'bottom'
+  return document.documentElement.dir === 'rtl' ? 'right' : 'bottom'
+}
+
 /** Percent of the dock's natural size. */
 export const DOCK_SCALE_MIN = 70
 export const DOCK_SCALE_MAX = 160
@@ -23,7 +37,7 @@ export const DOCK_SCALE_STEP = 5
 export function useDockPrefs() {
   const [side, setSide] = useLocalStorage<DockSide>({
     key: 'nav-dock-side',
-    defaultValue: 'bottom',
+    defaultValue: defaultDockSide(),
     getInitialValueInEffect: false,
   })
   /* Held open until someone says otherwise. A dock that starts hidden is a


### PR DESCRIPTION
`useDockPrefs` hardcoded `defaultValue: 'bottom'` for every locale. In an RTL layout that puts the identity tile — the anchor everything else in the row is read from — at the far end from where the reader's eye starts, so the one fixed landmark in the dock is the last thing they reach.

`defaultDockSide()` decides from `document.documentElement.dir` rather than from a locale list, so a host that flips direction for any reason gets the matching default. It is only a default: the dock's own menu still moves it, and once moved the stored side wins.

It also guards `typeof document === 'undefined'`, so a server render falls back to `bottom` instead of throwing.

## Tests

`useDockPrefs.test.ts` covers RTL, LTR, a page that never set `dir`, and the no-document case. Four tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)