### PR TITLE
fix(virtual-user): key the production guard on the configured environment

### DIFF
--- a/.changeset/virtual-user-production-env.md
+++ b/.changeset/virtual-user-production-env.md
@@ -1,0 +1,16 @@
+---
+'@pikku/core': patch
+'@pikku/cli': patch
+---
+
+Decide whether a virtual-user run is against production from the configured
+environment rather than `NODE_ENV`.
+
+A deployment whose staging is a production mirror runs `NODE_ENV=production`
+there too, so the old check refused every disposition on the one environment
+they exist to be used on. `startVirtualUserRun` now takes the `environments`
+generated beside the personas and the environment this process is (`PIKKU_ENV`
+by default), which is the same signal `personaEnvironmentRefusal` already
+checks at sign-in; the generated scaffold passes them. An environment that
+cannot be resolved is treated as production. `NODE_ENV` remains the answer for
+a project that configures no environments at all.

--- a/packages/cli/src/functions/wirings/virtual-user/serialize-virtual-user-functions.ts
+++ b/packages/cli/src/functions/wirings/virtual-user/serialize-virtual-user-functions.ts
@@ -287,7 +287,7 @@ import {
   virtualUserScheduleRunInput,
   writeVirtualUserSchedule,
 } from '@pikku/core/virtual-user'
-import { createPersonas, personaConfigs } from '${pathToPersonas}'
+import { createPersonas, personaConfigs, personaEnvironments } from '${pathToPersonas}'
 import {
   ExecuteVirtualUserRunInput,
   ExecuteVirtualUserRunOutput,
@@ -340,8 +340,11 @@ export const runVirtualUser = pikkuFunc({
       await startVirtualUserRun({
         store: virtualUserRunStore,
         personas: personaConfigs,
-        // Cast because an application's Config is its own interface and need
-        // not declare nodeEnv at all.
+        // Which of the configured environments this process is decides whether
+        // a run is against production. \`config\` is only the fallback for a
+        // project that configures none, and is cast because an application's
+        // Config is its own interface and need not declare nodeEnv at all.
+        environments: personaEnvironments,
         config: config as { nodeEnv?: string } | undefined,
         persona: input.persona,
         disposition: input.disposition,

--- a/packages/cli/src/functions/wirings/virtual-user/virtual-user-functions.test.ts
+++ b/packages/cli/src/functions/wirings/virtual-user/virtual-user-functions.test.ts
@@ -214,7 +214,7 @@ describe('serializeVirtualUserFunctions', () => {
   test('imports the generated personas rather than declaring any', () => {
     assert.match(
       out,
-      /import \{ createPersonas, personaConfigs \} from '\.\.\/\.\.\/\.\.\/\.pikku\/workflow\/pikku-personas\.gen\.js'/
+      /import \{ createPersonas, personaConfigs, personaEnvironments \} from '\.\.\/\.\.\/\.\.\/\.pikku\/workflow\/pikku-personas\.gen\.js'/
     )
   })
 

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,8 +5,8 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2884 observable things**: 916 exported names, plus
-1968 members on the classes and interfaces among them, reachable
+**2886 observable things**: 916 exported names, plus
+1970 members on the classes and interfaces among them, reachable
 through 54 entry points.
 
 An entry point whose exports are mostly *exclusive* is a self-contained
@@ -15,7 +15,7 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | entry point | exports | exclusive | members on those |
 | --- | ---: | ---: | ---: |
 | `./services` | 141 | 115 | 413 |
-| `./virtual-user` | 66 | 66 | 210 |
+| `./virtual-user` | 66 | 66 | 212 |
 | `./scenario` | 45 | 45 | 134 |
 | `./workflow` | 84 | 35 | 140 |
 | `./agent` | 50 | 48 | 81 |
@@ -2304,11 +2304,13 @@ export interface StartedVirtualUserRun {
   goals: string[]
   memory: Record<string, string>
 }
-startVirtualUserRun: ({ store, personas, config, persona: personaId, disposition: requested, seed: requestedSeed, goals, memory, startedBy, }: StartVirtualUserRunParams) => Promise<StartedVirtualUserRun>
+startVirtualUserRun: ({ store, personas, config, environments, environment, persona: personaId, disposition: requested, seed: requestedSeed, goals, memory, startedBy, }: StartVirtualUserRunParams) => Promise<StartedVirtualUserRun>
 export interface StartVirtualUserRunParams {
   store: VirtualUserRunStore | undefined
   personas: ScaffoldPersonas
   config: { nodeEnv?: string } | undefined
+  environments?: Readonly<Record<string, PersonaEnvironment>>
+  environment?: string
   persona: string
   disposition?: string
   seed?: number

--- a/packages/core/src/wirings/virtual-user/virtual-user-scaffold.test.ts
+++ b/packages/core/src/wirings/virtual-user/virtual-user-scaffold.test.ts
@@ -244,6 +244,65 @@ describe('startVirtualUserRun', () => {
     assert.equal(started[0].disposition, 'accountable')
   })
 
+  // The case NODE_ENV cannot answer: a staging environment that is a production
+  // mirror runs NODE_ENV=production too, and refusing every disposition there
+  // refuses them on the one environment they exist to be used on.
+  test('a non-production environment allows a probing disposition', async () => {
+    const { store, started } = runStore()
+    await startVirtualUserRun({
+      store,
+      personas,
+      config: { nodeEnv: 'production' },
+      environments: { staging: {}, production: { production: true } },
+      environment: 'staging',
+      persona: 'susan',
+      disposition: 'adversarial',
+    })
+    assert.equal(started[0].disposition, 'adversarial')
+  })
+
+  test('the configured production environment still refuses one', async () => {
+    const { store, started } = runStore()
+    await assert.rejects(
+      startVirtualUserRun({
+        store,
+        personas,
+        config: { nodeEnv: 'development' },
+        environments: { staging: {}, production: { production: true } },
+        environment: 'production',
+        persona: 'susan',
+        disposition: 'adversarial',
+      }),
+      /Only the 'accountable' disposition may run against production/
+    )
+    assert.equal(started.length, 0)
+  })
+
+  // An environment nobody can name is one whose data nobody can vouch for.
+  // PIKKU_ENV is cleared rather than passed as undefined: it is the default the
+  // parameter falls back to, so leaving it set would test the wrong thing.
+  test('an unresolved environment is treated as production', async () => {
+    const { store, started } = runStore()
+    const pikkuEnv = process.env.PIKKU_ENV
+    delete process.env.PIKKU_ENV
+    try {
+      await assert.rejects(
+        startVirtualUserRun({
+          store,
+          personas,
+          config: { nodeEnv: 'development' },
+          environments: { staging: {}, production: { production: true } },
+          persona: 'susan',
+          disposition: 'adversarial',
+        }),
+        /Only the 'accountable' disposition may run against production/
+      )
+    } finally {
+      if (pikkuEnv !== undefined) process.env.PIKKU_ENV = pikkuEnv
+    }
+    assert.equal(started.length, 0)
+  })
+
   test('refuses a persona that is declared as acted upon', async () => {
     const { store, started } = runStore()
     await assert.rejects(

--- a/packages/core/src/wirings/virtual-user/virtual-user-scaffold.ts
+++ b/packages/core/src/wirings/virtual-user/virtual-user-scaffold.ts
@@ -11,6 +11,7 @@ import { prepareVirtualUserRun } from './prepare-virtual-user-run.js'
 import { runVirtualUser as runVirtualUserEngine } from './run-virtual-user.js'
 import { personaVirtualUserTarget } from './virtual-user-target.js'
 import type { SchemaMap } from './virtual-user-derive.js'
+import type { PersonaEnvironment } from '../persona/persona-environments.js'
 import { PRODUCTION_DISPOSITION } from './virtual-user.types.js'
 import type {
   StepRecord,
@@ -160,8 +161,13 @@ export interface StartVirtualUserRunParams {
   /**
    * The app's config, read only for `nodeEnv` — structural because an
    * application's Config is its own interface and need not declare it at all.
+   * The fallback signal, used only by a project that configures no environments.
    */
   config: { nodeEnv?: string } | undefined
+  /** `environments` from pikku.config.json, as generated beside the personas. */
+  environments?: Readonly<Record<string, PersonaEnvironment>>
+  /** Which of them this process is. Defaults to `PIKKU_ENV`. */
+  environment?: string
   persona: string
   disposition?: string
   seed?: number
@@ -182,6 +188,33 @@ export interface StartedVirtualUserRun {
 }
 
 /**
+ * Whether this process is running against production, for the disposition rule.
+ *
+ * The configured environment wins over `NODE_ENV` because they answer different
+ * questions. A deployment whose staging is a production *mirror* runs
+ * `NODE_ENV=production` there too — keying on it refuses every disposition on
+ * the one environment they exist to be used on. `PIKKU_ENV` names which of the
+ * configured environments this is, which is the question actually being asked,
+ * and it is the same signal `personaEnvironmentRefusal` already checks at
+ * sign-in.
+ *
+ * Unresolved is treated as production: an environment nobody can name is one
+ * whose data nobody can vouch for. `NODE_ENV` remains the answer only for a
+ * project that configures no environments at all, which has no production
+ * environment declared for this to be wrong about.
+ */
+const isProductionRun = (
+  config: { nodeEnv?: string } | undefined,
+  environments: Readonly<Record<string, PersonaEnvironment>> | undefined,
+  environment: string | undefined
+): boolean => {
+  if (!environments || Object.keys(environments).length === 0) {
+    return config?.nodeEnv === 'production'
+  }
+  return environment ? Boolean(environments[environment]?.production) : true
+}
+
+/**
  * Resolves a request against the declaration and records the run.
  *
  * Everything up to the point a run exists, which is everything a caller and a
@@ -192,6 +225,8 @@ export const startVirtualUserRun = async ({
   store,
   personas,
   config,
+  environments,
+  environment = process.env.PIKKU_ENV,
   persona: personaId,
   disposition: requested,
   seed: requestedSeed,
@@ -210,8 +245,8 @@ export const startVirtualUserRun = async ({
   // does wrong, which is not a thing to do to real customers' data. Checked
   // against the effective disposition, so an override cannot smuggle one in.
   if (
-    config?.nodeEnv === 'production' &&
-    disposition !== PRODUCTION_DISPOSITION
+    disposition !== PRODUCTION_DISPOSITION &&
+    isProductionRun(config, environments, environment)
   ) {
     throw new Error(
       `Only the '${PRODUCTION_DISPOSITION}' disposition may run against production; "${personaId}" is ${disposition}`


### PR DESCRIPTION
`startVirtualUserRun` decided whether a run was against production from `NODE_ENV`. A deployment whose staging is a production *mirror* runs `NODE_ENV=production` there too, so every disposition but `accountable` was refused on the one environment they exist to be used on.

It now reads the `environments` generated beside the personas and the environment this process is, defaulting to `PIKKU_ENV` — the same signal `personaEnvironmentRefusal` already checks at sign-in. The generated scaffold passes both.

- An environment that cannot be resolved is treated as production: one nobody can name is one whose data nobody can vouch for.
- `NODE_ENV` remains the answer for a project that configures no environments at all, which has no production environment for it to be wrong about — so existing behaviour is unchanged there.

Three tests added alongside the two existing `NODE_ENV` ones, which still pass unchanged: a non-production environment allows a probing disposition despite `NODE_ENV=production`; the configured production environment still refuses one; an unresolved environment is treated as production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Virtual-user runs now determine production status from the configured environment, improving handling of staging and other non-production environments.
  * Unresolved environments are treated safely as production.
  * Projects without configured environments continue to use the existing `NODE_ENV` fallback.
  * Production safeguards now consistently prevent probing dispositions in production runs.
  * Generated virtual-user runs now receive the configured environment settings for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->