### PR TITLE
test(e2e): assert the ladder prose #1472 actually renders

### DIFF
--- a/e2e/tests/cli/scenario-run.test.ts
+++ b/e2e/tests/cli/scenario-run.test.ts
@@ -127,8 +127,18 @@ describe('pikku scenario run', () => {
     assertAllPassed(run)
     assert.match(
       run.output,
-      /^\s*When\s+the admin reads a function definition in the console\s+✓/m,
-      `expected the step ladder to render the declared prose:\n${run.output}`
+      /^\s*When\s+admin \(the Console administrator\) reads a function definition in the console\s+✓/m,
+      `expected the first mention to name the actor and their role:\n${run.output}`
+    )
+    assert.match(
+      run.output,
+      /^\s*Then\s+admin sees how editableFunc is declared\s+✓/m,
+      `expected a phase change to name the actor again, without the role:\n${run.output}`
+    )
+    assert.match(
+      run.output,
+      /^\s*And\s+sees the original greeting\s+✓/m,
+      `expected a repeated phase and actor to drop both:\n${run.output}`
     )
   })
 


### PR DESCRIPTION
`E2E CLI` has been red on `main` and therefore on **every open PR** — one test, `declared steps render a readable ladder`.

#1472 deliberately changed how the step ladder reads. The subject is now the actor key verbatim, with the role as an apposition on first mention only; a phase change re-names the actor without the role; a repeated phase *and* actor drop both:

```
When  admin (the Console administrator) reads a function definition in the console  ✓
Then  admin sees how editableFunc is declared                                       ✓
And   sees the original greeting                                                    ✓
```

The e2e assertion still expected the old `the admin ...` form, so it has failed on every run since that merge.

This asserts the three renderings the change actually introduced, rather than re-pinning a single string — a regression in any one of the paragraph rules now fails the test.

Note: the `Templates (24, ai-postgres, …)` failures on some PRs are unrelated and not a code issue — the CI OpenAI key is out of credits (`AI_APICallError: You have no credits remaining`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end coverage to reflect the latest readable step-ladder output.
  * Verified actor role labels, repeated actor and phase handling, and phase transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->