### PR TITLE
docs: a hand-driven browser session is not a test

### DIFF
--- a/.changeset/lucky-swans-wave.md
+++ b/.changeset/lucky-swans-wave.md
@@ -1,0 +1,5 @@
+---
+'@pikku/skills': patch
+---
+
+The three build skills now draw the line between the manual click-through (a smoke check, for layout) and verification: anything worth driving through the UI belongs in a scenario's browser step, not in a browser session steered by hand that nothing re-runs.

--- a/packages/skills/skills/pikku-build-app/SKILL.md
+++ b/packages/skills/skills/pikku-build-app/SKILL.md
@@ -464,8 +464,16 @@ built-in module: node:sqlite`.
 
 Open it, sign up, and click through what you built. **HTTP 200 is not evidence.**
 The pages are client-rendered: the server returns 200 with an empty shell, so a
-page whose component throws still looks fine to `curl`. Open it in a browser, or
-drive it headlessly and assert on the text that actually rendered.
+page whose component throws still looks fine to `curl`.
+
+That click-through is a smoke check, and it is the only thing it is. **Do not
+hand-drive a browser tool in place of a test.** Steering Playwright yourself
+proves a page rendered once, on your machine, in an order only you remember —
+nothing about it re-runs, so the next agent inherits a claim rather than a test,
+and a regression lands silently. When a journey is worth driving through the UI,
+it is worth writing as a browser step on §7's scenario and running
+`pikku scenario run local --spawn --run browser`: same clicks, same assertions,
+in the repo, green or red on every future run.
 
 ## 7. Prove it — scenarios
 

--- a/packages/skills/skills/pikku-build-quick/SKILL.md
+++ b/packages/skills/skills/pikku-build-quick/SKILL.md
@@ -178,8 +178,11 @@ exactly like an app bug, so if every request fails, check both came up.
 
 Sign up, click every screen. **HTTP 200 is not evidence:** pages are
 client-rendered, so the server returns 200 with an empty shell and a page whose
-component throws still looks fine to `curl`. Open a browser, or drive it
-headlessly and assert on rendered text.
+component throws still looks fine to `curl`.
+
+Looking is for the layout — the part only eyes catch. Assertions belong in the
+smoke scenario, not in a browser session you steered by hand: that session proves
+a screen rendered once, here, and nothing about it re-runs.
 
 **Screenshot at 390px too.** A layout that is fine at 1440 routinely breaks on a
 phone — an overflowing table, a row of buttons wrapped into a pile, a modal

--- a/packages/skills/skills/pikku-fabric/SKILL.md
+++ b/packages/skills/skills/pikku-fabric/SKILL.md
@@ -268,8 +268,12 @@ bun run dev
 Then open the app, sign up as a real user, and click through what you built.
 **HTTP 200 is not evidence.** These are client-rendered pages: the server returns
 200 with an empty shell, so a page whose component throws still looks fine to
-curl. Either open it in a browser or drive it headlessly and assert on rendered
-text.
+curl.
+
+That pass is a smoke check. Anything you would otherwise verify by hand-driving a
+browser tool belongs in a scenario's browser step, run with
+`pikku scenario run local --spawn --run browser` — a browser session you steered
+yourself proves nothing that re-runs.
 
 Secrets come from `process.env`, which the CLI populates from a `.env` in the
 working directory. `BETTER_AUTH_SECRET` is required — without it the first


### PR DESCRIPTION
`pikku-build-app`, `pikku-build-quick` and `pikku-fabric` all said "open it in a browser, or drive it headlessly and assert on rendered text" — which reads as licence to steer a browser tool through the journey and call it verified.

It isn't. That session proves a page rendered once, on one machine, in an order only the agent remembers; nothing about it re-runs, so a regression lands silently. The manual pass is a smoke check for layout — the part only eyes catch — and everything else belongs in a scenario browser step run with `pikku scenario run local --spawn --run browser`: same clicks, same assertions, in the repo, green or red on every future run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)