### PR TITLE
feat(core,cli): a step ladder reads as one paragraph, not a list of restatements

### DIFF
--- a/.changeset/scenario-prose-no-article.md
+++ b/.changeset/scenario-prose-no-article.md
@@ -1,0 +1,38 @@
+---
+'@pikku/core': patch
+'@pikku/cli': patch
+'@pikku/skills': patch
+---
+
+A step ladder reads as one paragraph, not a list of restatements
+
+Every step prefixed its actor with `the `, named that actor again, and repeated
+the phase keyword. A three-step run by one person said their name three times
+and `Given` three times, only read as English when the persona key happened to
+be a role noun, and never said who that person was — the fabric template's own
+placeholder came out as `the nadia opens /app`.
+
+```
+Given yasser (the founder) signs in
+When  yasser opens the dashboard
+And   sees the audit log
+And   nadia reviews the invite
+```
+
+The article is gone: the actor key is the subject verbatim, so a persona named
+after a person reads as that person. A repeated phase reads as `And`, the way
+Gherkin has always written it. A step that continues both the phase and the
+actor drops the repeated subject, because English drops a repeated subject in a
+compound predicate — it takes both, since eliding across a phase change gives
+`When opens the dashboard`, and a pronoun rather than a name would give `they
+sees`, step templates being authored in the third person singular.
+
+An actor is introduced once, by the persona's `jobTitle` — prose someone wrote
+for a reader. `roles` is authorisation, so a persona whose only description is a
+`reviewer` grant gets no introduction rather than one assembled out of grants.
+A row carries `sentenceWithRole` alongside `sentence`, set only where an actor
+is first named, so a renderer can offer the introduction as a toggle without
+parsing a composed sentence back apart.
+
+`{placeholder}` filling, the `#ordinal` lookup for repeated step names and an
+actorless step reading as its description alone are all unchanged.

--- a/packages/cli/src/functions/commands/scenario-formatter.test.ts
+++ b/packages/cli/src/functions/commands/scenario-formatter.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe('formatScenarioFailure', () => {
   const failure = () => ({
-    sentence: 'When  the shopper completes the checkout',
+    sentence: 'When  shopper completes the checkout',
     message: 'Timed out waiting for selector button[title="Edit"]',
     stack:
       'Error: Timed out waiting for selector button[title="Edit"]\n' +
@@ -23,7 +23,7 @@ describe('formatScenarioFailure', () => {
       projectRoot: '/project',
     }).join('\n')
 
-    assert.match(block, /failed at: When {2}the shopper completes the checkout/)
+    assert.match(block, /failed at: When {2}shopper completes the checkout/)
     assert.match(block, /Timed out waiting for selector/)
     assert.match(block, /checkout\.steps\.ts:71:5/)
   })
@@ -135,7 +135,7 @@ describe('formatScenarioReport', () => {
     durationMs: 412,
     steps: [
       {
-        sentence: 'Given the shopper buys an apple',
+        sentence: 'Given shopper buys an apple',
         status: 'succeeded',
         durationMs: 12,
       },
@@ -149,13 +149,13 @@ describe('formatScenarioReport', () => {
     error: 'expected 1 item, got 0',
     steps: [
       {
-        sentence: 'Then  the shopper sees the receipt',
+        sentence: 'Then  shopper sees the receipt',
         status: 'failed',
         error: 'expected 1 item, got 0',
       },
     ],
     failure: {
-      sentence: 'Then  the shopper sees the receipt',
+      sentence: 'Then  shopper sees the receipt',
       message: 'expected 1 item, got 0',
     },
   })
@@ -172,7 +172,7 @@ describe('formatScenarioReport', () => {
     })
 
     assert.equal(lines[0]!.text, 'PASS a shopper checks out (412ms)')
-    assert.match(lines[1]!.text, /Given the shopper buys an apple {2,}✓/)
+    assert.match(lines[1]!.text, /Given shopper buys an apple {2,}✓/)
     assert.equal(lines.at(-1)!.text, "1/1 scenarios passed against 'local'")
     assert.ok(
       lines.every((line) => line.level === 'info'),
@@ -292,14 +292,14 @@ describe('formatScenarioReport with a multi-line error', () => {
           'locator.waitFor: Timeout 15000ms exceeded.\nCall log:\n  - waiting for locator(…)',
         steps: [
           {
-            sentence: 'Then  the admin sees the addon',
+            sentence: 'Then  admin sees the addon',
             status: 'failed',
             error:
               'locator.waitFor: Timeout 15000ms exceeded.\nCall log:\n  - waiting for locator(…)',
           },
         ],
         failure: {
-          sentence: 'Then  the admin sees the addon',
+          sentence: 'Then  admin sees the addon',
           message:
             'locator.waitFor: Timeout 15000ms exceeded.\nCall log:\n  - waiting for locator(…)',
         },

--- a/packages/cli/src/functions/commands/scenario-formatter.ts
+++ b/packages/cli/src/functions/commands/scenario-formatter.ts
@@ -79,16 +79,21 @@ export const formatScenarioReport = (
 }
 
 export const buildStepLadder = (steps: ScenarioStepRow[]): string[] => {
-  const width = Math.max(0, ...steps.map(({ sentence }) => sentence.length))
-  return steps.map((step) => {
+  const sentences = steps.map(ladderSentence)
+  const width = Math.max(0, ...sentences.map((sentence) => sentence.length))
+  return steps.map((step, index) => {
     const glyph = step.status === 'succeeded' ? '✓' : '✗'
     const detail =
       step.status === 'succeeded' || !step.error
         ? formatDuration(step.durationMs)
         : firstLine(step.error)
-    return `  ${step.sentence.padEnd(width)}  ${glyph}  ${detail}`
+    return `  ${sentences[index]!.padEnd(width)}  ${glyph}  ${detail}`
   })
 }
+
+/** The ladder introduces an actor where the row offers an introduction. */
+const ladderSentence = (step: ScenarioStepRow) =>
+  step.sentenceWithRole ?? step.sentence
 
 /**
  * The one line a summary gets. A browser timeout's message carries its whole

--- a/packages/cli/src/functions/commands/scenario-ladder.test.ts
+++ b/packages/cli/src/functions/commands/scenario-ladder.test.ts
@@ -245,6 +245,162 @@ describe('scenarioSurfaceCoverage', () => {
   })
 })
 
+const personas = (overrides: Record<string, unknown> = {}) =>
+  [
+    {
+      id: 'shopper',
+      name: 'Shopper',
+      roles: ['customer'],
+      goals: [],
+      tags: [],
+      runnable: true,
+      ...overrides,
+    },
+  ] as any
+
+describe('an actor introduces themselves once', () => {
+  const rows = (personaList: any) =>
+    scenarioStepRows(
+      [
+        { stepName: 'buys an apple', status: 'succeeded' },
+        { stepName: 'checks out', status: 'succeeded' },
+        { stepName: 'sees a receipt', status: 'succeeded' },
+      ],
+      collectScenarioStepProse(
+        workflowMeta() as any,
+        functionsMeta() as any,
+        personaList
+      )
+    )
+
+  test('only the first step carries the role', () => {
+    const [first, second, third] = rows(personas({ jobTitle: 'founder' }))
+    assert.equal(
+      first!.sentenceWithRole?.trim(),
+      'Given shopper (the founder) buys an apple'
+    )
+    assert.equal(second!.sentenceWithRole, undefined)
+    assert.equal(third!.sentenceWithRole, undefined)
+  })
+
+  test('the plain sentence never carries the role, so a reader can drop it', () => {
+    const [first] = rows(personas({ jobTitle: 'founder' }))
+    assert.equal(first!.sentence.trim(), 'Given shopper buys an apple')
+  })
+
+  test('a job title beats the authorisation roles', () => {
+    const [first] = rows(personas({ jobTitle: 'founder', roles: ['admin'] }))
+    assert.ok(first!.sentenceWithRole?.includes('(the founder)'))
+  })
+
+  test('a role is not a job title, so it introduces nobody', () => {
+    const [first] = rows(personas({ roles: ['reviewer'] }))
+    assert.equal(first!.sentenceWithRole, undefined)
+  })
+
+  test('no personas at all leaves every row as it was', () => {
+    for (const row of rows([])) {
+      assert.equal(row.sentenceWithRole, undefined)
+    }
+  })
+
+  test('the ladder shows the introduction and pads to it', () => {
+    const lines = buildStepLadder(rows(personas({ jobTitle: 'founder' })))
+    assert.ok(
+      lines[0]!.includes('shopper (the founder) buys an apple'),
+      lines[0]
+    )
+    assert.ok(lines[1]!.includes('shopper completes the checkout'), lines[1])
+    assert.ok(!lines[1]!.includes('(the founder)'), lines[1])
+    const widths = new Set(lines.map((line) => line.indexOf('  ✓')))
+    assert.equal(widths.size, 1, 'every glyph lands in the same column')
+  })
+})
+
+describe('a run reads as one paragraph', () => {
+  const journeyMeta = {
+    steps: [
+      {
+        type: 'scenarioStep',
+        stepName: 'signs in',
+        stepFunc: 'a',
+        phase: 'given',
+        actor: 'yasser',
+      },
+      {
+        type: 'scenarioStep',
+        stepName: 'opens the dashboard',
+        stepFunc: 'b',
+        phase: 'when',
+        actor: 'yasser',
+      },
+      {
+        type: 'scenarioStep',
+        stepName: 'sees the audit log',
+        stepFunc: 'c',
+        phase: 'when',
+        actor: 'yasser',
+      },
+      {
+        type: 'scenarioStep',
+        stepName: 'reviews the invite',
+        stepFunc: 'd',
+        phase: 'when',
+        actor: 'nadia',
+      },
+    ],
+  }
+  const journeyFns = {
+    a: { pikkuFuncId: 'a' },
+    b: { pikkuFuncId: 'b' },
+    c: { pikkuFuncId: 'c' },
+    d: { pikkuFuncId: 'd' },
+  }
+  const cast = [
+    {
+      id: 'yasser',
+      name: 'Yasser',
+      jobTitle: 'founder',
+      roles: [],
+      goals: [],
+      tags: [],
+      runnable: true,
+    },
+    {
+      id: 'nadia',
+      name: 'Nadia',
+      roles: ['reviewer'],
+      goals: [],
+      tags: [],
+      runnable: true,
+    },
+  ]
+  const lines = () =>
+    buildStepLadder(
+      scenarioStepRows(
+        journeyMeta.steps.map((step) => ({
+          stepName: step.stepName,
+          status: 'succeeded',
+          durationMs: 1,
+        })) as any,
+        collectScenarioStepProse(
+          journeyMeta as any,
+          journeyFns as any,
+          cast as any
+        )
+      )
+    ).map((line) => line.replace(/\s+✓.*$/, '').trim())
+
+  test('the actor is introduced, then carried, then dropped', () => {
+    assert.deepEqual(lines(), [
+      'Given yasser (the founder) signs in',
+      'When  yasser opens the dashboard',
+      'And   sees the audit log',
+      'And   nadia reviews the invite',
+    ])
+  })
+})
+
 describe('buildStepLadder', () => {
   const prose = () =>
     collectScenarioStepProse(workflowMeta() as any, functionsMeta() as any)
@@ -265,17 +421,14 @@ describe('buildStepLadder', () => {
     )
 
     assert.equal(lines.length, 3)
-    assert.match(
-      lines[0]!,
-      /^ {2}Given the shopper buys an apple {2,}✓ {2}412ms$/
-    )
+    assert.match(lines[0]!, /^ {2}Given shopper buys an apple {2,}✓ {2}412ms$/)
     assert.match(
       lines[1]!,
-      /^ {2}When {2}the shopper completes the checkout {2,}✓ {2}1\.2s$/
+      /^ {2}When {2}shopper completes the checkout {2,}✓ {2}1\.2s$/
     )
     assert.match(
       lines[2]!,
-      /^ {2}Then {2}the shopper sees the receipt {2,}✗ {2}expected 1 item, got 0$/
+      /^ {2}Then {2}shopper sees the receipt {2,}✗ {2}expected 1 item, got 0$/
     )
 
     const columns = new Set(lines.map((line) => line.search(/[✓✗]/)))
@@ -292,7 +445,9 @@ describe('buildStepLadder', () => {
     )
 
     assert.equal(lines.length, 2)
-    assert.match(lines[1]!, /When {2}the shopper completes the checkout/)
+    // The same step twice is a continuation, so the second reads as `And`.
+    assert.match(lines[0]!, /When {2}shopper completes the checkout/)
+    assert.match(lines[1]!, /And {3}completes the checkout/)
   })
 
   test('a step with no recorded prose still appears, by its name', () => {
@@ -347,7 +502,7 @@ describe('step templates', () => {
       templatedProse()
     )
 
-    assert.match(lines[0]!, /Then {2}the shopper sees a receipt for an apple/)
+    assert.match(lines[0]!, /Then {2}shopper sees a receipt for an apple/)
   })
 
   test('the same step reads differently for each input it is called with', () => {
@@ -389,7 +544,7 @@ describe('step templates', () => {
 
     assert.match(
       lines[0]!,
-      /When {2}the shopper completes the checkout$|When {2}the shopper completes the checkout {2}/
+      /When {2}shopper completes the checkout$|When {2}shopper completes the checkout {2}/
     )
   })
 
@@ -427,8 +582,8 @@ describe('step templates', () => {
       collectScenarioStepProse(loopMeta as any, templatedMeta() as any)
     )
 
-    assert.match(lines[0]!, /Then {2}the shopper sees a receipt for an apple/)
-    assert.match(lines[1]!, /Then {2}the shopper sees a receipt for a pear/)
+    assert.match(lines[0]!, /Then {2}shopper sees a receipt for an apple/)
+    assert.match(lines[1]!, /And {3}sees a receipt for a pear/)
   })
 
   test('the step name still wins over the function fallback', () => {
@@ -446,7 +601,7 @@ describe('step templates', () => {
 
     assert.match(
       lines[0]!,
-      /When {2}the shopper completes the checkout/,
+      /When {2}shopper completes the checkout/,
       'a step recorded under a declared name is never re-resolved by function'
     )
   })
@@ -500,7 +655,7 @@ describe('step templates', () => {
       templatedProse()
     )
 
-    assert.match(lines[0]!, /Given the shopper buys an apple/)
+    assert.match(lines[0]!, /Given shopper buys an apple/)
   })
 })
 

--- a/packages/cli/src/functions/commands/scenario-ladder.ts
+++ b/packages/cli/src/functions/commands/scenario-ladder.ts
@@ -12,6 +12,7 @@ import { composeStepProse } from '@pikku/core/scenario'
 import type { ScenarioSurface, ScenarioStepPhase } from '@pikku/core/scenario'
 import type { WorkflowStepMeta } from '@pikku/core/workflow'
 import type { FunctionsMeta } from '@pikku/core/services'
+import type { PersonaDefinitions } from '@pikku/core/persona'
 import { KEYWORD_WIDTH } from './scenario-formatter.js'
 import type {
   ScenarioFailureDetail,
@@ -59,6 +60,12 @@ export interface ScenarioProse {
    * which is what it did before this index existed.
    */
   byStepFunc: Map<string, ScenarioStepProse>
+  /**
+   * What each actor is, keyed by the persona key a step records. A persona's
+   * job title is what a reader wants — "the founder" — and its first role is
+   * the fallback for a persona that declares no title.
+   */
+  roleByActor: Map<string, string>
 }
 
 /**
@@ -96,7 +103,8 @@ function* walkScenarioSteps(steps: unknown): Generator<any> {
  */
 export const collectScenarioStepProse = (
   workflowMeta: { steps?: WorkflowStepMeta[] } | undefined,
-  functionsMeta: FunctionsMeta
+  functionsMeta: FunctionsMeta,
+  personas: PersonaDefinitions = []
 ): ScenarioProse => {
   const byStepName = new Map<string, ScenarioStepProse>()
   const byStepFunc = new Map<string, ScenarioStepProse>()
@@ -126,7 +134,22 @@ export const collectScenarioStepProse = (
   for (const stepFunc of ambiguous) {
     byStepFunc.delete(stepFunc)
   }
-  return { byStepName, byStepFunc }
+  return { byStepName, byStepFunc, roleByActor: rolesByActor(personas) }
+}
+
+/**
+ * Only a job title introduces an actor. `roles` is authorisation — "reviewer"
+ * is a grant, not a description of who someone is — so a persona that declares
+ * no title gets no introduction rather than one assembled out of its grants.
+ */
+const rolesByActor = (personas: PersonaDefinitions): Map<string, string> => {
+  const roles = new Map<string, string>()
+  for (const persona of personas) {
+    if (persona.jobTitle) {
+      roles.set(persona.id, persona.jobTitle)
+    }
+  }
+  return roles
 }
 
 const sameProse = (a: ScenarioStepProse, b: ScenarioStepProse) =>
@@ -241,17 +264,31 @@ export const scenarioSurfaceCoverage = (
  * recorded under the name it was declared with is never re-resolved by a
  * function shared with another call site.
  */
-const stepSentence = (
+const stepProse = (
   step: ScenarioStepOutcome,
   prose: ScenarioProse
+): ScenarioStepProse | undefined =>
+  prose.byStepName.get(step.stepName) ??
+  prose.byStepName.get(baseName(step.stepName)) ??
+  (step.stepFunc ? prose.byStepFunc.get(step.stepFunc) : undefined)
+
+/** How a step follows the one recorded before it. */
+interface StepContinuation {
+  actorRole?: string
+  continuesPhase?: boolean
+  continuesActor?: boolean
+}
+
+const stepSentence = (
+  step: ScenarioStepOutcome,
+  prose: ScenarioProse,
+  continuation: StepContinuation = {}
 ): string => {
-  const parts =
-    prose.byStepName.get(step.stepName) ??
-    prose.byStepName.get(baseName(step.stepName)) ??
-    (step.stepFunc ? prose.byStepFunc.get(step.stepFunc) : undefined)
+  const parts = stepProse(step, prose)
   return parts
     ? composeStepProse({
         ...parts,
+        ...continuation,
         input: step.input,
         keywordWidth: KEYWORD_WIDTH,
       })
@@ -262,13 +299,41 @@ const stepSentence = (
 export const scenarioStepRows = (
   steps: ScenarioStepOutcome[],
   prose: ScenarioProse
-): ScenarioStepRow[] =>
-  steps.map((step) => ({
-    sentence: stepSentence(step, prose),
-    status: step.status,
-    durationMs: step.durationMs,
-    error: step.error,
-  }))
+): ScenarioStepRow[] => {
+  const introduced = new Set<string>()
+  let previous: ScenarioStepProse | undefined
+  return steps.map((step) => {
+    const parts = stepProse(step, prose)
+    const actor = parts?.actor
+    const role = actor ? prose.roleByActor.get(actor) : undefined
+    // Only the step that first names an actor carries their role, so a run
+    // that is one person doing eight things says who they are once.
+    const firstMention =
+      actor !== undefined && role !== undefined && !introduced.has(actor)
+    const continuation: StepContinuation = {
+      continuesPhase: previous !== undefined && previous.phase === parts?.phase,
+      continuesActor: previous !== undefined && previous.actor === actor,
+    }
+    if (actor) {
+      introduced.add(actor)
+    }
+    previous = parts
+    return {
+      sentence: stepSentence(step, prose, continuation),
+      ...(firstMention
+        ? {
+            sentenceWithRole: stepSentence(step, prose, {
+              ...continuation,
+              actorRole: role,
+            }),
+          }
+        : {}),
+      status: step.status,
+      durationMs: step.durationMs,
+      error: step.error,
+    }
+  })
+}
 
 const baseName = (stepName: string) => stepName.replace(/#\d+$/, '')
 

--- a/packages/cli/src/functions/commands/scenario.ts
+++ b/packages/cli/src/functions/commands/scenario.ts
@@ -484,7 +484,8 @@ export const scenarioRun = pikkuSessionlessFunc<
     ) => {
       const prose = collectScenarioStepProse(
         state.workflows?.meta?.[flowName],
-        functionsMeta
+        functionsMeta,
+        state.personas?.definitions ?? []
       )
       const steps = (await service.getRunSteps(runId)).map((step) => ({
         stepName: step.stepName,

--- a/packages/cli/src/functions/wirings/workflow/serialize-scenario-types.ts
+++ b/packages/cli/src/functions/wirings/workflow/serialize-scenario-types.ts
@@ -315,14 +315,14 @@ type PikkuScenarioStepConfigWithSchema<
   /**
    * What this step does, for the console and for whoever reads the source. It
    * is also the fallback prose when no \`template\` is declared, in which case a
-   * reporter renders "Given the shopper buys an apple". Defaults to the call
+   * reporter renders "Given shopper buys an apple". Defaults to the call
    * site's step name.
    */
   description?: string
   /**
    * The prose a reporter renders for this step, with \`{placeholders}\` filled
    * from the input the step was called with — \`'sees {packageName}'\` reports as
-   * "Then the admin sees @pikku/addon-todos". Every input field should appear,
+   * "Then admin sees @pikku/addon-todos". Every input field should appear,
    * so the report names the values under test rather than repeating one
    * sentence per call site.
    */

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,8 +5,8 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2856 observable things**: 901 exported names, plus
-1955 members on the classes and interfaces among them, reachable
+**2857 observable things**: 901 exported names, plus
+1956 members on the classes and interfaces among them, reachable
 through 53 entry points.
 
 An entry point whose exports are mostly *exclusive* is a self-contained
@@ -16,7 +16,7 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | --- | ---: | ---: | ---: |
 | `./services` | 141 | 115 | 413 |
 | `./virtual-user` | 66 | 66 | 210 |
-| `./scenario` | 45 | 45 | 133 |
+| `./scenario` | 45 | 45 | 134 |
 | `./workflow` | 84 | 35 | 140 |
 | `./agent` | 50 | 48 | 81 |
 | `./channel` | 32 | 32 | 84 |
@@ -1514,7 +1514,7 @@ export type WorkflowWireDoRPC = <TOutput = any, TInput = any>(
 
 ```ts
 addFeature: (featureId: string, feature: CoreFeature, packageName?: string | null) => void
-composeStepProse: ({ phase, description, template, input, actor, keywordWidth, }: { phase: ScenarioStepPhase; description: string; template?: string | undefined; input?: unknown; actor?: string | undefined; keywordWidth?: number | undefined; }) => string
+composeStepProse: ({ phase, description, template, input, actor, actorRole, continuesPhase, continuesActor, keywordWidth, }: { phase: ScenarioStepPhase; description: string; template?: string | undefined; input?: unknown; actor?: string | undefined; actorRole?: string | undefined; continuesPhase?: boolean | undefined; continuesActor?: boolean | undefined; keywordWidth?: number | undefined; }) => string
 export type CoreFeature = {
   name: string
   description?: string
@@ -1721,6 +1721,7 @@ export interface ScenarioStepOptions {
 export type ScenarioStepPhase = 'given' | 'when' | 'then'
 export interface ScenarioStepRow {
   sentence: string
+  sentenceWithRole?: string
   status: string
   durationMs?: number
   error?: string

--- a/packages/core/src/wirings/virtual-user/virtual-user-derive.test.ts
+++ b/packages/core/src/wirings/virtual-user/virtual-user-derive.test.ts
@@ -222,10 +222,10 @@ describe('deriving intents from scenarios', () => {
   test('the prose comes through with its placeholders left open', () => {
     const [intent] = deriveIntents(workflows, functions)
     assert.deepEqual(intent!.steps, [
-      'Given the orgAdmin is signed in',
+      'Given orgAdmin is signed in',
       // The scenario knows which address it invites. The user has to pick one.
-      'When the orgAdmin invites {email}',
-      'Then the orgAdmin sees the new member in the list',
+      'When orgAdmin invites {email}',
+      'Then orgAdmin sees the new member in the list',
     ])
   })
 
@@ -298,8 +298,8 @@ describe('deriving intents from scenarios', () => {
     )
 
     assert.deepEqual(intents[0]!.steps, [
-      'Given the orgAdmin is signed in',
-      'When the orgAdmin invites {email}',
+      'Given orgAdmin is signed in',
+      'When orgAdmin invites {email}',
     ])
     assert.deepEqual(intents[0]!.personas, ['orgAdmin'])
   })

--- a/packages/core/src/wirings/workflow/scenario-prose.test.ts
+++ b/packages/core/src/wirings/workflow/scenario-prose.test.ts
@@ -63,7 +63,7 @@ describe('composeStepProse', () => {
         input: { packageName: '@pikku/addon-todos' },
         actor: 'admin',
       }),
-      'Then the admin sees @pikku/addon-todos'
+      'Then admin sees @pikku/addon-todos'
     )
   })
 
@@ -75,7 +75,121 @@ describe('composeStepProse', () => {
         input: { packageName: '@pikku/addon-todos' },
         actor: 'admin',
       }),
-      'Then the admin sees an addon in the gallery'
+      'Then admin sees an addon in the gallery'
+    )
+  })
+})
+
+describe('composeStepProse with an actor role', () => {
+  test('the role renders as an apposition after the actor', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'given',
+        description: 'signs in',
+        actor: 'yasser',
+        actorRole: 'founder',
+      }),
+      'Given yasser (the founder) signs in'
+    )
+  })
+
+  test('no role renders exactly as it did before', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'given',
+        description: 'signs in',
+        actor: 'yasser',
+      }),
+      'Given yasser signs in'
+    )
+  })
+
+  test('a role without an actor has nothing to qualify, so it is dropped', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'then',
+        description: 'the receipt totals 4.50',
+        actorRole: 'founder',
+      }),
+      'Then the receipt totals 4.50'
+    )
+  })
+
+  test('the role sits inside the padded sentence, not the keyword column', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'when',
+        description: 'opens /app',
+        actor: 'nadia',
+        actorRole: 'head of ops',
+        keywordWidth: 5,
+      }),
+      'When  nadia (the head of ops) opens /app'
+    )
+  })
+})
+
+describe('composeStepProse continuations', () => {
+  test('a repeated phase reads as And', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'given',
+        description: 'is invited',
+        actor: 'nadia',
+        continuesPhase: true,
+      }),
+      'And nadia is invited'
+    )
+  })
+
+  test('the same actor continuing drops the repeated subject', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'when',
+        description: 'sees the audit log',
+        actor: 'yasser',
+        continuesPhase: true,
+        continuesActor: true,
+      }),
+      'And sees the audit log'
+    )
+  })
+
+  test('a new actor keeps their name even under And', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'given',
+        description: 'is invited',
+        actor: 'nadia',
+        continuesPhase: true,
+        continuesActor: false,
+      }),
+      'And nadia is invited'
+    )
+  })
+
+  test('the same actor across a phase change keeps the subject', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'when',
+        description: 'opens the dashboard',
+        actor: 'yasser',
+        continuesActor: true,
+      }),
+      'When yasser opens the dashboard'
+    )
+  })
+
+  test('an introduction is never dropped by a continuation', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'given',
+        description: 'is invited',
+        actor: 'nadia',
+        actorRole: 'reviewer',
+        continuesPhase: true,
+      }),
+      'And nadia (the reviewer) is invited'
     )
   })
 })
@@ -88,7 +202,7 @@ describe('composeStepProse basics', () => {
         description: 'buys an apple',
         actor: 'shopper',
       }),
-      'Given the shopper buys an apple'
+      'Given shopper buys an apple'
     )
     assert.equal(
       composeStepProse({
@@ -96,7 +210,18 @@ describe('composeStepProse basics', () => {
         description: 'sees a receipt',
         actor: 'shopper',
       }),
-      'Then the shopper sees a receipt'
+      'Then shopper sees a receipt'
+    )
+  })
+
+  test('a persona named after a person reads as that person', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'when',
+        description: 'opens /app',
+        actor: 'nadia',
+      }),
+      'When nadia opens /app'
     )
   })
 
@@ -117,7 +242,7 @@ describe('composeStepProse basics', () => {
         description: 'refreshes the dashboard',
         actor: 'admin',
       }),
-      'When the admin refreshes the dashboard'
+      'When admin refreshes the dashboard'
     )
   })
 
@@ -133,11 +258,11 @@ describe('composeStepProse basics', () => {
     )
 
     assert.deepEqual(rendered, [
-      'Given the shopper buys an apple',
-      'When  the shopper checks out',
-      'Then  the shopper sees a receipt',
+      'Given shopper buys an apple',
+      'When  shopper checks out',
+      'Then  shopper sees a receipt',
     ])
-    const columns = new Set(rendered.map((line) => line.indexOf('the shopper')))
+    const columns = new Set(rendered.map((line) => line.indexOf('shopper')))
     assert.equal(columns.size, 1, 'every sentence starts in the same column')
   })
 

--- a/packages/core/src/wirings/workflow/scenario-prose.ts
+++ b/packages/core/src/wirings/workflow/scenario-prose.ts
@@ -28,6 +28,9 @@ export const composeStepProse = ({
   template,
   input,
   actor,
+  actorRole,
+  continuesPhase,
+  continuesActor,
   keywordWidth,
 }: {
   phase: ScenarioStepPhase
@@ -35,16 +38,48 @@ export const composeStepProse = ({
   template?: string
   input?: unknown
   actor?: string
+  /**
+   * What this actor is, rendered as an apposition after their key — "yasser
+   * (the founder)". Only pass it where the actor has not been named yet: an
+   * ordinary run repeats one actor for a dozen steps, and repeating the role
+   * with them turns the one piece of context into the noise around it.
+   */
+  actorRole?: string
+  /**
+   * This step repeats the phase of the one before it, so it reads as `And`
+   * rather than saying `Given` three times — the same thing Gherkin does.
+   */
+  continuesPhase?: boolean
+  /**
+   * The step before this one had the same actor. Combined with `continuesPhase`
+   * the subject is dropped, because English drops a repeated subject in a
+   * compound predicate: "yasser opens the dashboard / and sees the audit log".
+   *
+   * It takes both. Dropping the subject across a phase change gives "When opens
+   * the dashboard", and a pronoun instead of a name would give "they sees",
+   * since step templates are authored in the third person singular.
+   */
+  continuesActor?: boolean
   keywordWidth?: number
 }): string => {
-  const keyword = capitalise(phase)
-  const subject = actor ? `the ${actor}` : ''
+  const keyword = capitalise(continuesPhase ? 'and' : phase)
+  // The actor key is the subject verbatim, with no article in front of it.
+  // "the ${actor}" only reads as English when the key happens to be a role
+  // noun — it turns a persona named after a person into "the nadia", which
+  // is the reporter quietly imposing a naming convention on the author.
+  const subject =
+    continuesPhase && continuesActor ? '' : composeSubject(actor, actorRole)
   const rendered = template ? renderStepTemplate(template, input) : description
   const sentence = [subject, rendered].filter(Boolean).join(' ')
   if (keywordWidth === undefined) {
     return [keyword, sentence].filter(Boolean).join(' ')
   }
   return `${keyword.padEnd(keywordWidth)} ${sentence}`
+}
+
+const composeSubject = (actor?: string, actorRole?: string): string => {
+  if (!actor) return ''
+  return actorRole ? `${actor} (the ${actorRole})` : actor
 }
 
 const capitalise = (value: string) =>

--- a/packages/core/src/wirings/workflow/scenario-run.types.ts
+++ b/packages/core/src/wirings/workflow/scenario-run.types.ts
@@ -38,6 +38,13 @@ export interface ScenarioArtifact {
 /** One step of a run, already joined to the prose that declared it. */
 export interface ScenarioStepRow {
   sentence: string
+  /**
+   * The same sentence with the actor's role in it — "yasser (the founder)
+   * signs in". Set only on the step that first names each actor, and only
+   * when a persona declares a job title or a role, so a reader who wants the
+   * context picks this and one who wants the bare run picks `sentence`.
+   */
+  sentenceWithRole?: string
   status: string
   durationMs?: number
   error?: string

--- a/packages/skills/skills/pikku-scenario/SKILL.md
+++ b/packages/skills/skills/pikku-scenario/SKILL.md
@@ -213,14 +213,14 @@ The **feature is the run unit**: `--flows` on a scenario whose every feature ent
 
 A scenario records what someone was **trying to do**, never the keystrokes they used to do it. This is the one decision that determines whether a suite survives its first redesign, and it applies to every step name you write.
 
-| Action ladder — wrong               | Intent ladder — right                               |
-| ----------------------------------- | --------------------------------------------------- |
-| `Given opens /shop`                 | `Given the shopper is browsing the shop`            |
-| `When clicks the category filter`   | `When the shopper buys the £5 strawberry milkshake` |
-| `And clicks "Drinks"`               | `Then it is in their basket`                        |
-| `And clicks the first product card` |                                                     |
-| `And clicks Add to basket`          |                                                     |
-| `Then sees "1 item"`                |                                                     |
+| Action ladder — wrong               | Intent ladder — right                           |
+| ----------------------------------- | ----------------------------------------------- |
+| `Given opens /shop`                 | `Given shopper is browsing the shop`            |
+| `When clicks the category filter`   | `When shopper buys the £5 strawberry milkshake` |
+| `And clicks "Drinks"`               | `Then it is in their basket`                    |
+| `And clicks the first product card` |                                                 |
+| `And clicks Add to basket`          |                                                 |
+| `Then sees "1 item"`                |                                                 |
 
 Three things go wrong with the left-hand column, and all three are expensive:
 
@@ -313,7 +313,7 @@ await scenario.when(
   { name: '£5 strawberry milkshake' },
   { actor: actors.shopper }
 )
-// reporter renders: When the shopper buys the £5 strawberry milkshake  ✓  1.2s
+// reporter renders: When shopper buys the £5 strawberry milkshake  ✓  1.2s
 ```
 
 **Every intent step begins by arriving.** `ensureOnShop` is not defensive noise — it is what lets a scenario start at any step, run alone, and be reordered without touching it. It checks first and navigates only if needed, so a scenario already on the shop pays nothing. This is about the _browser's_ starting position, not the database: there is still no state reset (see above), and you still scope what you create.
@@ -489,7 +489,7 @@ await scenario.given(
   { qty: 1 },
   { actor: actors.shopper }
 )
-// reporter renders: Given the shopper buys 1 apples   ✓  412ms
+// reporter renders: Given shopper buys 1 apples   ✓  412ms
 ```
 
 Rules that bite:


### PR DESCRIPTION
Was a two-PR stack (#1472 + #1476) and is now one commit on main. #1477 was a duplicate of the same tree and is closed.

Every step prefixed its actor with `the `, named that actor again, and repeated the phase keyword. A three-step run by one person said their name three times and "Given" three times, only read as English when the persona key happened to be a role noun, and never said who that person was — the fabric template's own placeholder came out as `the nadia opens /app`.

```
Given yasser (the founder) signs in
When  yasser opens the dashboard
And   sees the audit log
And   nadia reviews the invite
```

## The article

`composeStepProse` prefixed every actor-driven step with `the `. That was the reporter imposing a naming convention on keys the author chose, so it is gone: the actor key is the subject verbatim, and a persona named after a person reads as that person.

## `And` did not exist

`ScenarioStepPhase` is `'given' | 'when' | 'then'`, and nothing rendered `And` — a loop of four assertions printed `Then` four times. A step whose phase repeats the previous one now reads as `And`.

## Dropping the repeated subject, not pronouning it

A step that continues **both** the phase and the actor drops the subject, because English drops a repeated subject in a compound predicate.

It takes both conditions. Eliding across a phase change gives "When opens the dashboard". And a pronoun rather than a name would give "they sees the audit log" — step templates are authored in the third person singular (`'sees {packageName}'`), and singular *they* takes plural agreement, so substituting the subject alone breaks the verb. Dropping the subject sidesteps that entirely and works for every persona regardless of pronoun. A new actor keeps their name under `And` — see `nadia` above.

## Only a job title introduces anyone

`jobTitle` is prose someone wrote for a reader. `roles` is authorisation: "reviewer" is a grant, not a description of who someone is, so a persona that declares no title gets no introduction rather than one assembled out of its grants. That is why `nadia` above is not "(the reviewer)".

## Two sentences, so a renderer can choose

`ScenarioStepRow` gains `sentenceWithRole` alongside `sentence`, set only on the step that first names each actor. A show/hide toggle is `sentenceWithRole ?? sentence` — no parsing a composed sentence back apart. The console still reads `sentence` and is unchanged here.

## Tests

`composeStepProse` covers the bare subject, the apposition, the repeated phase, subject elision, a new actor under `And`, the same actor across a phase change, and an introduction surviving a continuation. The ladder covers first-mention-only, `sentence` staying role-free, a role introducing nobody, no personas at all, glyph-column alignment, and the four-line paragraph above end to end.

Two existing assertions changed: a step repeated under an `#ordinal` key and a loop iteration resolved by step function are both genuine continuations, so they now read as `And` — the behaviour they assert (prose resolution) is unchanged.

47 CLI and 54 core tests green; `api-report.md` regenerated, its gate and `public-surface` pass.

## Not in scope

The failure line (`✗ failed at: …`) still renders role-free and without continuation, since it appears under a ladder that already introduced the actor. `virtual-user-derive` composes step prose for agent prompts and is left explicit there on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Scenario prose now presents actor names without an unnecessary “the.”
  * Repeated phases use clearer “And” continuation phrasing.
  * Repeated actors are streamlined within the same phase.
  * First actor introductions may include the persona’s job title.
  * Scenario ladders preserve actor context for clearer aligned output.

* **Documentation**
  * Updated scenario examples and guidance to reflect the revised wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->