### PR TITLE
feat(console): the selected row lives in the URL

### DIFF
--- a/.changeset/selection-lives-in-the-url.md
+++ b/.changeset/selection-lives-in-the-url.md
@@ -1,0 +1,36 @@
+---
+'@pikku/console': patch
+---
+
+feat(console): the selected row lives in the URL
+
+Opening a row put the inspector's contents in React state and nowhere else, so
+a selection was gone the moment you reloaded, followed a link out and came
+back, or tried to send someone the thing you were looking at — `/functions` was
+the only address the functions page ever had, whichever function was open.
+
+The panel context now writes whatever is selected into the URL fragment and
+reads it back. A surface with one list writes the bare id — `/functions#getUser`,
+`/apis?tab=channels#events` — and one with several qualifies it, as
+`/jobs?tab=triggers#triggerSource:orderPlaced`, because there an id alone would
+not say which list owns it. Fragments are written with `replaceState`: the URL
+always describes the selection, but scanning a list does not fill the back
+stack.
+
+Restoring is the list's job rather than the provider's, because a panel renders
+from the metadata captured when it opened and only the list that fetched a row
+holds it. `usePanelUrl` is what a list registers with — it names the panel type,
+the rows, and how to open one — and it reopens whatever the fragment names as
+soon as the rows have loaded. Registered: functions, HTTP routes, MCP
+tools, gateways, schedulers, queues, triggers and their sources, middleware,
+permissions, secrets, variables and credential users.
+
+Channels are not panels but now address themselves the same way, and their row
+is two levels deep, so the fragment names both: `#chat` for the channel,
+`#chat/connect` for one of its handlers, `#chat/messages/send` for one action.
+The open channel moves out of `?id=`, which is still read so older links keep
+working. Switching tab on a tabbed surface drops the fragment, since a row in
+the tab you left is not on screen in the one you arrive at.
+
+`panelHref(type, id)` builds a link that opens a row on the page that owns its
+type, so one surface can point at a row on another and land with it selected.

--- a/packages/console/src/components/channel/ChannelNavTree.tsx
+++ b/packages/console/src/components/channel/ChannelNavTree.tsx
@@ -11,10 +11,8 @@ import { ChevronDown, ChevronRight } from 'lucide-react'
 import type { ChannelMeta } from '@pikku/core/channel'
 import styles from '../ui/console.module.css'
 
-export type ChannelSelection =
-  | { type: 'handler'; handler: string }
-  | { type: 'action'; category: string; action: string }
-  | null
+export type { ChannelSelection } from './channel-selection'
+import type { ChannelSelection } from './channel-selection'
 
 interface ChannelNavTreeProps {
   channelName: string

--- a/packages/console/src/components/channel/channel-selection.test.ts
+++ b/packages/console/src/components/channel/channel-selection.test.ts
@@ -1,0 +1,46 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { formatChannelRoute, parseChannelRoute } from './channel-selection.js'
+
+describe('channel routes in the fragment', () => {
+  test('a channel on its own', () => {
+    assert.deepEqual(parseChannelRoute('chat'), {
+      channelName: 'chat',
+      selected: null,
+    })
+    assert.equal(
+      formatChannelRoute({ channelName: 'chat', selected: null }),
+      'chat'
+    )
+  })
+
+  test('a handler inside a channel', () => {
+    const route = parseChannelRoute('chat/connect')
+    assert.deepEqual(route, {
+      channelName: 'chat',
+      selected: { type: 'handler', handler: 'connect' },
+    })
+    assert.equal(formatChannelRoute(route!), 'chat/connect')
+  })
+
+  test('an action inside a channel', () => {
+    const route = parseChannelRoute('chat/messages/send')
+    assert.deepEqual(route, {
+      channelName: 'chat',
+      selected: { type: 'action', category: 'messages', action: 'send' },
+    })
+    assert.equal(formatChannelRoute(route!), 'chat/messages/send')
+  })
+
+  test('a link from another page arrives type-qualified', () => {
+    assert.deepEqual(parseChannelRoute('channel:chat/connect'), {
+      channelName: 'chat',
+      selected: { type: 'handler', handler: 'connect' },
+    })
+  })
+
+  test('a fragment belonging to another list is not a channel route', () => {
+    assert.equal(parseChannelRoute('function:getUser'), null)
+    assert.equal(parseChannelRoute(''), null)
+  })
+})

--- a/packages/console/src/components/channel/channel-selection.ts
+++ b/packages/console/src/components/channel/channel-selection.ts
@@ -1,0 +1,49 @@
+import { decodePanelHash } from '../../lib/panel-url'
+
+export type ChannelSelection =
+  | { type: 'handler'; handler: string }
+  | { type: 'action'; category: string; action: string }
+  | null
+
+export interface ChannelRoute {
+  channelName: string
+  selected: ChannelSelection
+}
+
+/**
+ * The channels tab addresses itself the same way every other list does — the
+ * open row in the fragment — but its row is two levels deep, so the fragment
+ * names both: `#chat` for the channel, `#chat/connect` for one of its handlers,
+ * `#chat/messages/send` for one action. A `channel:` prefix is accepted so a
+ * link built by `panelHref` from another page lands here.
+ */
+export const parseChannelRoute = (hash: string): ChannelRoute | null => {
+  const target = decodePanelHash(hash)
+  if (!target || (target.type && target.type !== 'channel')) return null
+  const [channelName, ...rest] = target.id.split('/')
+  if (!channelName) return null
+  if (rest.length === 1) {
+    return { channelName, selected: { type: 'handler', handler: rest[0]! } }
+  }
+  if (rest.length === 2) {
+    return {
+      channelName,
+      selected: { type: 'action', category: rest[0]!, action: rest[1]! },
+    }
+  }
+  return { channelName, selected: null }
+}
+
+export const formatChannelRoute = ({
+  channelName,
+  selected,
+}: ChannelRoute): string => {
+  if (!channelName) return ''
+  if (selected?.type === 'handler') {
+    return `${channelName}/${selected.handler}`
+  }
+  if (selected?.type === 'action') {
+    return `${channelName}/${selected.category}/${selected.action}`
+  }
+  return channelName
+}

--- a/packages/console/src/components/console/TabbedSurface.tsx
+++ b/packages/console/src/components/console/TabbedSurface.tsx
@@ -3,6 +3,7 @@ import { Group, SegmentedControl, Stack, TextInput } from '@pikku/mantine/core'
 import { Search } from 'lucide-react'
 import type { I18nNode, I18nString } from '@pikku/react'
 import { useSearchParams } from '../../router'
+import { setUrlHash } from '../../hooks/useUrlHash'
 import { ConsoleSurface } from './ConsoleSurface'
 import { ResizablePanelLayout } from '../layout/ResizablePanelLayout'
 import { ListPageHeader } from '../layout/PageLayout'
@@ -93,6 +94,10 @@ export const TabbedSurface: React.FC<TabbedSurfaceProps> = (props) => {
 
   const handleTabChange = (value: string) => {
     setSearchQuery('')
+    // The fragment names a row in the tab being left; it means nothing in the
+    // next one, and leaving it there would have the URL describe a selection
+    // that is not on screen.
+    setUrlHash('')
     if (onTabChange) {
       onTabChange(value)
       return

--- a/packages/console/src/components/functions/FunctionsListPanel.tsx
+++ b/packages/console/src/components/functions/FunctionsListPanel.tsx
@@ -5,6 +5,7 @@ import { asI18n } from '@pikku/react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
 import { TableListPage } from '../layout/TableListPage'
 import { funcWrapperDefs } from '../ui/badge-defs'
@@ -80,6 +81,18 @@ export const FunctionsListPanel: React.FC<FunctionsListPanelProps> = ({
     searchQuery,
     showPikkuFunctions
   )
+  const allFunctions = useMemo(
+    () => (rawFunctions ?? []) as any[],
+    [rawFunctions]
+  )
+
+  usePanelUrl({
+    type: 'function',
+    items: allFunctions,
+    getId: (func: any) => func.pikkuFuncName || func.pikkuFuncId,
+    open: openFunction,
+  })
+
   const hasTestsColumn = useMemo(
     () => !!testsByFunction || functions.some((func: any) => !!func.tests),
     [functions, testsByFunction]

--- a/packages/console/src/components/http/HttpListPanel.tsx
+++ b/packages/console/src/components/http/HttpListPanel.tsx
@@ -5,6 +5,7 @@ import { asI18n } from '@pikku/react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { useHttpItems } from '../../hooks/useHttpItems'
 import { TableListPage } from '../layout/TableListPage'
 import { PikkuBadge } from '../ui/PikkuBadge'
@@ -26,6 +27,13 @@ export const HttpListPanel: React.FC<HttpListPanelProps> = ({
   const { openHTTPWire } = usePanelContext()
   useLocale()
   const { items: routes, loading } = useHttpItems()
+
+  usePanelUrl({
+    type: 'http',
+    items: routes,
+    getId: (route: any) => `http::${route.method}::${route.route}`,
+    open: openHTTPWire,
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/mcp/McpListPanel.tsx
+++ b/packages/console/src/components/mcp/McpListPanel.tsx
@@ -5,6 +5,7 @@ import { asI18n } from '@pikku/react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { useMcpItems } from '../../hooks/useMcpItems'
 import { TableListPage } from '../layout/TableListPage'
 import { PikkuBadge } from '../ui/PikkuBadge'
@@ -33,6 +34,13 @@ export const McpListPanel: React.FC<McpListPanelProps> = ({
     if (filter === 'all') return items
     return items.filter((item) => item.method === filter)
   }, [items, filter])
+
+  usePanelUrl({
+    type: 'mcp',
+    items,
+    getId: (item: any) => `mcp::${item.method}::${item.wireId || item.name}`,
+    open: openMCP,
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/middleware/MiddlewareListPanel.tsx
+++ b/packages/console/src/components/middleware/MiddlewareListPanel.tsx
@@ -5,6 +5,7 @@ import { asI18n } from '@pikku/react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import {
   useMiddlewareItems,
   type MiddlewareItem,
@@ -30,6 +31,13 @@ export const MiddlewareListPanel: React.FC<MiddlewareListPanelProps> = ({
   const { openMiddleware } = usePanelContext()
   useLocale()
   const { items, loading } = useMiddlewareItems()
+
+  usePanelUrl({
+    type: 'middleware',
+    items,
+    getId: (item) => item.id,
+    open: (id, item) => openMiddleware(id, item.data),
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/permissions/PermissionsListPanel.tsx
+++ b/packages/console/src/components/permissions/PermissionsListPanel.tsx
@@ -5,6 +5,7 @@ import { asI18n } from '@pikku/react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import {
   usePermissionItems,
   type PermissionItem,
@@ -30,6 +31,13 @@ export const PermissionsListPanel: React.FC<PermissionsListPanelProps> = ({
   const { openPermission } = usePanelContext()
   useLocale()
   const { items, loading } = usePermissionItems()
+
+  usePanelUrl({
+    type: 'permission',
+    items,
+    getId: (item) => item.id,
+    open: (id, item) => openPermission(id, item.data),
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/project/ProjectFunctions.tsx
+++ b/packages/console/src/components/project/ProjectFunctions.tsx
@@ -3,6 +3,7 @@ import { Text, Group } from '@pikku/mantine/core'
 import { asI18n } from '@pikku/react'
 import { FunctionSquare } from 'lucide-react'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
 import { TableListPage } from '../layout/TableListPage'
 import { PikkuBadge } from '../ui/PikkuBadge'
@@ -31,6 +32,13 @@ export const ProjectFunctions: React.FC<ProjectFunctionsProps> = ({
       )
     })
   }, [functions])
+
+  usePanelUrl({
+    type: 'function',
+    items: functions,
+    getId: (func: any) => func.pikkuFuncName || func.pikkuFuncId,
+    open: openFunction,
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/project/ProjectSecrets.tsx
+++ b/packages/console/src/components/project/ProjectSecrets.tsx
@@ -3,6 +3,7 @@ import { Text, Group } from '@pikku/mantine/core'
 import { asI18n } from '@pikku/react'
 import { KeyRound } from 'lucide-react'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { TableListPage } from '../layout/TableListPage'
 import { PikkuBadge } from '../ui/PikkuBadge'
 
@@ -29,6 +30,14 @@ export const ProjectSecrets: React.FC<ProjectSecretsProps> = ({
   emptyHero,
 }) => {
   const { openSecret } = usePanelContext()
+
+  usePanelUrl({
+    type: 'secret',
+    items: secrets,
+    getId: (secret) => secret.name,
+    open: (id, secret) =>
+      openSecret(id, { ...(secret.rawData ?? secret), installed }),
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/project/ProjectVariables.tsx
+++ b/packages/console/src/components/project/ProjectVariables.tsx
@@ -3,6 +3,7 @@ import { Text } from '@pikku/mantine/core'
 import { asI18n } from '@pikku/react'
 import { Settings2 } from 'lucide-react'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { TableListPage } from '../layout/TableListPage'
 
 export interface VariableMeta {
@@ -27,6 +28,14 @@ export const ProjectVariables: React.FC<ProjectVariablesProps> = ({
   emptyHero,
 }) => {
   const { openVariable } = usePanelContext()
+
+  usePanelUrl({
+    type: 'variable',
+    items: variables,
+    getId: (variable) => variable.name,
+    open: (id, variable) =>
+      openVariable(id, { ...(variable.rawData ?? variable), installed }),
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/queues/QueuesListPanel.tsx
+++ b/packages/console/src/components/queues/QueuesListPanel.tsx
@@ -5,6 +5,7 @@ import { asI18n } from '@pikku/react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { useQueueItems, type QueueItem } from '../../hooks/useQueueItems'
 import { TableListPage } from '../layout/TableListPage'
 import { PikkuBadge } from '../ui/PikkuBadge'
@@ -26,6 +27,13 @@ export const QueuesListPanel: React.FC<QueuesListPanelProps> = ({
   const { openQueue } = usePanelContext()
   useLocale()
   const { items, loading } = useQueueItems()
+
+  usePanelUrl({
+    type: 'queue',
+    items,
+    getId: (item) => item.name,
+    open: (id, item) => openQueue(id, item.data),
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/schedulers/SchedulersListPanel.tsx
+++ b/packages/console/src/components/schedulers/SchedulersListPanel.tsx
@@ -5,6 +5,7 @@ import { asI18n } from '@pikku/react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import {
   useSchedulerItems,
   type SchedulerItem,
@@ -29,6 +30,13 @@ export const SchedulersListPanel: React.FC<SchedulersListPanelProps> = ({
   const { openScheduler } = usePanelContext()
   useLocale()
   const { items, loading } = useSchedulerItems()
+
+  usePanelUrl({
+    type: 'scheduler',
+    items,
+    getId: (item) => item.name,
+    open: (id, item) => openScheduler(id, item.data),
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/tabs/ChannelTabContent.tsx
+++ b/packages/console/src/components/tabs/ChannelTabContent.tsx
@@ -1,5 +1,11 @@
-import React, { useState, useCallback } from 'react'
-import { useSearchParams, useNavigate } from '../../router'
+import React, { useCallback, useEffect, useMemo } from 'react'
+import { useSearchParams } from '../../router'
+import { useUrlHash } from '../../hooks/useUrlHash'
+import { encodePanelHash } from '../../lib/panel-url'
+import {
+  formatChannelRoute,
+  parseChannelRoute,
+} from '../channel/channel-selection'
 import { Radio } from 'lucide-react'
 import { EmptyStatePlaceholder } from '../layout/EmptyStatePlaceholder'
 import { ConsoleSurface } from '../console/ConsoleSurface'
@@ -20,15 +26,36 @@ const ChannelTabInner: React.FC<{
   allChannelsMeta: Record<string, ChannelMeta>
   searchQuery: string
 }> = ({ channelName, channelMeta, allChannelsMeta, searchQuery }) => {
-  const navigate = useNavigate()
-  const [selected, setSelected] = useState<ChannelSelection>(null)
+  const [hash, setHash] = useUrlHash()
 
-  const handleChannelSwitch = useCallback(
-    (name: string) => {
-      setSelected(null)
-      navigate(`/apis?tab=channels&id=${encodeURIComponent(name)}`)
+  const selected = useMemo(
+    () => parseChannelRoute(hash)?.selected ?? null,
+    [hash]
+  )
+
+  const writeRoute = useCallback(
+    (name: string, next: ChannelSelection) => {
+      setHash(
+        encodePanelHash(
+          'channel',
+          formatChannelRoute({ channelName: name, selected: next }),
+          true
+        ) ?? ''
+      )
     },
-    [navigate]
+    [setHash]
+  )
+
+  const handleSelect = useCallback(
+    (next: ChannelSelection) => writeRoute(channelName, next),
+    [channelName, writeRoute]
+  )
+
+  // Switching channel drops the handler selected in the old one — the fragment
+  // names a row inside a channel, and that row does not exist in the next.
+  const handleChannelSwitch = useCallback(
+    (name: string) => writeRoute(name, null),
+    [writeRoute]
   )
 
   return (
@@ -40,7 +67,7 @@ const ChannelTabInner: React.FC<{
           channel={channelMeta}
           allChannelsMeta={allChannelsMeta}
           selected={selected}
-          onSelect={setSelected}
+          onSelect={handleSelect}
           onChannelSwitch={handleChannelSwitch}
           searchQuery={searchQuery}
         />
@@ -66,15 +93,36 @@ export const ChannelTabContent: React.FC<ChannelTabContentProps> = ({
   searchQuery,
   emptyHero,
 }) => {
+  const [hash, setHash] = useUrlHash()
   const [searchParams] = useSearchParams()
-  const channelName = searchParams.get('id') || ''
   const { meta } = usePikkuMeta()
   useLocale()
 
+  // `?id=` is where the open channel used to live; still read so links written
+  // before it moved into the fragment keep working.
+  const channelName =
+    parseChannelRoute(hash)?.channelName || searchParams.get('id') || ''
   const allChannelsMeta = meta.channelsMeta || {}
   const channelNames = Object.keys(allChannelsMeta)
   const resolvedName = channelName || channelNames[0] || ''
   const channelMeta = allChannelsMeta[resolvedName]
+
+  // The tab opens on the first channel when nothing names one, and a link from
+  // another page arrives type-qualified. Either way the fragment is rewritten
+  // to what this page writes itself, so the address always describes the screen.
+  useEffect(() => {
+    if (!channelMeta) return
+    const canonical =
+      encodePanelHash(
+        'channel',
+        formatChannelRoute({
+          channelName: resolvedName,
+          selected: parseChannelRoute(hash)?.selected ?? null,
+        }),
+        true
+      ) ?? ''
+    if (canonical !== hash) setHash(canonical)
+  }, [channelMeta, hash, resolvedName, setHash])
 
   if (!channelMeta) {
     return (

--- a/packages/console/src/components/tabs/CredentialUsersTab.tsx
+++ b/packages/console/src/components/tabs/CredentialUsersTab.tsx
@@ -5,6 +5,7 @@ import { EmptyStatePlaceholder } from '../layout/EmptyStatePlaceholder'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
 import { usePikkuRPC } from '../../context/PikkuRpcProvider'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { useQuery } from '@tanstack/react-query'
 import { TableListPage } from '../layout/TableListPage'
 import { asI18n } from '@pikku/react'
@@ -87,6 +88,21 @@ export const CredentialUsersTab: React.FC<{ searchQuery?: string }> = ({
     const q = searchQuery.toLowerCase()
     return allRows.filter((row) => row.userId.toLowerCase().includes(q))
   }, [allRows, searchQuery])
+
+  usePanelUrl({
+    type: 'credentialUser',
+    items: allRows,
+    getId: (row) => row.userId,
+    open: (id, row) =>
+      openCredentialUser(id, {
+        credentials: row.credentials,
+        credentialsMeta: perUserCredentials.map((c) => ({
+          name: c.name,
+          displayName: c.displayName,
+          isOAuth2: c.isOAuth2,
+        })),
+      }),
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/tabs/GatewaysTab.tsx
+++ b/packages/console/src/components/tabs/GatewaysTab.tsx
@@ -3,6 +3,7 @@ import { Group, Text } from '@pikku/mantine/core'
 import { Network } from 'lucide-react'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { TableListPage } from '../layout/TableListPage'
 import { PikkuBadge } from '../ui/PikkuBadge'
 import { asI18n } from '@pikku/react'
@@ -25,6 +26,13 @@ export const GatewaysTab: React.FC<GatewaysTabProps> = ({
       .filter((gateway: any) => gateway.enabled !== false)
       .sort((a: any, b: any) => a.name.localeCompare(b.name))
   }, [meta.gatewayMeta])
+
+  usePanelUrl({
+    type: 'gateway',
+    items: gateways,
+    getId: (gateway: any) => gateway.name,
+    open: openGateway,
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/tabs/HttpTab.tsx
+++ b/packages/console/src/components/tabs/HttpTab.tsx
@@ -3,6 +3,7 @@ import { Text, Group } from '@pikku/mantine/core'
 import { Globe } from 'lucide-react'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { TableListPage } from '../layout/TableListPage'
 import { PikkuBadge } from '../ui/PikkuBadge'
 import { m } from '@/i18n/messages'
@@ -21,6 +22,13 @@ export const HttpTab: React.FC<HttpTabProps> = ({ searchQuery, emptyHero }) => {
       a.route.localeCompare(b.route)
     )
   }, [meta.httpMeta])
+
+  usePanelUrl({
+    type: 'http',
+    items: routes,
+    getId: (route: any) => `http::${route.method}::${route.route}`,
+    open: openHTTPWire,
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/tabs/McpTab.tsx
+++ b/packages/console/src/components/tabs/McpTab.tsx
@@ -3,6 +3,7 @@ import { Text } from '@pikku/mantine/core'
 import { Cpu } from 'lucide-react'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { TableListPage } from '../layout/TableListPage'
 import { PikkuBadge } from '../ui/PikkuBadge'
 import { m } from '@/i18n/messages'
@@ -21,6 +22,13 @@ export const McpTab: React.FC<McpTabProps> = ({ searchQuery, emptyHero }) => {
       (a.name || '').localeCompare(b.name || '')
     )
   }, [meta.mcpMeta])
+
+  usePanelUrl({
+    type: 'mcp',
+    items,
+    getId: (item: any) => `mcp::${item.method}::${item.wireId || item.name}`,
+    open: openMCP,
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/tabs/MiddlewareTab.tsx
+++ b/packages/console/src/components/tabs/MiddlewareTab.tsx
@@ -3,6 +3,7 @@ import { Text, Group } from '@pikku/mantine/core'
 import { Layers } from 'lucide-react'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { TableListPage } from '../layout/TableListPage'
 import { PikkuBadge } from '../ui/PikkuBadge'
 import { asI18n } from '@pikku/react'
@@ -46,6 +47,13 @@ export const MiddlewareTab: React.FC<{ searchQuery: string }> = ({
         item.data?.description?.toLowerCase().includes(q)
     )
   }, [allItems, searchQuery])
+
+  usePanelUrl({
+    type: 'middleware',
+    items: allItems,
+    getId: (item) => item.id,
+    open: (id, item) => openMiddleware(id, item.data),
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/tabs/PermissionsTab.tsx
+++ b/packages/console/src/components/tabs/PermissionsTab.tsx
@@ -3,6 +3,7 @@ import { Text, Group } from '@pikku/mantine/core'
 import { Shield } from 'lucide-react'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { TableListPage } from '../layout/TableListPage'
 import { PikkuBadge } from '../ui/PikkuBadge'
 import { asI18n } from '@pikku/react'
@@ -46,6 +47,13 @@ export const PermissionsTab: React.FC<{ searchQuery: string }> = ({
         item.data?.description?.toLowerCase().includes(q)
     )
   }, [allItems, searchQuery])
+
+  usePanelUrl({
+    type: 'permission',
+    items: allItems,
+    getId: (item) => item.id,
+    open: (id, item) => openPermission(id, item.data),
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/tabs/QueuesTab.tsx
+++ b/packages/console/src/components/tabs/QueuesTab.tsx
@@ -4,6 +4,7 @@ import { ListOrdered } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { usePikkuRPC } from '../../context/PikkuRpcProvider'
 import { TableListPage } from '../layout/TableListPage'
 import { asI18n } from '@pikku/react'
@@ -50,6 +51,13 @@ export const QueuesTab: React.FC<{
         item.pikkuFuncId?.toLowerCase().includes(q)
     )
   }, [allItems, searchQuery])
+
+  usePanelUrl({
+    type: 'queue',
+    items: allItems,
+    getId: (item: any) => item.wireId || item.name,
+    open: openQueue,
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/tabs/SchedulersTab.tsx
+++ b/packages/console/src/components/tabs/SchedulersTab.tsx
@@ -4,6 +4,7 @@ import { Clock } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { usePikkuRPC } from '../../context/PikkuRpcProvider'
 import { TableListPage } from '../layout/TableListPage'
 import { asI18n } from '@pikku/react'
@@ -88,6 +89,13 @@ export const SchedulersTab: React.FC<{
         item.schedule?.toLowerCase().includes(q)
     )
   }, [allItems, searchQuery])
+
+  usePanelUrl({
+    type: 'scheduler',
+    items: allItems,
+    getId: (item: any) => item.wireId || item.name,
+    open: openScheduler,
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/components/tabs/TriggersTab.tsx
+++ b/packages/console/src/components/tabs/TriggersTab.tsx
@@ -3,6 +3,7 @@ import { Text, Badge } from '@pikku/mantine/core'
 import { Zap } from 'lucide-react'
 import { usePikkuMeta } from '../../context/PikkuMetaContext'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { TableListPage } from '../layout/TableListPage'
 import { asI18n } from '@pikku/react'
 import { m } from '@/i18n/messages'
@@ -101,6 +102,13 @@ export const TriggersTab: React.FC<{
         p.trigger?.pikkuFuncId?.toLowerCase().includes(q)
     )
   }, [allPairs, searchQuery])
+
+  usePanelUrl({
+    type: 'trigger',
+    items: allPairs,
+    getId: (pair) => pair.name,
+    open: (id, pair) => openTrigger(id, pair.trigger),
+  })
 
   return (
     <TableListPage

--- a/packages/console/src/components/triggers/TriggersListPanel.tsx
+++ b/packages/console/src/components/triggers/TriggersListPanel.tsx
@@ -5,6 +5,7 @@ import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { Zap } from 'lucide-react'
 import { usePanelContext } from '../../context/PanelContext'
+import { usePanelUrl } from '../../hooks/usePanelUrl'
 import { useTriggerItems, type TriggerPair } from '../../hooks/useTriggerItems'
 import { TableListPage } from '../layout/TableListPage'
 import { PikkuBadge } from '../ui/PikkuBadge'
@@ -27,6 +28,19 @@ export const TriggersListPanel: React.FC<TriggersListPanelProps> = ({
   const { openTriggerSource, openTrigger } = usePanelContext()
   useLocale()
   const { items: pairs, loading } = useTriggerItems()
+
+  usePanelUrl({
+    type: 'trigger',
+    items: pairs,
+    getId: (pair) => pair.name,
+    open: (id, pair) => openTrigger(id, pair.trigger),
+  })
+  usePanelUrl({
+    type: 'triggerSource',
+    items: pairs,
+    getId: (pair) => pair.name,
+    open: (id, pair) => openTriggerSource(id, pair.source),
+  })
 
   const columns = useMemo(
     () => [

--- a/packages/console/src/context/PanelContext.tsx
+++ b/packages/console/src/context/PanelContext.tsx
@@ -1,5 +1,14 @@
-import React, { createContext, useContext, useState, useCallback } from 'react'
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react'
 import { toEnglishName } from '../lib/strings'
+import { useUrlHash } from '../hooks/useUrlHash'
+import { encodePanelHash, panelHashIsBare } from '../lib/panel-url'
 
 export type PanelType =
   | 'function'
@@ -104,6 +113,15 @@ interface PanelContextType {
   closePanel: (id: string) => void
   setActivePanel: (id: string) => void
   setActiveChild: (panelId: string, childId: string) => void
+  /**
+   * The selection this surface is being asked to restore, straight from the URL
+   * fragment. Lists watch it through `usePanelUrl` and open the row it names
+   * once they hold the row's metadata.
+   */
+  panelHash: string
+  /** The panel types this surface has lists for; see `usePanelUrl`. */
+  registeredPanelTypes: Set<PanelType>
+  registerPanelType: (type: PanelType) => () => void
 }
 
 export const PanelContext = createContext<PanelContextType | undefined>(
@@ -132,6 +150,49 @@ interface PanelProviderProps {
 export const PanelProvider: React.FC<PanelProviderProps> = ({ children }) => {
   const [panels, setPanels] = useState<Map<string, Panel>>(new Map())
   const [activePanel, setActivePanelState] = useState<string | null>(null)
+  const [panelHash, setPanelHash] = useUrlHash()
+  const [registeredPanelTypes, setRegisteredPanelTypes] = useState<
+    Set<PanelType>
+  >(() => new Set())
+  const registrationsRef = useRef(new Map<PanelType, number>())
+
+  const registerPanelType = useCallback((type: PanelType) => {
+    // Counted, not a plain set: two lists of the same type on one surface must
+    // not have the first to unmount cancel the second's registration.
+    const counts = registrationsRef.current
+    counts.set(type, (counts.get(type) ?? 0) + 1)
+    setRegisteredPanelTypes(new Set(counts.keys()))
+    return () => {
+      const remaining = (counts.get(type) ?? 1) - 1
+      if (remaining > 0) counts.set(type, remaining)
+      else counts.delete(type)
+      setRegisteredPanelTypes(new Set(counts.keys()))
+    }
+  }, [])
+
+  const wroteHashRef = useRef(false)
+
+  useEffect(() => {
+    const panel = activePanel ? panels.get(activePanel) : undefined
+    if (panel) {
+      wroteHashRef.current = true
+      setPanelHash(
+        encodePanelHash(
+          panel.data.type,
+          panel.data.id,
+          panelHashIsBare(registeredPanelTypes)
+        ) ?? ''
+      )
+      return
+    }
+    // Nothing selected. Only a fragment this surface wrote itself may be
+    // cleared — one that arrived in the URL has to survive until the list
+    // holding its row has loaded and can open it.
+    if (wroteHashRef.current) {
+      wroteHashRef.current = false
+      setPanelHash('')
+    }
+  }, [activePanel, panels, registeredPanelTypes, setPanelHash])
 
   const openPanelGeneric = useCallback(
     (type: PanelType, id: string, title: string, metadata?: any) => {
@@ -471,6 +532,9 @@ export const PanelProvider: React.FC<PanelProviderProps> = ({ children }) => {
         closePanel,
         setActivePanel,
         setActiveChild,
+        panelHash,
+        registeredPanelTypes,
+        registerPanelType,
       }}
     >
       {children}

--- a/packages/console/src/hooks/usePanelUrl.ts
+++ b/packages/console/src/hooks/usePanelUrl.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react'
+import { usePanelContextSafe, type PanelType } from '../context/PanelContext'
+import { decodePanelHash, panelHashIsBare } from '../lib/panel-url'
+
+export interface PanelUrlOptions<T> {
+  type: PanelType
+  /**
+   * The rows this list can open. Prefer the unfiltered set — a row hidden by
+   * the search box is still a row the URL may name.
+   */
+  items: readonly T[] | undefined
+  getId: (item: T) => string
+  open: (id: string, item: T) => void
+}
+
+/**
+ * Makes a list's selection survive a reload, a copied link and a step back into
+ * the page: the panel context writes the open row into the URL fragment, and
+ * this reopens whatever the fragment names as soon as the row's metadata is in
+ * hand.
+ *
+ * Restoring is the list's job rather than the provider's because a panel renders
+ * from the metadata captured when it opened, and only the list that fetched a
+ * row holds it. Registering the type is what tells the provider whether this
+ * surface can write a bare `#id` or must qualify it as `#type:id`.
+ */
+export function usePanelUrl<T>({
+  type,
+  items,
+  getId,
+  open,
+}: PanelUrlOptions<T>): void {
+  const panelContext = usePanelContextSafe()
+  const registerPanelType = panelContext?.registerPanelType
+  const panelHash = panelContext?.panelHash
+  const activePanel = panelContext?.activePanel
+  const registeredPanelTypes = panelContext?.registeredPanelTypes
+
+  // Read through refs so a list that rebuilds its callbacks each render does not
+  // re-run the restore, and so the effect below depends on the data alone.
+  const getIdRef = useRef(getId)
+  getIdRef.current = getId
+  const openRef = useRef(open)
+  openRef.current = open
+
+  useEffect(() => registerPanelType?.(type), [registerPanelType, type])
+
+  useEffect(() => {
+    if (!panelHash || !items?.length || !registeredPanelTypes) return
+    const target = decodePanelHash(panelHash)
+    if (!target) return
+    if (
+      target.type
+        ? target.type !== type
+        : !panelHashIsBare(registeredPanelTypes)
+    ) {
+      return
+    }
+    if (activePanel === `${type}-${target.id}`) return
+    const item = items.find((row) => getIdRef.current(row) === target.id)
+    if (item) openRef.current(target.id, item)
+  }, [panelHash, items, type, activePanel, registeredPanelTypes])
+}

--- a/packages/console/src/hooks/useUrlHash.ts
+++ b/packages/console/src/hooks/useUrlHash.ts
@@ -1,0 +1,52 @@
+import { useCallback, useSyncExternalStore } from 'react'
+
+/**
+ * The URL fragment, as state.
+ *
+ * Deliberately not part of the router shim: nothing routes on the fragment, so
+ * making every host (Fabric included) implement a `useHash` before the console
+ * could remember a selection would buy nothing. Reading `window.location`
+ * directly works under every router the console is mounted in.
+ *
+ * `replaceState` does not fire `hashchange`, so writers publish to the
+ * subscribers themselves — otherwise a panel opened by a click would update the
+ * URL and leave every reader on this page holding the previous value.
+ */
+const subscribers = new Set<() => void>()
+
+const notify = () => {
+  for (const subscriber of subscribers) subscriber()
+}
+
+const subscribe = (onChange: () => void) => {
+  subscribers.add(onChange)
+  window.addEventListener('hashchange', onChange)
+  window.addEventListener('popstate', onChange)
+  return () => {
+    subscribers.delete(onChange)
+    window.removeEventListener('hashchange', onChange)
+    window.removeEventListener('popstate', onChange)
+  }
+}
+
+const read = () =>
+  typeof window === 'undefined' ? '' : window.location.hash.replace(/^#/, '')
+
+export const setUrlHash = (next: string) => {
+  if (typeof window === 'undefined') return
+  if (read() === next) return
+  const { pathname, search } = window.location
+  // Replace rather than push: the URL tracks the selection so it can be copied
+  // and reloaded, but a list you are scanning must not fill the back stack.
+  window.history.replaceState(
+    window.history.state,
+    '',
+    `${pathname}${search}${next ? `#${next}` : ''}`
+  )
+  notify()
+}
+
+export const useUrlHash = (): [string, (next: string) => void] => {
+  const hash = useSyncExternalStore(subscribe, read, () => '')
+  return [hash, useCallback(setUrlHash, [])]
+}

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -292,6 +292,9 @@ export { ConsoleEditableProvider } from './context/ConsoleEditableContext'
 // Detail-panel system: lets an embedder (e.g. a canvas/graph view) open the
 // same right-hand configuration panels the pages use, by wire type + id.
 export { PanelProvider, usePanelContext } from './context/PanelContext'
+export { usePanelUrl } from './hooks/usePanelUrl'
+export type { PanelUrlOptions } from './hooks/usePanelUrl'
+export { panelHref } from './lib/panel-url'
 export type { PanelType, PanelData } from './context/PanelContext'
 export { PanelContainer } from './components/panel/PanelContainer'
 // Needed by an embedder that opens the workflow panel outside a workflow page:

--- a/packages/console/src/lib/panel-url.test.ts
+++ b/packages/console/src/lib/panel-url.test.ts
@@ -1,0 +1,60 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  decodePanelHash,
+  encodePanelHash,
+  panelHashIsBare,
+  panelHref,
+} from './panel-url.js'
+
+describe('panel url fragments', () => {
+  test('a surface with one list writes the bare id', () => {
+    assert.equal(panelHashIsBare(new Set(['function'])), true)
+    assert.equal(encodePanelHash('function', 'getUser', true), 'getUser')
+    assert.deepEqual(decodePanelHash('getUser'), {
+      type: null,
+      id: 'getUser',
+    })
+  })
+
+  test('a surface with several lists qualifies the id', () => {
+    assert.equal(panelHashIsBare(new Set(['trigger', 'triggerSource'])), false)
+    const hash = encodePanelHash('triggerSource', 'orderPlaced', false)
+    assert.equal(hash, 'triggerSource:orderPlaced')
+    assert.deepEqual(decodePanelHash(hash!), {
+      type: 'triggerSource',
+      id: 'orderPlaced',
+    })
+  })
+
+  test('the `::` inside a wire id is not a type separator', () => {
+    const id = 'http::GET::/users/:userId'
+    const bare = encodePanelHash('http', id, true)
+    assert.equal(bare, 'http::GET::/users/:userId')
+    assert.deepEqual(decodePanelHash(bare!), { type: null, id })
+    const qualified = encodePanelHash('http', id, false)
+    assert.deepEqual(decodePanelHash(qualified!), { type: 'http', id })
+  })
+
+  test('ids that need escaping round-trip', () => {
+    const id = 'send email #2'
+    const hash = encodePanelHash('function', id, true)
+    assert.equal(hash?.includes('#'), false)
+    assert.deepEqual(decodePanelHash(hash!), { type: null, id })
+  })
+
+  test('an unknown slug is read as part of a bare id', () => {
+    assert.deepEqual(decodePanelHash('nosuchtype:thing'), {
+      type: null,
+      id: 'nosuchtype:thing',
+    })
+  })
+
+  test('cross-page links carry the type', () => {
+    assert.equal(
+      panelHref('channel', 'events'),
+      '/apis?tab=channels#channel:events'
+    )
+    assert.equal(panelHref('workflowStep', 'step-1'), null)
+  })
+})

--- a/packages/console/src/lib/panel-url.ts
+++ b/packages/console/src/lib/panel-url.ts
@@ -1,0 +1,120 @@
+import type { PanelType } from '../context/PanelContext'
+
+/**
+ * How a selected row is written into the URL fragment, and read back out.
+ *
+ * A surface showing one kind of thing writes the bare id — `/functions#myFunc`,
+ * `/apis?tab=channels#events`. A surface showing several writes the type too —
+ * `/jobs?tab=triggers#trigger:orderPlaced` — because the id alone would not say
+ * which list owns it. Writer and reader apply the same rule (see
+ * `panelHashIsBare`), so a fragment always round-trips.
+ */
+export const PANEL_URL_SLUGS: Partial<Record<PanelType, string>> = {
+  function: 'function',
+  http: 'http',
+  channel: 'channel',
+  rpc: 'rpc',
+  scheduler: 'scheduler',
+  queue: 'queue',
+  cli: 'cli',
+  mcp: 'mcp',
+  gateway: 'gateway',
+  workflow: 'workflow',
+  trigger: 'trigger',
+  triggerSource: 'triggerSource',
+  middleware: 'middleware',
+  permission: 'permission',
+  agent: 'agent',
+  secret: 'secret',
+  variable: 'variable',
+  credentialUser: 'user',
+  email: 'email',
+  persona: 'persona',
+}
+
+const SLUG_TO_TYPE = new Map<string, PanelType>(
+  Object.entries(PANEL_URL_SLUGS).map(([type, slug]) => [
+    slug!,
+    type as PanelType,
+  ])
+)
+
+/**
+ * Where a panel of each type can be opened, for links that cross pages. Types
+ * that are only reachable from inside another surface — a workflow step, a
+ * database column — have no entry, and no link is offered for them.
+ */
+const PANEL_URL_PATHS: Partial<Record<PanelType, string>> = {
+  function: '/functions',
+  http: '/apis?tab=http',
+  channel: '/apis?tab=channels',
+  mcp: '/apis?tab=mcp',
+  cli: '/apis?tab=cli',
+  gateway: '/apis?tab=gateways',
+  scheduler: '/jobs?tab=schedulers',
+  queue: '/jobs?tab=queues',
+  trigger: '/jobs?tab=triggers',
+  triggerSource: '/jobs?tab=triggers',
+  middleware: '/runtime?tab=middleware',
+  permission: '/runtime?tab=permissions',
+  workflow: '/workflow',
+  agent: '/agents',
+  secret: '/secrets',
+  variable: '/variables',
+  credentialUser: '/credentials?tab=users',
+  email: '/emails',
+  persona: '/personas',
+}
+
+/** `:` and `/` are legal in a fragment and read far better left alone. */
+const encodeId = (id: string) =>
+  encodeURIComponent(id).replace(/%3A/gi, ':').replace(/%2F/gi, '/')
+
+const decodeId = (id: string) => {
+  try {
+    return decodeURIComponent(id)
+  } catch {
+    return id
+  }
+}
+
+/** A single `:` separates a type from an id; the `::` inside a wire id is not one. */
+const splitTypePrefix = (hash: string): [PanelType, string] | null => {
+  const match = /^([A-Za-z]+):(?!:)(.+)$/.exec(hash)
+  if (!match) return null
+  const type = SLUG_TO_TYPE.get(match[1]!)
+  return type ? [type, match[2]!] : null
+}
+
+export const panelHashIsBare = (registeredTypes: Set<PanelType>) =>
+  registeredTypes.size === 1
+
+export const encodePanelHash = (
+  type: PanelType,
+  id: string,
+  bare: boolean
+): string | null => {
+  const slug = PANEL_URL_SLUGS[type]
+  if (!slug) return null
+  return bare ? encodeId(id) : `${slug}:${encodeId(id)}`
+}
+
+/**
+ * The type and id a fragment names, or a bare id with no type when the surface
+ * it was written on had only one list to attribute it to.
+ */
+export const decodePanelHash = (
+  hash: string
+): { type: PanelType | null; id: string } | null => {
+  if (!hash) return null
+  const prefixed = splitTypePrefix(hash)
+  if (prefixed) return { type: prefixed[0], id: decodeId(prefixed[1]) }
+  return { type: null, id: decodeId(hash) }
+}
+
+/** A link that opens `id` on the page that owns its type, or null if none does. */
+export const panelHref = (type: PanelType, id: string): string | null => {
+  const path = PANEL_URL_PATHS[type]
+  const hash = encodePanelHash(type, id, false)
+  return path && hash ? `${path}#${hash}` : null
+}


### PR DESCRIPTION
Selecting a row put the inspector's contents in React state and nowhere else, so a selection was gone on reload, gone on coming back from a link, and impossible to send to anyone — `/functions` was the only address the functions page ever had, whichever function was open.

## How it addresses a row

The panel context writes whatever is selected into the URL fragment and reads it back.

| | |
|---|---|
| One list on the surface | `/functions#getUser`, `/agents#supportAgent` |
| Several lists | `/jobs?tab=triggers#triggerSource:orderPlaced` |
| Channels (two levels deep) | `#chat`, `#chat/connect`, `#chat/messages/send` |

Writer and reader apply the same rule, so a fragment always round-trips, and the `::` inside a wire id (`#http::GET::/users/:userId`) is not mistaken for a type separator. Fragments are written with `replaceState`: the URL always describes the selection, but scanning a list does not fill the back stack.

## How it is put together

- `useUrlHash` — the fragment as state. Deliberately not part of the router shim: nothing routes on the fragment, so making every host implement a `useHash` first would buy nothing.
- `usePanelUrl({ type, items, getId, open })` — what a list registers with. Restoring is the list's job rather than the provider's, because a panel renders from the metadata captured when it opened and only the list that fetched a row holds it. It restores from the unfiltered rows, so a link to a function the search box currently hides still opens. Registering the type is also what tells the provider whether the surface can write a bare `#id`.
- `panelHref(type, id)` — a link that opens a row on the page that owns its type, so one surface can point at a row on another and land with it selected. Type-qualified, and the target page rewrites it to its own canonical form on arrival.

Registered: functions, HTTP routes, MCP tools, gateways, schedulers, queues, triggers and their sources, middleware, permissions, secrets, variables, credential users. Channels are not panels but address themselves the same way; the open channel moves out of `?id=`, which is still read so older links keep working. Switching tab on a tabbed surface drops the fragment, since a row in the tab you left is not on screen in the one you arrive at.

Still page-local, for a later pass: scenarios, knowledge, virtual users, packages, and the CLI tree.

## Testing

`tsc --noEmit` and `oxlint` clean over every touched file; 11 new tests cover the fragment encodings (`src/lib/panel-url.test.ts`, `src/components/channel/channel-selection.test.ts`). Not exercised in a browser — the package's tests are pure-logic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)