### PR TITLE
fix(cli): validate static imports of bundler-stubbed packages

### DIFF
--- a/.changeset/violet-donkeys-smash.md
+++ b/.changeset/violet-donkeys-smash.md
@@ -1,0 +1,13 @@
+---
+'@pikku/cli': patch
+---
+
+validate: flag static imports of packages the deploy bundler stubs
+
+The deploy bundler replaces the AI SDK packages (`@pikku/ai-vercel`, `@ai-sdk/*`,
+`ai`) with `export {}` in every unit that does not require `agentRunner`, so a
+static named import of one in `services.ts` fails to bundle with an opaque
+esbuild error repeated once per unit. `pikku fabric validate` now reports this as
+`services-static-stubbed-import` and points at the lazy-import shape the starter
+template uses. The service-to-module map moved to its own module so the check and
+the bundler read the same list.

--- a/packages/cli/src/deploy/bundler/bundler.ts
+++ b/packages/cli/src/deploy/bundler/bundler.ts
@@ -34,6 +34,7 @@ import type {
   CompileInput,
   CompileResult,
 } from './bundler.interface.js'
+import { SERVICE_MODULE_MAP } from './service-module-map.js'
 
 /**
  * Mapping of service name -> gen file pattern that should be stubbed
@@ -41,22 +42,6 @@ import type {
  */
 const SERVICE_GEN_FILE_MAP: Record<string, RegExp> = {
   metaService: /pikku-meta-service\.gen/,
-}
-
-/**
- * Mapping of service name -> npm module patterns to stub when the service is
- * NOT required by a deployment unit. Unlike SERVICE_GEN_FILE_MAP these are
- * external packages, not gen files: a unit that doesn't wire the service never
- * executes the code path that imports them, so replacing them with `export {}`
- * keeps their (often large) trees out of the bundle.
- *
- * The AI SDKs (@pikku/ai-vercel + @ai-sdk/* + `ai`, ~3MB) are only constructed
- * when `agentRunner` is wired (agent units). Every non-agent unit stubs them.
- * The shared services factory must guard the runner construction behind a
- * defined-check on the dynamic import so a stubbed unit simply skips it.
- */
-const SERVICE_MODULE_MAP: Record<string, RegExp[]> = {
-  agentRunner: [/^@pikku\/ai-vercel/, /^@ai-sdk\//, /^ai$/],
 }
 
 /**

--- a/packages/cli/src/deploy/bundler/service-module-map.ts
+++ b/packages/cli/src/deploy/bundler/service-module-map.ts
@@ -1,0 +1,19 @@
+/**
+ * Mapping of service name -> npm module patterns to stub when the service is
+ * NOT required by a deployment unit. These are external packages, not gen
+ * files: a unit that doesn't wire the service never executes the code path
+ * that imports them, so replacing them with `export {}` keeps their (often
+ * large) trees out of the bundle.
+ *
+ * The AI SDKs (@pikku/ai-vercel + @ai-sdk/* + `ai`, ~3MB) are only constructed
+ * when `agentRunner` is wired (agent units). Every non-agent unit stubs them.
+ * The shared services factory must guard the runner construction behind a
+ * defined-check on the dynamic import so a stubbed unit simply skips it.
+ *
+ * It lives in its own module so `pikku validate` can warn about a static import
+ * of a stubbed package without pulling the bundler in — a check that reads a
+ * second copy of this list would go stale the first time the list changed.
+ */
+export const SERVICE_MODULE_MAP: Record<string, RegExp[]> = {
+  agentRunner: [/^@pikku\/ai-vercel/, /^@ai-sdk\//, /^ai$/],
+}

--- a/packages/cli/src/functions/validate/shared-checks.test.ts
+++ b/packages/cli/src/functions/validate/shared-checks.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from 'node:test'
 import {
   betterAuthTableAliases,
   migrationCreatesTable,
+  staticStubbedImports,
 } from './shared-checks.js'
 
 const AUTH_CONFIG = `
@@ -47,5 +48,71 @@ describe('betterAuthTableAliases', () => {
     const aliases = betterAuthTableAliases('verification', AUTH_CONFIG)
     assert.ok(aliases.some((name) => migrationCreatesTable(sql, name)))
     assert.ok(!migrationCreatesTable(sql, 'verification'))
+  })
+})
+
+describe('staticStubbedImports', () => {
+  test('reports a named import of a stubbed package', () => {
+    const found = staticStubbedImports(
+      "import { VercelAgentRunner } from '@pikku/ai-vercel'"
+    )
+    assert.deepStrictEqual(found, [
+      { module: '@pikku/ai-vercel', service: 'agentRunner' },
+    ])
+  })
+
+  test('reports every stubbed package in the file', () => {
+    const found = staticStubbedImports(
+      [
+        "import { VercelAgentRunner } from '@pikku/ai-vercel'",
+        "import { createOpenAI } from '@ai-sdk/openai'",
+        "import { Kysely } from 'kysely'",
+      ].join('\n')
+    )
+    assert.deepStrictEqual(
+      found.map((f) => f.module),
+      ['@pikku/ai-vercel', '@ai-sdk/openai']
+    )
+  })
+
+  test('ignores a type-only import', () => {
+    assert.deepStrictEqual(
+      staticStubbedImports(
+        "import type { VercelAgentRunner } from '@pikku/ai-vercel'"
+      ),
+      []
+    )
+  })
+
+  test('ignores a named clause whose bindings are all types', () => {
+    assert.deepStrictEqual(
+      staticStubbedImports(
+        "import { type VercelAgentRunner, type AgentStep } from '@pikku/ai-vercel'"
+      ),
+      []
+    )
+  })
+
+  test('ignores a dynamic import', () => {
+    assert.deepStrictEqual(
+      staticStubbedImports(
+        "const aiVercel = await import('@pikku/ai-vercel')"
+      ),
+      []
+    )
+  })
+
+  test('ignores a package the bundler never stubs', () => {
+    assert.deepStrictEqual(
+      staticStubbedImports("import { Kysely } from 'kysely'"),
+      []
+    )
+  })
+
+  test('does not confuse a package that merely starts with ai', () => {
+    assert.deepStrictEqual(
+      staticStubbedImports("import { thing } from 'airtable'"),
+      []
+    )
   })
 })

--- a/packages/cli/src/functions/validate/shared-checks.ts
+++ b/packages/cli/src/functions/validate/shared-checks.ts
@@ -11,6 +11,7 @@ import {
   runWebsocketDepsChecks,
 } from './websocket-deps-checks.js'
 import { resolveFromProject } from '../../utils/resolve-from-project.js'
+import { SERVICE_MODULE_MAP } from '../../deploy/bundler/service-module-map.js'
 
 export type Finding = ValidateFinding
 
@@ -155,6 +156,44 @@ export const betterAuthTableAliases = (
     override,
     override.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase(),
   ]
+}
+
+/**
+ * Static value imports of a package the deploy bundler stubs.
+ *
+ * A unit that does not require the service gets the package rewritten to
+ * `export {}`, so a static named import fails to bundle — once per unit, with
+ * an esbuild message that names the stub rather than the mistake. Type-only
+ * imports are erased before bundling and a side-effect import binds nothing,
+ * so neither is reported.
+ */
+export const staticStubbedImports = (
+  code: string
+): Array<{ module: string; service: string }> => {
+  const found: Array<{ module: string; service: string }> = []
+  const statements = code.matchAll(
+    /^[ \t]*import\s+(?!type\s)([\s\S]*?)\s*from\s*['"`]([^'"`]+)['"`]/gm
+  )
+  for (const statement of statements) {
+    const clause = statement[1]!
+    const specifier = statement[2]!
+    const named = clause.match(/^\{([\s\S]*)\}$/)
+    if (
+      named &&
+      named[1]!
+        .split(',')
+        .filter((binding) => binding.trim().length > 0)
+        .every((binding) => /^type\s/.test(binding.trim()))
+    ) {
+      continue
+    }
+    for (const [service, patterns] of Object.entries(SERVICE_MODULE_MAP)) {
+      if (patterns.some((pattern) => pattern.test(specifier))) {
+        found.push({ module: specifier, service })
+      }
+    }
+  }
+  return found
 }
 
 /**
@@ -462,13 +501,29 @@ export async function runSharedProjectChecks(
     }
 
     const servicesPath = join(fnDir, 'src', 'services.ts')
-    if (!(await readTextSafe(servicesPath))) {
+    const servicesText = await readTextSafe(servicesPath)
+    if (!servicesText) {
       w(
         'services-missing',
         'packages/functions/src/services.ts not found',
         servicesPath,
         'Create services.ts and export your service factory for the workspace'
       )
+    } else {
+      for (const { module, service } of staticStubbedImports(servicesText)) {
+        e(
+          'services-static-stubbed-import',
+          `services.ts imports '${module}' statically, but the deploy bundler stubs it in every unit that does not require '${service}'`,
+          servicesPath,
+          lines(
+            `Every unit without '${service}' gets '${module}' rewritten to \`export {}\`, so a static import fails to bundle there.`,
+            'Import the type only, then load the package when you build the service:',
+            `  const mod = await import('${module}')`,
+            '  if (mod.SomeExport) { ... }',
+            'See templates/starter-template/packages/functions/src/services.ts for the shape.'
+          )
+        )
+      }
     }
 
     // ── auth schema ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The deploy bundler stubs the AI SDK packages (`@pikku/ai-vercel`, `@ai-sdk/*`, `ai`) — rewriting them to `export {}` — in every unit that does not require `agentRunner`. That contract was documented only in a comment above `SERVICE_MODULE_MAP`, and nothing checked it.

A `services.ts` with a static named import of one of those packages therefore typechecks, passes `pikku fabric validate`, and then fails the deploy with an opaque esbuild error repeated once per non-agent unit:

```
No matching export in "pikku-stub:@pikku/ai-vercel" for import "VercelAgentRunner"
```

seminarhof hit this — ~40 identical errors, no indication that the cause was a stubbed module rather than a broken package.

## Change

- `SERVICE_MODULE_MAP` moves out of `bundler.ts` into `deploy/bundler/service-module-map.ts`, so the check and the bundler read the same list — a second copy would go stale the first time the list changed.
- `runSharedProjectChecks` gains `services-static-stubbed-import`: any non-type static import of a stubbed package in `packages/functions/src/services.ts` is reported as an error, pointing at the lazy-import shape the starter template already uses.

Type-only imports and `await import(...)` are both ignored, so the correct pattern stays quiet.

## Testing

- 7 new unit tests for `staticStubbedImports` (11 pass in the file, 0 fail): named import reported, every stubbed package reported, `import type` ignored, an all-type-bindings clause ignored, dynamic import ignored, unrelated packages ignored, and `airtable` not matched by the `^ai$` pattern.
- Run against seminarhof's real pre-fix `services.ts`: reports both `@pikku/ai-vercel` and `@ai-sdk/openai`. Against the fixed version: reports nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbD1Nm6beyHkCB8qujxcLw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `pikku fabric validate` now flags static runtime imports from stubbed AI SDK packages.
  - Validation identifies the affected package and service, while ignoring type-only and dynamic imports.
  - Error guidance recommends the lazy-import pattern used by the starter template.

- **Bug Fixes**
  - Prevented deployments from silently omitting functionality due to unsupported static imports.

- **Tests**
  - Added coverage for named, multiple, type-only, dynamic, and similarly prefixed imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->