### PR TITLE
pikku fabric report: agent-authored findings, fire-and-forget to fabric

### DIFF
--- a/.changeset/fabric-report-findings.md
+++ b/.changeset/fabric-report-findings.md
@@ -1,0 +1,10 @@
+---
+'@pikku/cli': patch
+'@pikku/skills': patch
+---
+
+`pikku fabric report` sends a finding — something about pikku that cost an agent time — to the linked fabric project. Nothing is written to the repo: there is no local queue to go stale, and the terminal prints exactly what left the machine. Reporting never fails a build, so an unreachable endpoint, an unlinked project or a logged-out user prints a line and moves on.
+
+The resolved `@pikku/*` versions are read off the installed tree rather than out of `package.json`, since a range says nothing about what actually ran. A skewed tree and a package resolving through a workspace or link are both flagged, because either is a reason to read the finding differently.
+
+The `pikku-feature` skill now tells an agent when to file one: work around it first, investigate only when there is no workaround, report at the depth already reached, and never patch pikku itself from inside a project that is using it.

--- a/.changeset/fabric-report-findings.md
+++ b/.changeset/fabric-report-findings.md
@@ -3,7 +3,11 @@
 '@pikku/skills': patch
 ---
 
-`pikku fabric report` sends a finding — something about pikku that cost an agent time — to the linked fabric project. Nothing is written to the repo, so nothing goes stale on an abandoned branch, and the terminal prints exactly what left the machine. Reporting never fails a build.
+`pikku fabric report` sends a finding — something about pikku that cost an agent time — to fabric. It needs a login but no linked project: a finding is about the framework rather than about anyone's project, and the reports worth having most come from checkouts that have nothing to name.
+
+The finding can be given as JSON on stdin (`--stdin`) instead of as flags. Half the fields are prose, and prose carries apostrophes, quotes, backticks and newlines — every one a shell metacharacter before it is a character in a sentence — so an error message pasted into `--error` used to break the command at its first newline. The same schema validates either path.
+
+Nothing is written to the repo, so nothing goes stale on an abandoned branch, and the terminal prints exactly what left the machine. Reporting never fails a build.
 
 A finding that cannot be sent is held in `~/.fabric/findings` rather than dropped: logged out, unlinked, or fabric unreachable are the states a finding is most likely to be describing, and a scaffold that never got far enough to log in is exactly the thing worth hearing about. The queue drains on the next report that succeeds, keeps the project each finding was filed against, and is bounded at 100. `pikku fabric findings list`, `flush` and `clear` inspect and control it.
 

--- a/.changeset/fabric-report-findings.md
+++ b/.changeset/fabric-report-findings.md
@@ -3,7 +3,9 @@
 '@pikku/skills': patch
 ---
 
-`pikku fabric report` sends a finding — something about pikku that cost an agent time — to the linked fabric project. Nothing is written to the repo: there is no local queue to go stale, and the terminal prints exactly what left the machine. Reporting never fails a build, so an unreachable endpoint, an unlinked project or a logged-out user prints a line and moves on.
+`pikku fabric report` sends a finding — something about pikku that cost an agent time — to the linked fabric project. Nothing is written to the repo, so nothing goes stale on an abandoned branch, and the terminal prints exactly what left the machine. Reporting never fails a build.
+
+A finding that cannot be sent is held in `~/.fabric/findings` rather than dropped: logged out, unlinked, or fabric unreachable are the states a finding is most likely to be describing, and a scaffold that never got far enough to log in is exactly the thing worth hearing about. The queue drains on the next report that succeeds, keeps the project each finding was filed against, and is bounded at 100. `pikku fabric findings list`, `flush` and `clear` inspect and control it.
 
 The resolved `@pikku/*` versions are read off the installed tree rather than out of `package.json`, since a range says nothing about what actually ran. A skewed tree and a package resolving through a workspace or link are both flagged, because either is a reason to read the finding differently.
 

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -69,6 +69,12 @@ import { FabricPublish } from './functions/publish.function.js'
 import { FabricAdd } from './functions/add.function.js'
 import { FabricReport } from './functions/report.function.js'
 import {
+  FabricFindingsList,
+  renderFindingsList,
+} from './functions/findings-list.function.js'
+import { FabricFindingsFlush } from './functions/findings-flush.function.js'
+import { FabricFindingsClear } from './functions/findings-clear.function.js'
+import {
   FabricAddonVerify,
   renderAddonVerify,
 } from './functions/addon-verify.function.js'
@@ -383,6 +389,28 @@ export const fabricCommands = defineCLICommands({
       deployTarget: { description: 'The deploy target in use' },
     },
   }),
+  findings: {
+    description:
+      'Inspect the findings held locally because they could not be sent',
+    subcommands: {
+      list: pikkuCLICommand({
+        func: FabricFindingsList,
+        render: renderFindingsList,
+        description: 'List the findings queued locally, waiting to be sent',
+      }),
+      flush: pikkuCLICommand({
+        func: FabricFindingsFlush,
+        description: 'Send every finding queued locally',
+        options: {
+          apiUrl: { description: 'Override the fabric-api URL for this call' },
+        },
+      }),
+      clear: pikkuCLICommand({
+        func: FabricFindingsClear,
+        description: 'Discard every queued finding without sending it',
+      }),
+    },
+  },
   metrics: pikkuCLICommand({
     func: FabricMetrics,
     description: 'Show request rate / error rate / latency for a stage',

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -67,6 +67,7 @@ import {
 import { FabricSmoke, renderSmoke } from './functions/smoke.function.js'
 import { FabricPublish } from './functions/publish.function.js'
 import { FabricAdd } from './functions/add.function.js'
+import { FabricReport } from './functions/report.function.js'
 import {
   FabricAddonVerify,
   renderAddonVerify,
@@ -340,6 +341,46 @@ export const fabricCommands = defineCLICommands({
         default: false,
       },
       json: { description: 'Machine-readable output', default: false },
+    },
+  }),
+  report: pikkuCLICommand({
+    parameters: '<title>',
+    func: FabricReport,
+    description:
+      'Report a finding — something about pikku that cost time — to the linked fabric project',
+    options: {
+      kind: {
+        description:
+          'product (fix pikku) or harness (fix the skill that misled you)',
+      },
+      model: { description: 'The model that hit this' },
+      expected: { description: 'What you expected pikku to do' },
+      actual: { description: 'What it did instead' },
+      skill: {
+        description: 'For a harness finding, the skill that misled you',
+      },
+      passage: { description: 'The passage in that skill it contradicts' },
+      command: { description: 'The command you ran' },
+      error: { description: "The error's message line, verbatim" },
+      repro: { description: 'The shortest way to reach it again' },
+      workaround: { description: 'What you did instead, inside the app' },
+      proposal: {
+        description:
+          'What pikku should do — named file and function, mechanism, suggested change',
+      },
+      tried: {
+        description:
+          'For an unresolved finding, what you tried and how each attempt failed',
+      },
+      unresolved: {
+        description: 'No workaround was found — a blocker, not a tax',
+        default: false,
+      },
+      area: { description: 'The part of pikku this is about' },
+      surface: { description: 'Where it showed up: local, deployed or both' },
+      cost: { description: 'What it cost, measured or estimated' },
+      run: { description: 'Run id, to group findings from one build' },
+      deployTarget: { description: 'The deploy target in use' },
     },
   }),
   metrics: pikkuCLICommand({

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -350,11 +350,16 @@ export const fabricCommands = defineCLICommands({
     },
   }),
   report: pikkuCLICommand({
-    parameters: '<title>',
+    parameters: '[title]',
     func: FabricReport,
     description:
-      'Report a finding — something about pikku that cost time — to the linked fabric project',
+      'Report a finding — something about pikku that cost time — to fabric',
     options: {
+      stdin: {
+        description:
+          'Read the whole finding as JSON on stdin instead of from flags (prose survives the shell intact)',
+        default: false,
+      },
       kind: {
         description:
           'product (fix pikku) or harness (fix the skill that misled you)',

--- a/packages/cli/src/fabric/functions/findings-clear.function.ts
+++ b/packages/cli/src/fabric/functions/findings-clear.function.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+import { pikkuSessionlessFunc } from '../../../.pikku/function/index.js'
+import { clearSpool } from '../lib/finding-spool.js'
+
+export const FabricFindingsClearInput = z.object({})
+
+export const FabricFindingsClearOutput = z.object({
+  dropped: z.number(),
+})
+
+export const FabricFindingsClear = pikkuSessionlessFunc({
+  description: 'Discard every finding queued locally without sending it.',
+  input: FabricFindingsClearInput,
+  output: FabricFindingsClearOutput,
+  func: async () => {
+    const dropped = await clearSpool()
+    console.log(`[fabric] dropped ${dropped} queued finding(s)`)
+    return { dropped }
+  },
+})

--- a/packages/cli/src/fabric/functions/findings-flush.function.ts
+++ b/packages/cli/src/fabric/functions/findings-flush.function.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+import { pikkuSessionlessFunc } from '../../../.pikku/function/index.js'
+import { resolveApiContext } from '../lib/config.js'
+import { flushSpool } from '../lib/finding-spool.js'
+
+export const FabricFindingsFlushInput = z.object({
+  apiUrl: z.string().optional(),
+})
+
+export const FabricFindingsFlushOutput = z.object({
+  sent: z.number(),
+  remaining: z.number(),
+  reason: z.string().optional(),
+})
+
+/**
+ * Explicitly asked for, so unlike `report` this one says plainly that it
+ * cannot run: someone who typed `flush` wants to know the login is missing,
+ * not to have the queue quietly stay put.
+ */
+export const FabricFindingsFlush = pikkuSessionlessFunc({
+  description: 'Send every finding queued locally.',
+  input: FabricFindingsFlushInput,
+  output: FabricFindingsFlushOutput,
+  func: async (_services, { apiUrl: apiUrlOverride }) => {
+    const ctx = await resolveApiContext({ apiUrlOverride })
+    if (!ctx.token)
+      throw new Error('Not logged in. Run `pikku fabric login` first.')
+
+    const result = await flushSpool({
+      apiUrl: ctx.apiUrl,
+      token: ctx.token,
+      projectId: ctx.projectId,
+    })
+    console.log(
+      result.remaining === 0
+        ? `[fabric] sent ${result.sent} finding(s)`
+        : `[fabric] sent ${result.sent}, ${result.remaining} still queued (${result.reason})`
+    )
+    return result
+  },
+})

--- a/packages/cli/src/fabric/functions/findings-list.function.ts
+++ b/packages/cli/src/fabric/functions/findings-list.function.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod'
+import { pikkuSessionlessFunc } from '../../../.pikku/function/index.js'
+import { readSpool } from '../lib/finding-spool.js'
+import { dim, table } from '../lib/output.js'
+
+export const FabricFindingsListInput = z.object({})
+
+export const FabricFindingsListOutput = z.object({
+  findings: z.array(
+    z.object({
+      title: z.string(),
+      kind: z.string(),
+      reason: z.string(),
+      reportedAt: z.string(),
+      projectId: z.string().nullable(),
+      file: z.string(),
+    })
+  ),
+})
+
+/**
+ * What is waiting to be sent. Without this the spool is invisible, and an
+ * agent has no way to tell a finding that reached fabric from one still
+ * sitting on the machine.
+ */
+export const FabricFindingsList = pikkuSessionlessFunc({
+  description: 'List the findings queued locally, waiting to be sent.',
+  input: FabricFindingsListInput,
+  output: FabricFindingsListOutput,
+  func: async () => ({
+    findings: (await readSpool()).map((entry) => ({
+      title: entry.payload.title,
+      kind: entry.payload.kind,
+      reason: entry.reason,
+      reportedAt: entry.payload.reportedAt,
+      projectId: entry.projectId,
+      file: entry.file,
+    })),
+  }),
+})
+
+type QueuedFinding = {
+  title: string
+  kind: string
+  reason: string
+  reportedAt: string
+}
+
+export const renderFindingsList = (
+  _s: unknown,
+  { findings }: { findings: QueuedFinding[] }
+): void => {
+  console.log('')
+  if (findings.length === 0) {
+    console.log(dim('  Nothing queued — every finding you filed was sent.'))
+    console.log('')
+    return
+  }
+  console.log(
+    table(
+      ['REPORTED', 'KIND', 'HELD BECAUSE', 'TITLE'],
+      findings.map((f) => [
+        f.reportedAt.slice(0, 16).replace('T', ' '),
+        f.kind,
+        f.reason,
+        f.title,
+      ])
+    )
+  )
+  console.log('')
+  console.log(dim('  `pikku fabric findings flush` sends them.'))
+  console.log('')
+}

--- a/packages/cli/src/fabric/functions/report.function.ts
+++ b/packages/cli/src/fabric/functions/report.function.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod'
+import { pikkuSessionlessFunc } from '../../../.pikku/function/index.js'
+import { resolveApiContext } from '../lib/config.js'
+import { collectReportEnvironment } from '../lib/report-environment.js'
+import {
+  FindingInput,
+  buildFindingPayload,
+  postFinding,
+  renderReceipt,
+  validateFinding,
+} from '../lib/finding.js'
+
+export const FabricReportInput = FindingInput
+
+export const FabricReportOutput = z.object({
+  sent: z.boolean(),
+  reason: z.string().optional(),
+})
+
+export const FabricReport = pikkuSessionlessFunc({
+  description:
+    'Report a finding — something about pikku that cost time — to the linked fabric project.',
+  input: FabricReportInput,
+  output: FabricReportOutput,
+  func: async (_services, input) => {
+    const problems = validateFinding(input)
+    if (problems.length > 0) {
+      throw new Error(problems.join('\n'))
+    }
+
+    const payload = buildFindingPayload(input, await collectReportEnvironment())
+    console.log(renderReceipt(payload))
+
+    const ctx = await resolveApiContext()
+    if (!ctx.token) {
+      console.log('[fabric] not logged in — finding not sent')
+      return { sent: false, reason: 'not-logged-in' }
+    }
+    if (!ctx.projectId) {
+      console.log('[fabric] no project linked — finding not sent')
+      return { sent: false, reason: 'not-linked' }
+    }
+
+    const result = await postFinding({
+      apiUrl: ctx.apiUrl,
+      token: ctx.token,
+      projectId: ctx.projectId,
+      payload,
+    })
+    console.log(
+      result.sent
+        ? '[fabric] finding sent'
+        : `[fabric] finding not sent (${result.reason})`
+    )
+    return result
+  },
+})

--- a/packages/cli/src/fabric/functions/report.function.ts
+++ b/packages/cli/src/fabric/functions/report.function.ts
@@ -5,6 +5,8 @@ import { collectReportEnvironment } from '../lib/report-environment.js'
 import {
   FindingInput,
   buildFindingPayload,
+  parseFinding,
+  parseFindingJson,
   postFinding,
   renderReceipt,
   validateFinding,
@@ -12,7 +14,15 @@ import {
 } from '../lib/finding.js'
 import { flushSpool, readSpool, spoolFinding } from '../lib/finding-spool.js'
 
-export const FabricReportInput = FindingInput
+/**
+ * Every field is optional here and the strictness lives in `FindingInput`,
+ * because `--stdin` supplies the whole finding at once and the flags then
+ * carry nothing. Whichever path was used, the same schema decides whether a
+ * finding is well-formed.
+ */
+export const FabricReportInput = FindingInput.partial().extend({
+  stdin: z.boolean().optional(),
+})
 
 export const FabricReportOutput = z.object({
   sent: z.boolean(),
@@ -21,11 +31,22 @@ export const FabricReportOutput = z.object({
   queued: z.number(),
 })
 
+const readStdin = async (): Promise<string> => {
+  if (process.stdin.isTTY) {
+    throw new Error(
+      '--stdin expects the finding as JSON on standard input, and nothing was piped in.'
+    )
+  }
+  const chunks: Buffer[] = []
+  for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk))
+  return Buffer.concat(chunks).toString('utf8')
+}
+
 /**
  * Every path that cannot send holds the finding instead. The states that stop
- * a send — logged out, unlinked, fabric unreachable — are the states a finding
- * is most likely to be describing, so dropping it loses exactly the reports
- * worth having.
+ * a send — logged out, fabric unreachable — are the states a finding is most
+ * likely to be describing, so dropping it loses exactly the reports worth
+ * having.
  */
 const hold = async (
   payload: FindingPayload,
@@ -43,24 +64,31 @@ const hold = async (
 
 export const FabricReport = pikkuSessionlessFunc({
   description:
-    'Report a finding — something about pikku that cost time — to the linked fabric project.',
+    'Report a finding — something about pikku that cost time — to fabric.',
   input: FabricReportInput,
   output: FabricReportOutput,
-  func: async (_services, input) => {
-    const problems = validateFinding(input)
+  func: async (_services, { stdin, ...flags }) => {
+    const parsed = stdin
+      ? parseFindingJson(await readStdin())
+      : parseFinding(flags)
+    if ('problems' in parsed) {
+      throw new Error(parsed.problems.join('\n'))
+    }
+
+    const problems = validateFinding(parsed.finding)
     if (problems.length > 0) {
       throw new Error(problems.join('\n'))
     }
 
-    const payload = buildFindingPayload(input, await collectReportEnvironment())
+    const payload = buildFindingPayload(
+      parsed.finding,
+      await collectReportEnvironment()
+    )
     console.log(renderReceipt(payload))
 
     const ctx = await resolveApiContext()
     if (!ctx.token) {
       return hold(payload, 'not-logged-in', ctx.projectId, 'not logged in')
-    }
-    if (!ctx.projectId) {
-      return hold(payload, 'not-linked', null, 'no project linked')
     }
 
     const flushed = await flushSpool({

--- a/packages/cli/src/fabric/functions/report.function.ts
+++ b/packages/cli/src/fabric/functions/report.function.ts
@@ -8,14 +8,38 @@ import {
   postFinding,
   renderReceipt,
   validateFinding,
+  type FindingPayload,
 } from '../lib/finding.js'
+import { flushSpool, readSpool, spoolFinding } from '../lib/finding-spool.js'
 
 export const FabricReportInput = FindingInput
 
 export const FabricReportOutput = z.object({
   sent: z.boolean(),
   reason: z.string().optional(),
+  spooled: z.boolean(),
+  queued: z.number(),
 })
+
+/**
+ * Every path that cannot send holds the finding instead. The states that stop
+ * a send — logged out, unlinked, fabric unreachable — are the states a finding
+ * is most likely to be describing, so dropping it loses exactly the reports
+ * worth having.
+ */
+const hold = async (
+  payload: FindingPayload,
+  reason: string,
+  projectId: string | null,
+  message: string
+) => {
+  await spoolFinding({ payload, reason, projectId })
+  const queued = (await readSpool()).length
+  console.log(
+    `[fabric] ${message} — finding queued (${queued} waiting, sent on your next report)`
+  )
+  return { sent: false, reason, spooled: true, queued }
+}
 
 export const FabricReport = pikkuSessionlessFunc({
   description:
@@ -33,12 +57,19 @@ export const FabricReport = pikkuSessionlessFunc({
 
     const ctx = await resolveApiContext()
     if (!ctx.token) {
-      console.log('[fabric] not logged in — finding not sent')
-      return { sent: false, reason: 'not-logged-in' }
+      return hold(payload, 'not-logged-in', ctx.projectId, 'not logged in')
     }
     if (!ctx.projectId) {
-      console.log('[fabric] no project linked — finding not sent')
-      return { sent: false, reason: 'not-linked' }
+      return hold(payload, 'not-linked', null, 'no project linked')
+    }
+
+    const flushed = await flushSpool({
+      apiUrl: ctx.apiUrl,
+      token: ctx.token,
+      projectId: ctx.projectId,
+    })
+    if (flushed.sent > 0) {
+      console.log(`[fabric] sent ${flushed.sent} finding(s) held from earlier`)
     }
 
     const result = await postFinding({
@@ -47,11 +78,15 @@ export const FabricReport = pikkuSessionlessFunc({
       projectId: ctx.projectId,
       payload,
     })
-    console.log(
-      result.sent
-        ? '[fabric] finding sent'
-        : `[fabric] finding not sent (${result.reason})`
-    )
-    return result
+    if (!result.sent) {
+      return hold(
+        payload,
+        result.reason ?? 'send-failed',
+        ctx.projectId,
+        `fabric did not accept it (${result.reason})`
+      )
+    }
+    console.log('[fabric] finding sent')
+    return { sent: true, spooled: false, queued: flushed.remaining }
   },
 })

--- a/packages/cli/src/fabric/lib/finding-spool.test.ts
+++ b/packages/cli/src/fabric/lib/finding-spool.test.ts
@@ -118,7 +118,11 @@ describe('spoolFinding', () => {
       reason: 'not-linked',
       projectId: null,
     })
-    await writeFile(join(dir, '2026-01-01T00-00-00-000Z-beef.json'), '{ not', 'utf8')
+    await writeFile(
+      join(dir, '2026-01-01T00-00-00-000Z-beef.json'),
+      '{ not',
+      'utf8'
+    )
 
     assert.equal((await readSpool()).length, 1)
   })

--- a/packages/cli/src/fabric/lib/finding-spool.test.ts
+++ b/packages/cli/src/fabric/lib/finding-spool.test.ts
@@ -221,25 +221,31 @@ describe('flushSpool', () => {
     )
   })
 
-  test('leaves an unlinked finding queued when there is still no project', async () => {
-    await spoolFinding({
-      payload: payload(),
-      reason: 'not-linked',
-      projectId: null,
-    })
+  test('sends a finding filed from a checkout that never linked a project', async () => {
+    let seen: unknown = 'unset'
+    await withServer(
+      (body) => {
+        seen = JSON.parse(body).projectId
+        return { status: 202 }
+      },
+      async (apiUrl) => {
+        await spoolFinding({
+          payload: payload(),
+          reason: 'not-linked',
+          projectId: null,
+        })
 
-    const result = await flushSpool({
-      apiUrl: 'http://127.0.0.1:1',
-      token: 'tok',
-      projectId: null,
-    })
+        const result = await flushSpool({
+          apiUrl,
+          token: 'tok',
+          projectId: null,
+        })
 
-    assert.deepEqual(result, {
-      sent: 0,
-      remaining: 1,
-      reason: 'no project linked',
-    })
-    assert.equal((await readSpool()).length, 1)
+        assert.deepEqual(result, { sent: 1, remaining: 0 })
+        assert.deepEqual(await readSpool(), [])
+      }
+    )
+    assert.equal(seen, null)
   })
 })
 

--- a/packages/cli/src/fabric/lib/finding-spool.test.ts
+++ b/packages/cli/src/fabric/lib/finding-spool.test.ts
@@ -1,0 +1,265 @@
+import { describe, test, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  SPOOL_LIMIT,
+  clearSpool,
+  flushSpool,
+  readSpool,
+  spoolFinding,
+} from './finding-spool.js'
+import type { FindingPayload } from './finding.js'
+import type { ReportEnvironment } from './report-environment.js'
+
+const environment: ReportEnvironment = {
+  packages: [{ name: '@pikku/cli', version: '0.12.113', linked: false }],
+  versionSkew: false,
+  linkedFramework: false,
+  node: 'v22.0.0',
+  packageManager: 'yarn@4.1.0',
+  platform: 'darwin-arm64',
+}
+
+/** A valid ISO instant `i` minutes after the hour the fixtures use. */
+const minutesIn = (i: number): string =>
+  new Date(Date.UTC(2026, 7, 29, 14, 0) + i * 60_000).toISOString()
+
+const payload = (overrides: Partial<FindingPayload> = {}): FindingPayload => ({
+  title: 'Scaffold never produced a pikku.config.json',
+  kind: 'product',
+  model: 'claude-opus-5',
+  expected: 'create to write a config',
+  actual: 'it wrote none',
+  workaround: 'wrote one by hand',
+  environment,
+  reportedAt: '2026-08-29T14:02:11.000Z',
+  ...overrides,
+})
+
+let dir: string
+const previous = process.env.FABRIC_FINDINGS_DIR
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'pikku-fabric-spool-'))
+  process.env.FABRIC_FINDINGS_DIR = dir
+})
+
+afterEach(async () => {
+  if (previous === undefined) delete process.env.FABRIC_FINDINGS_DIR
+  else process.env.FABRIC_FINDINGS_DIR = previous
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('spoolFinding', () => {
+  test('holds a finding filed before the repo was ever linked', async () => {
+    await spoolFinding({
+      payload: payload(),
+      reason: 'not-linked',
+      projectId: null,
+    })
+
+    const spooled = await readSpool()
+    assert.equal(spooled.length, 1)
+    assert.equal(spooled[0].reason, 'not-linked')
+    assert.equal(spooled[0].projectId, null)
+    assert.equal(
+      spooled[0].payload.title,
+      'Scaffold never produced a pikku.config.json'
+    )
+  })
+
+  test('reads back in the order the findings were filed', async () => {
+    for (const reportedAt of [
+      '2026-08-29T14:02:11.000Z',
+      '2026-08-27T09:00:00.000Z',
+      '2026-08-28T22:15:00.000Z',
+    ]) {
+      await spoolFinding({
+        payload: payload({ reportedAt, title: reportedAt }),
+        reason: 'not-logged-in',
+        projectId: null,
+      })
+    }
+
+    assert.deepEqual(
+      (await readSpool()).map((s) => s.payload.title),
+      [
+        '2026-08-27T09:00:00.000Z',
+        '2026-08-28T22:15:00.000Z',
+        '2026-08-29T14:02:11.000Z',
+      ]
+    )
+  })
+
+  test('drops the oldest past the cap so a logged-out machine stays bounded', async () => {
+    for (let i = 0; i < SPOOL_LIMIT + 5; i++) {
+      await spoolFinding({
+        payload: payload({
+          reportedAt: minutesIn(i),
+          title: `finding ${i}`,
+        }),
+        reason: 'not-logged-in',
+        projectId: null,
+      })
+    }
+
+    const spooled = await readSpool()
+    assert.equal(spooled.length, SPOOL_LIMIT)
+    assert.equal(spooled[0].payload.title, 'finding 5')
+  })
+
+  test('skips a corrupt entry rather than losing the rest', async () => {
+    await spoolFinding({
+      payload: payload(),
+      reason: 'not-linked',
+      projectId: null,
+    })
+    await writeFile(join(dir, '2026-01-01T00-00-00-000Z-beef.json'), '{ not', 'utf8')
+
+    assert.equal((await readSpool()).length, 1)
+  })
+})
+
+describe('clearSpool', () => {
+  test('empties the queue and says how many it dropped', async () => {
+    for (let i = 0; i < 3; i++) {
+      await spoolFinding({
+        payload: payload({ reportedAt: `2026-08-2${i}T00:00:00.000Z` }),
+        reason: 'not-linked',
+        projectId: null,
+      })
+    }
+
+    assert.equal(await clearSpool(), 3)
+    assert.deepEqual(await readdir(dir), [])
+  })
+})
+
+describe('flushSpool', () => {
+  test('sends every entry and empties the queue', async () => {
+    const seen: string[] = []
+    await withServer(
+      (body) => {
+        seen.push(JSON.parse(body).finding.title)
+        return { status: 202 }
+      },
+      async (apiUrl) => {
+        for (const [index, title] of ['first', 'second'].entries()) {
+          await spoolFinding({
+            payload: payload({ title, reportedAt: minutesIn(index) }),
+            reason: 'unreachable',
+            projectId: null,
+          })
+        }
+
+        const result = await flushSpool({
+          apiUrl,
+          token: 'tok',
+          projectId: 'prj_now',
+        })
+
+        assert.deepEqual(result, { sent: 2, remaining: 0 })
+        assert.deepEqual(await readSpool(), [])
+      }
+    )
+    assert.deepEqual(seen, ['first', 'second'])
+  })
+
+  test('keeps the project a finding was filed against, and adopts the current one only when it had none', async () => {
+    const projects: string[] = []
+    await withServer(
+      (body) => {
+        projects.push(JSON.parse(body).projectId)
+        return { status: 200 }
+      },
+      async (apiUrl) => {
+        await spoolFinding({
+          payload: payload({ reportedAt: '2026-08-29T14:00:00.000Z' }),
+          reason: 'unreachable',
+          projectId: 'prj_then',
+        })
+        await spoolFinding({
+          payload: payload({ reportedAt: '2026-08-29T14:01:00.000Z' }),
+          reason: 'not-linked',
+          projectId: null,
+        })
+
+        await flushSpool({ apiUrl, token: 'tok', projectId: 'prj_now' })
+      }
+    )
+    assert.deepEqual(projects, ['prj_then', 'prj_now'])
+  })
+
+  test('stops at the first refusal and leaves the rest queued', async () => {
+    let calls = 0
+    await withServer(
+      () => ({ status: ++calls === 1 ? 200 : 503 }),
+      async (apiUrl) => {
+        for (const [index, title] of ['first', 'second', 'third'].entries()) {
+          await spoolFinding({
+            payload: payload({ title, reportedAt: minutesIn(index) }),
+            reason: 'unreachable',
+            projectId: 'prj_1',
+          })
+        }
+
+        const result = await flushSpool({
+          apiUrl,
+          token: 'tok',
+          projectId: 'prj_1',
+        })
+
+        assert.equal(result.sent, 1)
+        assert.equal(result.remaining, 2)
+        assert.match(result.reason!, /503/)
+        assert.equal((await readSpool()).length, 2)
+      }
+    )
+  })
+
+  test('leaves an unlinked finding queued when there is still no project', async () => {
+    await spoolFinding({
+      payload: payload(),
+      reason: 'not-linked',
+      projectId: null,
+    })
+
+    const result = await flushSpool({
+      apiUrl: 'http://127.0.0.1:1',
+      token: 'tok',
+      projectId: null,
+    })
+
+    assert.deepEqual(result, {
+      sent: 0,
+      remaining: 1,
+      reason: 'no project linked',
+    })
+    assert.equal((await readSpool()).length, 1)
+  })
+})
+
+async function withServer(
+  handler: (body: string) => { status: number },
+  run: (url: string) => Promise<void>
+): Promise<void> {
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on('data', (c) => chunks.push(c))
+    req.on('end', () => {
+      res.writeHead(handler(Buffer.concat(chunks).toString('utf8')).status)
+      res.end()
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  try {
+    const { port } = server.address() as AddressInfo
+    await run(`http://127.0.0.1:${port}`)
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+}

--- a/packages/cli/src/fabric/lib/finding-spool.ts
+++ b/packages/cli/src/fabric/lib/finding-spool.ts
@@ -1,0 +1,160 @@
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { randomBytes } from 'node:crypto'
+import { postFinding, type FindingPayload } from './finding.js'
+
+/**
+ * A finding that could not be sent when it was filed, held until it can be.
+ *
+ * The cases that keep a finding from leaving — no token, no linked project, a
+ * fabric that is down — are the same cases the finding is most likely to be
+ * about: a scaffold that never got far enough to log in is exactly the thing
+ * worth hearing about, and printing it and dropping it loses it. The spool
+ * lives in `~/.fabric`, not the repo, so nothing goes stale on an abandoned
+ * branch and git never sees it.
+ */
+export interface SpooledFinding {
+  file: string
+  spooledAt: string
+  reason: string
+  projectId: string | null
+  payload: FindingPayload
+}
+
+/** Oldest entries past this are dropped, so a logged-out machine stays bounded. */
+export const SPOOL_LIMIT = 100
+
+export function spoolDir(): string {
+  return (
+    process.env.FABRIC_FINDINGS_DIR ?? join(homedir(), '.fabric', 'findings')
+  )
+}
+
+export async function spoolFinding(entry: {
+  payload: FindingPayload
+  reason: string
+  projectId: string | null
+}): Promise<string> {
+  const dir = spoolDir()
+  await mkdir(dir, { recursive: true })
+  const stamp = entry.payload.reportedAt.replace(/[:.]/g, '-')
+  const file = join(dir, `${stamp}-${randomBytes(3).toString('hex')}.json`)
+  await writeFile(
+    file,
+    JSON.stringify(
+      {
+        spooledAt: new Date().toISOString(),
+        reason: entry.reason,
+        projectId: entry.projectId,
+        payload: entry.payload,
+      },
+      null,
+      2
+    ) + '\n',
+    { encoding: 'utf8', mode: 0o600 }
+  )
+  await pruneSpool()
+  return file
+}
+
+/**
+ * Chronological, by the timestamp inside each finding rather than the one its
+ * name carries — the name is for a human reading the directory, and ordering
+ * the queue by it would make the send order a property of how a filename
+ * happens to sort. A file that no longer parses is skipped rather than thrown
+ * for: one corrupt entry is not a reason to lose the rest, or to fail the
+ * command that happened to notice.
+ */
+export async function readSpool(): Promise<SpooledFinding[]> {
+  const dir = spoolDir()
+  if (!existsSync(dir)) return []
+  const names = (await readdir(dir)).filter((n) => n.endsWith('.json'))
+  const entries: SpooledFinding[] = []
+  for (const name of names) {
+    const file = join(dir, name)
+    try {
+      const parsed = JSON.parse(await readFile(file, 'utf8'))
+      if (!parsed?.payload) continue
+      entries.push({
+        file,
+        spooledAt: parsed.spooledAt ?? '',
+        reason: parsed.reason ?? 'unknown',
+        projectId: parsed.projectId ?? null,
+        payload: parsed.payload as FindingPayload,
+      })
+    } catch {
+      continue
+    }
+  }
+  return entries.sort(
+    (a, b) =>
+      a.payload.reportedAt.localeCompare(b.payload.reportedAt) ||
+      a.file.localeCompare(b.file)
+  )
+}
+
+export async function clearSpool(): Promise<number> {
+  const entries = await readSpool()
+  for (const entry of entries) await rm(entry.file, { force: true })
+  return entries.length
+}
+
+async function pruneSpool(): Promise<void> {
+  const entries = await readSpool()
+  const excess = Math.max(0, entries.length - SPOOL_LIMIT)
+  for (const entry of entries.slice(0, excess)) {
+    await rm(entry.file, { force: true })
+  }
+}
+
+export interface FlushResult {
+  sent: number
+  remaining: number
+  reason?: string
+}
+
+/**
+ * Drain the spool oldest-first, stopping at the first entry fabric does not
+ * accept — a refusal usually means the next one will be refused too, and
+ * hammering an endpoint that just said no is the wrong thing for a command
+ * whose real job is something else.
+ *
+ * An entry keeps the project it was filed against; only one spooled before the
+ * repo was linked adopts the project linked now.
+ */
+export async function flushSpool(ctx: {
+  apiUrl: string
+  token: string
+  projectId: string | null
+}): Promise<FlushResult> {
+  const entries = await readSpool()
+  let sent = 0
+  for (const [index, entry] of entries.entries()) {
+    const projectId = entry.projectId ?? ctx.projectId
+    if (!projectId) {
+      return {
+        sent,
+        remaining: entries.length - sent,
+        reason: 'no project linked',
+      }
+    }
+    const result = await postFinding({
+      apiUrl: ctx.apiUrl,
+      token: ctx.token,
+      projectId,
+      payload: entry.payload,
+    })
+    if (!result.sent) {
+      return {
+        sent,
+        remaining: entries.length - index,
+        reason: result.reason,
+      }
+    }
+    await rm(entry.file, { force: true })
+    sent++
+  }
+  return { sent, remaining: 0 }
+}

--- a/packages/cli/src/fabric/lib/finding-spool.ts
+++ b/packages/cli/src/fabric/lib/finding-spool.ts
@@ -121,8 +121,9 @@ export interface FlushResult {
  * hammering an endpoint that just said no is the wrong thing for a command
  * whose real job is something else.
  *
- * An entry keeps the project it was filed against; only one spooled before the
- * repo was linked adopts the project linked now.
+ * An entry keeps the project it was filed against; one spooled before the repo
+ * was linked adopts the project linked now, and sends without one if there is
+ * still none.
  */
 export async function flushSpool(ctx: {
   apiUrl: string
@@ -132,18 +133,10 @@ export async function flushSpool(ctx: {
   const entries = await readSpool()
   let sent = 0
   for (const [index, entry] of entries.entries()) {
-    const projectId = entry.projectId ?? ctx.projectId
-    if (!projectId) {
-      return {
-        sent,
-        remaining: entries.length - sent,
-        reason: 'no project linked',
-      }
-    }
     const result = await postFinding({
       apiUrl: ctx.apiUrl,
       token: ctx.token,
-      projectId,
+      projectId: entry.projectId ?? ctx.projectId,
       payload: entry.payload,
     })
     if (!result.sent) {

--- a/packages/cli/src/fabric/lib/finding.test.ts
+++ b/packages/cli/src/fabric/lib/finding.test.ts
@@ -132,8 +132,11 @@ describe('renderReceipt', () => {
           error: 'TypeError: e.getFullYear is not a function',
           surface: 'deployed',
           cost: '98s vs 20s steady state',
+          run: 'run_412',
+          deployTarget: 'cloudflare',
         }),
-        environment
+        environment,
+        new Date('2026-08-29T14:02:11.000Z')
       )
     )
 
@@ -141,6 +144,9 @@ describe('renderReceipt', () => {
     assert.match(receipt, /command: pikku deploy/)
     assert.match(receipt, /error: TypeError: e\.getFullYear is not a function/)
     assert.match(receipt, /surface: deployed/)
+    assert.match(receipt, /run: run_412/)
+    assert.match(receipt, /deploy target: cloudflare/)
+    assert.match(receipt, /reported at: 2026-08-29T14:02:11\.000Z/)
     assert.match(receipt, /cost: 98s vs 20s steady state/)
     assert.match(receipt, /@pikku\/core@0\.12\.113/)
     assert.match(receipt, /model: claude-opus-5/)

--- a/packages/cli/src/fabric/lib/finding.test.ts
+++ b/packages/cli/src/fabric/lib/finding.test.ts
@@ -4,6 +4,7 @@ import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import {
   buildFindingPayload,
+  parseFindingJson,
   postFinding,
   renderReceipt,
   validateFinding,
@@ -184,6 +185,41 @@ describe('renderReceipt', () => {
     assert.match(receipt, /not all the same/)
     assert.match(receipt, /may be modified/)
     assert.match(receipt, /@pikku\/core@0\.12\.113 \(linked\)/)
+  })
+})
+
+describe('parseFindingJson', () => {
+  test('carries prose the shell would have mangled through intact', () => {
+    const error =
+      "TypeError: can't read `name` of undefined\n    at cn (index.js:1:8842)"
+    const parsed = parseFindingJson(JSON.stringify(finding({ error })))
+
+    assert.ok('finding' in parsed)
+    assert.equal(parsed.finding.error, error)
+  })
+
+  test('names the malformed JSON rather than throwing', () => {
+    const parsed = parseFindingJson('{ "title": ')
+
+    assert.ok('problems' in parsed)
+    assert.match(parsed.problems[0], /--stdin expected a JSON object/)
+  })
+
+  test('rejects JSON that is not an object', () => {
+    const parsed = parseFindingJson('["a finding"]')
+
+    assert.ok('problems' in parsed)
+    assert.deepEqual(parsed.problems, ['--stdin expected a JSON object.'])
+  })
+
+  test('names every field that is missing or wrong, in one pass', () => {
+    const parsed = parseFindingJson(
+      JSON.stringify({ title: 'x', kind: 'typo', expected: 'y' })
+    )
+
+    assert.ok('problems' in parsed)
+    const fields = parsed.problems.map((p) => p.split(':')[0])
+    assert.deepEqual(fields.sort(), ['actual', 'kind', 'model'])
   })
 })
 

--- a/packages/cli/src/fabric/lib/finding.test.ts
+++ b/packages/cli/src/fabric/lib/finding.test.ts
@@ -1,0 +1,296 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import {
+  buildFindingPayload,
+  postFinding,
+  renderReceipt,
+  validateFinding,
+  type FindingInput,
+} from './finding.js'
+import type { ReportEnvironment } from './report-environment.js'
+
+const environment: ReportEnvironment = {
+  packages: [
+    { name: '@pikku/cli', version: '0.12.113', linked: false },
+    { name: '@pikku/core', version: '0.12.113', linked: false },
+  ],
+  versionSkew: false,
+  linkedFramework: false,
+  node: 'v22.0.0',
+  packageManager: 'yarn@4.1.0',
+  platform: 'darwin-arm64',
+}
+
+const finding = (overrides: Partial<FindingInput> = {}): FindingInput => ({
+  title: 'Deployed errors answer with the minifier name',
+  kind: 'product',
+  model: 'claude-opus-5',
+  expected: 'the rpc to answer with PermissionDeniedError',
+  actual: 'it answered with cn',
+  workaround: 'matched on the status code instead of the name',
+  ...overrides,
+})
+
+describe('validateFinding', () => {
+  test('accepts a resolved product finding carrying a workaround', () => {
+    assert.deepEqual(validateFinding(finding()), [])
+  })
+
+  test('a harness finding must name the skill that misled it', () => {
+    const problems = validateFinding(finding({ kind: 'harness' }))
+
+    assert.equal(problems.length, 1)
+    assert.match(problems[0], /--skill/)
+  })
+
+  test('a harness finding naming its skill is accepted', () => {
+    assert.deepEqual(
+      validateFinding(
+        finding({
+          kind: 'harness',
+          skill: 'pikku-feature',
+          passage: 'Stage 4, the prebuild step',
+        })
+      ),
+      []
+    )
+  })
+
+  test('a resolved finding with neither workaround nor proposal is refused', () => {
+    const problems = validateFinding(finding({ workaround: undefined }))
+
+    assert.equal(problems.length, 1)
+    assert.match(problems[0], /--workaround/)
+  })
+
+  test('a proposal stands in for a workaround', () => {
+    assert.deepEqual(
+      validateFinding(
+        finding({
+          workaround: undefined,
+          proposal: 'keepNames in the bun bundler, as esbuild already does',
+        })
+      ),
+      []
+    )
+  })
+
+  test('an unresolved finding must carry what was tried', () => {
+    const problems = validateFinding(
+      finding({ unresolved: true, workaround: undefined })
+    )
+
+    assert.equal(problems.length, 1)
+    assert.match(problems[0], /--tried/)
+  })
+
+  test('unresolved and a workaround contradict each other', () => {
+    const problems = validateFinding(
+      finding({ unresolved: true, tried: 'three dead ends' })
+    )
+
+    assert.equal(problems.length, 1)
+    assert.match(problems[0], /no workaround was found/)
+  })
+
+  test('reports every problem at once', () => {
+    const problems = validateFinding(
+      finding({ kind: 'harness', unresolved: true })
+    )
+
+    assert.equal(problems.length, 3)
+    assert.match(problems.join('\n'), /--skill/)
+    assert.match(problems.join('\n'), /--tried/)
+    assert.match(problems.join('\n'), /no workaround was found/)
+  })
+})
+
+describe('buildFindingPayload', () => {
+  test('renames run to runId and stamps the environment and time', () => {
+    const payload = buildFindingPayload(
+      finding({ run: 'build-42' }),
+      environment,
+      new Date('2026-08-29T10:00:00.000Z')
+    )
+
+    assert.equal(payload.runId, 'build-42')
+    assert.equal('run' in payload, false)
+    assert.equal(payload.reportedAt, '2026-08-29T10:00:00.000Z')
+    assert.deepEqual(payload.environment, environment)
+  })
+})
+
+describe('renderReceipt', () => {
+  test('shows every field that left the machine', () => {
+    const receipt = renderReceipt(
+      buildFindingPayload(
+        finding({
+          command: 'pikku deploy',
+          error: 'TypeError: e.getFullYear is not a function',
+          surface: 'deployed',
+          cost: '98s vs 20s steady state',
+        }),
+        environment
+      )
+    )
+
+    assert.match(receipt, /Deployed errors answer with the minifier name/)
+    assert.match(receipt, /command: pikku deploy/)
+    assert.match(receipt, /error: TypeError: e\.getFullYear is not a function/)
+    assert.match(receipt, /surface: deployed/)
+    assert.match(receipt, /cost: 98s vs 20s steady state/)
+    assert.match(receipt, /@pikku\/core@0\.12\.113/)
+    assert.match(receipt, /model: claude-opus-5/)
+  })
+
+  test('omits fields that were not given rather than printing empties', () => {
+    const receipt = renderReceipt(buildFindingPayload(finding(), environment))
+
+    assert.equal(receipt.includes('command:'), false)
+    assert.equal(receipt.includes('error:'), false)
+    assert.equal(receipt.includes('cost:'), false)
+  })
+
+  test('marks an unresolved finding on its kind line', () => {
+    const receipt = renderReceipt(
+      buildFindingPayload(
+        finding({
+          unresolved: true,
+          workaround: undefined,
+          tried: 'two dead ends',
+        }),
+        environment
+      )
+    )
+
+    assert.match(receipt, /kind: product \(unresolved\)/)
+  })
+
+  test('calls out a skewed tree and a linked framework', () => {
+    const receipt = renderReceipt(
+      buildFindingPayload(finding(), {
+        ...environment,
+        packages: [
+          { name: '@pikku/cli', version: '0.12.35', linked: false },
+          { name: '@pikku/core', version: '0.12.113', linked: true },
+        ],
+        versionSkew: true,
+        linkedFramework: true,
+      })
+    )
+
+    assert.match(receipt, /not all the same/)
+    assert.match(receipt, /may be modified/)
+    assert.match(receipt, /@pikku\/core@0\.12\.113 \(linked\)/)
+  })
+})
+
+async function withServer(
+  handler: (
+    body: string,
+    headers: Record<string, string | string[] | undefined>
+  ) => { status: number; delayMs?: number },
+  run: (url: string) => Promise<void>
+): Promise<void> {
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on('data', (c) => chunks.push(c))
+    req.on('end', () => {
+      const { status, delayMs } = handler(
+        Buffer.concat(chunks).toString('utf8'),
+        req.headers
+      )
+      const reply = () => {
+        res.writeHead(status)
+        res.end()
+      }
+      if (delayMs) setTimeout(reply, delayMs).unref()
+      else reply()
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  try {
+    const { port } = server.address() as AddressInfo
+    await run(`http://127.0.0.1:${port}`)
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+}
+
+describe('postFinding', () => {
+  test('posts the finding under its project with a bearer token', async () => {
+    let seen: { body: string; auth?: string | string[] } | null = null
+
+    await withServer(
+      (body, headers) => {
+        seen = { body, auth: headers.authorization }
+        return { status: 202 }
+      },
+      async (apiUrl) => {
+        const result = await postFinding({
+          apiUrl,
+          token: 'tok_123',
+          projectId: 'prj_abc',
+          payload: buildFindingPayload(finding(), environment),
+        })
+
+        assert.deepEqual(result, { sent: true })
+      }
+    )
+
+    assert.equal(seen!.auth, 'Bearer tok_123')
+    const parsed = JSON.parse(seen!.body)
+    assert.equal(parsed.projectId, 'prj_abc')
+    assert.equal(parsed.finding.title, finding().title)
+    assert.equal(parsed.finding.environment.node, 'v22.0.0')
+  })
+
+  test('a refusal is reported, never thrown', async () => {
+    await withServer(
+      () => ({ status: 500 }),
+      async (apiUrl) => {
+        const result = await postFinding({
+          apiUrl,
+          token: 'tok_123',
+          projectId: 'prj_abc',
+          payload: buildFindingPayload(finding(), environment),
+        })
+
+        assert.equal(result.sent, false)
+        assert.match(result.reason!, /500/)
+      }
+    )
+  })
+
+  test('a slow endpoint times out instead of holding up the build', async () => {
+    await withServer(
+      () => ({ status: 202, delayMs: 500 }),
+      async (apiUrl) => {
+        const result = await postFinding({
+          apiUrl,
+          token: 'tok_123',
+          projectId: 'prj_abc',
+          payload: buildFindingPayload(finding(), environment),
+          timeoutMs: 20,
+        })
+
+        assert.equal(result.sent, false)
+      }
+    )
+  })
+
+  test('an unreachable endpoint is swallowed', async () => {
+    const result = await postFinding({
+      apiUrl: 'http://127.0.0.1:1',
+      token: 'tok_123',
+      projectId: 'prj_abc',
+      payload: buildFindingPayload(finding(), environment),
+      timeoutMs: 200,
+    })
+
+    assert.equal(result.sent, false)
+    assert.ok(result.reason)
+  })
+})

--- a/packages/cli/src/fabric/lib/finding.ts
+++ b/packages/cli/src/fabric/lib/finding.ts
@@ -25,6 +25,48 @@ export const FindingInput = z.object({
 
 export type FindingInput = z.infer<typeof FindingInput>
 
+export type ParsedFinding =
+  | { finding: FindingInput }
+  | { problems: string[] }
+
+/** Shape-check a finding from either path, naming every field that is wrong. */
+export function parseFinding(value: unknown): ParsedFinding {
+  const result = FindingInput.safeParse(value)
+  if (result.success) return { finding: result.data }
+  return {
+    problems: result.error.issues.map(
+      (issue) => `${issue.path.join('.') || 'finding'}: ${issue.message}`
+    ),
+  }
+}
+
+/**
+ * A finding read as JSON rather than assembled out of flags.
+ *
+ * Half the fields are prose, and prose carries apostrophes, quotes, backticks
+ * and newlines — every one of them a shell metacharacter before it is a
+ * character in a sentence. An error message pasted into `--error` breaks the
+ * command at its first newline; one carrying a backtick runs whatever follows
+ * it. JSON has its own escaping, so this path has none of that.
+ *
+ * Returns the finding or the problems with it, never throws: a malformed
+ * payload is a usage mistake worth naming precisely.
+ */
+export function parseFindingJson(raw: string): ParsedFinding {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error: any) {
+    return {
+      problems: [`--stdin expected a JSON object (${error.message}).`],
+    }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { problems: ['--stdin expected a JSON object.'] }
+  }
+  return parseFinding(parsed)
+}
+
 export interface FindingPayload extends Omit<FindingInput, 'run'> {
   runId?: string
   environment: ReportEnvironment
@@ -81,7 +123,13 @@ export function buildFindingPayload(
 export async function postFinding(opts: {
   apiUrl: string
   token: string
-  projectId: string
+  /**
+   * Provenance, not a routing key. A finding is about the framework rather
+   * than about anyone's project, and the reports worth having most — a
+   * scaffold that never produced a config, a first run that went wrong — come
+   * from checkouts that have no project to name.
+   */
+  projectId: string | null
   payload: FindingPayload
   timeoutMs?: number
 }): Promise<{ sent: boolean; reason?: string }> {

--- a/packages/cli/src/fabric/lib/finding.ts
+++ b/packages/cli/src/fabric/lib/finding.ts
@@ -25,9 +25,7 @@ export const FindingInput = z.object({
 
 export type FindingInput = z.infer<typeof FindingInput>
 
-export type ParsedFinding =
-  | { finding: FindingInput }
-  | { problems: string[] }
+export type ParsedFinding = { finding: FindingInput } | { problems: string[] }
 
 /** Shape-check a finding from either path, naming every field that is wrong. */
 export function parseFinding(value: unknown): ParsedFinding {

--- a/packages/cli/src/fabric/lib/finding.ts
+++ b/packages/cli/src/fabric/lib/finding.ts
@@ -183,6 +183,9 @@ export function renderReceipt(payload: FindingPayload): string {
   field('tried', payload.tried)
   field('proposal', payload.proposal)
   field('model', payload.model)
+  field('run', payload.runId)
+  field('deploy target', payload.deployTarget)
+  field('reported at', payload.reportedAt)
   const env = payload.environment
   field(
     'versions',

--- a/packages/cli/src/fabric/lib/finding.ts
+++ b/packages/cli/src/fabric/lib/finding.ts
@@ -1,0 +1,160 @@
+import { z } from 'zod'
+import type { ReportEnvironment } from './report-environment.js'
+
+export const FindingInput = z.object({
+  title: z.string(),
+  kind: z.enum(['product', 'harness']),
+  model: z.string(),
+  expected: z.string(),
+  actual: z.string(),
+  skill: z.string().optional(),
+  passage: z.string().optional(),
+  command: z.string().optional(),
+  error: z.string().optional(),
+  repro: z.string().optional(),
+  workaround: z.string().optional(),
+  proposal: z.string().optional(),
+  tried: z.string().optional(),
+  unresolved: z.boolean().optional(),
+  area: z.string().optional(),
+  surface: z.enum(['local', 'deployed', 'both']).optional(),
+  cost: z.string().optional(),
+  run: z.string().optional(),
+  deployTarget: z.string().optional(),
+})
+
+export type FindingInput = z.infer<typeof FindingInput>
+
+export interface FindingPayload extends Omit<FindingInput, 'run'> {
+  runId?: string
+  environment: ReportEnvironment
+  reportedAt: string
+}
+
+/**
+ * The rules the field set exists to enforce, checked before anything is sent.
+ *
+ * A usage mistake is the agent's own and is worth failing loudly for — unlike a
+ * failed send, which must never surface as a build failure. Every problem is
+ * returned at once so a malformed call is fixed in one pass.
+ */
+export function validateFinding(input: FindingInput): string[] {
+  const problems: string[] = []
+  if (input.kind === 'harness' && !input.skill) {
+    problems.push(
+      'A harness finding names the skill that misled you — pass --skill (and --passage for the line it contradicts).'
+    )
+  }
+  if (input.unresolved) {
+    if (!input.tried) {
+      problems.push(
+        'An unresolved finding carries what you tried and how each attempt failed — pass --tried.'
+      )
+    }
+    if (input.workaround) {
+      problems.push(
+        'Unresolved means no workaround was found. Drop --unresolved, or drop --workaround.'
+      )
+    }
+  } else if (!input.workaround && !input.proposal) {
+    problems.push(
+      'A resolved finding carries the workaround you used — pass --workaround, or --unresolved if there was none.'
+    )
+  }
+  return problems
+}
+
+export function buildFindingPayload(
+  input: FindingInput,
+  environment: ReportEnvironment,
+  now: Date = new Date()
+): FindingPayload {
+  const { run, ...rest } = input
+  return { ...rest, runId: run, environment, reportedAt: now.toISOString() }
+}
+
+/**
+ * Best-effort by construction. A finding is worth having and never worth
+ * failing a build for, so a refused, slow or unreachable endpoint is reported
+ * to the terminal and swallowed.
+ */
+export async function postFinding(opts: {
+  apiUrl: string
+  token: string
+  projectId: string
+  payload: FindingPayload
+  timeoutMs?: number
+}): Promise<{ sent: boolean; reason?: string }> {
+  try {
+    const response = await fetch(`${opts.apiUrl}/findings`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${opts.token}`,
+      },
+      body: JSON.stringify({
+        projectId: opts.projectId,
+        finding: opts.payload,
+      }),
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 5000),
+    })
+    if (!response.ok) {
+      return { sent: false, reason: `fabric answered ${response.status}` }
+    }
+    return { sent: true }
+  } catch (error: any) {
+    return { sent: false, reason: error?.message ?? 'request failed' }
+  }
+}
+
+/**
+ * The receipt. Nothing is written to disk, so the terminal is the only place
+ * the user sees what left their machine. Printed before the request goes out,
+ * so it is there whether or not the send succeeds.
+ */
+export function renderReceipt(payload: FindingPayload): string {
+  const lines: string[] = [`[fabric] reporting: ${payload.title}`]
+  const field = (label: string, value?: string) => {
+    if (value) lines.push(`  ${label}: ${value}`)
+  }
+  field(
+    'kind',
+    payload.unresolved ? `${payload.kind} (unresolved)` : payload.kind
+  )
+  field('area', payload.area)
+  field(
+    'skill',
+    payload.passage ? `${payload.skill} — ${payload.passage}` : payload.skill
+  )
+  field('command', payload.command)
+  field('expected', payload.expected)
+  field('actual', payload.actual)
+  field('error', payload.error)
+  field('surface', payload.surface)
+  field('cost', payload.cost)
+  field('repro', payload.repro)
+  field('workaround', payload.workaround)
+  field('tried', payload.tried)
+  field('proposal', payload.proposal)
+  field('model', payload.model)
+  const env = payload.environment
+  field(
+    'versions',
+    env.packages
+      .map((p) => `${p.name}@${p.version}${p.linked ? ' (linked)' : ''}`)
+      .join(' ') || 'no @pikku/* found'
+  )
+  if (env.versionSkew) {
+    lines.push('  note: the installed @pikku/* versions are not all the same')
+  }
+  if (env.linkedFramework) {
+    lines.push(
+      '  note: an @pikku/* resolves to a workspace or link — this app is running framework code that may be modified'
+    )
+  }
+  field(
+    'runtime',
+    `node ${env.node} ${env.platform} ${env.packageManager ?? ''}`.trim()
+  )
+  return lines.join('\n')
+}

--- a/packages/cli/src/fabric/lib/report-environment.test.ts
+++ b/packages/cli/src/fabric/lib/report-environment.test.ts
@@ -1,0 +1,202 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, rm, writeFile, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  collectReportEnvironment,
+  detectPackageManager,
+  findPikkuScope,
+  readPikkuPackages,
+} from './report-environment.js'
+
+async function makeTmp() {
+  return mkdtemp(join(tmpdir(), 'pikku-report-env-'))
+}
+
+async function installPackage(
+  scope: string,
+  name: string,
+  version: string
+): Promise<string> {
+  const dir = join(scope, name)
+  await mkdir(dir, { recursive: true })
+  await writeFile(
+    join(dir, 'package.json'),
+    JSON.stringify({ name: `@pikku/${name}`, version })
+  )
+  return dir
+}
+
+describe('readPikkuPackages', () => {
+  test('reads the installed version, not the declared range', async () => {
+    const root = await makeTmp()
+    try {
+      const scope = join(root, 'node_modules', '@pikku')
+      await installPackage(scope, 'core', '0.12.90')
+      await writeFile(
+        join(root, 'package.json'),
+        JSON.stringify({ dependencies: { '@pikku/core': '^0.12.35' } })
+      )
+
+      const packages = await readPikkuPackages(scope)
+
+      assert.deepEqual(packages, [
+        { name: '@pikku/core', version: '0.12.90', linked: false },
+      ])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags a package that resolves through a symlink', async () => {
+    const root = await makeTmp()
+    try {
+      const scope = join(root, 'node_modules', '@pikku')
+      await mkdir(scope, { recursive: true })
+      const checkout = await installPackage(
+        join(root, 'checkouts'),
+        'core',
+        '0.13.0-dev'
+      )
+      await symlink(checkout, join(scope, 'core'))
+
+      const [core] = await readPikkuPackages(scope)
+
+      assert.equal(core.linked, true)
+      assert.equal(core.version, '0.13.0-dev')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('skips an entry whose manifest is unreadable or unparseable', async () => {
+    const root = await makeTmp()
+    try {
+      const scope = join(root, 'node_modules', '@pikku')
+      await installPackage(scope, 'core', '0.12.90')
+      await mkdir(join(scope, 'empty'), { recursive: true })
+      await mkdir(join(scope, 'broken'), { recursive: true })
+      await writeFile(join(scope, 'broken', 'package.json'), '{ not json')
+
+      const packages = await readPikkuPackages(scope)
+
+      assert.deepEqual(
+        packages.map((p) => p.name),
+        ['@pikku/core']
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('findPikkuScope', () => {
+  test('walks up to the hoisted scope from a nested app', async () => {
+    const root = await makeTmp()
+    try {
+      const scope = join(root, 'node_modules', '@pikku')
+      await installPackage(scope, 'core', '0.12.90')
+      const app = join(root, 'apps', 'web')
+      await mkdir(app, { recursive: true })
+
+      assert.equal(await findPikkuScope(app), scope)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('ignores an empty scope directory and keeps walking', async () => {
+    const root = await makeTmp()
+    try {
+      const hoisted = join(root, 'node_modules', '@pikku')
+      await installPackage(hoisted, 'core', '0.12.90')
+      const app = join(root, 'apps', 'web')
+      await mkdir(join(app, 'node_modules', '@pikku'), { recursive: true })
+
+      assert.equal(await findPikkuScope(app), hoisted)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('detectPackageManager', () => {
+  test('prefers a declared packageManager over the lockfile', async () => {
+    const root = await makeTmp()
+    try {
+      await writeFile(
+        join(root, 'package.json'),
+        JSON.stringify({ packageManager: 'yarn@4.1.0' })
+      )
+      await writeFile(join(root, 'package-lock.json'), '{}')
+
+      assert.equal(await detectPackageManager(root), 'yarn@4.1.0')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('falls back to the lockfile when nothing is declared', async () => {
+    const root = await makeTmp()
+    try {
+      await writeFile(join(root, 'package.json'), JSON.stringify({}))
+      await writeFile(join(root, 'pnpm-lock.yaml'), '')
+
+      assert.equal(await detectPackageManager(root), 'pnpm')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('collectReportEnvironment', () => {
+  test('flags a skewed tree — the CLI pinned, its dependencies not', async () => {
+    const root = await makeTmp()
+    try {
+      const scope = join(root, 'node_modules', '@pikku')
+      await installPackage(scope, 'cli', '0.12.35')
+      await installPackage(scope, 'core', '0.12.90')
+
+      const env = await collectReportEnvironment(root)
+
+      assert.equal(env.versionSkew, true)
+      assert.equal(env.linkedFramework, false)
+      assert.deepEqual(
+        env.packages.map((p) => `${p.name}@${p.version}`),
+        ['@pikku/cli@0.12.35', '@pikku/core@0.12.90']
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('a uniform tree is not skewed', async () => {
+    const root = await makeTmp()
+    try {
+      const scope = join(root, 'node_modules', '@pikku')
+      await installPackage(scope, 'cli', '0.12.90')
+      await installPackage(scope, 'core', '0.12.90')
+
+      const env = await collectReportEnvironment(root)
+
+      assert.equal(env.versionSkew, false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('reports an empty package list rather than throwing when nothing is installed', async () => {
+    const root = await makeTmp()
+    try {
+      const env = await collectReportEnvironment(root)
+
+      assert.deepEqual(env.packages, [])
+      assert.equal(env.versionSkew, false)
+      assert.equal(env.linkedFramework, false)
+      assert.equal(env.node, process.version)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/fabric/lib/report-environment.test.ts
+++ b/packages/cli/src/fabric/lib/report-environment.test.ts
@@ -119,6 +119,22 @@ describe('findPikkuScope', () => {
       await rm(root, { recursive: true, force: true })
     }
   })
+
+  test('a hidden entry does not make an empty scope count as populated', async () => {
+    const root = await makeTmp()
+    try {
+      const hoisted = join(root, 'node_modules', '@pikku')
+      await installPackage(hoisted, 'core', '0.12.90')
+      const app = join(root, 'apps', 'web')
+      const empty = join(app, 'node_modules', '@pikku')
+      await mkdir(empty, { recursive: true })
+      await writeFile(join(empty, '.DS_Store'), '')
+
+      assert.equal(await findPikkuScope(app), hoisted)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('detectPackageManager', () => {

--- a/packages/cli/src/fabric/lib/report-environment.ts
+++ b/packages/cli/src/fabric/lib/report-environment.ts
@@ -1,0 +1,144 @@
+import { readFile, lstat, readdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+/** One installed `@pikku/*` package as it actually resolves on disk. */
+export interface PikkuPackageVersion {
+  name: string
+  version: string
+  /**
+   * Resolved through a symlink — a yarn workspace or a `yarn link`ed checkout
+   * rather than a published tarball. The framework is read-only during a build
+   * run, so a linked package is code that may already have been modified, and a
+   * finding describing it is describing something other than a release.
+   */
+  linked: boolean
+}
+
+export interface ReportEnvironment {
+  packages: PikkuPackageVersion[]
+  /**
+   * The resolved `@pikku/*` versions are not all the same. Pinning the CLI does
+   * not pin its `@pikku/*` dependencies, so a mixed tree is a common cause of
+   * behaviour that looks like a framework bug.
+   */
+  versionSkew: boolean
+  /** Any package is `linked` — see {@link PikkuPackageVersion.linked}. */
+  linkedFramework: boolean
+  node: string
+  packageManager: string | null
+  platform: string
+}
+
+/**
+ * Walk up from `startDir` for the first `node_modules/@pikku` that holds
+ * packages. A monorepo hoists to the root, an app installs locally, and either
+ * way the nearest populated scope is the one that was loaded.
+ */
+export async function findPikkuScope(startDir: string): Promise<string | null> {
+  let dir = startDir
+  while (true) {
+    const candidate = join(dir, 'node_modules', '@pikku')
+    if (existsSync(candidate)) {
+      const entries = await readdir(candidate).catch(() => [])
+      if (entries.length > 0) return candidate
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+/**
+ * Versions read off the installed tree rather than out of `package.json`. A
+ * range like `^0.12.35` says nothing about what ran, and the version that ran
+ * is the only one worth reporting.
+ */
+export async function readPikkuPackages(
+  scopeDir: string
+): Promise<PikkuPackageVersion[]> {
+  const entries = await readdir(scopeDir).catch(() => [])
+  const packages: PikkuPackageVersion[] = []
+  for (const entry of entries.sort()) {
+    if (entry.startsWith('.')) continue
+    const packageDir = join(scopeDir, entry)
+    const manifest = join(packageDir, 'package.json')
+    const raw = await readFile(manifest, 'utf8').catch(() => null)
+    if (!raw) continue
+    let version: unknown
+    try {
+      version = (JSON.parse(raw) as { version?: unknown }).version
+    } catch {
+      continue
+    }
+    if (typeof version !== 'string') continue
+    const stats = await lstat(packageDir).catch(() => null)
+    packages.push({
+      name: `@pikku/${entry}`,
+      version,
+      linked: stats?.isSymbolicLink() ?? false,
+    })
+  }
+  return packages
+}
+
+const LOCKFILES: [string, string][] = [
+  ['yarn.lock', 'yarn'],
+  ['pnpm-lock.yaml', 'pnpm'],
+  ['bun.lockb', 'bun'],
+  ['bun.lock', 'bun'],
+  ['package-lock.json', 'npm'],
+]
+
+/**
+ * `packageManager` in the nearest manifest is authoritative when it is set;
+ * otherwise the lockfile is the only evidence of what installed the tree.
+ */
+export async function detectPackageManager(
+  startDir: string
+): Promise<string | null> {
+  let dir = startDir
+  while (true) {
+    const manifest = join(dir, 'package.json')
+    if (existsSync(manifest)) {
+      const raw = await readFile(manifest, 'utf8').catch(() => null)
+      if (raw) {
+        try {
+          const declared = (JSON.parse(raw) as { packageManager?: unknown })
+            .packageManager
+          if (typeof declared === 'string' && declared.length > 0) {
+            return declared
+          }
+        } catch {
+          // An unparseable manifest tells us nothing; keep walking up.
+        }
+      }
+    }
+    for (const [lockfile, manager] of LOCKFILES) {
+      if (existsSync(join(dir, lockfile))) return manager
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+/**
+ * Everything about the run a finding needs and no agent should be asked for.
+ * All of it is a directory read — no network, no prompting.
+ */
+export async function collectReportEnvironment(
+  startDir: string = process.cwd()
+): Promise<ReportEnvironment> {
+  const scope = await findPikkuScope(startDir)
+  const packages = scope ? await readPikkuPackages(scope) : []
+  const versions = new Set(packages.map((p) => p.version))
+  return {
+    packages,
+    versionSkew: versions.size > 1,
+    linkedFramework: packages.some((p) => p.linked),
+    node: process.version,
+    packageManager: await detectPackageManager(startDir),
+    platform: `${process.platform}-${process.arch}`,
+  }
+}

--- a/packages/cli/src/fabric/lib/report-environment.ts
+++ b/packages/cli/src/fabric/lib/report-environment.ts
@@ -34,6 +34,11 @@ export interface ReportEnvironment {
  * Walk up from `startDir` for the first `node_modules/@pikku` that holds
  * packages. A monorepo hoists to the root, an app installs locally, and either
  * way the nearest populated scope is the one that was loaded.
+ *
+ * Populated means holding something `readPikkuPackages` would read, so the
+ * hidden entries it skips cannot qualify a scope either: a stray `.DS_Store` in
+ * an empty nested scope would otherwise end the walk there and report a tree
+ * with no packages in it.
  */
 export async function findPikkuScope(startDir: string): Promise<string | null> {
   let dir = startDir
@@ -41,7 +46,7 @@ export async function findPikkuScope(startDir: string): Promise<string | null> {
     const candidate = join(dir, 'node_modules', '@pikku')
     if (existsSync(candidate)) {
       const entries = await readdir(candidate).catch(() => [])
-      if (entries.length > 0) return candidate
+      if (entries.some((entry) => !entry.startsWith('.'))) return candidate
     }
     const parent = dirname(dir)
     if (parent === dir) return null

--- a/packages/cli/src/services.ts
+++ b/packages/cli/src/services.ts
@@ -123,6 +123,10 @@ const CONFIG_FREE_COMMANDS = new Set([
   'skills.install',
   'doc',
   'fabric.report',
+  'fabric.findings',
+  'fabric.findings.list',
+  'fabric.findings.flush',
+  'fabric.findings.clear',
 ])
 
 export const createConfig: CreateConfig<

--- a/packages/cli/src/services.ts
+++ b/packages/cli/src/services.ts
@@ -112,12 +112,17 @@ export const defaultCLIRenderer = pikkuCLIRender<ForwardedLogMessage>(
  * `skills install` writes agent skills into a repo that has no pikku.config.json
  * yet — that is the whole point of it — so it cannot require one to start, and
  * `doc` answers from the surface shipped inside the CLI rather than the project.
+ * `fabric report` files a finding about pikku itself: a scaffold that never
+ * produced a config, or a command run from the wrong directory, is exactly the
+ * kind of thing worth reporting, so demanding a config would refuse the finding
+ * at the moment it is most worth having.
  */
 const CONFIG_FREE_COMMANDS = new Set([
   'skills',
   'skills.list',
   'skills.install',
   'doc',
+  'fabric.report',
 ])
 
 export const createConfig: CreateConfig<

--- a/packages/skills/skills/pikku-feature/SKILL.md
+++ b/packages/skills/skills/pikku-feature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pikku-feature
 description: 'Drive create-a-feature work inside a Pikku project that already exists: discover project context, work on a feature branch, implement + verify + commit, and ask the user to review via the diff. TRIGGER when: the user asks to "create a feature", "add X to my Pikku project", "wire up a new endpoint", or anything that implies turning a natural-language request into Pikku functions/wirings/migrations within a working app. DO NOT TRIGGER when: the user asks for a one-off code edit in an existing function, asks about Pikku concepts (use pikku-concepts), or is building a whole app from a fresh scaffold rather than extending one (use pikku-build-app, or pikku-build-quick / pikku-build-platform).'
-allowed-tools: Bash(yarn pikku meta *), Bash(yarn pikku all *), Bash(yarn tsc), Bash(git status *), Bash(git diff *), Bash(git switch *), Bash(git checkout *), Bash(git checkout -b *), Bash(git add *), Bash(git commit *), Bash(git log *), Bash(git branch *)
+allowed-tools: Bash(yarn pikku meta *), Bash(yarn pikku all *), Bash(yarn tsc), Bash(git status *), Bash(git diff *), Bash(git switch *), Bash(git checkout *), Bash(git checkout -b *), Bash(git add *), Bash(git commit *), Bash(git log *), Bash(git branch *), Bash(yarn pikku fabric report *), Bash(npx pikku fabric report *)
 argument-hint: '<feature description>'
 ---
 
@@ -16,6 +16,7 @@ Use this skill as an execution checklist, not reference material.
 3. Make the smallest source change that satisfies the task. Keep generated files generated, and avoid hand-editing SDKs, schema output, or typegen.
 4. Validate with the narrowest relevant command first, then run `pikku-verify` or `pikku all` when functions, wirings, schemas, or generated clients may have changed.
 5. If validation fails, fix the source cause and rerun validation. Do not paper over generated errors by editing generated files.
+6. Report anything about pikku itself that cost you time, the moment it happens — see **Report what fought you**.
 
 End-to-end flow: **discover → state intent → branch → implement → verify → commit → hand to reviewer**.
 
@@ -246,6 +247,90 @@ feature/<slug>` and surface the PR-create URL.
 
 Do not push without explicit confirmation. Do not merge.
 
+## Report what fought you
+
+When pikku itself is what cost you time, report it with `pikku fabric report`.
+Nothing is written to the repo; the finding goes to the linked fabric project
+and the terminal shows you exactly what was sent.
+
+**Report at the moment it happens**, not at the end from memory — a run that
+falls over never reaches its end. One finding per thing that fought you.
+
+### The ladder
+
+1. **Find the quicker workaround.** The user is paying for their feature, not
+   for pikku's health.
+2. **Investigate** only when there is no workaround, or when the user asks why
+   something is slow or wrong.
+3. **Report at the depth you already reached.** Never spend extra effort to
+   file; never throw away effort you already spent. If the investigation took
+   you to the mechanism, the finding says so — named file, named function, what
+   is actually happening, and what pikku should do instead.
+
+**Never fix pikku itself.** Not a patch in `node_modules`, not a linked
+checkout, not a branch in the framework repo. Many agents each patching pikku to
+unblock themselves is many divergent copies and a merge problem nobody signed up
+for. Work around it in the app, report it, and let the fix happen once.
+
+### What counts
+
+Anything that cost you time and would cost the next person the same. Most of
+these never produce an error: output that is quietly wrong, a generated type
+that disagrees with the runtime, a check that passes when it should not, a
+narrowing you had to write by hand because the framework should have written it.
+**Having to write code the framework should have written for you is a finding.**
+
+So is anything that only shows up in one place — invisible locally, fatal
+deployed, or the reverse. Say which, with `--surface`.
+
+Not a finding: a preference, a thing you would have designed differently, or
+baseline noise that was already failing before you started.
+
+### Two kinds
+
+- `--kind product` — pikku behaved wrongly. Fixing it is a change to the
+  framework.
+- `--kind harness` — a skill misled you: it told you to run something that does
+  not exist, described a flag that is spelled differently, or contradicted what
+  the CLI actually did. Pass `--skill <name>` and `--passage "<the line or
+  section>"`. This is the most useful kind to file, because it is fixable
+  immediately — so file it even when the cost was small.
+
+### When there was no workaround
+
+Report it anyway with `--unresolved`, and put what you tried and how each
+attempt failed in `--tried`. That is what stops the next person walking the same
+dead ends. Tell the user what you did instead — abandoned it, shipped something
+degraded, or stopped.
+
+`--unresolved` means **no workaround was found**. It does not mean the
+workaround was unpleasant.
+
+### The command
+
+```bash
+pikku fabric report "<one-line title>" \
+  --kind product \
+  --model <the model you are> \
+  --expected "<what you expected pikku to do>" \
+  --actual "<what it did instead>" \
+  --command "<the command you ran>" \
+  --workaround "<what you did instead, inside the app>"
+```
+
+Add whichever of these you actually have: `--error` (the error's message line,
+verbatim), `--repro` (the shortest way to reach it again), `--proposal` (what
+pikku should do), `--area`, `--surface local|deployed|both`, `--cost` (measured
+if you measured it — "98s vs 20s steady" ranks; "slow" does not), `--run` (an id
+shared by every finding from this build), `--deploy-target`.
+
+Versions, platform and package manager are read off the installed tree for you.
+Do not pass them and do not ask the user for them.
+
+Reporting never fails a build: an unreachable endpoint, an unlinked project or a
+logged-out user prints a line and moves on. If it says the finding was not sent,
+carry on with the feature — do not try to fix it.
+
 ## Hard constraints
 
 The skill's `allowed-tools` does **not** permit:
@@ -254,7 +339,8 @@ The skill's `allowed-tools` does **not** permit:
 - `yarn dbmigrate` (never run migrations against the real DB during planning)
 - `pikku deploy apply` (never deploy)
 - secret writes
-- network calls beyond what the implementation requires
+- network calls beyond what the implementation requires, except
+  `pikku fabric report`, which is explicitly permitted
 
 If the feature genuinely needs any of these, **stop and ask** with a clear
 explanation of why and what would change.

--- a/packages/skills/skills/pikku-feature/SKILL.md
+++ b/packages/skills/skills/pikku-feature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pikku-feature
 description: 'Drive create-a-feature work inside a Pikku project that already exists: discover project context, work on a feature branch, implement + verify + commit, and ask the user to review via the diff. TRIGGER when: the user asks to "create a feature", "add X to my Pikku project", "wire up a new endpoint", or anything that implies turning a natural-language request into Pikku functions/wirings/migrations within a working app. DO NOT TRIGGER when: the user asks for a one-off code edit in an existing function, asks about Pikku concepts (use pikku-concepts), or is building a whole app from a fresh scaffold rather than extending one (use pikku-build-app, or pikku-build-quick / pikku-build-platform).'
-allowed-tools: Bash(yarn pikku meta *), Bash(yarn pikku all *), Bash(yarn tsc), Bash(git status *), Bash(git diff *), Bash(git switch *), Bash(git checkout *), Bash(git checkout -b *), Bash(git add *), Bash(git commit *), Bash(git log *), Bash(git branch *), Bash(yarn pikku fabric report *), Bash(npx pikku fabric report *)
+allowed-tools: Bash(yarn pikku meta *), Bash(yarn pikku all *), Bash(yarn tsc), Bash(git status *), Bash(git diff *), Bash(git switch *), Bash(git checkout *), Bash(git checkout -b *), Bash(git add *), Bash(git commit *), Bash(git log *), Bash(git branch *), Bash(yarn pikku fabric report *), Bash(npx --no pikku fabric report *)
 argument-hint: '<feature description>'
 ---
 
@@ -308,28 +308,44 @@ workaround was unpleasant.
 
 ### The command
 
+Send it as JSON on stdin. Most of a finding is prose, and prose carries
+apostrophes, quotes, backticks and newlines — each one a shell metacharacter
+before it is a character in your sentence. A stack trace passed to `--error`
+breaks the command at its first newline; a backtick in `--actual` runs whatever
+follows it. Quote the heredoc delimiter (`<<'EOF'`, never `<<EOF`) so the shell
+leaves the body alone.
+
 ```bash
-pikku fabric report "<one-line title>" \
-  --kind product \
-  --model <the model you are> \
-  --expected "<what you expected pikku to do>" \
-  --actual "<what it did instead>" \
-  --command "<the command you ran>" \
-  --workaround "<what you did instead, inside the app>"
+pikku fabric report --stdin <<'EOF'
+{
+  "title": "<one-line title>",
+  "kind": "product",
+  "model": "<the model you are>",
+  "expected": "<what you expected pikku to do>",
+  "actual": "<what it did instead>",
+  "command": "<the command you ran>",
+  "workaround": "<what you did instead, inside the app>"
+}
+EOF
 ```
 
-Add whichever of these you actually have: `--error` (the error's message line,
-verbatim), `--repro` (the shortest way to reach it again), `--proposal` (what
-pikku should do), `--area`, `--surface local|deployed|both`, `--cost` (measured
-if you measured it — "98s vs 20s steady" ranks; "slow" does not), `--run` (an id
-shared by every finding from this build), `--deploy-target`.
+Add whichever of these you actually have: `error` (the error's message line,
+verbatim), `repro` (the shortest way to reach it again), `proposal` (what pikku
+should do), `area`, `surface` (`local`, `deployed` or `both`), `cost` (measured
+if you measured it — "98s vs 20s steady" ranks; "slow" does not), `run` (an id
+shared by every finding from this build), `deployTarget`.
+
+The same fields exist as flags — `--kind`, `--expected` and so on — for a
+finding short enough to type. Anything with a newline or a quote in it goes
+through `--stdin`.
 
 Versions, platform and package manager are read off the installed tree for you.
 Do not pass them and do not ask the user for them.
 
-Reporting never fails a build: an unreachable endpoint, an unlinked project or a
-logged-out user prints a line and moves on. If it says the finding was not sent,
-carry on with the feature — do not try to fix it.
+Reporting never fails a build. A finding that cannot be sent — logged out, or
+fabric unreachable — is held on the machine and goes out with the next report
+that succeeds, so nothing you file is lost. If it says the finding was queued,
+carry on with the feature; do not try to fix it, and do not file it again.
 
 ## Hard constraints
 


### PR DESCRIPTION
Closes #1510.

An agent building an app on pikku hits things the framework got wrong — a diagnostic that names the wrong cause, a skill passage the CLI contradicts, a step that is invisible locally and fatal deployed. Today that knowledge dies in the transcript. This gives it one command to send, and the `pikku-feature` skill the rules for when to use it.

## `pikku fabric report`

```bash
pikku fabric report "Deployed errors answer with the minifier name" \
  --kind product \
  --model claude-opus-5 \
  --expected "the rpc to answer with PermissionDeniedError" \
  --actual "it answered with cn" \
  --command "pikku deploy" \
  --surface deployed \
  --workaround "matched on the status code instead"
```

```
[fabric] reporting: Deployed errors answer with the minifier name
  kind: product
  command: pikku deploy
  expected: the rpc to answer with PermissionDeniedError
  actual: it answered with cn
  surface: deployed
  workaround: matched on the status code instead
  model: claude-opus-5
  versions: @pikku/cli@0.12.35 @pikku/core@0.12.113
  note: the installed @pikku/* versions are not all the same
  runtime: node v24.18.1 darwin-arm64 yarn@4.1.0
[fabric] no project linked — finding not sent
```

**Nothing is written to the repo.** No `.pikku/findings/`, no sent-markers, no content-hashed filenames, no findings going stale on a branch someone abandoned. Dedup belongs server-side anyway, where it can count how many *distinct projects* hit a thing rather than how many runs did.

**A finding that cannot be sent is held, not dropped.** The states that stop a send — logged out, fabric unreachable — are the states a finding is most likely to be describing, so printing it and discarding it loses exactly the reports worth having. The queue lives in `~/.fabric/findings`, which is per-machine rather than per-checkout, so it has neither problem the repo-local version would have had: nothing goes stale on an abandoned branch and git never sees it. It drains oldest-first on the next report that succeeds, keeps the project each finding was filed against, stops at the first refusal rather than hammering an endpoint that just said no, and is bounded at 100. `pikku fabric findings list`, `flush` and `clear` inspect and control it.

**The finding can arrive as JSON.** `--stdin` takes the whole thing on standard input instead of across twenty-odd flags. Half the fields are prose, and prose carries apostrophes, quotes, backticks and newlines — every one a shell metacharacter before it is a character in a sentence, so an error message pasted into `--error` broke the command at its first newline and one carrying a backtick ran whatever followed it. JSON has its own escaping. `FindingInput` validates either path, so nothing downstream knows which was used.

```bash
pikku fabric report --stdin <<'EOF'
{ "title": "…", "kind": "product", "model": "…", "expected": "…", "actual": "…" }
EOF
```

**The terminal is the receipt.** The payload prints before the request leaves, so the user sees exactly what left their machine whether or not the send succeeds.

**Reporting never fails a build.** An unreachable endpoint, a refusal, an unlinked project or a logged-out user prints a line and moves on. Only a malformed call throws, because that one is the agent's own mistake and worth failing loudly for. It is config-free for the same reason — a scaffold that never produced a `pikku.config.json` is exactly the kind of thing worth reporting, so demanding one would refuse the finding at the moment it is most worth having.

## What the CLI fills in

Read off the installed tree, never out of `package.json` — `^0.12.35` says nothing about what ran:

- every resolved `@pikku/*` version, with **skew flagged**. Pinning the CLI does not pin its `@pikku/*` dependencies, so a mixed tree is a common cause of behaviour that looks like a framework bug, and triage can see it before reading a word of the prose.
- **whether any `@pikku/*` resolves through a symlink** — a workspace or a `yarn link`ed checkout. The framework is read-only during a build run, so a linked package means the finding describes code that may already have been modified.
- node version, package manager (declared `packageManager` first, lockfile as fallback), platform.

The model is the one field the CLI cannot derive, so it is agent-supplied. It separates a framework that is genuinely confusing from a skill only some models can follow — and, paired with the skill name a harness finding already carries, it is how you check whether an edit fixed it for the model that failed.

## Two kinds, and the rules the schema enforces

- `--kind product` — pikku behaved wrongly.
- `--kind harness` — a skill misled you. Requires `--skill`, plus `--passage` for the line it contradicts. This half is a patch to a markdown file in our own corpus, so it closes in hours rather than weeks.

`validateFinding` refuses a harness finding with no skill, an unresolved finding with no `--tried`, an unresolved finding that also claims a workaround, and a resolved finding carrying neither workaround nor proposal. All problems are returned at once so a malformed call is fixed in one pass.

`--unresolved` means **no workaround was found** — a blocker rather than a tax — not that the workaround was unpleasant. With no workaround to describe, the payload is what was tried and how each attempt failed, which is what stops the next agent walking the same dead ends.

## The skill

`pikku-feature` gains a **Report what fought you** section with the ladder: find the quicker workaround first, because the user is paying for their feature and not for pikku's health; investigate only when there is no workaround or the user asks; report at the depth already reached — never spend extra to file, never discard what was spent.

It says explicitly that **most findings never produce an error** — output that is quietly wrong, a generated type that disagrees with the runtime, a check that passes when it should not, a narrowing you had to write by hand. *Having to write code the framework should have written for you is a finding.* That class is the expensive one and the one an agent will otherwise never file, because nothing prompted it.

And it says **never fix pikku itself** — not in `node_modules`, not through a linked checkout, not as a branch in the framework repo. Many agents each patching pikku to unblock themselves is many divergent copies and a merge problem nobody signed up for.

## What fabric needs to build

This PR is the OSS half. The ingest endpoint is a separate change in the fabric repo; the contract the CLI sends is:

```
POST {apiUrl}/findings
Authorization: Bearer <token from `pikku fabric login`>
Content-Type: application/json

{
  "projectId": "prj_…" | null,
  "finding": {
    "title", "kind": "product" | "harness", "model",
    "expected", "actual",
    "skill?", "passage?", "command?", "error?", "repro?",
    "workaround?", "proposal?", "tried?", "unresolved?",
    "area?", "surface?": "local" | "deployed" | "both",
    "cost?", "runId?", "deployTarget?",
    "reportedAt": "<iso>",
    "environment": {
      "packages": [{ "name", "version", "linked" }],
      "versionSkew": boolean,
      "linkedFramework": boolean,
      "node", "packageManager", "platform"
    }
  }
}
```

Any 2xx counts as accepted. The CLI treats a non-2xx as not-sent and spools the finding.

`projectId` is nullable and is **provenance, not a routing key**. Sending needs a login and nothing else — the same rule `fabric addon add` and `fabric projects` already follow. A finding is about the framework rather than about anyone's project, and the reports worth having most, a scaffold that never produced a config or a first run that went wrong, come from checkouts that have no project to name. Requiring a link would refuse exactly those.

## Tests

27 new tests. `report-environment` covers reading the installed version rather than the declared range, flagging a symlinked package, skipping an unreadable manifest, walking past an empty scope to the hoisted one, `packageManager` beating the lockfile, and a skewed versus uniform tree. `finding` covers every validation rule including all three firing at once, the receipt showing what was sent and omitting what was not, and `postFinding` against a real local server for the accepted, refused, timed-out and unreachable paths.

`@pikku/cli` 1549 tests green, `@pikku/skills` 10 green, `tsc` clean on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `fabric report` for submitting structured findings with context such as errors, reproduction steps, workarounds, and proposals.
  - Displays a receipt including environment details, version mismatches, and linked framework information.
  - Reports are handled safely when the user is not signed in, no project is linked, or the reporting service is unavailable.

- **Documentation**
  - Updated feature guidance with instructions for recording findings and using the new command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
