### PR TITLE
feat(make-import): Make.com blueprint importer

### DIFF
--- a/WORKFLOW-IMPORT-RESEARCH.md
+++ b/WORKFLOW-IMPORT-RESEARCH.md
@@ -1,0 +1,301 @@
+# Workflow Engine Import — Research & Recommendation
+
+**Date:** 2026-07-16
+**Question:** Which workflow engines besides n8n can we import from, following the `@pikku/n8n-import` concept?
+
+**Verdict: Make first** (revised — see §4c). Activepieces is a close second and remains the choice if ToS exposure is unacceptable.
+
+> **Revision history.** This doc first recommended **Activepieces**, on two claims that did not survive measurement: (a) "~55% catalog overlap, better than Make" — an artifact of measuring against AP's full 723-piece catalog; real-usage coverage is **47%**, a tie with Make's 46% and worse on weighted (74% vs 82%). (b) "Activepieces has no corpus" — false; `cloud.activepieces.com/api/v1/templates` serves **420 templates unauthenticated**.
+>
+> Also corrected en route: Zapier *does* have an official JSON export (§4); Make's routers are **sequential, not parallel** (§4).
+>
+> **Every error ran the same direction — pessimism toward options not being advocated.** Weigh the final call accordingly.
+
+---
+
+## 1. What n8n-import actually is
+
+Pipeline: **parse export JSON → normalized IR (roles) → topology DAG → expression classifier → integration map → codegen**.
+
+Module sizes (`packages/n8n-import/src`, 15,216 lines total):
+
+| Module | Lines | Engine-specific? |
+|---|---:|---|
+| `integration-map.ts` | 7,605 | ✅ Fully — n8n node-type keys |
+| `codegen.ts` | 1,636 | ❌ Nearly clean (one `__rl`, one `fixedCollection`) |
+| `parse-n8n.ts` | 455 | ✅ Fully |
+| `native-map.ts` | 452 | ✅ n8n idioms (`fromRL`, `fixedCollection`) |
+| `branch.ts` | 196 | ⚠️ Mostly |
+| `topology.ts` | 193 | ❌ Reusable concept |
+| `expressions.ts` | 192 | ✅ Syntax; ❌ the IR it emits |
+| `types.ts` | 179 | ⚠️ IR reusable, n8n types not |
+| `http-auth-map.ts` | 164 | ❌ Recipe table reusable |
+| `credentials.ts` | 164 | ⚠️ |
+| `naming.ts`, `output-schema.ts` | 221 | ❌ Reusable |
+
+### The two load-bearing insights
+
+**1. The `ClassifiedExpression` IR is the engine-agnostic seam.**
+```ts
+type ClassifiedExpression =
+  | { kind: 'literal';   value: unknown }
+  | { kind: 'ref';       nodeId: string; path?: string }
+  | { kind: 'template';  parts: string[]; refs: RefPart[] }
+  | { kind: 'transform'; expression: string }
+```
+Every engine's expression language just needs a new classifier targeting these four tiers. This already exists and is correct.
+
+**2. The value is the right-hand side of `integration-map.ts`, and it's portable.**
+The table maps `n8n type + resource + operation` → `google-drive:filesGet`. For a second engine you rewrite the **keys** and keep the **targets**. That's why integration identity in the source format is the decisive selection criterion — not graph shape.
+
+### Caveats about our own code
+
+- `@pikku/addon-graph` primitives are *themselves* n8n: `splitOut`, `removeDuplicates`, `renameKeys`, `summarize`, `stopAndError`, `limit`, `sort`, `aggregate`, `dateTime`, `crypto`, `wait`. A second engine will pressure this vocabulary.
+- The 216-addon catalog mirrors n8n's connector long tail (Mautic, Vero, Uproc, Peekalink, Mocean, Egoi).
+- **`$fromAI` is a known deferred gap.** `http-tool.ts:45` treats any `$fromAI` param as non-static and emits a throwing stub — comment calls the LLM-filled input schema "a v2 concern." An n8n tool's parameter schema is never declared in one place; it's synthesized from `$fromAI()` calls scattered across parameter expression strings.
+- The harness (`harness/run.ts`) runs a corpus through parse → codegen → tsc, classifying clean/partial/failed. **Corpus availability is a first-class selection criterion.**
+
+---
+
+## 2. Recommendation: Activepieces
+
+**Why it wins on the only criterion that matters — integration mapping value:**
+
+- **`pieceName` + `pieceVersion`** is a near-exact analogue of n8n's `type` + `typeVersion`. `integration-map.ts` is already keyed on that shape.
+- **723 pieces**, all MIT.
+- **104 of our 216 addons have an exact normalized-name counterpart** — and that undercounts (our `aws-s3`/`aws-ses`/`aws-sns`/`aws-sqs`/`aws-lambda` land on their `amazon-*`). Real overlap ≈ **55%**.
+- **License verified firsthand.** Root `LICENSE` grants MIT Expat to everything outside `packages/ee/`; there is **no separate LICENSE under `packages/pieces/`**. This **refuted my prior** that the catalog was carved out.
+
+**Known costs (all bounded):**
+
+- Flow is a `nextAction` **linked chain**, not a DAG. `ROUTER` nests via `children[]`; `LOOP_ON_ITEMS` via `firstLoopAction`. → rewrite `topology.ts` (193 lines, the small one).
+- `{{step.field}}` is parsed by a **custom brace tokenizer, not real Mustache**, despite the `mustache-utils.ts` filename. → bespoke lexer.
+- Schema is at `LATEST_FLOW_SCHEMA_VERSION = '22'` and **has already broken once** (BRANCH → ROUTER).
+- UI export documented only in a [community post](https://community.activepieces.com/t/flow-import-export-support-files-and-zip-format/6826), not `/docs`. API: `GET /v1/flows/{id}`.
+
+**The open risk — and the reason to spike:** whether `ROUTER` / `LOOP_ON_ITEMS` lower cleanly onto `graph:branch` / `graph:fanout`. Make's routers famously don't (see below). No further research answers this; only a spike against real flows does.
+
+---
+
+## 3. Full engine matrix
+
+| Engine | Export | Topology | Integration identity | Legal | Verdict |
+|---|---|---|---|---|---|
+| **Activepieces** | ✅ JSON | ⚠️ Linked chain | ✅ `pieceName`+`version`, 723 MIT pieces | ✅ MIT (verified) | **BUILD** |
+| **Make** | ✅ Blueprint UI + API | ⚠️ Nested `flow[]`/`routes[]`; routers = **sequential gated fan-out** (§4) | ✅ `facebook-pages:CreatePost`+`version` | ⚠️ ToS competitive-use | Commercial play — risk lower than first assessed |
+| **Power Automate** | ✅ Public MIT JSON Schema | ✅ `runAfter` labeled DAG | ✅ `apiId`+`operationId` | ✅ Cleanest commercial | Enterprise play |
+| **Dify** | ✅ DSL YAML | ✅ Real DAG | ⚠️ 653 tools but **opaque plugins** | ✅ Apache-2.0+2 conditions | Second (AI track) |
+| **Flowise** | ✅ JSON (double-encoded) | ✅ Real DAG | ⚠️ ~40–70 tools, readable TS | ✅ Apache-2.0 (not `enterprise/`) | AI track first step |
+| **Node-RED** | ✅ Flat array | ✅ Real edges | ❌ **Unnamespaced, 1,990 collisions** | ✅ Apache-2.0 | **SKIP** |
+| **Zapier** | ⚠️ All-Zaps, undocumented | ❌ No edges, order implicit | ❌ `selected_api` ≠ API id | ❌ ToS §4(b)(v) | **SKIP** |
+| **Windmill** | ✅ OpenFlow | ⚠️ Ordered modules | ❌ **No registry at all** | ⚠️ AGPL core / **Apache-2.0 spec** | SKIP (no integrations) |
+| **Kestra** | ✅ YAML | ⚠️ Only `Dag` task has edges | ⚠️ FQCN, **not version-stable** | ✅ Apache-2.0 | Tier 2 |
+| **Langflow** | ✅ JSON | ✅ Real DAG | ❌ **Composio proxy, single-digit native** | ✅ MIT | **SKIP** |
+| **Step Functions** | ✅ ASL JSON | ✅ `Next`/`Choices` | ❌ AWS ARNs only, no SaaS | ✅ Spec public | SKIP |
+| **Automatisch** | ⚠️ Source-only, undocumented | ⚠️ Mostly linear | ⚠️ `appKey`, ~80 apps | ⚠️ AGPL | SKIP |
+| **Workato** | ✅ `GET /api/recipes/:id` | ⚠️ Nested `block[]` | ✅ provider+name+keyword | ❌ **Worst — bans benchmarking** | SKIP |
+| **Tray** | ✅ UI; API Embedded-only | ✅ `steps_structure` | ✅ connector+operation | ⚠️ MSA §2.3(vi) | SKIP |
+| **Pipedream** | ⚠️ Schema **unpublished** | ❌ Linear; **no control-flow export** | ✅ `slack-send-message@0.1.1` | ❌ Registry bans competing use | SKIP |
+| **Retool** | ✅ UI JSON | ⚠️ `blockData`+edges | ⚠️ Undocumented | ⚠️ MSA §3.3(h) | SKIP |
+| **Rivet** | ✅ YAML v4 | ⚠️ String edges | ❌ Zero integrations | ✅ MIT | Dead (last human commit 2025-08-20) |
+| **Sim** | ✅ **JSON, not YAML** | ✅ blocks+edges | ⚠️ ~230–240 real (not "1,000+") | ⚠️ Apache-2.0, `ee/` no-derivatives | SKIP |
+| **Bedrock Flows** | ✅ JSON | ✅ **Typed `Conditional` vs `Data`** | ❌ AWS only | — | Prior art only |
+| **Temporal / Airflow / Dagster / Prefect** | ❌ | — | — | — | **The workflow *is* code** |
+| **BPMN / Camunda** | ✅ XML | ✅ Cleanest edge list | ⚠️ Camunda 8 license unverified | ⚠️ | Tier 2 |
+
+---
+
+## 4. Findings that change the build
+
+### Zapier — my prior was refuted
+Zapier **does** have an official documented JSON export: Settings → Security and data → Data management → "Download my Zap workflows," available Free through Enterprise ([help article](https://help.zapier.com/hc/en-us/articles/8496308481933-Import-and-export-Zap-workflows-in-your-Team-or-Enterprise-account), updated 2026-05-29). But: **all-or-nothing** (not per-Zap), **schema undocumented**, **no edges** (order implicit), **no expression language** (just `{{NodeID__Field}}` tokens). Zapier MCP / Agents give nothing machine-readable — all 15 meta-tools execute actions.
+
+### Node-RED is a trap
+Wins on format (flat array, `wires[i]` = target ids for output port `i`), license (Apache-2.0, OpenJS Foundation), and corpus. Loses on the only thing that matters:
+- Type ids are **bare unnamespaced strings** (`mqtt out`, `publish`). The flow JSON **does not record which npm module a node came from**.
+- Live catalogue: **6,132 modules declaring 17,928 node types; 1,990 type ids claimed by >1 module** (`lower-case` by 23 packages, `socketio-config` by 14).
+- **Config-node references are indistinguishable from plain string values** (`"broker": "241f674b.fabaa8"`) — unresolvable without each package's `.html` editor schema.
+- Core is only **49 node types**; ~99.7% of the palette is community.
+- Ecosystem is IoT/MQTT-shaped → poor overlap with our SaaS addon catalog.
+
+### Make's routers are not branches — they're gated fan-out, executed sequentially
+
+**Corrected 2026-07-16.** An earlier draft of this doc claimed routes fire "in parallel." **That was wrong** (agent-sourced, repeated unverified). [Make's docs](https://help.make.com/router) state plainly:
+
+> "Routes are processed sequentially, not in parallel. Make won't process the second route unless it finishes processing the first one."
+
+Route order is user-configurable (right-click → "order routes"), and route 1's **entire downstream chain** completes before route 2 begins.
+
+**Correct semantics:** one bundle → every route whose filter passes runs, **non-exclusively**, **in route order**, and routes **cannot merge back** (each is an independent terminal chain).
+
+**Correct lowering — no new primitive needed.** `branch.ts` already documents the gate we need:
+> "Filter: slot 0 = kept (no fallback — a false result dead-ends)."
+
+So a router → **N independent Filter-shaped branch nodes**, each fed `ref(routerPredecessor)`, each dead-ending when its condition fails. Reuses the existing lowering path.
+
+**Two wrong lowerings, in opposite directions:**
+- `graph:branch` (exclusive, one-winner) → drops routes that should have fired.
+- `Promise.all` / concurrent fan-out → introduces concurrency Make doesn't have.
+
+**`graph:fanout` is the wrong primitive.** Per `fanout.ts`, it maps *one rpc over N items*; a router is *N chains over one item* — the transpose.
+
+**The real remaining risk — ordering.** Pikku's graph would likely run N independent gated chains **concurrently** (nothing connects them). Route order is observable whenever routes touch shared state (route 1 creates a record, route 2 updates it). Options: emit an explicit sequencing edge (route N's gate depends on route N-1's completion), or accept concurrency and surface an `ImportDiagnostic`.
+
+**Verdict: not a semantic trap — a sequencing rule.** Downgrades Make's risk materially.
+
+**Still true:** structure is nested (`flow[]` + `routes[].flow[]`), not a DAG.
+
+### The AI cluster has an ugly inversion
+The only AI engine with a real SaaS catalog (Dify, 653 tools) is the one where **the schemas aren't in the file** — all 653 are out-of-process plugins; a `tool` node serializes only `provider_id`/`tool_name` + an untyped param bag. Dify also only exports a graph for **2 of its 8 app modes** (`workflow`, `advanced-chat`).
+
+Langflow is **not an integration play at all**: the entire `slack_composio.py` is four lines declaring `app_name = "slack"`. Slack/Jira/GitHub/Linear/Airtable/Discord/Google Sheets are Composio stubs; Salesforce/HubSpot/Stripe/Twilio don't exist. **Our 216 addons are strictly better than Langflow's catalog.** It also embeds full Python source per node (`template.code`, ~37,800 chars for the stock Agent) and `exec()`s it unsandboxed (GHSA-vwmf-pq79-vjvx, CVE-2026-33017, CVE-2026-5027).
+
+Flowise is the best *learning* target on the AI track: **64 in-repo versioned flow JSONs** (24 chatflows + 14 agentflows + 13 agentflowsv2 + 13 tools), readable in-repo TS schemas, **JS-only code nodes** that port to a TS runtime. But V1 (everything is an edge) and V2 (everything inlined, tools as array) are architecturally opposite = **two importers**.
+
+### Legal pattern across commercial platforms
+Every one pairs "you own your workflows" with "you may not access the Service to build a competing product." **Risk-minimizing architecture: the user exports their own file and hands it to us; our code never touches their platform.** That reframes "accessing the Service" as "parsing a file."
+
+- **Worst:** Workato — additionally bans "benchmarking, comparative or competitive purposes," and binds *the user*, not just us.
+- **Precedent:** [migromat.com](https://migromat.com/) sells Make→n8n conversion commercially, no visible enforcement.
+
+### n8n's own license — resolved, we're fine
+n8n ships under the **Sustainable Use License**; GitHub reports `NOASSERTION`. **n8n is not open source.** But the SUL restricts *the software*, and exported workflow JSON is *user data*. n8n's own docs list as **ALLOWED**: *"Creating an n8n node for your product **or any other integration between your product and n8n**."* Real constraints: don't vendor n8n source, never touch `.ee.` files, don't market with the trademark. Type strings and JSON shapes are interface facts.
+
+### Cross-cutting: budget for the payload, not the topology
+Nearly every candidate has near-identical graph topology. The difficulty always lives elsewhere:
+- **Credentials are stripped on export** in Node-RED, Dify, Flowise, Langflow → all need a re-binding step (our `credentials.ts` + `http-auth-map.ts` generalizes).
+- **RAG/knowledge content referenced by opaque ID** everywhere → dangling pointers are unavoidable; surface as `ImportDiagnostic`, not a broken emit.
+- **Build version detection before schema work.** Dify declares `CURRENT_APP_DSL_VERSION = "0.7.0"` against 0.6.x files in its own repo; Langflow starters stamp `last_tested_version: 1.8.0` against a 1.10.2 runtime; Flowise stamps a float `version` per node; Activepieces is at schema v22 and already broke once.
+
+---
+
+## 4b. Make — measured (2026-07-16)
+
+### Corpus & legal: solved
+- **`integromat/make-skills` is Make's OWN org, MIT (`Copyright (c) 2026 Make`), actively pushed.**
+- Ships **10 popular-template blueprints** + a **blueprint format spec under MIT**: `blueprint-construction.md` (30KB), `routing.md`, `filtering.md`, `mapping.md`, `iterations.md`, `merging.md`, `aggregations.md`. **This is a documented spec, not reverse engineering.**
+- Make also runs a **public template library** (`make.com/en/templates`) with fetchable blueprints via `public-templates_list` / `public-templates_get-blueprint` (MCP — needs a token, so that path *does* touch the Service).
+- Community blueprints are abundant on GitHub.
+- **This dissolves the corpus/ToS problem.** Earlier draft claimed sourcing a corpus required a Make account. False — vendor MIT corpus + user-published data. Only an API-pull connector still touches the Service.
+- Note: `make.com` returns **403** to scripted fetches (bot-protected). Don't scrape; use GitHub.
+
+### Format (verified from a real blueprint)
+```json
+{ "blueprint": { "flow": [...], "metadata": {} }, "controller": {}, "scheduling": {}, ... }
+```
+```json
+{ "id": 2,
+  "module": "google-email:ActionSendEmail", "version": 2,
+  "mapper": { "to": ["{{1.`0`}}"], "subject": "{{1.`1`}}", "html": "{{1.`2`}}" },
+  "metadata": { "parameters": [{ "name": "account", "type": "account:google-restricted" }] } }
+```
+**Better than n8n in three ways:**
+1. `module` is a **single `service:operation` string** — flatter than n8n's `type`+`resource`+`operation` triple, and already in our rpc namespace shape.
+2. Refs are `{{1.\`0\`}}` — **numeric module ids → rename-safe**. n8n's name-keyed connections are not.
+3. `mapper` is exactly the 1:1 field map `NativeFieldSpec` was built for; `parameters` (config) is cleanly split from `mapper` (data).
+
+`metadata.parameters[].type` (`account:google-restricted`) types the credential binding → `credentials.ts`.
+
+### Router — ground truth
+```json
+"module": "builtin:BasicRouter",
+"routes": [ { "flow": [ { "id": 3, "module": "google-calendar:createAnEvent",
+      "filter": { "name": "Doesn't Exist",
+        "conditions": [[ {"a": "{{1...Status.name}}", "b": "Scheduled", "o": "text:equal"} ]] } },
+    { "id": 4, "module": "notion:updateADatabaseItem", "filter": null } ] }, ... ]
+```
+- Each route = `{flow: [...]}`; the route's **head module carries a `filter`** — that's the gate. `filter: null` on the rest.
+- `conditions: [[...]]` = **OR of ANDs** → maps onto `BranchSpec.cases[].combinator` directly.
+- `{a, b, o}` → `RawCondition {left, right, operation}`; `o: "text:equal"` splits type+operation exactly like n8n v2's `operator: {type, operation}` → reuse the `V1_OPERATION` translation-table pattern.
+- **`filter` sits on modules, not routes** — any module can be gated. Make's filters are edge-level, more general than routers.
+- `builtin:BasicFeeder` = iterator → a genuine `graph:fanout`.
+
+### Catalog coverage (237 real blueprints mined from GitHub)
+
+| Measure | Result |
+|---|---|
+| Distinct apps seen | **115** (18 builtins + 97 real integrations) |
+| Distinct `app:operation` | **377** |
+| Covered by a pikku addon (distinct) | **45/97 = 46%** |
+| **Covered, weighted by real usage** | **988/1,199 = 82%** |
+
+**"3,000 apps" is marketing** — same inflation as n8n's "1946" (real 440) and Sim's "1,000+" (real ~240).
+
+⚠️ **The two overlap numbers are not comparable.** Activepieces' **55%** is catalog-vs-catalog name matching; Make's comparable figure is **46%**. Make's **82%** is usage-weighted — computable only because Make has a public corpus and Activepieces doesn't.
+
+### The architectural surprise
+**Builtins are 1,609 / 2,808 module instances = 57% of everything** (`builtin` 617, `util` 292, `http` 237, `gateway` 203, `json` 96, `regexp` 48).
+
+→ **For Make, the long pole is `native-map` / `@pikku/addon-graph`, not `integration-map`** — the exact inverse of n8n. Make's builtins don't all have `addon-graph` equivalents, and that vocabulary is currently n8n's core node list. **This is where a Make importer's real cost sits.**
+
+### Incidental catalog gap (independent of any importer)
+Unmatched by usage: `gemini-ai` (26), `anthropic-claude` (7), `perplexity-ai` (5). We have `ai/openai` and `ai/ollama` but **no Anthropic and no Gemini addon**.
+
+---
+
+## 4c. Make vs Activepieces — measured head-to-head (2026-07-16)
+
+Both measured against real corpora, same method, same alias/builtin handling.
+
+| | **Make** | **Activepieces** |
+|---|---|---|
+| Corpus | 237 blueprints mined from GitHub + public template library | **420 templates** — `cloud.activepieces.com/api/v1/templates`, **no auth**, 3.9MB |
+| Distinct integrations used | 97 | 96 |
+| Covered — distinct | 45/97 = **46%** | 45/96 = **47%** |
+| Covered — **weighted by usage** | **988/1,199 = 82%** | **1,333/1,811 = 74%** |
+| Builtins share of all modules | 1,609/2,808 = **57%** | 986/2,797 = **35%** |
+| Module/piece id | `google-sheets:watchRows` — flat `service:operation` | `@activepieces/piece-linear` + `pieceVersion` |
+| Refs | `{{1.\`0\`}}` numeric → **rename-safe** | `{{step_1['job_id']}}` — step-name keyed |
+| Topology | nested `flow[]` / `routes[].flow[]` | `nextAction` linked chain |
+| Format spec | ✅ **MIT, vendor-published** (`blueprint-construction.md`, 30KB) | ⚠️ community post only |
+| Legal | ⚠️ ToS competitive-use (avoidable via file-upload architecture) | ✅ **MIT, self-hosted, zero ToS** |
+| Migration demand | **High** | Low |
+
+**Decision: Make.** Once coverage is a tie, Make wins on format quality (flat id already in our rpc shape, rename-safe refs, router → existing `BranchSpec`), a **vendor-published MIT format spec** (better documentation than we had for n8n), and far larger migration demand.
+
+**What Activepieces retains — and when to pick it instead:**
+- **Zero ToS exposure anywhere** (parser, connector, *and* corpus). If counsel rules the competitive-use clause unacceptable, AP is the answer and the drop-off is small.
+- **Materially lighter builtins burden** (35% vs 57%) — less `addon-graph` work.
+
+**Top Make gaps by usage:** `gemini-ai` (26), `sellsy` (22), `apify` (20), `json2video` (10), `anthropic-claude` (7).
+**Top AP gaps by usage:** `text-ai` (97), `pipedrive` (47), `telegram-bot` (39), `workable` (32), `firecrawl` (23), `perplexity-ai` (20), `jira-cloud` (20).
+
+⚠️ Both weighted figures carry classification noise — the builtin/integration split is judgment (e.g. AP's `text-ai` may be a builtin AI helper, which would raise AP's weighted number). Treat 82% vs 74% as "Make somewhat better," not a precise gap.
+
+---
+
+## 5. Recorded disagreement
+
+Two agents from other sessions (not spawned by this work, lacking the addon-catalog context) called Activepieces a **"structural reject"** — reason: recursive nested `nextAction` tree, no `edges` array, data edges only inside `{{step_1['job_id']}}` strings.
+
+**Facts agreed. Conclusion rejected.** Their implicit criterion was "can I reuse my ReactFlow nodes+edges parser." Against our seams both objections invert:
+
+1. **A linked chain is a degenerate DAG.** Synthesizing topology from `nextAction` is *easier* than parsing n8n's `connections` map (keyed by node *name*, then `[outputIndex][connectionIndex]`). `topology.ts` is the 193-line module, not the 7,605-line one.
+2. **String-embedded data refs are the problem `expressions.ts` already solves.** n8n's `$node["X"].json.field` is *also* a data edge hiding in a string — that's why the four-tier IR exists. `{{step_1['job_id']}}` is a different regex against the same design.
+
+One of those agents' top recommendation was "build the n8n importer first" — already done. Weight accordingly.
+
+**What would actually change the recommendation:** Activepieces ROUTER/LOOP_ON_ITEMS failing to lower onto `graph:branch`/`graph:fanout`, the way Make's routers fail. That's the spike.
+
+---
+
+## 6. Next steps
+
+1. **Audit Make's builtins first — not the integrations.** They're 57% of all module instances and the actual long pole. Enumerate `builtin:*` / `util:*` / `json` / `regexp` / `gateway` against `@pikku/addon-graph`'s current vocabulary (which is n8n's core node list) and size the gap. **This is the estimate that decides the project**, and neither the research nor the first recommendation had it on the board.
+2. **Read Make's MIT spec before writing a parser** — `skills/make-scenario-building/blueprint-construction.md` (30KB) plus `routing.md`, `filtering.md`, `mapping.md`, `iterations.md`, `merging.md`, `aggregations.md`. Vendor documentation; don't reverse-engineer what's already written down.
+3. **Spike the Make parser** on the mined corpus. Router lowering is already understood (§4b) — the open risks are `builtin:BasicAggregator` / `util:*` semantics and IML expression coverage.
+4. **Extract the shared core** into `@pikku/workflow-import-core` *before* the second importer, not retrofitted: `codegen` + `naming` + `output-schema` + the `ClassifiedExpression` / `ParsedWorkflow` IR. Each engine then ships `parse` + `expressions` + `integration-map` + its own topology synthesis.
+5. **Port the harness pattern** (parse → codegen → tsc; clean/partial/failed). Corpus sources — **Make:** 237 mined from GitHub + `integromat/make-skills` (MIT) + public template library; **Activepieces:** 420 via `cloud.activepieces.com/api/v1/templates` (no auth); Flowise ships 64; Langflow ships 42; Node-RED has `catalogue.nodered.org/catalogue.json`.
+6. **Counsel question, in parallel:** can we ship an API-pull Make connector, or file-upload only? The parser and corpus are clean; only automated Service access is at issue. If the answer is unacceptable → **switch to Activepieces**, which costs ~8 points of weighted coverage and buys a lighter builtins burden.
+7. **Unrelated catalog gap:** no Anthropic and no Gemini addon (`gemini-ai` is Make's #1 unmatched app by usage; `perplexity-ai` appears in both corpora).
+
+---
+
+## 7. Open / unverified
+
+- Cloud ToS for Dify, Flowise, Langflow (self-hosted licenses are clear; hosted terms are not).
+- Camunda 8's current license (Camunda License 1.0, source-available) — unverified.
+- Automatisch "switched to Sustainable Use" rumor — flagged as **likely false**, unverified.
+- Dagster/Prefect licenses verified only at search-summary level.
+- Activepieces corpus availability — no in-repo example flows found; needs sourcing before a harness is viable.
+- Every "competitive use" clause is a **counsel question, not an engineering one**.

--- a/packages/make-import/.gitignore
+++ b/packages/make-import/.gitignore
@@ -1,0 +1,3 @@
+.corpus/
+harness-report.json
+dist/

--- a/packages/make-import/harness/emit-one.ts
+++ b/packages/make-import/harness/emit-one.ts
@@ -1,0 +1,17 @@
+/** Emit one blueprint and print the generated files — eyeball the real output. */
+import { readFileSync } from 'node:fs'
+import { generateWorkflowFromN8n } from '../../n8n-import/src/codegen.js'
+import { parseMake } from '../src/parse-make.js'
+
+const file = process.argv[2]!
+const parsed = parseMake(JSON.parse(readFileSync(file, 'utf8')), 'demo')
+
+console.log(`workflow : ${parsed.name}`)
+console.log(`modules  : ${parsed.nodes.map((n) => `${n.name}(${n.type})`).join(' -> ')}`)
+console.log(`warnings : ${JSON.stringify(parsed.warnings.map((w) => w.kind))}\n`)
+
+const res = generateWorkflowFromN8n(parsed, { rpcPrefix: 'make' })
+for (const [path, content] of Object.entries(res.files)) {
+  console.log(`\n${'='.repeat(70)}\n${path}\n${'='.repeat(70)}`)
+  console.log(content)
+}

--- a/packages/make-import/harness/run.ts
+++ b/packages/make-import/harness/run.ts
@@ -81,6 +81,20 @@ for (const file of files) {
   for (const m of parsed.modulesSeen) moduleFreq.set(m, (moduleFreq.get(m) ?? 0) + 1)
   for (const w of parsed.warnings) warnFreq.set(w.kind, (warnFreq.get(w.kind) ?? 0) + 1)
 
+  // An un-lowerable route gate has no safe degradation — emitting the workflow
+  // would run gated (often destructive) routes unconditionally. Skip it.
+  if (parsed.fatal) {
+    rows.push({
+      file,
+      outcome: 'skipped',
+      modules: parsed.nodes.length,
+      stubs: 0,
+      reason: 'un-lowerable route gate',
+      warnings: parsed.warnings.map((w) => w.kind),
+    })
+    continue
+  }
+
   try {
     const res = generateWorkflowFromN8n(parsed, { rpcPrefix: 'make' })
     if (res.diagnostics.some((d) => d.type === 'error')) {

--- a/packages/make-import/harness/run.ts
+++ b/packages/make-import/harness/run.ts
@@ -1,0 +1,189 @@
+/**
+ * Coverage harness for @pikku/make-import.
+ *
+ * Runs a corpus of Make blueprint JSON through parse → codegen and classifies
+ * each as clean / partial / failed / skipped.
+ *
+ *   yarn harness --dir <path>    # a folder of .json blueprints
+ *   yarn harness --limit 100
+ *
+ * Corpus provenance: public GitHub blueprints + `integromat/make-skills` (MIT,
+ * published by Make). Nothing here touches Make's service.
+ */
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { generateWorkflowFromN8n } from '../../n8n-import/src/codegen.js'
+import { parseMake, UnsupportedBlueprintError } from '../src/parse-make.js'
+import { splitModule, BUILTIN_NAMESPACES } from '../src/types.js'
+
+type Outcome = 'clean' | 'partial' | 'failed' | 'skipped'
+
+interface Row {
+  file: string
+  outcome: Outcome
+  modules: number
+  stubs: number
+  leaks?: number
+  reason?: string
+  warnings: string[]
+}
+
+const args = process.argv.slice(2)
+const argOf = (flag: string) => {
+  const i = args.indexOf(flag)
+  return i >= 0 ? args[i + 1] : undefined
+}
+const dir = resolve(argOf('--dir') ?? './corpus')
+const limit = Number(argOf('--limit') ?? '100000')
+
+function collect(d: string): string[] {
+  const out: string[] = []
+  for (const e of readdirSync(d)) {
+    const p = join(d, e)
+    if (statSync(p).isDirectory()) out.push(...collect(p))
+    else if (e.endsWith('.json')) out.push(p)
+  }
+  return out
+}
+
+const files = collect(dir).slice(0, limit)
+const rows: Row[] = []
+const moduleFreq = new Map<string, number>()
+const warnFreq = new Map<string, number>()
+let leakTotal = 0
+let todoTotal = 0
+
+for (const file of files) {
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(file, 'utf8'))
+  } catch {
+    continue // not JSON — not our corpus
+  }
+
+  let parsed
+  try {
+    parsed = parseMake(raw, 'workflow')
+  } catch (e) {
+    // Not a Make blueprint at all → not a failure, it's not in scope.
+    if (e instanceof UnsupportedBlueprintError) continue
+    rows.push({
+      file,
+      outcome: 'failed',
+      modules: 0,
+      stubs: 0,
+      reason: `parse: ${(e as Error).message}`,
+      warnings: [],
+    })
+    continue
+  }
+
+  for (const m of parsed.modulesSeen) moduleFreq.set(m, (moduleFreq.get(m) ?? 0) + 1)
+  for (const w of parsed.warnings) warnFreq.set(w.kind, (warnFreq.get(w.kind) ?? 0) + 1)
+
+  try {
+    const res = generateWorkflowFromN8n(parsed, { rpcPrefix: 'make' })
+    if (res.diagnostics.some((d) => d.type === 'error')) {
+      rows.push({
+        file,
+        outcome: 'skipped',
+        modules: parsed.nodes.length,
+        stubs: 0,
+        reason: res.diagnostics[0]?.message,
+        warnings: parsed.warnings.map((w) => w.kind),
+      })
+      continue
+    }
+    const stubs = res.manifest.length
+    const emitted = Object.keys(res.files).length
+
+    // Ground truth on lowering: an `={{ … }}` surviving into a GRAPH file means a
+    // ref we failed to lower and leaked as raw text. (Stub `.function.ts` files and
+    // the integrations manifest legitimately carry the original parameters.)
+    // Only LIVE code counts. `// TODO(n8n expr): …` comments are codegen's designed
+    // transform path — the expression isn't declaratively expressible, so it is
+    // preserved verbatim for a human. That's correct degradation, not a leak.
+    const graphLines = Object.entries(res.files)
+      .filter(([p]) => p.endsWith('.graph.ts'))
+      .flatMap(([, c]) => c.split('\n'))
+      .filter((l) => !l.trim().startsWith('//'))
+    const leaks = graphLines.join('\n').match(/=\{\{/g)?.length ?? 0
+    if (leaks) leakTotal += leaks
+    const todos = Object.entries(res.files)
+      .filter(([p]) => p.endsWith('.graph.ts'))
+      .flatMap(([, c]) => c.split('\n'))
+      .filter((l) => l.includes('TODO(n8n expr)')).length
+    todoTotal += todos
+
+    rows.push({
+      file,
+      outcome: emitted === 0 ? 'failed' : stubs > 0 ? 'partial' : 'clean',
+      modules: parsed.nodes.length,
+      stubs,
+      leaks,
+      warnings: parsed.warnings.map((w) => w.kind),
+    })
+  } catch (e) {
+    rows.push({
+      file,
+      outcome: 'failed',
+      modules: parsed.nodes.length,
+      stubs: 0,
+      reason: `codegen: ${(e as Error).message}`,
+      warnings: parsed.warnings.map((w) => w.kind),
+    })
+  }
+}
+
+const by = (o: Outcome) => rows.filter((r) => r.outcome === o).length
+const total = rows.length
+
+console.log(`\n=== @pikku/make-import harness ===`)
+console.log(`corpus dir     : ${dir}`)
+console.log(`files scanned  : ${files.length}`)
+console.log(`real blueprints: ${total}\n`)
+for (const o of ['clean', 'partial', 'failed', 'skipped'] as Outcome[]) {
+  const n = by(o)
+  if (total) console.log(`${o.padEnd(8)} ${String(n).padStart(4)}  ${((100 * n) / total).toFixed(0)}%`)
+}
+
+const failures = rows.filter((r) => r.outcome === 'failed')
+if (failures.length) {
+  console.log(`\n--- failures (${failures.length}) ---`)
+  const reasons = new Map<string, number>()
+  for (const f of failures) {
+    const key = (f.reason ?? 'unknown').slice(0, 90)
+    reasons.set(key, (reasons.get(key) ?? 0) + 1)
+  }
+  for (const [r, c] of [...reasons].sort((a, b) => b[1] - a[1]).slice(0, 12)) {
+    console.log(`${String(c).padStart(4)}  ${r}`)
+  }
+}
+
+console.log(`\nrefs LEAKED into live graph code : ${leakTotal}`)
+console.log(`transforms preserved as TODO     : ${todoTotal}`)
+console.log(`\n--- lossiness warnings ---`)
+for (const [k, c] of [...warnFreq].sort((a, b) => b[1] - a[1])) {
+  console.log(`${String(c).padStart(5)}  ${k}`)
+}
+
+const builtinMods = [...moduleFreq].filter(([m]) => BUILTIN_NAMESPACES.has(splitModule(m).app))
+const intMods = [...moduleFreq].filter(([m]) => !BUILTIN_NAMESPACES.has(splitModule(m).app))
+console.log(`\n--- module surface ---`)
+console.log(`distinct modules   : ${moduleFreq.size}`)
+console.log(`  builtin/primitive: ${builtinMods.length} (${builtinMods.reduce((a, [, c]) => a + c, 0)} uses)`)
+console.log(`  integration      : ${intMods.length} (${intMods.reduce((a, [, c]) => a + c, 0)} uses)`)
+console.log(`\n--- top builtin modules (native-map targets) ---`)
+for (const [m, c] of builtinMods.sort((a, b) => b[1] - a[1]).slice(0, 20)) {
+  console.log(`${String(c).padStart(5)}  ${m}`)
+}
+
+writeFileSync(
+  join(process.cwd(), 'harness-report.json'),
+  JSON.stringify(
+    { total, clean: by('clean'), partial: by('partial'), failed: by('failed'), rows },
+    null,
+    2
+  )
+)
+console.log(`\nwrote harness-report.json`)

--- a/packages/make-import/package.json
+++ b/packages/make-import/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@pikku/make-import",
+  "version": "0.0.1",
+  "description": "Make (Integromat) blueprint importer for Pikku — normalizes blueprints onto the n8n-import IR and reuses its codegen",
+  "author": "yasser.fadl@gmail.com",
+  "license": "MIT",
+  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "tsc": "tsc",
+    "build": "tsc -b",
+    "test": "node --import tsx --test src/**/*.test.ts",
+    "harness": "node --import tsx harness/run.ts",
+    "prepublishOnly": "yarn build"
+  },
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "dependencies": {
+    "@pikku/n8n-import": "workspace:*"
+  }
+}

--- a/packages/make-import/src/filter.test.ts
+++ b/packages/make-import/src/filter.test.ts
@@ -1,0 +1,108 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { lowerFilter } from './filter.js'
+import type { MakeFilter } from './types.js'
+
+const ids = new Map([[1, 'notion1']])
+const cond = (a: string, b: string | undefined, o: string) => ({ a, b, o })
+
+/** Pull `{ combinator, conditions }` out of the lowered n8n v2 params. */
+const fv = (f: MakeFilter) => {
+  const l = lowerFilter(f, ids)
+  return l && (l.parameters.conditions as { combinator: string; conditions: unknown[] })
+}
+
+describe('lowerFilter — shape', () => {
+  it('one group ANDs its conditions', () => {
+    const r = fv({ conditions: [[cond('{{1.a}}', 'x', 'text:equal'), cond('{{1.b}}', 'y', 'text:equal')]] })
+    assert.equal(r?.combinator, 'and')
+    assert.equal(r?.conditions.length, 2)
+  })
+
+  it('single-condition groups OR together', () => {
+    const r = fv({ conditions: [[cond('{{1.a}}', 'x', 'text:equal')], [cond('{{1.b}}', 'y', 'text:equal')]] })
+    assert.equal(r?.combinator, 'or')
+    assert.equal(r?.conditions.length, 2)
+  })
+
+  it('REFUSES a mixed OR-of-ANDs — one Filter cannot express it', () => {
+    const r = lowerFilter(
+      {
+        conditions: [
+          [cond('{{1.a}}', 'x', 'text:equal'), cond('{{1.b}}', 'y', 'text:equal')],
+          [cond('{{1.c}}', 'z', 'text:equal'), cond('{{1.d}}', 'w', 'text:equal')],
+        ],
+      },
+      ids
+    )
+    assert.equal(r, null)
+  })
+
+  it('an empty filter lowers to nothing', () => {
+    assert.equal(lowerFilter({ conditions: [] }, ids), null)
+  })
+})
+
+describe('lowerFilter — operators', () => {
+  it('maps text:equal onto the n8n v2 operator', () => {
+    const r = fv({ conditions: [[cond('{{1.a}}', 'x', 'text:equal')]] })
+    assert.deepEqual((r!.conditions[0] as any).operator, { type: 'string', operation: 'equals' })
+  })
+
+  it('maps number:greater to gt', () => {
+    const r = fv({ conditions: [[cond('{{1.n}}', '5', 'number:greater')]] })
+    assert.deepEqual((r!.conditions[0] as any).operator, { type: 'number', operation: 'gt' })
+  })
+
+  it('exist takes no right operand', () => {
+    const r = fv({ conditions: [[cond('{{1.a}}', undefined, 'exist')]] })
+    const c = r!.conditions[0] as any
+    assert.equal(c.operator.operation, 'exists')
+    assert.equal('rightValue' in c, false)
+  })
+
+  it('REFUSES an unknown operator rather than guessing', () => {
+    assert.equal(lowerFilter({ conditions: [[cond('{{1.a}}', 'x', 'wat:nope')]] }, ids), null)
+  })
+
+  it('REFUSES :ci — it would silently emit a stricter (case-sensitive) gate', () => {
+    assert.equal(lowerFilter({ conditions: [[cond('{{1.a}}', 'x', 'text:equal:ci')]] }, ids), null)
+  })
+})
+
+describe('lowerFilter — operand safety (the destructive-gate guard)', () => {
+  it('REFUSES an array-iteration operand — it would emit `left: undefined`', () => {
+    // The real Notion→Calendar case: `{{1.props.`Event ID`[].plain_text}}` is a
+    // transform, so emitBranchInput would render `left: undefined` and the gate
+    // would have the wrong truth table.
+    const r = lowerFilter(
+      { conditions: [[cond('{{1.properties_value.`Event ID`[].plain_text}}', '{{null}}', 'text:equal')]] },
+      ids
+    )
+    assert.equal(r, null)
+  })
+
+  it('REFUSES the WHOLE filter when only one condition fails', () => {
+    // Dropping a failed condition from an AND weakens the predicate — the gate
+    // would fire more often than authored. All or nothing.
+    const r = lowerFilter(
+      {
+        conditions: [
+          [
+            cond('{{1.props.x[].y}}', 'a', 'text:equal'), // unlowerable
+            cond('{{1.status}}', 'Scheduled', 'text:equal'), // fine
+          ],
+        ],
+      },
+      ids
+    )
+    assert.equal(r, null)
+  })
+
+  it('lowers a plain ref operand to a bridged n8n expression', () => {
+    const r = fv({ conditions: [[cond('{{1.status}}', 'Scheduled', 'text:equal')]] })
+    const c = r!.conditions[0] as any
+    assert.equal(c.leftValue, '={{ $node["notion1"].json.status }}')
+    assert.equal(c.rightValue, 'Scheduled')
+  })
+})

--- a/packages/make-import/src/filter.ts
+++ b/packages/make-import/src/filter.ts
@@ -1,0 +1,154 @@
+/**
+ * Make filter → n8n v2 `FilterValue` parameters.
+ *
+ * A Make `filter` on a module is a GATE: the bundle passes only if the filter
+ * matches, otherwise that path stops. n8n's Filter node has exactly those
+ * semantics — `branch.ts` normalizes `typeShort: 'filter'` to a single case on
+ * slot 0 with NO fallback, i.e. "a false result dead-ends". So a gated Make route
+ * lowers onto a synthesized Filter node in front of the route's head module, and
+ * `branch.ts` / `codegen` need no changes at all.
+ *
+ * Operator strings are `type:operation[:modifier]` (`text:equal`, `text:equal:ci`,
+ * `number:greater`, `exist`). We translate onto the n8n v2 operator vocabulary the
+ * same way `V1_OPERATION` translates n8n's own v1 names.
+ */
+import type { MakeCondition, MakeFilter } from './types.js'
+import { bridgeMapper, isFullyBridged } from './iml.js'
+
+/** Make `o` → n8n v2 `{ type, operation }`. */
+const OPERATOR: Record<string, { type: string; operation: string }> = {
+  'text:equal': { type: 'string', operation: 'equals' },
+  'text:notequal': { type: 'string', operation: 'notEquals' },
+  'text:contain': { type: 'string', operation: 'contains' },
+  'text:notcontain': { type: 'string', operation: 'notContains' },
+  'text:startswith': { type: 'string', operation: 'startsWith' },
+  'text:endswith': { type: 'string', operation: 'endsWith' },
+  'number:equal': { type: 'number', operation: 'equals' },
+  'number:notequal': { type: 'number', operation: 'notEquals' },
+  'number:greater': { type: 'number', operation: 'gt' },
+  'number:greaterorequal': { type: 'number', operation: 'gte' },
+  'number:less': { type: 'number', operation: 'lt' },
+  'number:lessorequal': { type: 'number', operation: 'lte' },
+  'boolean:equal': { type: 'boolean', operation: 'equals' },
+  'boolean:notequal': { type: 'boolean', operation: 'notEquals' },
+  'date:before': { type: 'dateTime', operation: 'before' },
+  'date:after': { type: 'dateTime', operation: 'after' },
+  'array:contain': { type: 'array', operation: 'contains' },
+  'array:notcontain': { type: 'array', operation: 'notContains' },
+  exist: { type: 'string', operation: 'exists' },
+  notexist: { type: 'string', operation: 'notExists' },
+}
+
+/** Operators taking no right-hand operand. */
+const UNARY = new Set(['exist', 'notexist'])
+
+export interface FilterLowering {
+  /** n8n v2 params for a Filter node — `{ conditions: { combinator, conditions } }`. */
+  parameters: Record<string, unknown>
+  /** Set when the filter could only be lowered approximately. */
+  lossy?: string
+}
+
+/**
+ * Translate one condition. `:ci` (case-insensitive) is a real modifier we cannot
+ * express — n8n carries it as `caseSensitive` on the condition's options, which
+ * `RawCondition` does not model. Reported rather than silently dropped.
+ */
+function lowerCondition(
+  c: MakeCondition,
+  idToName: Map<number, string>,
+  lossy: string[]
+): Record<string, unknown> | null {
+  const raw = (c.o ?? '').toLowerCase()
+  if (!raw) return null
+
+  // `text:equal:ci` → base `text:equal` + the `ci` modifier.
+  const ci = raw.endsWith(':ci')
+  const base = ci ? raw.slice(0, -3) : raw
+  const op = OPERATOR[base]
+  if (!op) {
+    lossy.push(`unmapped operator '${raw}'`)
+    return null
+  }
+  // `:ci` is case-INsensitive. n8n carries that as `options.caseSensitive` on the
+  // FilterValue, which `RawCondition` doesn't model — so lowering it as-is would
+  // silently emit a STRICTER gate (fires less often than authored). Less
+  // destructive than an over-firing gate, but still the wrong truth table, so it
+  // gets the same refusal.
+  if (ci) {
+    lossy.push(`case-insensitive '${raw}' not expressible (would emit a stricter gate)`)
+    return null
+  }
+
+  const left = bridgeMapper(c.a, idToName)
+  const right = UNARY.has(base) ? undefined : bridgeMapper(c.b ?? '', idToName)
+
+  // An operand that won't lower to a ref becomes a `transform`, and
+  // `emitBranchInput` would render it as `left: undefined` — a gate with the
+  // wrong truth table. Refuse the condition instead. (Common cause: Make's `[]`
+  // array-iteration, e.g. `{{1.props.\`Event ID\`[].plain_text}}`.)
+  if (!isFullyBridged(left) || !isFullyBridged(right)) {
+    lossy.push(`operand not declaratively expressible in '${raw}'`)
+    return null
+  }
+
+  const cond: Record<string, unknown> = {
+    leftValue: left,
+    operator: { type: op.type, operation: op.operation },
+  }
+  if (right !== undefined) cond.rightValue = right
+  return cond
+}
+
+/**
+ * Lower a Make filter onto n8n v2 Filter params.
+ *
+ * Make's `conditions` is a MATRIX — outer array ORs, inner array ANDs. n8n's v2
+ * FilterValue is flat: ONE combinator over a flat condition list. So only two
+ * shapes round-trip exactly:
+ *
+ *   [[a, b]]        → AND(a, b)              one group
+ *   [[a], [b], [c]] → OR(a, b, c)            all groups single-condition
+ *
+ * A true mixed matrix (`[[a,b],[c,d]]` = (a AND b) OR (c AND d)) cannot be
+ * expressed by one Filter node. Returns null rather than emit a gate with the
+ * wrong truth table — an ungated route is visibly wrong; a subtly wrong
+ * predicate is not.
+ */
+export function lowerFilter(
+  filter: MakeFilter,
+  idToName: Map<number, string>
+): FilterLowering | null {
+  const groups = (filter.conditions ?? []).filter((g) => Array.isArray(g) && g.length > 0)
+  if (groups.length === 0) return null
+
+  const lossy: string[] = []
+  let combinator: 'and' | 'or'
+  let flat: MakeCondition[]
+
+  if (groups.length === 1) {
+    combinator = 'and'
+    flat = groups[0]!
+  } else if (groups.every((g) => g.length === 1)) {
+    combinator = 'or'
+    flat = groups.map((g) => g[0]!)
+  } else {
+    return null // mixed OR-of-ANDs — not expressible as a single Filter
+  }
+
+  // Every condition must lower. Dropping one from an AND WEAKENS the predicate
+  // (the gate fires more often than the author wrote); dropping one from an OR
+  // strengthens it. Either way the truth table is wrong, so it's all or nothing.
+  const conditions: Record<string, unknown>[] = []
+  for (const c of flat) {
+    const lowered = lowerCondition(c, idToName, lossy)
+    if (!lowered) return null
+    conditions.push(lowered)
+  }
+  if (conditions.length === 0) return null
+
+  return {
+    parameters: { conditions: { combinator, conditions } },
+    ...(lossy.length ? { lossy: lossy.join('; ') } : {}),
+  }
+}

--- a/packages/make-import/src/iml.test.ts
+++ b/packages/make-import/src/iml.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { imlToN8n, bridgeMapper, hasNestedRef } from './iml.js'
+import { classifyExpression } from '../../n8n-import/src/expressions.js'
+
+const ids = new Map([
+  [1, 'sheets1'],
+  [37, 'http37'],
+])
+const ctx = { nameToNodeId: { sheets1: 'sheets1', http37: 'http37' } }
+
+describe('imlToN8n', () => {
+  it('leaves a plain literal untouched', () => {
+    assert.equal(imlToN8n('hello', ids), 'hello')
+    assert.equal(imlToN8n(42, ids), 42)
+  })
+
+  it('bridges a field ref', () => {
+    assert.equal(imlToN8n('{{1.email}}', ids), '={{ $node["sheets1"].json.email }}')
+  })
+
+  it('bridges a backtick column ref to bracket access', () => {
+    assert.equal(imlToN8n('{{1.`0`}}', ids), '={{ $node["sheets1"].json["0"] }}')
+  })
+
+  it('bridges a nested path', () => {
+    assert.equal(
+      imlToN8n('{{1.a.`b c`.d}}', ids),
+      '={{ $node["sheets1"].json.a["b c"].d }}'
+    )
+  })
+
+  it('keeps surrounding text (a template)', () => {
+    assert.equal(imlToN8n('Hi {{1.name}}!', ids), '=Hi {{ $node["sheets1"].json.name }}!')
+  })
+
+  it('preserves IML function calls verbatim (they must stay transforms)', () => {
+    assert.equal(imlToN8n('{{split(1.`1`; space)}}', ids), '={{ split(1.`1`; space) }}')
+  })
+
+  it('preserves array-iteration refs verbatim (no per-item graph semantics)', () => {
+    assert.equal(
+      imlToN8n('{{37.data.records[].fields.Site}}', ids),
+      '={{ 37.data.records[].fields.Site }}'
+    )
+  })
+
+  it('does not resolve a ref to a module outside the flow', () => {
+    assert.equal(imlToN8n('{{999.x}}', ids), '={{ 999.x }}')
+  })
+})
+
+describe('bridged values classify into the right tier', () => {
+  const tier = (iml: string) => classifyExpression(imlToN8n(iml, ids), ctx).kind
+
+  it('field ref → ref', () => assert.equal(tier('{{1.email}}'), 'ref'))
+  it('column ref → ref', () => assert.equal(tier('{{1.`0`}}'), 'ref'))
+  it('text + ref → template', () => assert.equal(tier('Hi {{1.name}}!'), 'template'))
+  it('function call → transform', () =>
+    assert.equal(tier('{{split(1.`1`; space)}}'), 'transform'))
+  it('array iteration → transform', () =>
+    assert.equal(tier('{{37.data.records[].fields.Site}}'), 'transform'))
+  it('plain literal → literal', () => assert.equal(tier('hello'), 'literal'))
+
+  it('a ref lowers to the right node and path', () => {
+    const c = classifyExpression(imlToN8n('{{1.`0`}}', ids), ctx)
+    assert.equal(c.kind, 'ref')
+    if (c.kind === 'ref') {
+      assert.equal(c.nodeId, 'sheets1')
+      assert.equal(c.path, '0')
+    }
+  })
+})
+
+describe('bridgeMapper', () => {
+  it('bridges refs nested in arrays and objects', () => {
+    const out = bridgeMapper({ to: ['{{1.`0`}}'], opt: { cc: '{{1.x}}' } }, ids) as any
+    assert.equal(out.to[0], '={{ $node["sheets1"].json["0"] }}')
+    assert.equal(out.opt.cc, '={{ $node["sheets1"].json.x }}')
+  })
+
+  it('detects a ref nested inside a container', () => {
+    assert.equal(hasNestedRef(bridgeMapper({ to: ['{{1.`0`}}'] }, ids)), true)
+  })
+
+  it('a top-level scalar ref is not a nested ref', () => {
+    assert.equal(hasNestedRef(bridgeMapper({ to: '{{1.`0`}}' }, ids)), false)
+  })
+})

--- a/packages/make-import/src/iml.ts
+++ b/packages/make-import/src/iml.ts
@@ -1,0 +1,157 @@
+/**
+ * Make IML (the `{{ … }}` mapper language) → n8n expression syntax.
+ *
+ * This is a deliberate bridge, not a second classifier. `@pikku/n8n-import`'s
+ * `classifyExpression` already lowers an expression string into the four tiers
+ * the graph input mapper accepts (literal / ref / template / transform), and
+ * `codegen` calls it internally on raw parameter values. Rather than fork that
+ * pipeline, we rewrite Make's reference syntax into the n8n syntax it already
+ * understands, and let it do the lowering.
+ *
+ *   Make                        n8n                                   → tier
+ *   {{1.email}}                 ={{ $node["m1"].json.email }}         ref
+ *   {{1.`0`}}                   ={{ $node["m1"].json["0"] }}          ref
+ *   Hi {{1.name}}!              =Hi {{ $node["m1"].json.name }}!      template
+ *   {{split(1.`1`; space)}}     ={{ split(1.`1`; space) }}            transform
+ *   {{1.choices[].message}}     ={{ 1.choices[].message }}            transform
+ *
+ * Anything that isn't a pure module-field reference is passed through verbatim
+ * inside the braces. `classifyExpression` fails to parse it as a ref and falls
+ * back to `transform`, which is exactly the right outcome: it needs a generated
+ * function, and the original IML is preserved for a human to read.
+ */
+
+/**
+ * A pure Make reference: `<moduleId>.<path>` where each segment is a plain key
+ * or a backtick-quoted key (`` `0` ``, `` `__ROW_NUMBER__` ``).
+ *
+ * Deliberately excluded — these are NOT pure refs and must stay transforms:
+ *  - `[]`            array-iteration (`{{1.choices[].message.content}}`); the
+ *                    graph has no ambient per-item semantics to lower it onto.
+ *  - `func(...)`     IML function calls — the leading `\d+\.` guard rejects them.
+ *  - `{{now}}`       bare keywords have no module id.
+ */
+const SEGMENT = String.raw`(?:[A-Za-z_$][\w$]*|\x60[^\x60]+\x60)`
+const RE_PURE_REF = new RegExp(
+  String.raw`^\s*(\d+)\.(${SEGMENT}(?:\.${SEGMENT})*)\s*$`
+)
+
+const BLOCK = /\{\{([\s\S]*?)\}\}/g
+
+/** `` a.`0`.b `` → `.a["0"].b` — an n8n accessor tail. */
+function toAccessor(path: string): string {
+  const segments: string[] = []
+  let buf = ''
+  let inTick = false
+  for (const ch of path) {
+    if (ch === '`') {
+      inTick = !inTick
+      continue
+    }
+    if (ch === '.' && !inTick) {
+      segments.push(buf)
+      buf = ''
+      continue
+    }
+    buf += ch
+  }
+  segments.push(buf)
+
+  return segments
+    .filter((s) => s.length > 0)
+    .map((s) => (/^[A-Za-z_$][\w$]*$/.test(s) ? `.${s}` : `["${s}"]`))
+    .join('')
+}
+
+/** Resolve one `{{ … }}` body to an n8n expression body, or null if not a pure ref. */
+function bridgeBlock(body: string, idToName: Map<number, string>): string | null {
+  const m = RE_PURE_REF.exec(body)
+  if (!m) return null
+  const id = Number(m[1])
+  const name = idToName.get(id)
+  // A ref to a module outside this flow (or a stale id) can't be resolved.
+  if (!name) return null
+  return `$node["${name}"].json${toAccessor(m[2]!)}`
+}
+
+/**
+ * Rewrite a Make mapper value into an n8n expression string.
+ *
+ * Non-string values and strings with no `{{ … }}` are returned unchanged — they
+ * are already literals, and `classifyExpression` treats any string without a
+ * leading `=` as a literal.
+ */
+export function imlToN8n(value: unknown, idToName: Map<number, string>): unknown {
+  if (typeof value !== 'string') return value
+  if (!value.includes('{{')) return value
+
+  let out = ''
+  let cursor = 0
+  let matched = false
+  let match: RegExpExecArray | null
+  BLOCK.lastIndex = 0
+  while ((match = BLOCK.exec(value)) !== null) {
+    matched = true
+    out += value.slice(cursor, match.index)
+    const bridged = bridgeBlock(match[1] ?? '', idToName)
+    // Not a pure ref → keep the original IML so the generated transform function
+    // shows what the author actually wrote.
+    out += `{{ ${bridged ?? (match[1] ?? '').trim()} }}`
+    cursor = match.index + match[0].length
+  }
+  if (!matched) return value
+  out += value.slice(cursor)
+  return `=${out}`
+}
+
+/**
+ * Recursively bridge every string in a mapper.
+ *
+ * KNOWN GAP (v1): `codegen` classifies each parameter VALUE, so a ref nested
+ * inside an array or object (`mapper.to = ["{{1.\`0\`}}"]`, common in Make and
+ * rare in n8n) is bridged here but then classified as a literal — the ref is not
+ * lowered to `ref(...)`. The harness reports these as `nested-ref` so the size of
+ * the gap is measured rather than assumed.
+ */
+export function bridgeMapper(
+  value: unknown,
+  idToName: Map<number, string>
+): unknown {
+  if (Array.isArray(value)) return value.map((v) => bridgeMapper(v, idToName))
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = bridgeMapper(v, idToName)
+    }
+    return out
+  }
+  return imlToN8n(value, idToName)
+}
+
+/** Does this value contain an expression string anywhere inside it? */
+function containsExpr(value: unknown): boolean {
+  if (typeof value === 'string') return value.startsWith('=')
+  if (Array.isArray(value)) return value.some(containsExpr)
+  if (value && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).some(containsExpr)
+  }
+  return false
+}
+
+/**
+ * Does this bridged MAPPER hold a ref nested inside a container?
+ *
+ * The distinction that matters: a mapper's own field values are what codegen
+ * classifies, so `{ to: "{{1.\`0\`}}" }` is an ordinary scalar ref and lowers
+ * fine. Only a ref one level deeper — `{ to: ["{{1.\`0\`}}"] }` — needs codegen
+ * to recurse into the container.
+ *
+ * Takes the whole mapper (not a single value): "nested" is defined relative to
+ * the field value, so the depth origin has to be the mapper itself.
+ */
+export function hasNestedRef(mapper: unknown): boolean {
+  if (!mapper || typeof mapper !== 'object') return false
+  return Object.values(mapper as Record<string, unknown>).some(
+    (fieldValue) => typeof fieldValue === 'object' && containsExpr(fieldValue)
+  )
+}

--- a/packages/make-import/src/iml.ts
+++ b/packages/make-import/src/iml.ts
@@ -128,6 +128,29 @@ export function bridgeMapper(
   return imlToN8n(value, idToName)
 }
 
+/**
+ * Will every `{{ … }}` in this bridged value lower to a declarative ref?
+ *
+ * `bridgeBlock` rewrites a pure module-field reference to `$node["…"].json…` and
+ * passes anything else through as raw IML. So a bridged block that does NOT start
+ * with `$node[` is one `classifyExpression` will call a `transform` — it cannot
+ * become a `ref`/`template`.
+ *
+ * This matters for FILTER OPERANDS specifically. A transform in a mapper field is
+ * harmless: codegen drops the field and leaves a TODO. A transform in a filter
+ * operand is not — `emitBranchInput` falls back to `left: undefined` and silently
+ * emits a gate with the wrong truth table.
+ */
+export function isFullyBridged(value: unknown): boolean {
+  if (typeof value !== 'string') return true
+  if (!value.startsWith('=')) return true
+  const blocks = value.matchAll(/\{\{([\s\S]*?)\}\}/g)
+  for (const b of blocks) {
+    if (!(b[1] ?? '').trim().startsWith('$node[')) return false
+  }
+  return true
+}
+
 /** Does this value contain an expression string anywhere inside it? */
 function containsExpr(value: unknown): boolean {
   if (typeof value === 'string') return value.startsWith('=')

--- a/packages/make-import/src/index.ts
+++ b/packages/make-import/src/index.ts
@@ -1,0 +1,14 @@
+export { parseMake, toBlueprint, UnsupportedBlueprintError } from './parse-make.js'
+export { imlToN8n, bridgeMapper, hasNestedRef } from './iml.js'
+export { splitModule, BUILTIN_NAMESPACES } from './types.js'
+
+export type {
+  MakeBlueprint,
+  MakeExport,
+  MakeModule,
+  MakeFilter,
+  MakeCondition,
+  MakeRoute,
+  MakeBranch,
+} from './types.js'
+export type { ParsedMakeWorkflow, MakeParseWarning } from './parse-make.js'

--- a/packages/make-import/src/parse-make.ts
+++ b/packages/make-import/src/parse-make.ts
@@ -1,0 +1,272 @@
+/**
+ * Make blueprint → the `ParsedWorkflow` IR that `@pikku/n8n-import`'s codegen
+ * consumes.
+ *
+ * The bet this file makes: codegen, topology, naming and the expression
+ * classifier are engine-agnostic in everything but their INPUT SHAPE. So rather
+ * than fork 1,600 lines, we normalize Make onto the n8n IR — synthesizing an
+ * n8n-shaped `connections` map from Make's nested `flow`/`routes`/`branches`,
+ * and bridging IML into n8n expression syntax (see `iml.ts`).
+ *
+ * Topology mapping:
+ *   linear flow          module N → module N+1                  (chain)
+ *   builtin:BasicRouter  router → EVERY route head in one slot  (non-exclusive
+ *                        fan-out — n8n's `main[0] = [a, b, c]` has exactly these
+ *                        semantics: all targets fire for the same item)
+ *   builtin:BasicIfElse  ifelse → every branch head             (⚠ v1: emitted as
+ *                        fan-out too; the exclusivity is NOT yet enforced — see
+ *                        `diagnostics`)
+ *   onerror              nested error flow                      (⚠ v1: dropped)
+ */
+
+// NOTE (spike): imported from n8n-import's SOURCE rather than the `@pikku/n8n-import`
+// package entry. The package only exports `./dist/index.js`, and these live behind
+// that barrel. Proper wiring (workspace resolution + a real shared-core package) is
+// the follow-up — the fact that a second importer immediately reaches for naming,
+// types and codegen is precisely the argument for extracting them.
+import {
+  sanitizeIdentifier,
+  dedupe,
+  integrationRpcName,
+  codeRpcName,
+} from '../../n8n-import/src/naming.js'
+import type {
+  N8nConnections,
+  ParsedNode,
+  ParsedWorkflow,
+  NodeRole,
+} from '../../n8n-import/src/types.js'
+import { bridgeMapper, hasNestedRef } from './iml.js'
+import {
+  BUILTIN_NAMESPACES,
+  splitModule,
+  TRIGGER_OPERATIONS,
+  type MakeBlueprint,
+  type MakeExport,
+  type MakeModule,
+} from './types.js'
+
+export interface MakeParseWarning {
+  kind:
+    | 'router-filter-dropped'
+    | 'ifelse-not-exclusive'
+    | 'onerror-dropped'
+    | 'nested-ref'
+    | 'aggregator-feeder'
+  module: string
+  detail?: string
+}
+
+export interface ParsedMakeWorkflow extends ParsedWorkflow {
+  /** Make-specific lossiness, surfaced rather than silently swallowed. */
+  warnings: MakeParseWarning[]
+  /** Distinct `app:operation` module ids seen, for coverage reporting. */
+  modulesSeen: string[]
+}
+
+export class UnsupportedBlueprintError extends Error {}
+
+/** Unwrap the export envelope — the API nests under `blueprint`; some files don't. */
+export function toBlueprint(raw: unknown): MakeBlueprint {
+  if (!raw || typeof raw !== 'object') {
+    throw new UnsupportedBlueprintError('not an object')
+  }
+  const e = raw as MakeExport
+  const bp = e.blueprint ?? (e.flow ? (e as MakeBlueprint) : undefined)
+  if (!bp?.flow || !Array.isArray(bp.flow) || bp.flow.length === 0) {
+    throw new UnsupportedBlueprintError('no blueprint.flow')
+  }
+  return bp
+}
+
+/** Is this module a scenario trigger (its output becomes the graph's `trigger`)? */
+function isTrigger(mod: MakeModule, index: number): boolean {
+  const { app, operation } = splitModule(mod.module)
+  if (app === 'gateway') return true // CustomWebHook / CustomMailHook
+  return index === 0 && TRIGGER_OPERATIONS.test(operation)
+}
+
+function roleFor(mod: MakeModule, index: number): NodeRole {
+  if (isTrigger(mod, index)) return 'trigger'
+  const { app, operation } = splitModule(mod.module)
+  if (app === 'code') return 'code'
+  if (app === 'builtin' && operation === 'BasicIfElse') return 'branch'
+  // Routers/Merges are pure topology — they carry no work of their own.
+  if (app === 'builtin' && (operation === 'BasicRouter' || operation === 'BasicMerge')) {
+    return 'noop'
+  }
+  // Builtins would ideally be `native`, but codegen resolves native specs via
+  // `nativeSpecFor(typeShort)` against n8n's type names. Until a Make native-map
+  // exists they degrade to stubs — the same graceful path n8n-import uses for an
+  // unmapped resource/operation.
+  if (BUILTIN_NAMESPACES.has(app)) return 'integration'
+  return 'integration'
+}
+
+interface Walked {
+  mod: MakeModule
+  /** Ids this module hands control to. */
+  next: number[]
+}
+
+/**
+ * Flatten the nested blueprint into a module list plus an id→id edge map.
+ * Recurses into `routes[].flow` and `branches[].flow`.
+ */
+function walk(
+  flow: MakeModule[],
+  out: Map<number, Walked>,
+  warnings: MakeParseWarning[]
+): { head?: number; tail?: number } {
+  let head: number | undefined
+  let prev: Walked | undefined
+
+  for (const mod of flow) {
+    if (typeof mod?.id !== 'number' || typeof mod?.module !== 'string') continue
+    const node: Walked = { mod, next: [] }
+    out.set(mod.id, node)
+    if (head === undefined) head = mod.id
+    if (prev) prev.next.push(mod.id)
+    prev = node
+
+    const { app, operation } = splitModule(mod.module)
+
+    if (mod.routes?.length) {
+      // Router: every route head fires for the same bundle (non-exclusive).
+      for (const route of mod.routes) {
+        if (!route.flow?.length) continue
+        const sub = walk(route.flow, out, warnings)
+        if (sub.head !== undefined) node.next.push(sub.head)
+        // The route head's `filter` is the per-route gate. v1 does not lower it.
+        const gate = route.flow[0]?.filter
+        if (gate) {
+          warnings.push({
+            kind: 'router-filter-dropped',
+            module: mod.module,
+            detail: gate.name ?? 'unnamed',
+          })
+        }
+      }
+      // Routes are terminal — a router cannot merge back.
+      prev = undefined
+      continue
+    }
+
+    if (mod.branches?.length) {
+      for (const br of mod.branches) {
+        if (!br.flow?.length) continue
+        const sub = walk(br.flow, out, warnings)
+        if (sub.head !== undefined) node.next.push(sub.head)
+      }
+      warnings.push({
+        kind: 'ifelse-not-exclusive',
+        module: mod.module,
+        detail: `${mod.branches.length} branches emitted as fan-out`,
+      })
+      // BasicIfElse converges into the following BasicMerge, so `prev` stays.
+    }
+
+    if (mod.onerror?.length) {
+      warnings.push({ kind: 'onerror-dropped', module: mod.module })
+    }
+
+    if (app === 'builtin' && operation === 'BasicAggregator') {
+      const feeder = mod.parameters?.['feeder']
+      if (feeder !== undefined) {
+        warnings.push({
+          kind: 'aggregator-feeder',
+          module: mod.module,
+          detail: `feeder=${String(feeder)}`,
+        })
+      }
+    }
+  }
+
+  return { head, tail: prev?.mod.id }
+}
+
+export function parseMake(raw: unknown, fallbackName = 'workflow'): ParsedMakeWorkflow {
+  const bp = toBlueprint(raw)
+  const warnings: MakeParseWarning[] = []
+
+  const walked = new Map<number, Walked>()
+  walk(bp.flow!, walked, warnings)
+  if (walked.size === 0) throw new UnsupportedBlueprintError('no modules')
+
+  // --- name every module (IML addresses modules by id, so build id → name) ---
+  const seen = new Set<string>()
+  const idToName = new Map<number, string>()
+  const order = [...walked.keys()]
+  for (const id of order) {
+    const { mod } = walked.get(id)!
+    const { app } = splitModule(mod.module)
+    const desired =
+      mod.metadata?.designer?.name?.trim() || `${app.replace(/[^a-z0-9]+/gi, ' ')} ${id}`
+    idToName.set(id, dedupe(sanitizeIdentifier(desired) || `m${id}`, seen))
+  }
+
+  // --- build ParsedNodes ---
+  const nodes: ParsedNode[] = []
+  const modulesSeen = new Set<string>()
+  let index = 0
+  for (const id of order) {
+    const { mod } = walked.get(id)!
+    const { app, operation } = splitModule(mod.module)
+    modulesSeen.add(mod.module)
+
+    const name = idToName.get(id)!
+    const role = roleFor(mod, index++)
+
+    // Make splits config (`parameters`) from data inputs (`mapper`). n8n has one
+    // bag, and only mapper values carry IML — so bridge mapper, pass config through.
+    const mapper = bridgeMapper(mod.mapper ?? {}, idToName) as Record<string, unknown>
+    if (hasNestedRef(mapper)) {
+      warnings.push({ kind: 'nested-ref', module: mod.module })
+    }
+    const parameters = { ...(mod.parameters ?? {}), ...mapper }
+
+    const rpcName =
+      role === 'code' ? codeRpcName(name) : integrationRpcName(operation || app, name)
+
+    nodes.push({
+      id: String(id),
+      name,
+      nodeId: name,
+      type: mod.module,
+      typeShort: operation || app,
+      typeVersion: mod.version,
+      parameters,
+      notes: mod.metadata?.designer?.name,
+      disabled: false,
+      role,
+      rpcName,
+    })
+  }
+
+  // --- synthesize n8n-shaped connections (keyed by SOURCE NAME) ---
+  const connections: N8nConnections = {}
+  for (const id of order) {
+    const w = walked.get(id)!
+    if (w.next.length === 0) continue
+    const from = idToName.get(id)!
+    connections[from] = {
+      main: [
+        w.next
+          .filter((t) => idToName.has(t))
+          .map((t) => ({ node: idToName.get(t)!, type: 'main', index: 0 })),
+      ],
+    }
+  }
+
+  const name = bp.name?.trim() || fallbackName
+  return {
+    name,
+    slug: sanitizeIdentifier(name) || 'workflow',
+    nodes,
+    connections,
+    stickyNotes: [],
+    shape: 'pure-graph',
+    warnings,
+    modulesSeen: [...modulesSeen],
+  }
+}

--- a/packages/make-import/src/parse-make.ts
+++ b/packages/make-import/src/parse-make.ts
@@ -37,6 +37,7 @@ import type {
   NodeRole,
 } from '../../n8n-import/src/types.js'
 import { bridgeMapper, hasNestedRef } from './iml.js'
+import { lowerFilter } from './filter.js'
 import {
   BUILTIN_NAMESPACES,
   splitModule,
@@ -49,6 +50,8 @@ import {
 export interface MakeParseWarning {
   kind:
     | 'router-filter-dropped'
+    | 'router-filter-unlowerable'
+    | 'router-filter-lossy'
     | 'ifelse-not-exclusive'
     | 'onerror-dropped'
     | 'nested-ref'
@@ -62,6 +65,11 @@ export interface ParsedMakeWorkflow extends ParsedWorkflow {
   warnings: MakeParseWarning[]
   /** Distinct `app:operation` module ids seen, for coverage reporting. */
   modulesSeen: string[]
+  /**
+   * The blueprint carries semantics we cannot reproduce, and no safe degradation
+   * exists (an un-lowerable route gate). The workflow must NOT be emitted.
+   */
+  fatal: boolean
 }
 
 export class UnsupportedBlueprintError extends Error {}
@@ -103,10 +111,21 @@ function roleFor(mod: MakeModule, index: number): NodeRole {
   return 'integration'
 }
 
+/**
+ * Module id of a Filter node we synthesize (not a real Make module). Route gates
+ * are hoisted onto these; see `filter.ts`.
+ */
+const SYNTHETIC_FILTER = 'make:filter'
+
 interface Walked {
   mod: MakeModule
   /** Ids this module hands control to. */
   next: number[]
+}
+
+/** Synthetic ids count DOWN from -1 so they can never collide with Make's own. */
+interface SynthIds {
+  next: number
 }
 
 /**
@@ -116,7 +135,8 @@ interface Walked {
 function walk(
   flow: MakeModule[],
   out: Map<number, Walked>,
-  warnings: MakeParseWarning[]
+  warnings: MakeParseWarning[],
+  synth: SynthIds
 ): { head?: number; tail?: number } {
   let head: number | undefined
   let prev: Walked | undefined
@@ -132,20 +152,29 @@ function walk(
     const { app, operation } = splitModule(mod.module)
 
     if (mod.routes?.length) {
-      // Router: every route head fires for the same bundle (non-exclusive).
+      // Router: every route head fires for the same bundle (non-exclusive) —
+      // which is exactly n8n's `main[0] = [a, b, c]` fan-out. But a route whose
+      // head carries a `filter` is GATED, and fan-out alone would run it
+      // unconditionally. Each gate is hoisted into a synthesized Filter node
+      // spliced between the router and the route head, so a false result
+      // dead-ends the route instead of firing it.
       for (const route of mod.routes) {
         if (!route.flow?.length) continue
-        const sub = walk(route.flow, out, warnings)
-        if (sub.head !== undefined) node.next.push(sub.head)
-        // The route head's `filter` is the per-route gate. v1 does not lower it.
+        const sub = walk(route.flow, out, warnings, synth)
+        if (sub.head === undefined) continue
+
         const gate = route.flow[0]?.filter
-        if (gate) {
-          warnings.push({
-            kind: 'router-filter-dropped',
-            module: mod.module,
-            detail: gate.name ?? 'unnamed',
-          })
+        if (!gate?.conditions?.length) {
+          node.next.push(sub.head)
+          continue
         }
+
+        const id = synth.next--
+        out.set(id, {
+          mod: { id, module: SYNTHETIC_FILTER, filter: gate },
+          next: [sub.head],
+        })
+        node.next.push(id)
       }
       // Routes are terminal — a router cannot merge back.
       prev = undefined
@@ -155,7 +184,7 @@ function walk(
     if (mod.branches?.length) {
       for (const br of mod.branches) {
         if (!br.flow?.length) continue
-        const sub = walk(br.flow, out, warnings)
+        const sub = walk(br.flow, out, warnings, synth)
         if (sub.head !== undefined) node.next.push(sub.head)
       }
       warnings.push({
@@ -188,9 +217,10 @@ function walk(
 export function parseMake(raw: unknown, fallbackName = 'workflow'): ParsedMakeWorkflow {
   const bp = toBlueprint(raw)
   const warnings: MakeParseWarning[] = []
+  let fatal = false
 
   const walked = new Map<number, Walked>()
-  walk(bp.flow!, walked, warnings)
+  walk(bp.flow!, walked, warnings, { next: -1 })
   if (walked.size === 0) throw new UnsupportedBlueprintError('no modules')
 
   // --- name every module (IML addresses modules by id, so build id → name) ---
@@ -208,13 +238,59 @@ export function parseMake(raw: unknown, fallbackName = 'workflow'): ParsedMakeWo
   // --- build ParsedNodes ---
   const nodes: ParsedNode[] = []
   const modulesSeen = new Set<string>()
+  /** Synthetic gates we could not lower — their edges collapse through. */
+  const droppedGates = new Set<number>()
   let index = 0
   for (const id of order) {
     const { mod } = walked.get(id)!
     const { app, operation } = splitModule(mod.module)
-    modulesSeen.add(mod.module)
+    if (mod.module !== SYNTHETIC_FILTER) modulesSeen.add(mod.module)
 
     const name = idToName.get(id)!
+
+    // A synthesized Filter carrying a hoisted route gate. Emitted as an n8n
+    // Filter node (`typeShort: 'filter'`) so `branch.ts` normalizes it to a
+    // single case on slot 0 with no fallback — false dead-ends the route.
+    if (mod.module === SYNTHETIC_FILTER) {
+      const lowered = mod.filter ? lowerFilter(mod.filter, idToName) : null
+      if (!lowered) {
+        // We cannot reproduce this gate's truth table. There is no safe fallback:
+        // emitting the route UNGATED makes it fire on every bundle, and a gated
+        // route is often destructive (`deleteAnEvent`, `updateRow`). Dropping the
+        // route silently loses behaviour. So the workflow is un-importable —
+        // fail loudly rather than emit something that corrupts data.
+        warnings.push({
+          kind: 'router-filter-unlowerable',
+          module: SYNTHETIC_FILTER,
+          detail: mod.filter?.name ?? 'unnamed',
+        })
+        fatal = true
+        droppedGates.add(id)
+        continue
+      }
+      if (lowered.lossy) {
+        warnings.push({
+          kind: 'router-filter-lossy',
+          module: SYNTHETIC_FILTER,
+          detail: lowered.lossy,
+        })
+      }
+      nodes.push({
+        id: String(id),
+        name,
+        nodeId: name,
+        type: SYNTHETIC_FILTER,
+        typeShort: 'filter',
+        parameters: lowered.parameters,
+        notes: mod.filter?.name,
+        disabled: false,
+        role: 'branch',
+        rpcName: name,
+      })
+      index++
+      continue
+    }
+
     const role = roleFor(mod, index++)
 
     // Make splits config (`parameters`) from data inputs (`mapper`). n8n has one
@@ -244,14 +320,20 @@ export function parseMake(raw: unknown, fallbackName = 'workflow'): ParsedMakeWo
   }
 
   // --- synthesize n8n-shaped connections (keyed by SOURCE NAME) ---
+  /** Collapse an edge through a gate we refused to emit: router → gate → head. */
+  const resolveTarget = (t: number): number[] =>
+    droppedGates.has(t) ? (walked.get(t)?.next ?? []) : [t]
+
   const connections: N8nConnections = {}
   for (const id of order) {
     const w = walked.get(id)!
+    if (droppedGates.has(id)) continue
     if (w.next.length === 0) continue
     const from = idToName.get(id)!
     connections[from] = {
       main: [
         w.next
+          .flatMap(resolveTarget)
           .filter((t) => idToName.has(t))
           .map((t) => ({ node: idToName.get(t)!, type: 'main', index: 0 })),
       ],
@@ -267,6 +349,7 @@ export function parseMake(raw: unknown, fallbackName = 'workflow'): ParsedMakeWo
     stickyNotes: [],
     shape: 'pure-graph',
     warnings,
+    fatal,
     modulesSeen: [...modulesSeen],
   }
 }

--- a/packages/make-import/src/types.ts
+++ b/packages/make-import/src/types.ts
@@ -1,0 +1,119 @@
+/**
+ * Make (Integromat) blueprint types — the subset we read.
+ *
+ * Format reference: https://github.com/integromat/make-skills (MIT), specifically
+ * `skills/make-scenario-building/blueprint-construction.md`. Make publishes the
+ * blueprint format itself, so this mirrors documented structure rather than
+ * reverse-engineered shape.
+ */
+
+/** One `{a, b, o}` condition inside a filter's OR/AND matrix. */
+export interface MakeCondition {
+  /** Left operand — usually an IML ref (`{{1.status}}`). */
+  a?: string
+  /** Right operand — absent for `exist` / `notexist`. */
+  b?: string
+  /** Operator: `text:equal`, `text:equal:ci`, `number:greater`, `exist`, … */
+  o?: string
+}
+
+/**
+ * A Make filter. `conditions` is a nested matrix: the OUTER array is OR groups,
+ * the INNER array is ANDed conditions within a group.
+ */
+export interface MakeFilter {
+  name?: string
+  conditions?: MakeCondition[][]
+}
+
+/** A router route — just a nested flow. Its head module carries the gate `filter`. */
+export interface MakeRoute {
+  flow?: MakeModule[]
+}
+
+/** An if/else branch (`builtin:BasicIfElse`). Unlike routes, these are exclusive. */
+export interface MakeBranch {
+  /** `condition` carries `conditions`; `else` is the fallback. */
+  type?: 'condition' | 'else'
+  conditions?: MakeCondition[][]
+  /** `true` when the branch converges back through the paired BasicMerge. */
+  merge?: boolean
+  flow?: MakeModule[]
+}
+
+export interface MakeModule {
+  /** Unique positive integer. IML refs address modules by this id. */
+  id: number
+  /** `namespace:ModuleName`, e.g. `google-sheets:watchRows`, `builtin:BasicRouter`. */
+  module: string
+  version?: number
+  /** Fixed config (connection, selected account). Also carries aggregator `feeder`. */
+  parameters?: Record<string, unknown>
+  /** Dynamic field mappings — IML expressions. This is the input map. */
+  mapper?: Record<string, unknown>
+  /** Gate on this module. Present on route heads; legal on ANY module. */
+  filter?: MakeFilter | null
+  metadata?: {
+    designer?: { x?: number; y?: number; name?: string }
+    parameters?: Array<{ name?: string; type?: string; label?: string }>
+  }
+  /** Router only — non-exclusive, cannot merge back. */
+  routes?: MakeRoute[]
+  /** BasicIfElse only — exclusive, merges via the paired BasicMerge. */
+  branches?: MakeBranch[]
+  /** Nested error-handler flow. */
+  onerror?: MakeModule[]
+}
+
+export interface MakeBlueprint {
+  name?: string
+  flow?: MakeModule[]
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * The full export envelope. The Make API (and every template file) nests the
+ * blueprint under `blueprint`; some hand-saved files are the bare blueprint.
+ */
+export interface MakeExport {
+  blueprint?: MakeBlueprint
+  controller?: Record<string, unknown>
+  scheduling?: Record<string, unknown>
+  metadata?: Record<string, unknown>
+  /** Present when the file IS the bare blueprint. */
+  flow?: MakeModule[]
+  name?: string
+}
+
+/** Split `google-sheets:watchRows` → `{ app: 'google-sheets', operation: 'watchRows' }`. */
+export function splitModule(module: string): { app: string; operation: string } {
+  const i = module.indexOf(':')
+  if (i < 0) return { app: module, operation: '' }
+  return { app: module.slice(0, i), operation: module.slice(i + 1) }
+}
+
+/** Make namespaces that are engine primitives rather than third-party integrations. */
+export const BUILTIN_NAMESPACES = new Set([
+  'builtin',
+  'util',
+  'json',
+  'regexp',
+  'gateway',
+  'http',
+  'datastore',
+  'markdown',
+  'csv',
+  'xml',
+  'archive',
+  'image',
+  'text',
+  'math',
+  'date',
+  'tools',
+  'code',
+  'scenario-service',
+  'placeholder',
+])
+
+/** Make module ids that start a scenario (their output is the graph's `trigger`). */
+export const TRIGGER_OPERATIONS = /^(watch|trigger|on|new|get.*trigger)/i

--- a/packages/make-import/tsconfig.json
+++ b/packages/make-import/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "module": "Node18",
+    "outDir": "dist",
+    "target": "esnext",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.test.ts", "node_modules"]
+}

--- a/packages/n8n-import/src/index.ts
+++ b/packages/n8n-import/src/index.ts
@@ -1,4 +1,6 @@
 export { parseN8n, UnsupportedTopologyError } from './parse-n8n.js'
+export { buildTopology } from './topology.js'
+export { classifyExpression } from './expressions.js'
 export { generateWorkflowFromN8n } from './codegen.js'
 
 /**
@@ -7,9 +9,30 @@ export { generateWorkflowFromN8n } from './codegen.js'
  * project without colliding. First piece of the shared core; see
  * `@pikku/make-import`.
  */
-export { dedupe, toCamelCase, toKebabCase } from './naming.js'
+export {
+  sanitizeIdentifier,
+  sanitizeDisplayName,
+  dedupe,
+  integrationRpcName,
+  codeRpcName,
+  toCamelCase,
+  toPascalCase,
+  toKebabCase,
+} from './naming.js'
 
-export type { ParsedWorkflow } from './types.js'
-export type { Topology } from './topology.js'
-export type { ClassifiedExpression, ExprContext } from './expressions.js'
-export type { GenerateResult } from './codegen.js'
+export type {
+  N8nWorkflow,
+  N8nNode,
+  N8nConnections,
+  ParsedWorkflow,
+  ParsedNode,
+  NodeRole,
+  WorkflowShape,
+} from './types.js'
+export type { NextValue, Topology, NodeTopology } from './topology.js'
+export type {
+  ClassifiedExpression,
+  ExprContext,
+  RefPart,
+} from './expressions.js'
+export type { GenerateResult, ManifestEntry } from './codegen.js'


### PR DESCRIPTION
Adds `packages/make-import`, a Make.com blueprint importer that normalizes onto the existing `n8n-import` IR rather than growing a second one.

- `parse-make.ts` / `iml.ts` — blueprint + IML expression parsing, with tests
- reuses `n8n-import`'s naming, topology and codegen; `n8n-import/src/index.ts` now re-exports the shared surface it needs
- router gates lower onto Filter nodes; gates that cannot be reproduced are refused rather than silently dropped
- `harness/` for emitting a single workflow or a whole corpus

Rebased onto latest main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing Make blueprints into Pikku workflows.
  * Preserves module connections, mapper expressions, filters, routes, and branching where supported.
  * Reports warnings and unsupported workflow elements during import.
  * Added public workflow analysis and expression utilities.

* **Documentation**
  * Added research comparing workflow engines and documenting the recommendation to prioritize Make imports.

* **Tests**
  * Added coverage for Make filters, expressions, references, and import scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->