### PR TITLE
feat(cli): add `fabric projects` to list projects and their ids

### DIFF
--- a/.changeset/cyan-pugs-listen.md
+++ b/.changeset/cyan-pugs-listen.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': minor
+---
+
+Add `pikku fabric projects`, listing the projects in your organization with their ids. The fabric API already exposed `fabricCliProjects`; no command called it, so a project's id was reachable only through the web console — and a checkout whose `pikkufabric.config.json` still held the `__PROJECT_ID__` placeholder could run no other fabric command to recover it. `fabric init` was no help either: it only creates, so against a project that already exists it fails with a 409 carrying no id. Projects matching the local config are marked.

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -38,6 +38,10 @@ import {
   renderDeployUnits,
 } from './functions/deploy-units.function.js'
 import { FabricStatus, renderStatus } from './functions/status.function.js'
+import {
+  FabricProjectsList,
+  renderProjectsList,
+} from './functions/projects-list.function.js'
 import { FabricErrors, renderErrors } from './functions/errors.function.js'
 import {
   FabricDbSchema,
@@ -361,6 +365,12 @@ export const fabricCommands = defineCLICommands({
     func: FabricStatus,
     render: renderStatus,
     description: 'Show the linked project status (active + in-flight deploy)',
+  }),
+  projects: pikkuCLICommand({
+    func: FabricProjectsList,
+    render: renderProjectsList,
+    description:
+      'List the projects in your organization, with their ids (works unlinked)',
   }),
   errors: pikkuCLICommand({
     func: FabricErrors,

--- a/packages/cli/src/fabric/functions/projects-list.function.ts
+++ b/packages/cli/src/fabric/functions/projects-list.function.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod'
+import { pikkuSessionlessFunc } from '../../../.pikku/function/index.js'
+import { findProjectConfig, resolveApiContext } from '../lib/config.js'
+import { getFabricRPC } from '../lib/http.js'
+import { dim } from '../lib/output.js'
+
+export const FabricProjectsListInput = z.object({
+  apiUrl: z.string().optional(),
+})
+
+export const FabricProjectsListOutput = z.object({
+  projects: z.array(
+    z.object({
+      projectId: z.string(),
+      name: z.string(),
+      slug: z.string(),
+      status: z.string(),
+      productionBranch: z.string(),
+      gitRepoUrl: z.string().nullable(),
+      createdAt: z.string(),
+      linked: z.boolean(),
+    })
+  ),
+})
+
+/**
+ * The only fabric command that does not need a linked project, which is the
+ * point of it: a checkout whose config still holds `__PROJECT_ID__` can run
+ * nothing else, and `fabric init` cannot recover the id either — it creates,
+ * so against an existing project it fails with a 409 that carries no id.
+ */
+export const FabricProjectsList = pikkuSessionlessFunc({
+  description: 'List the projects in your organization.',
+  input: FabricProjectsListInput,
+  output: FabricProjectsListOutput,
+  func: async (_services, { apiUrl: apiUrlOverride }) => {
+    const ctx = await resolveApiContext({ apiUrlOverride })
+    if (!ctx.token)
+      throw new Error('Not logged in. Run `pikku fabric login` first.')
+
+    const rpc = getFabricRPC({ apiUrl: ctx.apiUrl, token: ctx.token })
+    const { projects } = await rpc.invoke('fabricCliProjects', {})
+
+    const local = await findProjectConfig()
+    const linkedId = local?.config.projectId
+
+    return {
+      projects: projects.map((project) => ({
+        ...project,
+        linked: linkedId !== undefined && project.projectId === linkedId,
+      })),
+    }
+  },
+})
+
+type FabricProject = {
+  projectId: string
+  name: string
+  gitRepoUrl: string | null
+  linked: boolean
+}
+
+export const renderProjectsList = (
+  _s: unknown,
+  { projects }: { projects: FabricProject[] }
+): void => {
+  console.log('')
+  if (projects.length === 0) {
+    console.log(
+      dim('  No projects yet. Run `pikku fabric link` to create one.')
+    )
+    console.log('')
+    return
+  }
+
+  const width = Math.max(...projects.map((p) => p.name.length))
+  for (const project of projects) {
+    console.log(
+      `  ${project.linked ? '*' : ' '} ${project.name.padEnd(width)}  ${project.projectId}  ${dim(
+        project.gitRepoUrl ?? 'no repo'
+      )}`
+    )
+  }
+  console.log('')
+  if (projects.some((p) => p.linked)) {
+    console.log(dim('  * this checkout'))
+    console.log('')
+  }
+}


### PR DESCRIPTION
Adds `pikku fabric projects`.

The fabric API already exposes `fabricCliProjects`, but no CLI command called it, so a project's id was reachable only through the web console. That leaves a real dead end: a checkout whose `pikkufabric.config.json` still holds the `__PROJECT_ID__` placeholder can run no other fabric command to recover it, and `fabric init` is no help — it only creates, so against a project that already exists it fails with a 409 carrying no id.

This is therefore the one command in the group that deliberately does not require a linked project. It marks projects matching the local config with `*` so "which of these is the repo I'm standing in" doesn't have to be answered by reading uuids by eye.

```
  * nodejs-meetup            9bffdc7a-…  https://github.com/pikkujs/nodejs-meetup
    aws-console-diagnostics  16814579-…  https://github.com/vlandor/aws-console-diagnostics
    houseshare               01dccbe0-…  https://github.com/vlandor/houseshare

  * this checkout
```

Pure CLI change; no server work. Verified against a live account — the listing above is real output, and pasting the id into a placeholder config made `pikku fabric status` resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)