### PR TITLE
feat(core,cli): a step ladder reads as one paragraph, not a list of restatements

### DIFF
--- a/.changeset/scenario-actor-job-title.md
+++ b/.changeset/scenario-actor-job-title.md
@@ -1,0 +1,34 @@
+---
+'@pikku/core': patch
+'@pikku/cli': patch
+---
+
+A step ladder reads as one paragraph, not as a list of restatements
+
+Every step named its actor by persona key and repeated the phase keyword, so a
+three-step run by one person said their name three times and "Given" three
+times, and never said who that person was.
+
+A ladder now introduces an actor once and carries them:
+
+```
+Given yasser (the founder) signs in
+When  yasser opens the dashboard
+And   sees the audit log
+And   nadia reviews the invite
+```
+
+A repeated phase reads as `And`, the way Gherkin has always written it. A step
+that continues both the phase and the actor drops the repeated subject, because
+English drops a repeated subject in a compound predicate. It takes both: eliding
+across a phase change gives "When opens the dashboard", and a pronoun instead of
+a name would give "they sees", since step templates are authored in the third
+person singular.
+
+The introduction is the persona's `jobTitle` — prose someone wrote for a reader.
+`roles` is authorisation, so a persona whose only description is a `reviewer`
+grant gets no introduction rather than one assembled out of its grants.
+
+A row carries `sentenceWithRole` alongside `sentence`, set only where an actor
+is first named, so a renderer can offer the introduction as a toggle without
+parsing a composed sentence back apart.

--- a/packages/cli/src/functions/commands/scenario-formatter.ts
+++ b/packages/cli/src/functions/commands/scenario-formatter.ts
@@ -79,16 +79,21 @@ export const formatScenarioReport = (
 }
 
 export const buildStepLadder = (steps: ScenarioStepRow[]): string[] => {
-  const width = Math.max(0, ...steps.map(({ sentence }) => sentence.length))
-  return steps.map((step) => {
+  const sentences = steps.map(ladderSentence)
+  const width = Math.max(0, ...sentences.map((sentence) => sentence.length))
+  return steps.map((step, index) => {
     const glyph = step.status === 'succeeded' ? '✓' : '✗'
     const detail =
       step.status === 'succeeded' || !step.error
         ? formatDuration(step.durationMs)
         : firstLine(step.error)
-    return `  ${step.sentence.padEnd(width)}  ${glyph}  ${detail}`
+    return `  ${sentences[index]!.padEnd(width)}  ${glyph}  ${detail}`
   })
 }
+
+/** The ladder introduces an actor where the row offers an introduction. */
+const ladderSentence = (step: ScenarioStepRow) =>
+  step.sentenceWithRole ?? step.sentence
 
 /**
  * The one line a summary gets. A browser timeout's message carries its whole

--- a/packages/cli/src/functions/commands/scenario-ladder.test.ts
+++ b/packages/cli/src/functions/commands/scenario-ladder.test.ts
@@ -245,6 +245,162 @@ describe('scenarioSurfaceCoverage', () => {
   })
 })
 
+const personas = (overrides: Record<string, unknown> = {}) =>
+  [
+    {
+      id: 'shopper',
+      name: 'Shopper',
+      roles: ['customer'],
+      goals: [],
+      tags: [],
+      runnable: true,
+      ...overrides,
+    },
+  ] as any
+
+describe('an actor introduces themselves once', () => {
+  const rows = (personaList: any) =>
+    scenarioStepRows(
+      [
+        { stepName: 'buys an apple', status: 'succeeded' },
+        { stepName: 'checks out', status: 'succeeded' },
+        { stepName: 'sees a receipt', status: 'succeeded' },
+      ],
+      collectScenarioStepProse(
+        workflowMeta() as any,
+        functionsMeta() as any,
+        personaList
+      )
+    )
+
+  test('only the first step carries the role', () => {
+    const [first, second, third] = rows(personas({ jobTitle: 'founder' }))
+    assert.equal(
+      first!.sentenceWithRole?.trim(),
+      'Given shopper (the founder) buys an apple'
+    )
+    assert.equal(second!.sentenceWithRole, undefined)
+    assert.equal(third!.sentenceWithRole, undefined)
+  })
+
+  test('the plain sentence never carries the role, so a reader can drop it', () => {
+    const [first] = rows(personas({ jobTitle: 'founder' }))
+    assert.equal(first!.sentence.trim(), 'Given shopper buys an apple')
+  })
+
+  test('a job title beats the authorisation roles', () => {
+    const [first] = rows(personas({ jobTitle: 'founder', roles: ['admin'] }))
+    assert.ok(first!.sentenceWithRole?.includes('(the founder)'))
+  })
+
+  test('a role is not a job title, so it introduces nobody', () => {
+    const [first] = rows(personas({ roles: ['reviewer'] }))
+    assert.equal(first!.sentenceWithRole, undefined)
+  })
+
+  test('no personas at all leaves every row as it was', () => {
+    for (const row of rows([])) {
+      assert.equal(row.sentenceWithRole, undefined)
+    }
+  })
+
+  test('the ladder shows the introduction and pads to it', () => {
+    const lines = buildStepLadder(rows(personas({ jobTitle: 'founder' })))
+    assert.ok(
+      lines[0]!.includes('shopper (the founder) buys an apple'),
+      lines[0]
+    )
+    assert.ok(lines[1]!.includes('shopper completes the checkout'), lines[1])
+    assert.ok(!lines[1]!.includes('(the founder)'), lines[1])
+    const widths = new Set(lines.map((line) => line.indexOf('  ✓')))
+    assert.equal(widths.size, 1, 'every glyph lands in the same column')
+  })
+})
+
+describe('a run reads as one paragraph', () => {
+  const journeyMeta = {
+    steps: [
+      {
+        type: 'scenarioStep',
+        stepName: 'signs in',
+        stepFunc: 'a',
+        phase: 'given',
+        actor: 'yasser',
+      },
+      {
+        type: 'scenarioStep',
+        stepName: 'opens the dashboard',
+        stepFunc: 'b',
+        phase: 'when',
+        actor: 'yasser',
+      },
+      {
+        type: 'scenarioStep',
+        stepName: 'sees the audit log',
+        stepFunc: 'c',
+        phase: 'when',
+        actor: 'yasser',
+      },
+      {
+        type: 'scenarioStep',
+        stepName: 'reviews the invite',
+        stepFunc: 'd',
+        phase: 'when',
+        actor: 'nadia',
+      },
+    ],
+  }
+  const journeyFns = {
+    a: { pikkuFuncId: 'a' },
+    b: { pikkuFuncId: 'b' },
+    c: { pikkuFuncId: 'c' },
+    d: { pikkuFuncId: 'd' },
+  }
+  const cast = [
+    {
+      id: 'yasser',
+      name: 'Yasser',
+      jobTitle: 'founder',
+      roles: [],
+      goals: [],
+      tags: [],
+      runnable: true,
+    },
+    {
+      id: 'nadia',
+      name: 'Nadia',
+      roles: ['reviewer'],
+      goals: [],
+      tags: [],
+      runnable: true,
+    },
+  ]
+  const lines = () =>
+    buildStepLadder(
+      scenarioStepRows(
+        journeyMeta.steps.map((step) => ({
+          stepName: step.stepName,
+          status: 'succeeded',
+          durationMs: 1,
+        })) as any,
+        collectScenarioStepProse(
+          journeyMeta as any,
+          journeyFns as any,
+          cast as any
+        )
+      )
+    ).map((line) => line.replace(/\s+✓.*$/, '').trim())
+
+  test('the actor is introduced, then carried, then dropped', () => {
+    assert.deepEqual(lines(), [
+      'Given yasser (the founder) signs in',
+      'When  yasser opens the dashboard',
+      'And   sees the audit log',
+      'And   nadia reviews the invite',
+    ])
+  })
+})
+
 describe('buildStepLadder', () => {
   const prose = () =>
     collectScenarioStepProse(workflowMeta() as any, functionsMeta() as any)
@@ -289,7 +445,9 @@ describe('buildStepLadder', () => {
     )
 
     assert.equal(lines.length, 2)
-    assert.match(lines[1]!, /When {2}shopper completes the checkout/)
+    // The same step twice is a continuation, so the second reads as `And`.
+    assert.match(lines[0]!, /When {2}shopper completes the checkout/)
+    assert.match(lines[1]!, /And {3}completes the checkout/)
   })
 
   test('a step with no recorded prose still appears, by its name', () => {
@@ -425,7 +583,7 @@ describe('step templates', () => {
     )
 
     assert.match(lines[0]!, /Then {2}shopper sees a receipt for an apple/)
-    assert.match(lines[1]!, /Then {2}shopper sees a receipt for a pear/)
+    assert.match(lines[1]!, /And {3}sees a receipt for a pear/)
   })
 
   test('the step name still wins over the function fallback', () => {

--- a/packages/cli/src/functions/commands/scenario-ladder.ts
+++ b/packages/cli/src/functions/commands/scenario-ladder.ts
@@ -12,6 +12,7 @@ import { composeStepProse } from '@pikku/core/scenario'
 import type { ScenarioSurface, ScenarioStepPhase } from '@pikku/core/scenario'
 import type { WorkflowStepMeta } from '@pikku/core/workflow'
 import type { FunctionsMeta } from '@pikku/core/services'
+import type { PersonaDefinitions } from '@pikku/core/persona'
 import { KEYWORD_WIDTH } from './scenario-formatter.js'
 import type {
   ScenarioFailureDetail,
@@ -59,6 +60,12 @@ export interface ScenarioProse {
    * which is what it did before this index existed.
    */
   byStepFunc: Map<string, ScenarioStepProse>
+  /**
+   * What each actor is, keyed by the persona key a step records. A persona's
+   * job title is what a reader wants — "the founder" — and its first role is
+   * the fallback for a persona that declares no title.
+   */
+  roleByActor: Map<string, string>
 }
 
 /**
@@ -96,7 +103,8 @@ function* walkScenarioSteps(steps: unknown): Generator<any> {
  */
 export const collectScenarioStepProse = (
   workflowMeta: { steps?: WorkflowStepMeta[] } | undefined,
-  functionsMeta: FunctionsMeta
+  functionsMeta: FunctionsMeta,
+  personas: PersonaDefinitions = []
 ): ScenarioProse => {
   const byStepName = new Map<string, ScenarioStepProse>()
   const byStepFunc = new Map<string, ScenarioStepProse>()
@@ -126,7 +134,22 @@ export const collectScenarioStepProse = (
   for (const stepFunc of ambiguous) {
     byStepFunc.delete(stepFunc)
   }
-  return { byStepName, byStepFunc }
+  return { byStepName, byStepFunc, roleByActor: rolesByActor(personas) }
+}
+
+/**
+ * Only a job title introduces an actor. `roles` is authorisation — "reviewer"
+ * is a grant, not a description of who someone is — so a persona that declares
+ * no title gets no introduction rather than one assembled out of its grants.
+ */
+const rolesByActor = (personas: PersonaDefinitions): Map<string, string> => {
+  const roles = new Map<string, string>()
+  for (const persona of personas) {
+    if (persona.jobTitle) {
+      roles.set(persona.id, persona.jobTitle)
+    }
+  }
+  return roles
 }
 
 const sameProse = (a: ScenarioStepProse, b: ScenarioStepProse) =>
@@ -241,17 +264,31 @@ export const scenarioSurfaceCoverage = (
  * recorded under the name it was declared with is never re-resolved by a
  * function shared with another call site.
  */
-const stepSentence = (
+const stepProse = (
   step: ScenarioStepOutcome,
   prose: ScenarioProse
+): ScenarioStepProse | undefined =>
+  prose.byStepName.get(step.stepName) ??
+  prose.byStepName.get(baseName(step.stepName)) ??
+  (step.stepFunc ? prose.byStepFunc.get(step.stepFunc) : undefined)
+
+/** How a step follows the one recorded before it. */
+interface StepContinuation {
+  actorRole?: string
+  continuesPhase?: boolean
+  continuesActor?: boolean
+}
+
+const stepSentence = (
+  step: ScenarioStepOutcome,
+  prose: ScenarioProse,
+  continuation: StepContinuation = {}
 ): string => {
-  const parts =
-    prose.byStepName.get(step.stepName) ??
-    prose.byStepName.get(baseName(step.stepName)) ??
-    (step.stepFunc ? prose.byStepFunc.get(step.stepFunc) : undefined)
+  const parts = stepProse(step, prose)
   return parts
     ? composeStepProse({
         ...parts,
+        ...continuation,
         input: step.input,
         keywordWidth: KEYWORD_WIDTH,
       })
@@ -262,13 +299,41 @@ const stepSentence = (
 export const scenarioStepRows = (
   steps: ScenarioStepOutcome[],
   prose: ScenarioProse
-): ScenarioStepRow[] =>
-  steps.map((step) => ({
-    sentence: stepSentence(step, prose),
-    status: step.status,
-    durationMs: step.durationMs,
-    error: step.error,
-  }))
+): ScenarioStepRow[] => {
+  const introduced = new Set<string>()
+  let previous: ScenarioStepProse | undefined
+  return steps.map((step) => {
+    const parts = stepProse(step, prose)
+    const actor = parts?.actor
+    const role = actor ? prose.roleByActor.get(actor) : undefined
+    // Only the step that first names an actor carries their role, so a run
+    // that is one person doing eight things says who they are once.
+    const firstMention =
+      actor !== undefined && role !== undefined && !introduced.has(actor)
+    const continuation: StepContinuation = {
+      continuesPhase: previous !== undefined && previous.phase === parts?.phase,
+      continuesActor: previous !== undefined && previous.actor === actor,
+    }
+    if (actor) {
+      introduced.add(actor)
+    }
+    previous = parts
+    return {
+      sentence: stepSentence(step, prose, continuation),
+      ...(firstMention
+        ? {
+            sentenceWithRole: stepSentence(step, prose, {
+              ...continuation,
+              actorRole: role,
+            }),
+          }
+        : {}),
+      status: step.status,
+      durationMs: step.durationMs,
+      error: step.error,
+    }
+  })
+}
 
 const baseName = (stepName: string) => stepName.replace(/#\d+$/, '')
 

--- a/packages/cli/src/functions/commands/scenario.ts
+++ b/packages/cli/src/functions/commands/scenario.ts
@@ -484,7 +484,8 @@ export const scenarioRun = pikkuSessionlessFunc<
     ) => {
       const prose = collectScenarioStepProse(
         state.workflows?.meta?.[flowName],
-        functionsMeta
+        functionsMeta,
+        state.personas?.definitions ?? []
       )
       const steps = (await service.getRunSteps(runId)).map((step) => ({
         stepName: step.stepName,

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,8 +5,8 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2856 observable things**: 901 exported names, plus
-1955 members on the classes and interfaces among them, reachable
+**2857 observable things**: 901 exported names, plus
+1956 members on the classes and interfaces among them, reachable
 through 53 entry points.
 
 An entry point whose exports are mostly *exclusive* is a self-contained
@@ -16,7 +16,7 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | --- | ---: | ---: | ---: |
 | `./services` | 141 | 115 | 413 |
 | `./virtual-user` | 66 | 66 | 210 |
-| `./scenario` | 45 | 45 | 133 |
+| `./scenario` | 45 | 45 | 134 |
 | `./workflow` | 84 | 35 | 140 |
 | `./agent` | 50 | 48 | 81 |
 | `./channel` | 32 | 32 | 84 |
@@ -1514,7 +1514,7 @@ export type WorkflowWireDoRPC = <TOutput = any, TInput = any>(
 
 ```ts
 addFeature: (featureId: string, feature: CoreFeature, packageName?: string | null) => void
-composeStepProse: ({ phase, description, template, input, actor, keywordWidth, }: { phase: ScenarioStepPhase; description: string; template?: string | undefined; input?: unknown; actor?: string | undefined; keywordWidth?: number | undefined; }) => string
+composeStepProse: ({ phase, description, template, input, actor, actorRole, continuesPhase, continuesActor, keywordWidth, }: { phase: ScenarioStepPhase; description: string; template?: string | undefined; input?: unknown; actor?: string | undefined; actorRole?: string | undefined; continuesPhase?: boolean | undefined; continuesActor?: boolean | undefined; keywordWidth?: number | undefined; }) => string
 export type CoreFeature = {
   name: string
   description?: string
@@ -1721,6 +1721,7 @@ export interface ScenarioStepOptions {
 export type ScenarioStepPhase = 'given' | 'when' | 'then'
 export interface ScenarioStepRow {
   sentence: string
+  sentenceWithRole?: string
   status: string
   durationMs?: number
   error?: string

--- a/packages/core/src/wirings/workflow/scenario-prose.test.ts
+++ b/packages/core/src/wirings/workflow/scenario-prose.test.ts
@@ -80,6 +80,120 @@ describe('composeStepProse', () => {
   })
 })
 
+describe('composeStepProse with an actor role', () => {
+  test('the role renders as an apposition after the actor', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'given',
+        description: 'signs in',
+        actor: 'yasser',
+        actorRole: 'founder',
+      }),
+      'Given yasser (the founder) signs in'
+    )
+  })
+
+  test('no role renders exactly as it did before', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'given',
+        description: 'signs in',
+        actor: 'yasser',
+      }),
+      'Given yasser signs in'
+    )
+  })
+
+  test('a role without an actor has nothing to qualify, so it is dropped', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'then',
+        description: 'the receipt totals 4.50',
+        actorRole: 'founder',
+      }),
+      'Then the receipt totals 4.50'
+    )
+  })
+
+  test('the role sits inside the padded sentence, not the keyword column', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'when',
+        description: 'opens /app',
+        actor: 'nadia',
+        actorRole: 'head of ops',
+        keywordWidth: 5,
+      }),
+      'When  nadia (the head of ops) opens /app'
+    )
+  })
+})
+
+describe('composeStepProse continuations', () => {
+  test('a repeated phase reads as And', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'given',
+        description: 'is invited',
+        actor: 'nadia',
+        continuesPhase: true,
+      }),
+      'And nadia is invited'
+    )
+  })
+
+  test('the same actor continuing drops the repeated subject', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'when',
+        description: 'sees the audit log',
+        actor: 'yasser',
+        continuesPhase: true,
+        continuesActor: true,
+      }),
+      'And sees the audit log'
+    )
+  })
+
+  test('a new actor keeps their name even under And', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'given',
+        description: 'is invited',
+        actor: 'nadia',
+        continuesPhase: true,
+        continuesActor: false,
+      }),
+      'And nadia is invited'
+    )
+  })
+
+  test('the same actor across a phase change keeps the subject', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'when',
+        description: 'opens the dashboard',
+        actor: 'yasser',
+        continuesActor: true,
+      }),
+      'When yasser opens the dashboard'
+    )
+  })
+
+  test('an introduction is never dropped by a continuation', () => {
+    assert.equal(
+      composeStepProse({
+        phase: 'given',
+        description: 'is invited',
+        actor: 'nadia',
+        actorRole: 'reviewer',
+        continuesPhase: true,
+      }),
+      'And nadia (the reviewer) is invited'
+    )
+  })
+})
+
 describe('composeStepProse basics', () => {
   test('renders the gherkin keyword, the actor and the description', () => {
     assert.equal(

--- a/packages/core/src/wirings/workflow/scenario-prose.ts
+++ b/packages/core/src/wirings/workflow/scenario-prose.ts
@@ -28,6 +28,9 @@ export const composeStepProse = ({
   template,
   input,
   actor,
+  actorRole,
+  continuesPhase,
+  continuesActor,
   keywordWidth,
 }: {
   phase: ScenarioStepPhase
@@ -35,20 +38,48 @@ export const composeStepProse = ({
   template?: string
   input?: unknown
   actor?: string
+  /**
+   * What this actor is, rendered as an apposition after their key — "yasser
+   * (the founder)". Only pass it where the actor has not been named yet: an
+   * ordinary run repeats one actor for a dozen steps, and repeating the role
+   * with them turns the one piece of context into the noise around it.
+   */
+  actorRole?: string
+  /**
+   * This step repeats the phase of the one before it, so it reads as `And`
+   * rather than saying `Given` three times — the same thing Gherkin does.
+   */
+  continuesPhase?: boolean
+  /**
+   * The step before this one had the same actor. Combined with `continuesPhase`
+   * the subject is dropped, because English drops a repeated subject in a
+   * compound predicate: "yasser opens the dashboard / and sees the audit log".
+   *
+   * It takes both. Dropping the subject across a phase change gives "When opens
+   * the dashboard", and a pronoun instead of a name would give "they sees",
+   * since step templates are authored in the third person singular.
+   */
+  continuesActor?: boolean
   keywordWidth?: number
 }): string => {
-  const keyword = capitalise(phase)
+  const keyword = capitalise(continuesPhase ? 'and' : phase)
   // The actor key is the subject verbatim, with no article in front of it.
   // "the ${actor}" only reads as English when the key happens to be a role
   // noun — it turns a persona named after a person into "the nadia", which
   // is the reporter quietly imposing a naming convention on the author.
-  const subject = actor ?? ''
+  const subject =
+    continuesPhase && continuesActor ? '' : composeSubject(actor, actorRole)
   const rendered = template ? renderStepTemplate(template, input) : description
   const sentence = [subject, rendered].filter(Boolean).join(' ')
   if (keywordWidth === undefined) {
     return [keyword, sentence].filter(Boolean).join(' ')
   }
   return `${keyword.padEnd(keywordWidth)} ${sentence}`
+}
+
+const composeSubject = (actor?: string, actorRole?: string): string => {
+  if (!actor) return ''
+  return actorRole ? `${actor} (the ${actorRole})` : actor
 }
 
 const capitalise = (value: string) =>

--- a/packages/core/src/wirings/workflow/scenario-run.types.ts
+++ b/packages/core/src/wirings/workflow/scenario-run.types.ts
@@ -38,6 +38,13 @@ export interface ScenarioArtifact {
 /** One step of a run, already joined to the prose that declared it. */
 export interface ScenarioStepRow {
   sentence: string
+  /**
+   * The same sentence with the actor's role in it — "yasser (the founder)
+   * signs in". Set only on the step that first names each actor, and only
+   * when a persona declares a job title or a role, so a reader who wants the
+   * context picks this and one who wants the bare run picks `sentence`.
+   */
+  sentenceWithRole?: string
   status: string
   durationMs?: number
   error?: string


### PR DESCRIPTION
Stacked on #1472 — review that one first.

Every step named its actor by persona key and repeated the phase keyword, so a three-step run by one person said their name three times and "Given" three times, and never said who that person was.

```
Given yasser (the founder) signs in
When  yasser opens the dashboard
And   sees the audit log
And   nadia reviews the invite
```

## `And` did not exist

`ScenarioStepPhase` is `'given' | 'when' | 'then'`, and nothing rendered `And` — a loop of four assertions printed `Then` four times. A step whose phase repeats the previous one now reads as `And`, the way Gherkin has always written it.

## Dropping the repeated subject, not pronouning it

A step that continues **both** the phase and the actor drops the subject, because English drops a repeated subject in a compound predicate.

It takes both conditions. Eliding across a phase change gives "When opens the dashboard". And a pronoun rather than a name would give "they sees the audit log" — step templates are authored in the third person singular (`'sees {packageName}'`), and singular *they* takes plural agreement, so substituting the subject alone breaks the verb. Dropping the subject sidesteps that entirely and works for every persona regardless of pronoun.

A new actor keeps their name under `And` — see `nadia` above.

## Only a job title introduces anyone

`jobTitle` is prose someone wrote for a reader. `roles` is authorisation: "reviewer" is a grant, not a description of who someone is, so a persona that declares no title gets no introduction rather than one assembled out of its grants. That is why `nadia` above is not "(the reviewer)".

## Two sentences, so a renderer can choose

`ScenarioStepRow` gains `sentenceWithRole` alongside `sentence`, set only on the step that first names each actor. A show/hide toggle is `sentenceWithRole ?? sentence` — no parsing a composed sentence back apart. The console still reads `sentence` and is unchanged here; the toggle is the follow-up this makes possible.

## Tests

`composeStepProse` covers the apposition, the repeated phase, subject elision, a new actor under `And`, the same actor across a phase change, and an introduction surviving a continuation. The ladder covers first-mention-only, `sentence` staying role-free, a role introducing nobody, no personas at all, glyph-column alignment, and the four-line paragraph above end to end.

Two existing assertions changed. A step repeated under an `#ordinal` key and a loop iteration resolved by step function are both genuine continuations, so they now read as `And` — the behaviour they assert (prose resolution) is unchanged.

47 CLI and 46 core tests green; `api-report.md` regenerated, its gate and `public-surface` pass.

## Not in scope

The failure line (`✗ failed at: …`) still renders role-free and without continuation, since it appears under a ladder that already introduced the actor. `virtual-user-derive` composes step prose for agent prompts and is left explicit there on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)