### PR TITLE
feat(core): add the InboundEmail contract

### DIFF
--- a/.changeset/inbound-email-contract.md
+++ b/.changeset/inbound-email-contract.md
@@ -1,0 +1,15 @@
+---
+'@pikku/core': patch
+---
+
+Add the `InboundEmail` contract
+
+The outbound half of email has lived in core for a while — `EmailService`,
+`SendEmailInput`. `InboundEmail` is the shape every inbound source hands to a
+trigger handler, so a handler wired to Cloudflare, IMAP, Gmail or a local SMTP
+listener is the same handler.
+
+The source parses MIME and passes a whole message, attachments inline. Nothing
+is persisted on the way, so a hosted source never accumulates a corpus of tenant
+mail. Mailbox operations are deliberately absent: they mean nothing to a source
+handed a single message that never sees the mailbox it came from.

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,8 +5,8 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2856 observable things**: 901 exported names, plus
-1955 members on the classes and interfaces among them, reachable
+**2883 observable things**: 904 exported names, plus
+1979 members on the classes and interfaces among them, reachable
 through 53 entry points.
 
 An entry point whose exports are mostly *exclusive* is a self-contained
@@ -14,7 +14,7 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 
 | entry point | exports | exclusive | members on those |
 | --- | ---: | ---: | ---: |
-| `./services` | 141 | 115 | 413 |
+| `./services` | 144 | 118 | 437 |
 | `./virtual-user` | 66 | 66 | 210 |
 | `./scenario` | 45 | 45 | 133 |
 | `./workflow` | 84 | 35 | 140 |
@@ -4551,6 +4551,36 @@ export interface GroupMeta {
   count: number
   instanceIds: string[]
   isFactory: boolean
+}
+export interface InboundEmail {
+  source: string
+  messageId: string
+  receivedAt: string
+  mailbox?: string
+  from: InboundEmailAddress
+  to: InboundEmailAddress[]
+  cc?: InboundEmailAddress[]
+  replyTo?: InboundEmailAddress[]
+  subject?: string
+  sentAt?: string
+  inReplyTo?: string
+  references?: string[]
+  headers: Record<string, string>
+  text?: string
+  html?: string
+  attachments: InboundEmailAttachment[]
+}
+export interface InboundEmailAddress {
+  address: string
+  name?: string
+}
+export interface InboundEmailAttachment {
+  filename?: string
+  contentType: string
+  size: number
+  contentId?: string
+  inline: boolean
+  content: string
 }
 export class InMemoryAgentRunStateService implements AgentRunStateService {
   async createRun(run: CreateRunInput): Promise<string>

--- a/packages/core/src/services/inbound-email.ts
+++ b/packages/core/src/services/inbound-email.ts
@@ -1,0 +1,49 @@
+export interface InboundEmailAddress {
+  address: string
+  name?: string
+}
+
+export interface InboundEmailAttachment {
+  filename?: string
+  contentType: string
+  size: number
+  contentId?: string
+  inline: boolean
+  /** base64 */
+  content: string
+}
+
+/**
+ * One received message, in the shape every inbound source produces.
+ *
+ * The source parses MIME and hands over a whole message. Nothing is persisted
+ * on the way, so a handler that ignores an attachment costs nothing and a
+ * hosted source never accumulates a corpus of tenant mail. The price is a size
+ * ceiling: a source refuses a message larger than it will hold in memory, and
+ * refuses it temporarily so the sender retries rather than bounces.
+ *
+ * Mailbox operations (mark as read, move, delete) are deliberately absent.
+ * They exist on IMAP and Gmail and mean nothing to a source handed a single
+ * message that never sees the mailbox it came from, so they stay in the
+ * source's own package and a read-only handler runs against any of them.
+ */
+export interface InboundEmail {
+  /** The `wireTriggerSource` that produced this, for a handler wired to more than one. */
+  source: string
+  messageId: string
+  receivedAt: string
+  mailbox?: string
+  from: InboundEmailAddress
+  to: InboundEmailAddress[]
+  cc?: InboundEmailAddress[]
+  replyTo?: InboundEmailAddress[]
+  subject?: string
+  sentAt?: string
+  /** Carry these into the reply; a reply is always a new send, never a mutation of this message. */
+  inReplyTo?: string
+  references?: string[]
+  headers: Record<string, string>
+  text?: string
+  html?: string
+  attachments: InboundEmailAttachment[]
+}

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -53,6 +53,11 @@ export type {
   SendTemplateEmailInput,
   SendTextEmailInput,
 } from './email-service.js'
+export type {
+  InboundEmail,
+  InboundEmailAddress,
+  InboundEmailAttachment,
+} from './inbound-email.js'
 export {
   renderEmail,
   type EmailAssets,


### PR DESCRIPTION
The outbound half of email has lived in core for a while — `EmailService`, `SendEmailInput`. This is the other half: the shape every inbound source hands to a trigger handler, so a handler wired to Cloudflare Email Routing, IMAP, Gmail or a local SMTP listener is the same handler.

## The shape

The source parses MIME and passes a whole message, with attachments inline as base64. Nothing is persisted on the way, which keeps a hosted source from accumulating a corpus of tenant mail. The price is a size ceiling: a source refuses a message larger than it will hold in memory, and refuses it *temporarily*, so the sender retries rather than bounces.

`source` names the `wireTriggerSource` that produced the message, for a handler wired to more than one. `inReplyTo` / `references` are carried so a reply is always a new send rather than a mutation of the received message.

## What is deliberately absent

Mailbox operations — mark as read, move, delete. They exist on IMAP and Gmail and mean nothing to a source handed a single message that never sees the mailbox it came from, so they stay in the source's own package and a read-only handler runs against any of them.

## Scope

Contract only — three exported types and their barrel entry. No source implements it yet; that lands per-runtime. `api-report.md` is regenerated (+27 observable things), and `api-report.test.ts` plus `public-surface.test.ts` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)