### PR TITLE
chore(changeset): the fabric projects command is a patch

### DIFF
--- a/.changeset/cyan-pugs-listen.md
+++ b/.changeset/cyan-pugs-listen.md
@@ -1,5 +1,5 @@
 ---
-'@pikku/cli': minor
+'@pikku/cli': patch
 ---
 
 Add `pikku fabric projects`, listing the projects in your organization with their ids. The fabric API already exposed `fabricCliProjects`; no command called it, so a project's id was reachable only through the web console — and a checkout whose `pikkufabric.config.json` still held the `__PROJECT_ID__` placeholder could run no other fabric command to recover it. `fabric init` was no help either: it only creates, so against a project that already exists it fails with a 409 carrying no id. Projects matching the local config are marked.


### PR DESCRIPTION
`.changeset/cyan-pugs-listen.md` was the only pending changeset on `main` marked `minor`; every other one is `patch`. Adding `pikku fabric projects` is a new command, not a version line this repo's ~40 dependents should have to react to.

Left as-is, the next release cuts a minor for `@pikku/cli` on the back of one additive command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `pikku fabric projects` command to list projects with their IDs and identify those matching the local configuration.

* **Chores**
  * Updated the release classification for this change to a patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->