### PR TITLE
ci: let the latest push to main win

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,19 @@ on:
     branches:
       - main
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+# Latest wins. A push to main supersedes whatever is already running for main,
+# rather than queueing behind it — without this, a burst of merges left each run
+# discarded in turn while still waiting for a runner, and a fix could sit merged
+# but unreleased for hours.
+#
+# The newest run carries every commit that came before it, so nothing is lost by
+# cancelling an older one. The exception to keep in mind is `release`: a run
+# cancelled part-way through `yarn release` can leave some packages published at
+# the new version and others not. Closing that window means moving `release` into
+# a workflow of its own, which this deliberately does not do.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # better-auth now throws on a missing BETTER_AUTH_SECRET (mapSession errors no
 # longer swallowed), so every job that builds/prerenders/runs a template needs


### PR DESCRIPTION
## Why

`main.yml` had:

```yaml
concurrency: ${{ github.workflow }}-${{ github.ref }}
```

One key for every push to main, and `cancel-in-progress` left at its default of `false`. GitHub holds at most **one** pending run per key, so each new merge discarded the pending one and took its slot. With runs waiting on runner capacity, that meant merges were cancelling each other before any of them started:

- `32976248375` — #1469 — cancelled
- `32976287018` — #1467 — cancelled
- `32976436209` — #1470 — cancelled

Three consecutive main runs discarded, and the fix in #1469 sat merged but unreleased for over an hour because the run that would have regenerated the Version Packages PR never got to execute.

## What changed

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Latest wins outright. The newest run carries every commit that came before it, so cancelling an older one loses no coverage and no changeset — whatever the discarded run would have released, the newer one releases instead.

## The residual window

Worth being explicit about, since it is the one thing this trades away: a run cancelled part-way through `yarn release` can leave some packages published at the new version and others not. `cancel-in-progress` cannot distinguish a publish from a test job.

Closing that properly means giving `release` a workflow of its own, with a concurrency group that never cancels, triggered off the CI workflow completing. That is a larger change and is deliberately not part of this PR.

Paired with #1478, which took the ~100-job verifier and template matrices off the release critical path — that shortens each run, this stops runs being discarded before they start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbD1Nm6beyHkCB8qujxcLw
