### PR TITLE
fix(console): draw the nav dock's separator

### DIFF
--- a/.changeset/dock-separator-visible.md
+++ b/.changeset/dock-separator-visible.md
@@ -1,0 +1,9 @@
+---
+'@pikku/console': patch
+---
+
+Draw the nav dock's separator. It was a 3.6-gap spacer with `background: none`,
+so the zones it divides read as one uninterrupted row — the grouping was there
+in the markup and invisible on screen. It is now a 2px pill in the hint colour,
+which is the same mark and width the dock's own pull hint already uses, rather
+than the 1px hairline that could not hold contrast against blurred glass.

--- a/packages/console/src/components/nav-dock/NavDock.module.css
+++ b/packages/console/src/components/nav-dock/NavDock.module.css
@@ -195,13 +195,25 @@
   gap: var(--pf-dock-gap);
 }
 
-/* Grouping by space, not by rule. A 1px hairline on blurred glass measures
-   1.3:1 — it was doing hierarchy work it could not carry. */
+/* Space alone did not read: at 3.6 gaps it is a pause a user reports as "there
+   is no separator". A 1px hairline is still out — on blurred glass it measures
+   1.3:1 — so the rule is a 2px pill in the hint colour, the one mark on this
+   surface already proven to carry at that width. */
 .dockSep {
   flex: 0 0 auto;
   width: calc(var(--pf-dock-gap) * 3.6);
-  height: 1px;
-  background: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dockSep::before {
+  content: '';
+  width: 2px;
+  height: calc(var(--pf-tile) * 0.44);
+  border-radius: 1px;
+  background: var(--pf-hint);
+  opacity: 0.55;
 }
 
 /* A tile. Fixed box — deliberately no macOS magnification: magnification moves
@@ -978,8 +990,13 @@
 }
 
 .dockStrip[data-axis='y'] .dockSep {
-  width: 1px;
+  width: auto;
   height: calc(var(--pf-dock-gap) * 3.6);
+}
+
+.dockStrip[data-axis='y'] .dockSep::before {
+  width: calc(var(--pf-tile) * 0.44);
+  height: 2px;
 }
 
 .dockStrip[data-axis='y'] .dockHint {


### PR DESCRIPTION
`.dockSep` was a 3.6-gap spacer with `background: none`. The zones it divides read as one uninterrupted row, so the grouping existed in the markup and nowhere on screen — reported from fabric as "I can't see the separator".

It is now a 2px pill in `--pf-hint`, centred in the same gap, with the y-axis variant rotated to match.

The 1px hairline the old comment rejected stays rejected — on blurred glass it measured 1.3:1. 2px in `--pf-hint` is the dock's own pull hint, already proven to carry at that width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)