### PR TITLE
fix(core): resolve a variable's declared default instead of dropping it

### DIFF
--- a/.changeset/variable-schema-defaults.md
+++ b/.changeset/variable-schema-defaults.md
@@ -1,0 +1,14 @@
+---
+'@pikku/core': minor
+'@pikku/cli': minor
+---
+
+Resolve a variable's declared default instead of dropping it.
+
+`defineVariable` takes a schema, and a schema can carry a default — `z.enum(['https://api.github.com']).default('https://api.github.com')` is the shape most addons declare their base URL with. Nothing read it. `variables.get('GITHUB_BASE_URL')` returned `undefined` on a host that had not set it, and the `as string` at the call site hid that until a request went to `undefined/repos/...`.
+
+The default now resolves in `TypedVariablesService`, which is the layer that knows what was declared — `VariablesService` only knows what a host put in it. A stored value always wins; a schema with no default still resolves to `undefined`.
+
+`VariableStatus` gains `hasDefault`, and `getMissing()` no longer lists a variable that defaults: it has a value, just not one anybody has to supply. `isConfigured` still means what it said — that a host set it.
+
+For this to work the generated `TYPED_VARIABLES_META` now carries the schema as a value rather than only `z.infer`-ing its type, so the schema module is retained in the emit instead of being elided.

--- a/packages/cli/src/functions/wirings/variables/serialize-variables-types.test.ts
+++ b/packages/cli/src/functions/wirings/variables/serialize-variables-types.test.ts
@@ -100,3 +100,28 @@ describe('serializeVariablesTypes — shipping the declared set', () => {
     )
   })
 })
+
+describe('serializeVariablesTypes — carrying the declared schema', () => {
+  // Without the schema as a value in the metadata, a `.default()` in the
+  // declaration is unreachable at runtime: the service has no way to ask.
+  test('puts the schema on the metadata entry, not just in the type map', () => {
+    const output = schemaBackedVariable('API URL')
+    assert.match(output, /'API_URL': \{[^}]*schema: \(\) => ApiUrlSchema/)
+    assert.deepEqual(parseErrors(output), [])
+  })
+
+  // This file and the one declaring the schema import each other, so evaluating
+  // the schema at module scope throws before it is initialized.
+  test('defers reading the schema, so the import cycle stays harmless', () => {
+    const output = schemaBackedVariable('API URL')
+    assert.doesNotMatch(output, /schema: ApiUrlSchema/)
+  })
+
+  test('imports the schema as a value so the emit keeps it', () => {
+    const output = schemaBackedVariable('API URL')
+    assert.match(
+      output,
+      /^import \{ ApiUrlSchema \} from '\.\.\/\.\.\/src\/variables\.js'$/m
+    )
+  })
+})

--- a/packages/cli/src/functions/wirings/variables/serialize-variables-types.ts
+++ b/packages/cli/src/functions/wirings/variables/serialize-variables-types.ts
@@ -49,8 +49,12 @@ export const serializeVariablesTypes = ({
         mapEntries.push(
           `  '${meta.variableId}': z.infer<typeof ${schemaRef.variableName}>`
         )
+        // The schema is emitted behind a thunk because this file and the one
+        // declaring the schema import each other: reading it while the modules
+        // are still initializing throws `Cannot access '<schema>' before
+        // initialization`, and deferring the read to first use avoids the cycle.
         metaEntries.push(
-          `  '${meta.variableId}': { name: '${name}', displayName: ${literal(meta.displayName)} }`
+          `  '${meta.variableId}': { name: '${name}', displayName: ${literal(meta.displayName)}, schema: () => ${schemaRef.variableName} }`
         )
       }
     }

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5058,6 +5058,7 @@ export interface UploadURLResult {
 export type VariableMeta = {
   name: string
   displayName: string
+  schema?: StandardSchemaV1 | (() => StandardSchemaV1)
 }
 export interface VariablesService {
   get<T = string>(name: string): Promise<T | undefined> | T | undefined

--- a/packages/core/src/services/typed-variables-service.test.ts
+++ b/packages/core/src/services/typed-variables-service.test.ts
@@ -2,6 +2,7 @@ import { describe, test } from 'node:test'
 import assert from 'node:assert'
 import { TypedVariablesService } from './typed-variables-service.js'
 import { LocalVariablesService } from './local-variables.js'
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 
 describe('TypedVariablesService', () => {
   const createService = (vars: Record<string, string | undefined> = {}) => {
@@ -69,5 +70,97 @@ describe('TypedVariablesService', () => {
     const service = createService({ DB_URL: 'val', API_KEY: 'key' })
     const missing = await service.getMissing()
     assert.strictEqual(missing.length, 0)
+  })
+})
+
+/**
+ * Stands in for `z.enum([...]).default(...)`: a schema that answers `undefined`
+ * with a value rather than an issue. Core declares no schema library of its
+ * own, so the contract under test is Standard Schema's, not Zod's.
+ */
+const withDefault = <T>(value: T): StandardSchemaV1<unknown, T> => ({
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: (input: unknown) =>
+      input === undefined ? { value } : { value: input as T },
+  },
+})
+
+const noDefault: StandardSchemaV1<unknown, string> = {
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: (input: unknown) =>
+      typeof input === 'string'
+        ? { value: input }
+        : { issues: [{ message: 'expected a string' }] },
+  },
+}
+
+describe('TypedVariablesService schema defaults', () => {
+  const createService = (vars: Record<string, string | undefined> = {}) =>
+    new TypedVariablesService(new LocalVariablesService(vars), {
+      GITHUB_BASE_URL: {
+        name: 'GITHUB_BASE_URL',
+        displayName: 'GitHub Base URL',
+        schema: withDefault('https://api.github.com'),
+      },
+      API_KEY: {
+        name: 'API_KEY',
+        displayName: 'API Key',
+        schema: noDefault,
+      },
+      // The form code generation emits, deferred past the import cycle.
+      REGION: {
+        name: 'REGION',
+        displayName: 'Region',
+        schema: () => withDefault('eu-west-1'),
+      },
+    })
+
+  test('resolves a declared default when the host sets nothing', async () => {
+    const service = createService()
+    assert.strictEqual(
+      await service.get('GITHUB_BASE_URL'),
+      'https://api.github.com'
+    )
+  })
+
+  test('prefers the host value over the default', async () => {
+    const service = createService({ GITHUB_BASE_URL: 'https://ghe.internal' })
+    assert.strictEqual(
+      await service.get('GITHUB_BASE_URL'),
+      'https://ghe.internal'
+    )
+  })
+
+  test('stays undefined when the schema carries no default', async () => {
+    const service = createService()
+    assert.strictEqual(await service.get('API_KEY'), undefined)
+  })
+
+  test('resolves a default behind a thunk', async () => {
+    const service = createService()
+    assert.strictEqual(await service.get('REGION'), 'eu-west-1')
+  })
+
+  test('a defaulted variable is not missing', async () => {
+    const service = createService()
+    const missing = await service.getMissing()
+    assert.deepStrictEqual(
+      missing.map((v) => v.variableId),
+      ['API_KEY']
+    )
+  })
+
+  test('status separates having a default from being configured', async () => {
+    const service = createService()
+    const status = await service.getAllStatus()
+    const github = status.find((s) => s.variableId === 'GITHUB_BASE_URL')!
+    assert.strictEqual(github.isConfigured, false)
+    assert.strictEqual(github.hasDefault, true)
+    const apiKey = status.find((s) => s.variableId === 'API_KEY')!
+    assert.strictEqual(apiKey.hasDefault, false)
   })
 })

--- a/packages/core/src/services/typed-variables-service.ts
+++ b/packages/core/src/services/typed-variables-service.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { VariablesService } from './variables-service.js'
 
 export interface VariableStatus {
@@ -5,13 +6,35 @@ export interface VariableStatus {
   name: string
   displayName: string
   isConfigured: boolean
+  /** Whether the declaration answers for itself when the host sets nothing. */
+  hasDefault: boolean
 }
 
 export type VariableMeta = {
   name: string
   displayName: string
+  /**
+   * The shape the variable was declared with. It is the schema itself rather
+   * than a description of it, because a default is only knowable by running it:
+   * `undefined` goes in and, if the declaration carries one, the default comes
+   * back out.
+   *
+   * A thunk is accepted, and is what code generation emits. The generated file
+   * and the file declaring the schema import each other, so reading the schema
+   * while the modules are still initializing throws — deferring the read until
+   * a variable is actually asked for is what keeps the cycle harmless.
+   */
+  schema?: StandardSchemaV1 | (() => StandardSchemaV1)
 }
 
+const isPromise = (value: unknown): value is Promise<unknown> =>
+  typeof (value as Promise<unknown> | undefined)?.then === 'function'
+
+/**
+ * A declared default is the answer to a variable nobody set, so it is resolved
+ * here rather than in `VariablesService`: the store knows what a host has put
+ * in it, and only this layer knows what was declared.
+ */
 export class TypedVariablesService<
   TMap = Record<string, unknown>,
 > implements VariablesService {
@@ -25,13 +48,23 @@ export class TypedVariablesService<
   ): Promise<TMap[K] | undefined> | TMap[K] | undefined
   get<T = string>(name: string): Promise<T | undefined> | T | undefined
   get(name: string): Promise<unknown> | unknown {
-    return this.variables.get(name)
+    const stored = this.variables.get(name)
+    if (isPromise(stored)) {
+      return stored.then((value) =>
+        value === undefined ? this.resolveDefault(name) : value
+      )
+    }
+    return stored === undefined ? this.resolveDefault(name) : stored
   }
 
   getVariables<T extends Record<string, unknown> = Record<string, unknown>>(
     names: (keyof T & string)[]
   ): Promise<Partial<T>> | Partial<T> {
-    return this.variables.getVariables<T>(names)
+    const stored = this.variables.getVariables<T>(names)
+    if (isPromise(stored)) {
+      return stored.then((values) => this.withDefaults(names, values))
+    }
+    return this.withDefaults(names, stored)
   }
 
   getAll():
@@ -62,14 +95,72 @@ export class TypedVariablesService<
         name: meta.name,
         displayName: meta.displayName,
         isConfigured: all[variableId] !== undefined,
+        hasDefault: (await this.resolveDefault(variableId)) !== undefined,
       })
     }
 
     return results
   }
 
+  /**
+   * What a deployment still has to be told. A variable that defaults is not on
+   * this list — it has a value, just not one anybody has to supply.
+   */
   async getMissing(): Promise<VariableStatus[]> {
     const all = await this.getAllStatus()
-    return all.filter((v) => !v.isConfigured)
+    return all.filter((v) => !v.isConfigured && !v.hasDefault)
+  }
+
+  /**
+   * The value the declaration answers with when the host set nothing, or
+   * `undefined` when it does not answer for itself.
+   */
+  private resolveDefault(name: string): Promise<unknown> | unknown {
+    const declared = this.variablesMeta[name]?.schema
+    if (!declared) {
+      return undefined
+    }
+    const schema = typeof declared === 'function' ? declared() : declared
+    const result = schema['~standard'].validate(undefined)
+    if (isPromise(result)) {
+      return result.then(unwrapDefault)
+    }
+    return unwrapDefault(result)
+  }
+
+  /**
+   * Kept synchronous when the defaults resolve synchronously, so a caller that
+   * did not await `getVariables` before does not have to start.
+   */
+  private withDefaults<T extends Record<string, unknown>>(
+    names: (keyof T & string)[],
+    values: Partial<T>
+  ): Promise<Partial<T>> | Partial<T> {
+    const out: Record<string, unknown> = { ...values }
+    const pending: Promise<void>[] = []
+    for (const name of names) {
+      if (out[name] !== undefined) continue
+      const fallback = this.resolveDefault(name)
+      if (isPromise(fallback)) {
+        pending.push(
+          fallback.then((value) => {
+            if (value !== undefined) out[name] = value
+          })
+        )
+      } else if (fallback !== undefined) {
+        out[name] = fallback
+      }
+    }
+    if (pending.length > 0) {
+      return Promise.all(pending).then(() => out as Partial<T>)
+    }
+    return out as Partial<T>
   }
 }
+
+/**
+ * A schema with no default rejects `undefined`, which is not a failure here —
+ * it is the answer that there is nothing to fall back to.
+ */
+const unwrapDefault = (result: StandardSchemaV1.Result<unknown>) =>
+  result.issues ? undefined : result.value

--- a/verifiers/variables/package.json
+++ b/verifiers/variables/package.json
@@ -20,6 +20,6 @@
   "scripts": {
     "build": "tsc -b",
     "pikku": "pikku",
-    "test": "pikku && tsc -b"
+    "test": "pikku && tsc -b && ./test.sh"
   }
 }

--- a/verifiers/variables/src/test-variable-defaults.ts
+++ b/verifiers/variables/src/test-variable-defaults.ts
@@ -1,0 +1,31 @@
+/**
+ * Verifies that a `.default()` in a declaration is a value at runtime.
+ *
+ * The schema reaches `TypedVariablesService` through the generated metadata, so
+ * this only passes if code generation carried the schema across as a value —
+ * which is the half that is easy to lose.
+ */
+import assert from 'node:assert/strict'
+import { LocalVariablesService } from '@pikku/core/services'
+import { TypedVariablesService } from '#pikku/variables'
+
+const unset = new TypedVariablesService(new LocalVariablesService({}))
+
+assert.equal(await unset.get('API_BASE_URL'), 'https://api.example.com')
+console.log('✓ a declared default answers a variable nobody set')
+
+assert.equal(await unset.get('SERVER_CONFIG'), undefined)
+console.log('✓ a declaration with no default still resolves to undefined')
+
+const missing = await unset.getMissing()
+assert.deepEqual(
+  missing.map((v) => v.variableId),
+  ['SERVER_CONFIG']
+)
+console.log('✓ a defaulted variable is not something the host must supply')
+
+const configured = new TypedVariablesService(
+  new LocalVariablesService({ API_BASE_URL: 'https://api.example.com' })
+)
+assert.equal(await configured.get('API_BASE_URL'), 'https://api.example.com')
+console.log('✓ a host value is taken over the default')

--- a/verifiers/variables/src/variables.ts
+++ b/verifiers/variables/src/variables.ts
@@ -13,3 +13,15 @@ defineVariable({
   variableId: 'SERVER_CONFIG',
   schema: serverConfigSchema,
 })
+
+export const apiBaseUrlSchema = z
+  .enum(['https://api.example.com'])
+  .default('https://api.example.com')
+
+defineVariable({
+  name: 'api-base-url',
+  displayName: 'API Base URL',
+  description: 'Where the API lives. There is only one, so it defaults.',
+  variableId: 'API_BASE_URL',
+  schema: apiBaseUrlSchema,
+})

--- a/verifiers/variables/test.sh
+++ b/verifiers/variables/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+echo "=== Variables Verifier Tests ==="
+
+echo ""
+echo "=== Testing declared defaults ==="
+npx tsx src/test-variable-defaults.ts
+
+echo ""
+echo "=== All tests passed ==="


### PR DESCRIPTION
A variable declared with a schema that carries a default was still reported as
something the deployment had to be told. The default was written down and never
read.

Two links were missing:

- **The metadata dropped the schema.** `VariableMeta` carried `name` and
  `displayName` only, so by the time `TypedVariablesService` was asked for a
  value there was nothing left to ask for a default.
- **Code generation used the schema in type position only.** The generated
  `pikku-variables.gen.ts` referenced the schema for typing and emitted no value,
  so nothing could run it at runtime.

## What this does

`TypedVariablesService.get` now falls back to the declared default when the host
set nothing, and `getMissing()` stops listing a variable that answers for
itself. `VariableStatus` gains `hasDefault` so a caller can still tell "nobody
set it" from "nobody has to".

The default is extracted by running the schema over `undefined` through
[Standard Schema](https://standardschema.dev) — vendor-neutral, and the same
mechanism `workflow-approval.ts` already uses. A schema with no default rejects
`undefined`; that is the answer "there is nothing to fall back on", not a
failure.

## The thunk

The schema is emitted as `schema: () => appUrlSchema`, not `schema: appUrlSchema`.

A user's `variables.ts` imports `defineVariable` from the generated
`#pikku/variables`, and the generated file imports the schema back. While the
reference was type-only, tsc elided it and the cycle was harmless. Emitting a
value reference retains it and the cycle turns fatal —
`Cannot access 'appUrlSchema' before initialization`, which then cascades into
`[PKU724] 'SingletonServices' resolved to no services at all`. Deferring the
read to first use keeps the cycle harmless. `VariableMeta.schema` accepts both
forms.

## Scope

This does not by itself unblock a Fabric deploy that is waiting on a defaulted
variable: `missingVariables` on the deploy path arrives from the Fabric API, so
that gate is server-side. What it fixes is the declaration losing the fact that
it defaults — locally, in `getMissing()`, and everywhere the metadata is read.

Worth noting as a separate follow-up: `TypedSecretService.getSecret` honours
`optional`, but its `getAllStatus`/`getMissing` do not, so an optional secret
that is unset is still reported missing. Same shape of bug, different surface;
left alone here.

## Tests

- `packages/core/src/services/typed-variables-service.test.ts` — six cases:
  default resolved when unset, host value preferred over it, `undefined` when
  no default is declared, a default behind a thunk, a defaulted variable absent
  from `getMissing()`, and `isConfigured` separated from `hasDefault`. Hand-
  rolled Standard Schema objects rather than zod, which core does not depend on.
- `packages/cli/.../serialize-variables-types.test.ts` — asserts the emitted
  entry carries `schema: () => ApiUrlSchema` and explicitly does *not* carry the
  eager form, so the cycle cannot come back.
- `verifiers/variables` gains a runtime half (it compiled only before): a real
  `pikku` generation, then assertions against `TypedVariablesService` from
  `#pikku/variables`.
