### PR TITLE
feat(console): export AuthContext so a host can supply the auth value

### DIFF
--- a/.changeset/console-export-auth-context.md
+++ b/.changeset/console-export-auth-context.md
@@ -1,0 +1,9 @@
+---
+'@pikku/console': patch
+---
+
+Export `AuthContext` so a host without a console login of its own can supply the auth value directly.
+
+`AdminUsersPage`, `useAdminUsers` and the user action menus and drawers all read `useAuth()` for the caller's identity, their scopes and the `pikkuAdmin*` user-admin calls. That value only ever came from `AuthProvider`, which builds it from a Better Auth cookie session on `{serverUrl}/api/auth` — so a host embedding these pages without such a session got a thrown `useAuth must be used within an AuthProvider` rather than a degraded page. Fabric is the case in hand: it reaches a sandbox with a bearer token that the app already maps to a scoped session, so it has both a user and scopes, just not a cookie to fetch them with.
+
+`AuthContext` now joins `PikkuRPCContext` and `ConsoleNavigatorCtx` as a context a host may provide itself. `AuthProvider`, `useAuth`, `useOptionalAuth`, the `AuthContextValue` and `AuthUser` types, and `createConsoleAuthClient` (which builds the `client` the value requires) are exported alongside it. Nothing about the standalone console changes — it still mounts `AuthProvider` and reads the same context.

--- a/packages/console/src/context/AuthContext.tsx
+++ b/packages/console/src/context/AuthContext.tsx
@@ -86,7 +86,13 @@ export interface AuthContextValue {
   setUserPassword: (userId: string, newPassword: string) => Promise<void>
 }
 
-const AuthContext = createContext<AuthContextValue | null>(null)
+/**
+ * Exported so a host that has no console login of its own can provide the value
+ * itself — Fabric reaches a sandbox with a bearer token rather than a Better
+ * Auth cookie, so it has a user and scopes but no `AuthProvider` to build them.
+ * Without this the user pages are unreachable outside the standalone console.
+ */
+export const AuthContext = createContext<AuthContextValue | null>(null)
 
 /**
  * The user-management RPCs the host app scaffolds. They cannot appear in the

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -15,6 +15,20 @@ export { reactRouterAdapter } from './adapters/react-router'
 // Page gate context (host apps use this to inject a body override while keeping headers visible)
 export { PageGateContext } from './context/PageGateContext'
 
+// Auth — the console's own login state. A host without a console login (Fabric,
+// which reaches a sandbox with a bearer token) provides `AuthContext` itself so
+// the user pages resolve; `createConsoleAuthClient` builds the client the value
+// requires.
+export {
+  AuthContext,
+  AuthProvider,
+  useAuth,
+  useOptionalAuth,
+} from './context/AuthContext'
+export type { AuthContextValue, AuthUser } from './context/AuthContext'
+export { createConsoleAuthClient } from './lib/auth-client'
+export type { ConsoleAuthClient } from './lib/auth-client'
+
 // Users — presentation-only table shared by AdminUsersPage and external hosts
 // (e.g. Fabric's server-brokered stage Users tab).
 export { UsersTable } from './components/users/UsersTable'


### PR DESCRIPTION
## Why

`AdminUsersPage`, `useAdminUsers`, `UserActionsMenu`, `UserActionDrawer` and `CreateUserDrawer` all call `useAuth()` — for the caller's identity, their scopes (`can('admin:users:*')` decides which actions render) and the `pikkuAdmin*` user-admin RPCs.

That value only ever came from `AuthProvider`, which builds it from a Better Auth cookie session against `{serverUrl}/api/auth`. A host embedding these pages without such a session gets a thrown `useAuth must be used within an AuthProvider`, not a degraded page — and since `UsersDirectoryPanel` mounts the action components unconditionally, there is no partial way in either.

Fabric is the case in hand. Its sandbox console reaches the app with a bearer token that the app already maps to a scoped session (`authBearer` on `PIKKU_CONSOLE_TOKEN`), so it has a user and it has scopes — it just has no cookie to fetch them with, and deliberately mounts no `AuthProvider`. `useOptionalAuth` was added for exactly this host, but it only helps components that can render without auth; the user pages cannot.

## What

`AuthContext` becomes exported, joining `PikkuRPCContext` and `ConsoleNavigatorCtx` as a context a host may provide itself. Exported alongside it: `AuthProvider`, `useAuth`, `useOptionalAuth`, the `AuthContextValue` and `AuthUser` types, and `createConsoleAuthClient` — the last so a host can build the `client` field the value requires rather than reimplementing the Better Auth client config.

Two export statements and a doc comment. Nothing about the standalone console changes: it still mounts `AuthProvider`, which still provides the same context.

## Testing

Not typechecked locally — the fresh worktree has no install, and `packages/console`'s generated `src/paraglide` is absent. The change re-exports symbols that are already exported at their definitions (`AuthContext.tsx`, `lib/auth-client.ts`), and none of the six names collide with anything else in `src/index.ts`. Leaving that to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)