### PR TITLE
feat(console): the URL as state, over whichever router is reading it

### DIFF
--- a/.changeset/url-state-over-any-router.md
+++ b/.changeset/url-state-over-any-router.md
@@ -1,0 +1,24 @@
+---
+'@pikku/console': patch
+---
+
+feat(console): the URL as state, over whichever router is reading it
+
+Keeping something on screen in the URL is the same handful of rules every time
+— merge rather than overwrite the params you don't own, clear on null, fall
+back to the first row when the value names one that is gone, replace rather
+than push so scanning a list does not fill the back stack — and they were being
+written out again at each call site, here and in every host with pages of its
+own.
+
+`createUrlState(useSearchParams)` holds the rules and takes the router,
+returning `useUrlState(key)`, `useUrlSelection(key, options)` and
+`useUrlWrite()` for a change that means nothing by halves. The console binds it
+to the router shim and exports the bound hooks; a host binds it to its own
+router, which is what a page outside the shim's provider needs — Fabric's file
+tree and ticket board are its pages, not the console's, and they keep a
+selection by the same rules.
+
+`TabbedSurface` is the first to use it. Its tab used to be written by replacing
+the whole param set, which quietly dropped every other param on the surface;
+the tab and the search box it clears now go in one merged write.

--- a/packages/console/src/components/console/TabbedSurface.tsx
+++ b/packages/console/src/components/console/TabbedSurface.tsx
@@ -2,8 +2,12 @@ import React, { useState } from 'react'
 import { Group, SegmentedControl, Stack, TextInput } from '@pikku/mantine/core'
 import { Search } from 'lucide-react'
 import type { I18nNode, I18nString } from '@pikku/react'
-import { useSearchParams } from '../../router'
 import { setUrlHash } from '../../hooks/useUrlHash'
+import {
+  useUrlSelection,
+  useUrlState,
+  useUrlWrite,
+} from '../../hooks/url-state'
 import { ConsoleSurface } from './ConsoleSurface'
 import { ResizablePanelLayout } from '../layout/ResizablePanelLayout'
 import { ListPageHeader } from '../layout/PageLayout'
@@ -80,16 +84,19 @@ export const TabbedSurface: React.FC<TabbedSurfaceProps> = (props) => {
     onTabChange,
   } = props
   useLocale()
-  const [searchParams, setSearchParams] = useSearchParams()
+  const [linkedTab] = useUrlSelection(
+    searchParamKey,
+    tabs.map((tab) => tab.value)
+  )
+  const writeUrl = useUrlWrite()
   // `?search=` makes one row of a tab linkable from elsewhere — a knowledge note
   // naming `http:/entries` sends the reader to the endpoint it is about. Only the
   // initial value: from then on the box is theirs, and rewriting the URL as they
   // type would put every keystroke in the back button.
-  const [searchQuery, setSearchQuery] = useState(
-    () => searchParams.get('search') ?? ''
-  )
+  const [linkedSearch] = useUrlState('search')
+  const [searchQuery, setSearchQuery] = useState(() => linkedSearch ?? '')
 
-  const requested = activeTab ?? searchParams.get(searchParamKey)
+  const requested = activeTab ?? linkedTab
   const active = tabs.find((tab) => tab.value === requested) ?? tabs[0]!
 
   const handleTabChange = (value: string) => {
@@ -102,7 +109,10 @@ export const TabbedSurface: React.FC<TabbedSurfaceProps> = (props) => {
       onTabChange(value)
       return
     }
-    setSearchParams({ [searchParamKey]: value })
+    // One write: the box is cleared above, so the param that seeded it goes in
+    // the same step as the tab — left behind it would name a search no longer
+    // being run. Pushed, not replaced: back belongs to the tab you came from.
+    writeUrl({ [searchParamKey]: value, search: null }, { replace: false })
   }
 
   const segmented = (

--- a/packages/console/src/hooks/url-state.test.ts
+++ b/packages/console/src/hooks/url-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { applyUrlParams, resolveUrlSelection } from './url-state.js'
+
+describe('applyUrlParams', () => {
+  it('leaves a param this surface does not own alone', () => {
+    const next = applyUrlParams(new URLSearchParams('tab=http&runId=7'), {
+      file: 'src/index.ts',
+    })
+    assert.equal(next.get('runId'), '7')
+    assert.equal(next.get('file'), 'src/index.ts')
+  })
+
+  it('clears on null and on empty, so one setter can do both', () => {
+    const next = applyUrlParams(new URLSearchParams('tab=http&search=user'), {
+      tab: null,
+      search: '',
+    })
+    assert.equal(next.get('tab'), null)
+    assert.equal(next.get('search'), null)
+  })
+
+  it('writes every key in one pass', () => {
+    const next = applyUrlParams(new URLSearchParams('tab=http&search=user'), {
+      tab: 'channels',
+      search: null,
+    })
+    assert.equal(next.toString(), 'tab=channels')
+  })
+})
+
+describe('resolveUrlSelection', () => {
+  it('keeps a value that names a row', () => {
+    assert.equal(resolveUrlSelection('b', ['a', 'b']), 'b')
+  })
+
+  it('falls back to the first when the row has gone', () => {
+    assert.equal(resolveUrlSelection('gone', ['a', 'b']), 'a')
+    assert.equal(resolveUrlSelection(null, ['a', 'b']), 'a')
+  })
+
+  it('is null when there is nothing to select', () => {
+    assert.equal(resolveUrlSelection('a', []), null)
+  })
+})

--- a/packages/console/src/hooks/url-state.ts
+++ b/packages/console/src/hooks/url-state.ts
@@ -1,0 +1,98 @@
+import { useCallback } from 'react'
+import { useSearchParams as useConsoleSearchParams } from '../router'
+import type { ConsoleRouter } from '../router'
+
+export type UrlState = [string | null, (next: string | null) => void]
+
+export type UrlWrite = (
+  next: Record<string, string | null>,
+  options?: { replace?: boolean }
+) => void
+
+export interface UrlStateOptions {
+  /**
+   * Replaces by default: the URL tracks what is on screen so it can be copied
+   * and reloaded, but scanning a list must not fill the back stack. A tab is
+   * the exception — going back to the one you came from is what the button is
+   * for — so those pass `false`.
+   */
+  replace?: boolean
+}
+
+/**
+ * The rules for keeping what is on screen in the URL, over whichever router is
+ * reading it.
+ *
+ * The console reads the host's router through the shim; a host with pages of
+ * its own (Fabric) has those pages outside the shim's provider and reads its
+ * own. Both want the same rules — merge rather than overwrite the other params,
+ * clear on null, fall back to the first row when the value names one that is
+ * gone — so the rules live here once and each side binds its `useSearchParams`.
+ */
+/** Merged, never overwritten: a param this surface does not own stays put. */
+export const applyUrlParams = (
+  prev: URLSearchParams,
+  next: Record<string, string | null>
+): URLSearchParams => {
+  const updated = new URLSearchParams(prev)
+  for (const [key, value] of Object.entries(next)) {
+    if (value === null || value === '') updated.delete(key)
+    else updated.set(key, value)
+  }
+  return updated
+}
+
+/** An absent or unknown value falls back to the first option. */
+export const resolveUrlSelection = (
+  value: string | null,
+  options: readonly string[]
+): string | null =>
+  value !== null && options.includes(value) ? value : (options[0] ?? null)
+
+export const createUrlState = (
+  useSearchParams: ConsoleRouter['useSearchParams']
+) => {
+  /** Several params in one write, for a change that means nothing by halves. */
+  const useUrlWrite = (): UrlWrite => {
+    const [, setSearchParams] = useSearchParams()
+    return useCallback(
+      (next, options) => {
+        setSearchParams((prev) => applyUrlParams(prev, next), {
+          replace: options?.replace ?? true,
+        })
+      },
+      [setSearchParams]
+    )
+  }
+
+  const useUrlState = (key: string, options?: UrlStateOptions): UrlState => {
+    const [searchParams] = useSearchParams()
+    const write = useUrlWrite()
+    const replace = options?.replace
+    const set = useCallback(
+      (next: string | null) => write({ [key]: next }, { replace }),
+      [write, key, replace]
+    )
+    return [searchParams.get(key), set]
+  }
+
+  /**
+   * A value that has to name one of `options` — an absent or unknown one falls
+   * back to the first, so a bare URL lands on something and a link to a row
+   * that has since gone does not leave the surface empty.
+   */
+  const useUrlSelection = (
+    key: string,
+    options: readonly string[],
+    stateOptions?: UrlStateOptions
+  ): UrlState => {
+    const [value, set] = useUrlState(key, stateOptions)
+    return [resolveUrlSelection(value, options), set]
+  }
+
+  return { useUrlWrite, useUrlState, useUrlSelection }
+}
+
+export const { useUrlWrite, useUrlState, useUrlSelection } = createUrlState(
+  useConsoleSearchParams
+)

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -307,6 +307,15 @@ export { ConsoleEditableProvider } from './context/ConsoleEditableContext'
 // same right-hand configuration panels the pages use, by wire type + id.
 export { PanelProvider, usePanelContext } from './context/PanelContext'
 export { usePanelUrl } from './hooks/usePanelUrl'
+// The URL as state, for a host with pages of its own: bind `createUrlState` to
+// that host's router and its pages keep a selection the way the console's do.
+export {
+  createUrlState,
+  useUrlState,
+  useUrlSelection,
+  useUrlWrite,
+} from './hooks/url-state'
+export type { UrlState, UrlWrite, UrlStateOptions } from './hooks/url-state'
 export type { PanelUrlOptions } from './hooks/usePanelUrl'
 export { panelHref } from './lib/panel-url'
 export type { PanelType, PanelData } from './context/PanelContext'


### PR DESCRIPTION
Keeping something on screen in the URL is the same handful of rules every time — merge rather than overwrite the params you don't own, clear on null, fall back to the first row when the value names one that is gone, replace rather than push so scanning a list does not fill the back stack — and they were being written out again at each call site, here and in every host with pages of its own.

`createUrlState(useSearchParams)` holds the rules and takes the router:

```ts
const { useUrlState, useUrlSelection, useUrlWrite } = createUrlState(useSearchParams)
```

The console binds it to the router shim and exports the bound hooks. A host binds it to its own router, which is what a page outside the shim's provider needs — Fabric's file tree and ticket board are its pages, not the console's, and they should keep a selection by the same rules rather than a second copy of them.

`TabbedSurface` is the first caller. Its tab used to be written as `setSearchParams({ tab: value })`, which replaced the whole param set and quietly dropped every other param on the surface; the tab and the search box it clears now go in one merged write, still pushed rather than replaced, because back belongs to the tab you came from.

The selection fragment from #1490 is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added router-agnostic URL state hooks for preserving selections, tabs, and search parameters.
  * Added support for host applications to connect console URL state to their own routers.
  * Added merged URL updates that preserve unrelated query parameters.
  * Tab changes now update the tab and clear search parameters together.

* **Bug Fixes**
  * Selections now fall back to the first available option when the selected item is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->