### PR TITLE
fix(better-auth): provisionPersonas provisions

### DIFF
--- a/.changeset/tidy-pandas-provision.md
+++ b/.changeset/tidy-pandas-provision.md
@@ -1,0 +1,14 @@
+---
+'@pikku/better-auth': patch
+'@pikku/cli': patch
+---
+
+Persona provisioning actually provisions.
+
+Two things stopped `provisionPersonas` from ever creating an account. It read
+`$context` off the better-auth instance without awaiting it — every other call
+site does — so the orphan sweep died on `undefined.findMany`, and a cast to
+`any` kept the compiler quiet about it. And nothing set `PIKKU_ENV`, so the
+environment rule failed closed and skipped every persona before it got that
+far; `pikku dev` now names the local environment from `environments` in
+pikku.config.json, preferring one called `local`.

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -40,6 +40,7 @@ import {
 import { loadUserBootstrap, loadUserModule } from './load-user-project.js'
 import { registerScenarioInstrumentation } from '../wirings/scenarios/register-scenario-instrumentation.js'
 import { startCoverageService } from './start-coverage.js'
+import { resolveDevEnvironmentName } from './environment.js'
 import { createDevAgentRunner } from './dev-agent-runner.js'
 import { resolveConsoleMount } from './serve-console.js'
 import { serverReadyLine } from '../../server/server-ready.js'
@@ -72,6 +73,9 @@ export const dev = pikkuSessionlessFunc<
     { rpc }
   ) => {
     process.env.PIKKU_DEV_QUICK_LOGIN ??= 'true'
+    process.env.PIKKU_ENV ??= resolveDevEnvironmentName(
+      config.environments ?? {}
+    )
     enableDevActorSignIn(logger)
     applyModelAliasOverride(logger, model, config.models)
     if (test) {

--- a/packages/cli/src/functions/commands/environment.test.ts
+++ b/packages/cli/src/functions/commands/environment.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { resolveEnvironment } from './environment.js'
+import { resolveDevEnvironmentName, resolveEnvironment } from './environment.js'
 
 const environments = {
   local: {
@@ -175,5 +175,35 @@ describe('resolveEnvironment', () => {
         }),
       /--app-url storefront '\/_frontend\/storefront\/' is not a valid absolute URL/
     )
+  })
+})
+
+describe('resolveDevEnvironmentName', () => {
+  test('a loopback environment is what dev runs as', () => {
+    assert.equal(resolveDevEnvironmentName(environments), 'local')
+  })
+
+  test("'local' wins over another loopback environment", () => {
+    assert.equal(
+      resolveDevEnvironmentName({
+        e2e: { apiUrl: 'http://127.0.0.1:4078' },
+        local: { apiUrl: 'http://localhost:4077' },
+      }),
+      'local'
+    )
+  })
+
+  test('a remote or production environment is never dev', () => {
+    assert.equal(
+      resolveDevEnvironmentName({
+        staging: { apiUrl: 'https://api.staging.test' },
+        production: { apiUrl: 'https://api.test', production: true },
+      }),
+      undefined
+    )
+  })
+
+  test('no configured environments resolves to nothing rather than a guess', () => {
+    assert.equal(resolveDevEnvironmentName({}), undefined)
   })
 })

--- a/packages/cli/src/functions/commands/environment.ts
+++ b/packages/cli/src/functions/commands/environment.ts
@@ -149,3 +149,29 @@ export const parseAppUrls = (
   }
   return { base, byApp }
 }
+
+/**
+ * The environment name `pikku dev` is running as, for anything that gates on
+ * `PIKKU_ENV` — persona provisioning above all, which fails closed and so
+ * provisions nothing at all when nobody says where the process is.
+ *
+ * Local means a configured, non-production environment whose `apiUrl` is a
+ * loopback host; `local` wins when several qualify. A project that configures
+ * none gets `undefined` rather than a guess.
+ */
+export const resolveDevEnvironmentName = (
+  environments: Record<string, PikkuEnvironment>
+): string | undefined => {
+  const candidates = Object.entries(environments).filter(([, environment]) => {
+    if (environment.production) {
+      return false
+    }
+    try {
+      return LOCAL_HOSTNAMES.has(new URL(environment.apiUrl).hostname)
+    } catch {
+      return false
+    }
+  })
+  const preferred = candidates.find(([name]) => name === 'local')
+  return (preferred ?? candidates[0])?.[0]
+}

--- a/packages/services/better-auth/src/provision-personas.ts
+++ b/packages/services/better-auth/src/provision-personas.ts
@@ -149,7 +149,7 @@ export const provisionPersonas = async (
       'Provisioning personas requires better-auth to be wired (services.auth is missing)'
     )
   }
-  const ctx = (await auth()).$context as any
+  const ctx = (await (await auth()).$context) as any
 
   const banAvailable =
     typeof ctx.hasPlugin === 'function'


### PR DESCRIPTION
`provisionPersonas` never created an account. Two faults hid each other.

**It read `$context` without awaiting it.** `auth.$context` is a promise; every other call site in the package awaits it. `const ctx = (await auth()).$context as any` — the cast is what kept the compiler quiet — so `ctx.internalAdapter` and `ctx.adapter` were both `undefined`, and the orphan sweep died on `undefined.findMany`.

**Nothing set `PIKKU_ENV`.** `personaEnvironmentRefusal` fails closed on an unresolved environment, correctly, so every persona was skipped before reaching the code that would have thrown on the first one. That is why the first fault went unseen: the loop never ran.

`pikku dev` now names the local environment from `environments` in pikku.config.json — a configured, non-production one on a loopback host, preferring the one called `local`. A project that configures none gets nothing set rather than a guess, and the refusal message still says what to do.

Verified against a real app (personas declared, `provisionPersonas` in `afterStart`): before, `WARN: ... Cannot read properties of undefined (reading 'findMany')` and zero rows; after, `personas: 5 role grant(s) applied` and the actor accounts in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)