### PR TITLE
ci: keep the release gate on the critical path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -429,19 +429,15 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs:
-      [
-        validate-deps,
-        lint,
-        unit-tests,
-        verifiers,
-        verifiers-workflows-db,
-        verifiers-db-schema-db,
-        templates,
-        templates-no-services,
-        template-runtime-targets,
-        e2e,
-      ]
+    # Only the gates that protect a publish. The verifier and template matrices
+    # still run on every push to main, but they no longer stand between a merge
+    # and the registry: ~100 jobs across two package managers held the Version
+    # Packages PR shut for the length of the slowest one, and `develop.yml` had
+    # already run the same matrix against the same tree on the branch.
+    #
+    # What stays: validate-deps (workspace-protocol deps and peer ranges are
+    # precisely what must not reach npm), lint, build, unit-tests, e2e.
+    needs: [validate-deps, build, lint, unit-tests, e2e]
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}


### PR DESCRIPTION
## Why

`release` in `main.yml` waited on the full verifier and template matrices:

```yaml
needs:
  [validate-deps, lint, unit-tests, verifiers, verifiers-workflows-db,
   verifiers-db-schema-db, templates, templates-no-services,
   template-runtime-targets, e2e]
```

That is roughly 100 jobs — ~25 verifiers and ~20 templates, each crossed with yarn and bun. Changesets cannot open or update the Version Packages PR until every one of them is green, so a merge to main is a release only after the slowest job in a 100-wide fan-out finishes.

The same matrix already ran on the branch. `develop.yml` triggers on every push except main and runs the identical verifier and template jobs; a squash merge lands an all-but-identical tree. The main run is re-proving what the PR proved, on the one path where the latency costs a release rather than a review cycle.

## What changed

```yaml
needs: [validate-deps, build, lint, unit-tests, e2e]
```

The verifier and template matrices still run on every push to main — they are unchanged and still report. They simply no longer sit between a merge and the registry.

What still gates a publish is what protects one:

- **validate-deps** — workspace-protocol dependencies and peer-range drift are precisely the things that must not reach npm, and it costs five minutes.
- **build**, **unit-tests**, **e2e** — listed explicitly. `unit-tests` and `e2e` already declared `needs: build`, so build was transitively required; naming it makes the gate readable.
- **lint**.

`sync-templates-stackblitz` still `needs: release` and is unaffected. The binary upload and Homebrew steps read `packages/cli/release/binaries/*`, which `yarn release` produces inside the release job itself — they never consumed artifacts from the jobs being dropped, and `verifiers-binary` was not in `needs` before this change either.

## Trade-off

A verifier or template regression that somehow reaches main without having failed on the PR would now be caught after publish rather than before it. That is the deliberate cost: those matrices are broad compatibility signal, not release safety, and they have already run once against the same code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbD1Nm6beyHkCB8qujxcLw
