### PR TITLE
refactor(cli): rename the config's locale field to metaLocale

### DIFF
--- a/.changeset/silver-moons-jam.md
+++ b/.changeset/silver-moons-jam.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Rename the `locale` field in `pikku.config.json` to `metaLocale`. It sets the language of the meta the Console renders back to your team, not the language your app speaks to its users — a config that still says `locale` now fails with an error saying where the value moved.

--- a/packages/cli/src/utils/pikku-cli-config.test.ts
+++ b/packages/cli/src/utils/pikku-cli-config.test.ts
@@ -5,11 +5,11 @@ import { join } from 'node:path'
 import { after, describe, test } from 'node:test'
 import { rmSync } from 'node:fs'
 import {
-  DEFAULT_LOCALE,
+  DEFAULT_META_LOCALE,
   PikkuCLIConfigError,
   assertSchemaDirectoriesAreDistinct,
   getPikkuCLIConfig,
-  normalizeLocale,
+  normalizeMetaLocale,
   tryGetPikkuCLIConfig,
 } from './pikku-cli-config.js'
 
@@ -164,7 +164,7 @@ describe('getPikkuCLIConfig', () => {
     )
   })
 
-  test('locale defaults to English when the config does not name one', async () => {
+  test('metaLocale defaults to English when the config does not name one', async () => {
     const root = await writeConfig()
 
     const config = await getPikkuCLIConfig(
@@ -173,11 +173,11 @@ describe('getPikkuCLIConfig', () => {
       []
     )
 
-    assert.equal(config.locale, DEFAULT_LOCALE)
+    assert.equal(config.metaLocale, DEFAULT_META_LOCALE)
   })
 
-  test('a declared locale survives the load, canonicalized', async () => {
-    const root = await writeConfig({ locale: 'de-de' })
+  test('a declared metaLocale survives the load, canonicalized', async () => {
+    const root = await writeConfig({ metaLocale: 'de-de' })
 
     const config = await getPikkuCLIConfig(
       silentLogger,
@@ -185,18 +185,35 @@ describe('getPikkuCLIConfig', () => {
       []
     )
 
-    assert.equal(config.locale, 'de-DE')
+    assert.equal(config.metaLocale, 'de-DE')
   })
 
-  test('a locale that is not a language tag names itself in the error', async () => {
-    const root = await writeConfig({ locale: 'de_DE' })
+  test('the former spelling `locale` is refused with the new name', async () => {
+    const root = await writeConfig({ locale: 'de' })
 
     await assert.rejects(
       () =>
         getPikkuCLIConfig(silentLogger, join(root, 'pikku.config.json'), []),
       (error: unknown) => {
         assert.ok(error instanceof PikkuCLIConfigError)
-        assert.match(error.message, /locale in pikku\.config\.json/)
+        assert.match(error.message, /renamed to metaLocale/)
+        // The error has to teach the distinction, not just the new spelling —
+        // being ignored is what the rename exists to prevent.
+        assert.match(error.message, /defaultLocale in active\.json/)
+        return true
+      }
+    )
+  })
+
+  test('a metaLocale that is not a language tag names itself in the error', async () => {
+    const root = await writeConfig({ metaLocale: 'de_DE' })
+
+    await assert.rejects(
+      () =>
+        getPikkuCLIConfig(silentLogger, join(root, 'pikku.config.json'), []),
+      (error: unknown) => {
+        assert.ok(error instanceof PikkuCLIConfigError)
+        assert.match(error.message, /metaLocale in pikku\.config\.json/)
         assert.match(error.message, /"de_DE"/)
         return true
       }
@@ -326,34 +343,34 @@ describe('assertSchemaDirectoriesAreDistinct', () => {
   })
 })
 
-describe('normalizeLocale', () => {
-  test('an absent locale is English rather than an error', () => {
-    assert.equal(normalizeLocale(undefined), DEFAULT_LOCALE)
-    assert.equal(normalizeLocale(null), DEFAULT_LOCALE)
+describe('normalizeMetaLocale', () => {
+  test('an absent metaLocale is English rather than an error', () => {
+    assert.equal(normalizeMetaLocale(undefined), DEFAULT_META_LOCALE)
+    assert.equal(normalizeMetaLocale(null), DEFAULT_META_LOCALE)
   })
 
   test('canonicalizes so one language is one value downstream', () => {
-    assert.equal(normalizeLocale('en'), 'en')
-    assert.equal(normalizeLocale(' de '), 'de')
-    assert.equal(normalizeLocale('pt-br'), 'pt-BR')
-    assert.equal(normalizeLocale('EN-gb'), 'en-GB')
+    assert.equal(normalizeMetaLocale('en'), 'en')
+    assert.equal(normalizeMetaLocale(' de '), 'de')
+    assert.equal(normalizeMetaLocale('pt-br'), 'pt-BR')
+    assert.equal(normalizeMetaLocale('EN-gb'), 'en-GB')
   })
 
   test('rejects the POSIX underscore people reach for', () => {
-    assert.throws(() => normalizeLocale('de_DE'), PikkuCLIConfigError)
+    assert.throws(() => normalizeMetaLocale('de_DE'), PikkuCLIConfigError)
   })
 
   test('rejects what is not a tag at all', () => {
-    assert.throws(() => normalizeLocale(''), PikkuCLIConfigError)
-    assert.throws(() => normalizeLocale('   '), PikkuCLIConfigError)
-    assert.throws(() => normalizeLocale('German, please'), PikkuCLIConfigError)
-    assert.throws(() => normalizeLocale(42), PikkuCLIConfigError)
-    assert.throws(() => normalizeLocale(['de']), PikkuCLIConfigError)
+    assert.throws(() => normalizeMetaLocale(''), PikkuCLIConfigError)
+    assert.throws(() => normalizeMetaLocale('   '), PikkuCLIConfigError)
+    assert.throws(() => normalizeMetaLocale('German, please'), PikkuCLIConfigError)
+    assert.throws(() => normalizeMetaLocale(42), PikkuCLIConfigError)
+    assert.throws(() => normalizeMetaLocale(['de']), PikkuCLIConfigError)
   })
 
   test('the error points at the two settings it is not', () => {
     assert.throws(
-      () => normalizeLocale('de_DE'),
+      () => normalizeMetaLocale('de_DE'),
       /Identifiers stay English regardless.*defaultLocale in active\.json/s
     )
   })

--- a/packages/cli/src/utils/pikku-cli-config.ts
+++ b/packages/cli/src/utils/pikku-cli-config.ts
@@ -120,15 +120,15 @@ export const assertSchemaDirectoriesAreDistinct = (
 }
 
 /**
- * The `locale` a project gets when its config does not name one.
+ * The `metaLocale` a project gets when its config does not name one.
  *
  * English, and it stays English for almost every project — the field changes
  * what the Console reads back to a human, not who the product is for.
  */
-export const DEFAULT_LOCALE = 'en'
+export const DEFAULT_META_LOCALE = 'en'
 
 /**
- * `locale` is handed on to codegen and the Console as a language tag, so a
+ * `metaLocale` is handed on to codegen and the Console as a language tag, so a
  * value they cannot interpret is worse than none: it degrades quietly to "some
  * language" a long way from the line that is wrong. `Intl.getCanonicalLocales`
  * is the BCP-47 grammar Node already ships, and it catches the mistake people
@@ -137,14 +137,14 @@ export const DEFAULT_LOCALE = 'en'
  * It returns the canonical spelling rather than what was typed, so `EN-gb` and
  * `en-GB` are one value downstream instead of two that never compare equal.
  */
-export const normalizeLocale = (locale: unknown): string => {
-  if (locale === undefined || locale === null) {
-    return DEFAULT_LOCALE
+export const normalizeMetaLocale = (metaLocale: unknown): string => {
+  if (metaLocale === undefined || metaLocale === null) {
+    return DEFAULT_META_LOCALE
   }
 
-  if (typeof locale === 'string') {
+  if (typeof metaLocale === 'string') {
     try {
-      const [canonical] = Intl.getCanonicalLocales(locale.trim())
+      const [canonical] = Intl.getCanonicalLocales(metaLocale.trim())
       if (canonical) {
         return canonical
       }
@@ -155,7 +155,7 @@ export const normalizeLocale = (locale: unknown): string => {
   }
 
   throw new PikkuCLIConfigError(
-    `locale in pikku.config.json is not a language tag: ${JSON.stringify(locale)}. ` +
+    `metaLocale in pikku.config.json is not a language tag: ${JSON.stringify(metaLocale)}. ` +
       `Use a BCP-47 code — "en", "de", "pt-BR" — with a hyphen rather than an underscore. ` +
       `It sets the language of the meta the Console renders back to your team (function and step descriptions, feature and scenario names). ` +
       `Identifiers stay English regardless, and the language the app speaks to its users is defaultLocale in active.json, not this.`
@@ -194,6 +194,29 @@ export const resolveFrontendConfig = (
     urlPrefix: urlPrefix === '/' ? '/' : urlPrefix.replace(/\/+$/, ''),
     spaFallback: frontend.spaFallback ?? true,
   }
+}
+
+/**
+ * The field's former name, kept only to say it moved.
+ *
+ * `locale` shipped in 0.12.120 and nothing has ever read it, so dropping it
+ * silently would cost nobody anything at runtime — but it would cost them the
+ * one thing the rename was for. A config that still says `locale` is a config
+ * whose author believed it did something; leaving it to be ignored teaches the
+ * opposite of the distinction the new name exists to draw.
+ */
+const assertMetaLocaleNotSpelledLocale = (result: Record<string, unknown>) => {
+  if (!('locale' in result)) {
+    return
+  }
+
+  throw new PikkuCLIConfigError(
+    `locale in pikku.config.json has been renamed to metaLocale. ` +
+      `Rename the field — the value is unchanged. ` +
+      `It was renamed because "locale", sitting beside baseLocale, defaultLocale and supportedLocales, reads as the language your app speaks to its users; it is not that. ` +
+      `It is the language of the meta the Console renders back to your team — function and step descriptions, feature and scenario names. ` +
+      `What a visitor opens the app in is defaultLocale in active.json.`
+  )
 }
 
 const _getPikkuCLIConfig = async (
@@ -1208,7 +1231,8 @@ const _getPikkuCLIConfig = async (
       result.tsconfig = join(result.rootDir, result.tsconfig)
     }
 
-    result.locale = normalizeLocale(result.locale)
+    assertMetaLocaleNotSpelledLocale(result as unknown as Record<string, unknown>)
+    result.metaLocale = normalizeMetaLocale(result.metaLocale)
 
     assertSchemaDirectoriesAreDistinct(result)
 

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -324,15 +324,21 @@ export type PikkuCLIInput = {
    *
    * - **It never renames anything.** Identifiers — functions, components,
    *   types, variables, files, database tables and columns — are English
-   *   whatever this is set to. `locale: "de"` buys a German `description`, not
-   *   a `getUebersicht` or a `vorgang` table.
+   *   whatever this is set to. `metaLocale: "de"` buys a German `description`,
+   *   not a `getUebersicht` or a `vorgang` table.
    * - **It is not the product's UI language.** What the app says to its users
    *   lives in `messages/<locale>.json`, and which language a first-time
    *   visitor is served is `active.json`'s `defaultLocale`. `baseLocale` in
    *   `project.inlang/settings.json` names the message *source* and stays
    *   `en`, or `--add-locale` has no English catalogue to translate from.
+   *
+   * The name carries the distinction rather than relying on the prose above:
+   * a field called `locale`, sitting beside `baseLocale`, `defaultLocale` and
+   * `supportedLocales`, reads as the app's runtime locale — which is exactly
+   * the confusion that produced the German-identifiers build this field was
+   * added to prevent.
    */
-  locale?: string
+  metaLocale?: string
 
   configDir: string
   tsconfig: string

--- a/packages/skills/skills/pikku-build-app/SKILL.md
+++ b/packages/skills/skills/pikku-build-app/SKILL.md
@@ -28,7 +28,7 @@ project shaped so `pikku fabric init` later adopts it with zero rework.
 ## Agent Operating Procedure
 
 1. Discover before editing. Run `pikku info functions --verbose --silent` and
-   read `AGENTS.md` before your first change. Read `locale` in
+   read `AGENTS.md` before your first change. Read `metaLocale` in
    `pikku.config.json` too: it is the language every `description`, `title` and
    step `template` you write must be in (§1a). Identifiers stay English whatever
    it says.
@@ -92,21 +92,21 @@ settle all three explicitly before you write code.
 | Axis            | What it covers                                                                                                                       | Where it goes                                                                     |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | **Identifiers** | Function, component, type, variable and file names. Database tables and columns. Commit messages.                                    | Nowhere — **always English**, no setting, not negotiable                          |
-| **Meta**        | `description` on functions and steps, `name`/`title` on features and scenarios, step `template`, role and persona descriptions        | `locale` in `pikku.config.json`, default `en`                                     |
+| **Meta**        | `description` on functions and steps, `name`/`title` on features and scenarios, step `template`, role and persona descriptions        | `metaLocale` in `pikku.config.json`, default `en`                                     |
 | **Product UI**  | Every string the app shows a user                                                                                                    | `messages/<locale>.json`, and `defaultLocale` for what a first-time visitor opens in |
 
 **Identifiers are English.** The product's market does not change this and
-neither does `locale`. Identifiers are the surface the generated `#pikku/*`
+neither does `metaLocale`. Identifiers are the surface the generated `#pikku/*`
 clients, `pikku info`, the typed RPC map and the Kysely types all bind to, and
 unlike a string an identifier cannot be translated later — renaming one is a
 migration. A German practice management tool gets `getWorklist`, `case`,
 `event`, not `getUebersicht`, `vorgang`, `ereignis`.
 
-**Meta follows `locale`.** Write the team's answer into `pikku.config.json` in
+**Meta follows `metaLocale`.** Write the team's answer into `pikku.config.json` in
 this phase, before there is any meta to be wrong:
 
 ```json
-{ "locale": "de" }
+{ "metaLocale": "de" }
 ```
 
 It exists for the Pikku Console. Meta is the one part of a project the Console
@@ -114,7 +114,7 @@ renders back to a human, so a team working in German reads their own functions,
 features and scenario reports in German. Default `en` and do not ask when the
 project is obviously English. **On every later run, read this field first and
 author descriptions, titles and step templates in it** — a project whose
-`locale` you ignored reports half in one language and half in another.
+`metaLocale` you ignored reports half in one language and half in another.
 
 **Product UI is the message catalogue.** `messages/<locale>.json` via
 `pikku-i18n`, with `defaultLocale` deciding what a visitor opens in.
@@ -131,7 +131,7 @@ A German medical portal, correctly:
 // apps/app/src/i18n/active.json   (or: fabric i18n --default-locale de)
 { "defaultLocale": "de" }
 // pikku.config.json
-{ "locale": "de" }
+{ "metaLocale": "de" }
 ```
 
 Record the two non-obvious answers as a `decisions/` note in §2 — neither is

--- a/packages/skills/skills/pikku-build-platform/SKILL.md
+++ b/packages/skills/skills/pikku-build-platform/SKILL.md
@@ -158,7 +158,7 @@ that is the finding.
 every added locale is cloned from, so three locales is `locales: ["en", …]` and
 never a repointed base. Shipping locales is also not a reason for anything in
 the code to stop being English: identifiers are English in every project, and
-the language of `description`/`title`/`template` is `locale` in
+the language of `description`/`title`/`template` is `metaLocale` in
 `pikku.config.json`. See `pikku-build-app` §1a.
 
 ### Emails — `pikku-emails`

--- a/packages/skills/skills/pikku-build-quick/SKILL.md
+++ b/packages/skills/skills/pikku-build-quick/SKILL.md
@@ -54,7 +54,7 @@ defaults are the point.
 
 Do not ask about language either — take the defaults and note them in §6.
 Identifiers are English in every project, whatever the product's market;
-`locale` in `pikku.config.json` (the language of `description`/`title`/step
+`metaLocale` in `pikku.config.json` (the language of `description`/`title`/step
 `template`, which the Console renders) stays `en` unless the user already told
 you otherwise. If the request says the app's UI is not English, that is the
 message catalogue only: add the locale and set `defaultLocale`, and leave

--- a/packages/skills/skills/pikku-concepts/SKILL.md
+++ b/packages/skills/skills/pikku-concepts/SKILL.md
@@ -138,7 +138,7 @@ Services can be destructured inline in the `func` signature (e.g. `async ({ logg
 
 ```typescript
 pikkuFunc({
-  // Identity and documentation — prose, so it follows `locale` in
+  // Identity and documentation — prose, so it follows `metaLocale` in
   // pikku.config.json (default `en`). The identifier does not; see
   // "What Language You Write In".
   title?: string,           // Human-readable name
@@ -333,12 +333,12 @@ bottom.
 | Axis            | What it covers                                                                                                                                                    | What decides it                                                                                             |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | **Identifiers** | Function, component, type, variable and file names. Database tables and columns. Branch names and commit messages.                                                | Nothing. **Always English.** There is no setting.                                                           |
-| **Meta**        | The prose authored _inside_ the code: `description` on functions and steps, `name`/`title` on features and scenarios, step `template`, role/persona descriptions. | `locale` in `pikku.config.json`. Defaults to `en`.                                                          |
+| **Meta**        | The prose authored _inside_ the code: `description` on functions and steps, `name`/`title` on features and scenarios, step `template`, role/persona descriptions. | `metaLocale` in `pikku.config.json`. Defaults to `en`.                                                          |
 | **Product UI**  | Every string the app shows a user.                                                                                                                                | `messages/<locale>.json`, with `active.json`'s `defaultLocale` choosing what a first-time visitor opens in. |
 
 ### Identifiers are English, and nothing changes that
 
-Not the product's market, not the team's working language, and **not `locale`**.
+Not the product's market, not the team's working language, and **not `metaLocale`**.
 A German medical practice, an Arabic marketplace and a Japanese logistics tool
 all get `getOverview`, `AttentionStripe`, `case`, `event`.
 
@@ -350,10 +350,10 @@ A `vorgang` table types as `Vorgang` in Kysely and reads as noise to everyone wh
 did not name it, and unlike a string it cannot be translated later — renaming an
 identifier is a migration, not an edit.
 
-### Meta follows `locale`, and that is what the field is for
+### Meta follows `metaLocale`, and that is what the field is for
 
 ```json
-{ "locale": "de" }
+{ "metaLocale": "de" }
 ```
 
 Meta is the one part of a project the **Pikku Console** renders back to a human.
@@ -366,7 +366,7 @@ Read it before you author meta, and write descriptions, titles and templates in
 it. Absent, it is `en`. It is a BCP-47 tag (`en`, `de`, `pt-BR` — a hyphen, not
 an underscore), and the CLI rejects anything else by name.
 
-`locale` is **not** licence to rename anything. `locale: "de"` buys a German
+`metaLocale` is **not** licence to rename anything. `metaLocale: "de"` buys a German
 `description: 'Zeigt die Arbeitsliste'` on a function still called
 `getWorklist`.
 
@@ -405,7 +405,7 @@ settings, each on its own axis:
 { "defaultLocale": "de" }
 
 // pikku.config.json — the language the team reads their Console in
-{ "locale": "de" }
+{ "metaLocale": "de" }
 ```
 
 Identifiers stay English throughout. When a brief tells you the product speaks a

--- a/packages/skills/skills/pikku-fabric/SKILL.md
+++ b/packages/skills/skills/pikku-fabric/SKILL.md
@@ -416,7 +416,7 @@ These apply in every Fabric app:
 - **No hand-editing `.pikku/db/schema.gen.ts`** — write a migration and re-run `pikku db migrate`.
 - **One runtime unit per file** — never define multiple functions/workflows in a single source file.
 - **Workflow steps don't need manual wiring** — `pikkuSessionlessFunc` step functions in `*.steps.ts` files are auto-discovered by codegen.
-- **Identifiers are English** — functions, components, types, files, database tables and columns, in every app whatever market it serves. The team's language is `locale` in `pikku.config.json` and reaches `description`/`title`/`template` only; the app's language is the message catalogue, where `baseLocale` stays `en` and `defaultLocale` decides what a visitor opens in. `pikku fabric validate` warns (`app-base-locale-not-english-<app>`) when an app repoints its base.
+- **Identifiers are English** — functions, components, types, files, database tables and columns, in every app whatever market it serves. The team's language is `metaLocale` in `pikku.config.json` and reaches `description`/`title`/`template` only; the app's language is the message catalogue, where `baseLocale` stays `en` and `defaultLocale` decides what a visitor opens in. `pikku fabric validate` warns (`app-base-locale-not-english-<app>`) when an app repoints its base.
 
 ## Converting an existing app to Fabric format
 
@@ -432,7 +432,7 @@ Fix every `error` and `warn` in the output before continuing. Then:
 2. **Replace route handlers with pikkuFuncs**: extract business logic into `pikkuFunc`/`pikkuSessionlessFunc`, add `wireHTTP` or `expose: true` for transport.
 3. **Replace DI/IoC with pikkuServices**: move service construction to `createSingletonServices` in `services.ts`.
 4. **Replace `process.env` calls**: plain config becomes `defineVariable` + `variables.get()`, anything sensitive becomes `defineSecret` + `secrets.getSecret()`.
-5. **Add `pikku.config.json`** at project root with `srcDirectories`, `outDir`, and `clientFiles` — plus `locale` if the team does not work in English, which is the language every `description`, `title` and step `template` is then authored in.
+5. **Add `pikku.config.json`** at project root with `srcDirectories`, `outDir`, and `clientFiles` — plus `metaLocale` if the team does not work in English, which is the language every `description`, `title` and step `template` is then authored in.
 6. **Add `pikkufabric.config.json`** at project root with `projectId`, `production.domain`, and `frontends` (production is always `main`, so there is no `production.branch`).
 7. **Run `pikku all`** — verify codegen succeeds and there are no type errors.
 8. **Run `pikku fabric validate`** once more to confirm no structural issues remain.

--- a/packages/skills/skills/pikku-feature/SKILL.md
+++ b/packages/skills/skills/pikku-feature/SKILL.md
@@ -41,7 +41,7 @@ schemas (`yarn pikku meta functions get <id>`) or workflow steps
 **Capability rule:** do not introduce new wires of a type whose
 `capabilities.<type>` is `false` unless the user explicitly asked for it.
 
-**Language rule:** read `locale` in `pikku.config.json` (default `en`). It is
+**Language rule:** read `metaLocale` in `pikku.config.json` (default `en`). It is
 the language of every `description`, `title` and step `template` you author —
 the meta the Pikku Console renders back to the team. It renames nothing:
 functions, components, types, files, tables and columns are English in every

--- a/packages/skills/skills/pikku-i18n/SKILL.md
+++ b/packages/skills/skills/pikku-i18n/SKILL.md
@@ -25,7 +25,7 @@ this skill. Three axes:
 | Axis            | What it covers                                                                                          | What sets it                                                    |
 | --------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
 | **Identifiers** | Function, component, type and file names; database tables and columns                                   | Nothing — always English, no setting                            |
-| **Meta**        | `description` / `name` / `title` / `template` authored inside the code, which the Pikku Console renders | `locale` in `pikku.config.json`, default `en`                   |
+| **Meta**        | `description` / `name` / `title` / `template` authored inside the code, which the Pikku Console renders | `metaLocale` in `pikku.config.json`, default `en`                   |
 | **Product UI**  | Every string the app shows a user                                                                       | `messages/<locale>.json` + `defaultLocale` — **this axis only** |
 
 A non-English product moves the third row and nothing else.
@@ -57,7 +57,7 @@ So a German medical portal is **three** settings, not one:
 { "defaultLocale": "de" }
 
 // pikku.config.json — the language the team reads their Console in
-{ "locale": "de" }
+{ "metaLocale": "de" }
 ```
 
 In the Fabric template both of the first two have a command, so you rarely edit

--- a/packages/skills/skills/pikku-scenario/SKILL.md
+++ b/packages/skills/skills/pikku-scenario/SKILL.md
@@ -367,7 +367,7 @@ string the generated step map is keyed by — the file name, and every helper in
 are English in every project regardless of who the product is for or what
 language the team speaks. There is no setting that changes this.
 
-**Prose follows `locale` in `pikku.config.json`** (default `en`). That is a
+**Prose follows `metaLocale` in `pikku.config.json`** (default `en`). That is a
 step's `description` and `template`, a feature's `name` and `description`, a
 scenario's `title`, and the positional step names passed to
 `scenario.given/when/then`. Read the field before you write any of them.
@@ -378,7 +378,7 @@ language. The report is the deliverable, and it is read by the team; the
 identifier is an API, and it is read by the toolchain.
 
 ```typescript
-// pikku.config.json: { "locale": "de" }
+// pikku.config.json: { "metaLocale": "de" }
 export const buysAnApple = pikkuScenarioStep<{ qty: number }, { orderId: string }>({
   name: 'buysAnApple',          // identifier — English, always
   description: 'kauft einen Apfel',  // prose — follows locale
@@ -392,19 +392,19 @@ export const buysAnApple = pikkuScenarioStep<{ qty: number }, { orderId: string 
 Note what does **not** change: `placeOrder` is still `placeOrder`, and the file
 is still `apple.scenario.ts`.
 
-A product with a non-English UI is not on its own a reason to set `locale` — that
+A product with a non-English UI is not on its own a reason to set `metaLocale` — that
 is the app's language, not the team's. Ask, or leave it `en`.
 
-**Where a non-`en` `locale` still shows English, today.** The reporter composes a
+**Where a non-`en` `metaLocale` still shows English, today.** The reporter composes a
 sentence as `<Keyword> the <actor> <template>` (`composeStepProse`), and both the
 keyword and the article `the` are English literals. The Console translates the
 Given/When/Then keywords into its own UI language; the CLI reporter does not, and
-nothing translates `the`. So `locale: "de"` gives you German step prose inside an
+nothing translates `the`. So `metaLocale: "de"` gives you German step prose inside an
 English frame — `Given the shopper kauft 1 Äpfel`. Write templates that read
 acceptably in that frame rather than trying to defeat it. A second gap: where a
 function or scenario declares no `title`, the Console falls back to splitting the
 **identifier** into an English-looking label (`toEnglishName`), so under a
-non-`en` `locale` meta is worth authoring rather than leaving to the fallback.
+non-`en` `metaLocale` meta is worth authoring rather than leaving to the fallback.
 
 ### `then` bindings are witnesses, not alternatives
 
@@ -833,7 +833,7 @@ Services are plain objects — a Pikku function is pure business logic, so a moc
 | Assuming a clean database                           | There is no state reset — it may be a staging server. Scope what you create.                                                |
 | `sleep()` before asserting                          | Use `expectEventually`.                                                                                                     |
 | A step named `clicksAddToBasket` / `opensThePage`   | That is an action, not an intent. Name the step for what the actor wanted; put the clicking in a utility.                   |
-| A step named `kauftEinenApfel` / a `vorgang` table   | Identifiers are English in every project. The German belongs in `description` / `template`, and only when `pikku.config.json` sets `locale`.  |
+| A step named `kauftEinenApfel` / a `vorgang` table   | Identifiers are English in every project. The German belongs in `description` / `template`, and only when `pikku.config.json` sets `metaLocale`.  |
 | A browser step that assumes it is already on a page | It can then only run mid-flow. Arrive first — check the URL, navigate if needed.                                            |
 | `getByLabel('Full Name')` in a translated app        | Passes only in the base locale, and a copy edit breaks it as an unexplained timeout. Locate by message key.                 |
 | A `browser` binding guarding `if (!browser)`        | The binding guarantees it. The guard hides the real error, which is a missing actor (`PKU677`).                             |


### PR DESCRIPTION
`locale` in `pikku.config.json` sets the language of the **meta** — function and step descriptions, feature and scenario names — that the Console renders back to your team. Sitting beside `baseLocale`, `defaultLocale` and `supportedLocales`, the name reads as the language the app speaks to its users, which is exactly the confusion that produced the German-identifiers build the field was added to prevent.

- `locale` → `metaLocale`, `DEFAULT_LOCALE` → `DEFAULT_META_LOCALE`, `normalizeLocale` → `normalizeMetaLocale`
- a config that still says `locale` throws, naming where the value moved, rather than being silently ignored
- `types/config.d.ts` and the eight SKILL.md files that document the field follow

`packages/cli/src/utils/pikku-cli-config.test.ts`: 26/26 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)