### PR TITLE
fix(console): keep the scenario step panel working outside its surface

### DIFF
--- a/.changeset/sour-donkeys-invite.md
+++ b/.changeset/sour-donkeys-invite.md
@@ -1,0 +1,5 @@
+---
+'@pikku/console': patch
+---
+
+Fix the scenarios step panel throwing `useWorkflowContext must be used within WorkflowProvider` when a host mounts the panel container outside the surface that opened it. The step's workflow meta now travels on the panel data, and `ScenarioStepPanel` mounts its own provider from it, falling back to an ambient one.

--- a/packages/console/src/components/scenarios/ScenarioStepPanel.tsx
+++ b/packages/console/src/components/scenarios/ScenarioStepPanel.tsx
@@ -10,7 +10,11 @@ import {
   WorkflowStepConfiguration,
 } from '../project/panels/WorkflowStepPanels'
 import { ScenarioStepCode } from './ScenarioStepCode'
-import { useWorkflowNode } from '../../context/WorkflowContext'
+import {
+  useWorkflowContextSafe,
+  useWorkflowNode,
+  WorkflowProvider,
+} from '../../context/WorkflowContext'
 import { usePanelContext } from '../../context/PanelContext'
 
 const PHASE_LABEL: Record<string, () => string> = {
@@ -27,6 +31,7 @@ type ScenarioStepPanelProps = {
     actor?: string
     actorName?: string
     stepName?: string
+    workflow?: unknown
   }
 }
 
@@ -34,8 +39,25 @@ type ScenarioStepPanelProps = {
  * A scenario step read as a step: the sentence it was written as, the phase it
  * runs in and the actor it runs as — with the scenario step behind it named,
  * rather than the generic `rpc` a workflow node would show.
+ *
+ * The workflow meta travels on the panel data rather than being read off an
+ * ambient provider, because a host mounts the panel container wherever it
+ * likes — the Fabric console docks it on the end edge, a sibling of the
+ * surface that opened it, so that surface's provider is not above this.
  */
 export const ScenarioStepPanel: React.FC<ScenarioStepPanelProps> = ({
+  stepId,
+  metadata,
+}) => {
+  const ambient = useWorkflowContextSafe()
+  return (
+    <WorkflowProvider workflow={metadata.workflow ?? ambient?.workflow}>
+      <ScenarioStepBody stepId={stepId} metadata={metadata} />
+    </WorkflowProvider>
+  )
+}
+
+const ScenarioStepBody: React.FC<ScenarioStepPanelProps> = ({
   stepId,
   metadata,
 }) => {

--- a/packages/console/src/components/scenarios/ScenariosWorkspace.tsx
+++ b/packages/console/src/components/scenarios/ScenariosWorkspace.tsx
@@ -85,7 +85,8 @@ export const ScenariosWorkspace: React.FC<ScenariosWorkspaceProps> = ({
 
   return (
     /* the provider sits above the panel so a step's details can read its own
-       scenario's workflow meta, not just the document's */
+       scenario's workflow meta, not just the document's — a host that mounts
+       the panel outside this tree reads the same meta off the panel data */
     <WorkflowProvider workflow={stepWorkflow}>
       <ResizablePanelLayout
         header={
@@ -141,7 +142,11 @@ export const ScenariosWorkspace: React.FC<ScenariosWorkspaceProps> = ({
             onOpenPersona={showPersona}
             onSelectStep={(workflow, stepId, stepType, metadata) => {
               setStepWorkflow(workflow)
-              openWorkflowStep(stepId, stepType, { ...metadata, stepType })
+              openWorkflowStep(stepId, stepType, {
+                ...metadata,
+                stepType,
+                workflow,
+              })
             }}
           />
         ) : (


### PR DESCRIPTION
## Issue

Opening a scenario step in the Fabric console's scenarios screen blows the panel up with:

```
useWorkflowContext must be used within WorkflowProvider
```

`ScenariosWorkspace` mounts `WorkflowProvider` around its own layout, but a host is free to mount the panel container elsewhere — the Fabric console docks it on the end edge, a **sibling** of the screen that opened it. `ScenarioStepPanel` (and the `WorkflowStepInput` / `WorkflowStepOutput` / `WorkflowStepConfiguration` sections it renders) then read a context that is not above them.

## Fix

The step's workflow meta travels on the panel data instead of relying on where the host puts the panel:

- `ScenariosWorkspace` passes `workflow` in the metadata it hands to `openWorkflowStep`.
- `ScenarioStepPanel` mounts its own `WorkflowProvider` from that metadata, falling back to an ambient provider so the graph surface is unchanged.

## Test plan

- `tsc` on `packages/console` is clean apart from two pre-existing errors (`assistant-ui` `useComposerRuntime`, `vite.config.ts` stack depth).
- Verified against the Fabric console's `HostedConsoleScreen`, which is the host that mounts `PanelContainer` as a sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)