### PR TITLE
refactor(better-auth): prefix the plugin factories with `pikku`

### DIFF
--- a/.changeset/pikku-prefix-better-auth-plugin-exports.md
+++ b/.changeset/pikku-prefix-better-auth-plugin-exports.md
@@ -1,0 +1,27 @@
+---
+'@pikku/better-auth': patch
+'@pikku/inspector': patch
+'@pikku/addon-admin': patch
+'@pikku/skills': patch
+'@pikku/cli': patch
+---
+
+Prefix the better-auth plugin factories with `pikku`: `pikkuActor`, `pikkuBan`,
+`pikkuFabric`, `pikkuDelegatedAuth` and `pikkuCredentialOAuth`.
+
+A `betterAuth({ plugins: [...] })` array mixes this package's plugins with
+better-auth's own, and until now nothing at the call site told them apart —
+`plugins: [actor(...), ban(), fabric(...), organization()]` reads as four
+plugins from one place when only the last is better-auth's. The prefix says
+which package a plugin came from where it is actually wired.
+
+The old names are still exported as deprecated aliases bound to the same
+functions, so no import has to change. Nothing about the plugins themselves
+moved: the `id` each registers under — `pikku-ban`, `actor`, `fabric`,
+`delegated-auth`, `credential-oauth` — is unchanged, so no deployed database or
+session is affected.
+
+The pieces that read a plugin's _export_ name rather than its id accept both:
+`PLUGIN_REGISTRY` is keyed under the prefixed and the bare name, and the
+`pikku validate` ban/actor checks and the `scaffold.userAdmin` ban check count
+either spelling as wired. Their messages now point at the new names.

--- a/e2e/packages/functions/src/auth.ts
+++ b/e2e/packages/functions/src/auth.ts
@@ -2,9 +2,9 @@ import { betterAuth } from 'better-auth'
 import { getMigrations } from 'better-auth/db/migration'
 import { bearer } from 'better-auth/plugins'
 import {
-  actor,
-  ban,
-  credentialOAuth,
+  pikkuActor,
+  pikkuBan,
+  pikkuCredentialOAuth,
   credentialOAuthProviders,
   resolvedUserHoldsScopes,
   ADMIN_SCOPES,
@@ -54,18 +54,18 @@ export const auth = pikkuBetterAuth(
       // is gated on the `admin` scope tree, declared by @pikku/addon-admin's
       // defineScope, which this app inherits.
       //
-      // ban() carries no authorization of its own: it adds the three columns a
+      // pikkuBan() carries no authorization of its own: it adds the three columns a
       // ban lives in and refuses a session for a banned user. Who may ban is
       // decided by `admin:users:ban` on the RPC.
       plugins: [
-        ban(),
+        pikkuBan(),
         bearer(),
-        actor({
+        pikkuActor({
           secret: (await variables.get('SCENARIO_ACTOR_SECRET')) ?? '',
         }),
         // Every defineCredential oauth2 declaration becomes a provider here, so
         // linking an account is what makes getCredential(name) resolve.
-        credentialOAuth({
+        pikkuCredentialOAuth({
           config: await credentialOAuthProviders(
             CREDENTIAL_OAUTH2_CONFIGS,
             secrets,

--- a/examples/online-shop/src/auth.ts
+++ b/examples/online-shop/src/auth.ts
@@ -1,5 +1,5 @@
 import { betterAuth } from 'better-auth'
-import { actor, ban, fabric } from '@pikku/better-auth'
+import { pikkuActor, pikkuBan, pikkuFabric } from '@pikku/better-auth'
 import { pikkuBetterAuth } from '#pikku/auth'
 
 /**
@@ -74,23 +74,23 @@ export const auth = pikkuBetterAuth(
       // db/sqlite/0002-user-actor.sql) signed in by pikkuScenario via
       // POST /api/auth/sign-in/actor { email, secret }. Never signs in real users.
       //
-      // ban(): adds the banned/banExpires/banReason columns (see
+      // pikkuBan(): adds the banned/banExpires/banReason columns (see
       // db/sqlite/0003-admin.sql) and the session hook that refuses a banned
       // user a session. better-auth's own admin() is refused by the inspector:
       // it authorizes on a `user.role` column while pikku authorizes on scopes,
       // and everything else it offered — list, create, ban, remove, revoke
       // sessions, set password — is scoped RPCs in @pikku/addon-admin.
       //
-      // fabric(): exposes /api/auth/sign-in/fabric — the Fabric control plane
+      // pikkuFabric(): exposes /api/auth/sign-in/fabric — the Fabric control plane
       // mints a short-lived RS256 token and signs in as a synthetic `fabric: true`
       // admin operator (db/sqlite/0004-fabric.sql), so the console Users tab can
       // list/impersonate real users without the operator being one of them. It
       // verifies against FABRIC_AUTH_PUBLIC_KEY; a missing key disables the
       // endpoint.
       plugins: [
-        actor({ secret: SCENARIO_ACTOR_SECRET }),
-        ban(),
-        fabric({ publicKey: FABRIC_AUTH_PUBLIC_KEY }),
+        pikkuActor({ secret: SCENARIO_ACTOR_SECRET }),
+        pikkuBan(),
+        pikkuFabric({ publicKey: FABRIC_AUTH_PUBLIC_KEY }),
       ],
     })
   }

--- a/packages/addon/pikku-admin/README.md
+++ b/packages/addon/pikku-admin/README.md
@@ -38,12 +38,12 @@ directory without granting the ability to ban anyone. Note the absence of
 own, so declaring `admin` there would force the umbrella grant on every caller.
 
 `admin:users:*` needs better-auth wired, and banning additionally needs its
-`ban()` plugin from `@pikku/better-auth` for the columns to exist:
+`pikkuBan()` plugin from `@pikku/better-auth` for the columns to exist:
 
 ```ts
-import { ban } from '@pikku/better-auth'
+import { pikkuBan } from '@pikku/better-auth'
 
-betterAuth({ plugins: [ban()] })
+betterAuth({ plugins: [pikkuBan()] })
 ```
 
 better-auth's own `admin()` plugin is neither needed nor wanted here. These

--- a/packages/addon/pikku-admin/src/functions/set-user-banned.function.ts
+++ b/packages/addon/pikku-admin/src/functions/set-user-banned.function.ts
@@ -5,7 +5,7 @@ import { SetUserBannedInput, Success } from '../lib/user.schemas.js'
 export const setUserBanned = pikkuFunc({
   title: 'Ban or Unban User',
   description:
-    'Bans a user — revoking their sessions and blocking sign-in — or lifts an existing ban. An expiry lets the ban lapse on its own; without one it holds until it is lifted. Requires better-auth wired with the `ban()` plugin.',
+    'Bans a user — revoking their sessions and blocking sign-in — or lifts an existing ban. An expiry lets the ban lapse on its own; without one it holds until it is lifted. Requires better-auth wired with the `pikkuBan()` plugin.',
   expose: true,
   scopes: ['admin:users:ban'],
   input: SetUserBannedInput,

--- a/packages/addon/pikku-admin/src/lib/user.schemas.ts
+++ b/packages/addon/pikku-admin/src/lib/user.schemas.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 /**
  * A user, as the directory sees one. Ban state is optional because those
- * columns belong to the `ban()` plugin: a host without it reports no ban state
+ * columns belong to the `pikkuBan()` plugin: a host without it reports no ban state
  * at all, which a client can render as "unknown" rather than as a misleading
  * "not banned".
  */

--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -91,8 +91,8 @@ async function makeValidProject(root: string) {
   await writeFile(
     join(root, 'packages', 'functions', 'src', 'auth.wiring.ts'),
     [
-      "import { actor } from '@pikku/better-auth'",
-      'export const auth = () => ({ plugins: [actor({ secret: undefined })] })',
+      "import { pikkuActor } from '@pikku/better-auth'",
+      'export const auth = () => ({ plugins: [pikkuActor({ secret: undefined })] })',
       '',
     ].join('\n'),
     'utf8'

--- a/packages/cli/src/functions/commands/validate.test.ts
+++ b/packages/cli/src/functions/commands/validate.test.ts
@@ -137,8 +137,8 @@ async function makeValidWorkspace(root: string) {
   await writeFile(
     join(root, 'packages', 'functions', 'src', 'wirings', 'auth.wiring.ts'),
     [
-      "import { actor } from '@pikku/better-auth'",
-      'export const auth = () => ({ plugins: [actor({ secret: undefined })] })',
+      "import { pikkuActor } from '@pikku/better-auth'",
+      'export const auth = () => ({ plugins: [pikkuActor({ secret: undefined })] })',
       '',
     ].join('\n'),
     'utf8'

--- a/packages/cli/src/functions/validate/auth-plugin-checks.test.ts
+++ b/packages/cli/src/functions/validate/auth-plugin-checks.test.ts
@@ -20,6 +20,17 @@ const writeSource = async (
 }
 
 const AUTH_WITH_BAN = [
+  "import { pikkuBetterAuth, pikkuBan } from '@pikku/better-auth'",
+  "import { betterAuth } from 'better-auth'",
+  'export const auth = pikkuBetterAuth(() =>',
+  '  betterAuth({ plugins: [pikkuBan()] })',
+  ')',
+].join('\n')
+
+// pikkuBan() was named ban() until the plugins grew their pikku prefix. The
+// alias is still exported, so an app that never renamed its import must still
+// read as banning users.
+const AUTH_WITH_DEPRECATED_BAN_ALIAS = [
   "import { pikkuBetterAuth, ban } from '@pikku/better-auth'",
   "import { betterAuth } from 'better-auth'",
   'export const auth = pikkuBetterAuth(() =>',
@@ -54,7 +65,7 @@ describe('runAuthPluginChecks', () => {
       const admin = findings.find((f) => f.id === 'better-auth-admin-plugin')
       assert.ok(admin, 'admin() must be reported')
       assert.equal(admin.severity, 'error')
-      assert.match(admin.fixHint, /ban\(\)/)
+      assert.match(admin.fixHint, /pikkuBan\(\)/)
       assert.match(admin.path, /auth\.ts$/)
     } finally {
       await rm(root, { recursive: true, force: true })
@@ -74,10 +85,20 @@ describe('runAuthPluginChecks', () => {
     }
   })
 
-  test('is silent when ban() is wired', async () => {
+  test('is silent when pikkuBan() is wired', async () => {
     const root = await makeTmp()
     try {
       await writeSource(root, 'auth.ts', AUTH_WITH_BAN)
+      assert.deepEqual(await runAuthPluginChecks(root, config), [])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('is silent when the deprecated ban() alias is wired', async () => {
+    const root = await makeTmp()
+    try {
+      await writeSource(root, 'auth.ts', AUTH_WITH_DEPRECATED_BAN_ALIAS)
       assert.deepEqual(await runAuthPluginChecks(root, config), [])
     } finally {
       await rm(root, { recursive: true, force: true })

--- a/packages/cli/src/functions/validate/auth-plugin-checks.ts
+++ b/packages/cli/src/functions/validate/auth-plugin-checks.ts
@@ -133,7 +133,7 @@ const configuresPlugin = (
  * running two authorization models and projecting one onto the other. The
  * inspector refuses it outright at prebuild; this reports the same thing
  * without one, and additionally catches the quieter half of the migration, an
- * app that dropped `admin()` and never wired `ban()`, which keeps its ban
+ * app that dropped `admin()` and never wired `pikkuBan()`, which keeps its ban
  * columns and its ban UI while silently enforcing nothing.
  */
 export const runAuthPluginChecks = async (
@@ -157,7 +157,13 @@ export const runAuthPluginChecks = async (
     if (!text) continue
     if (configuresPlugin(text, 'better-auth/plugins', 'admin'))
       adminFiles.push(file)
-    if (configuresPlugin(text, '@pikku/better-auth', 'ban')) bansAnywhere = true
+    // `pikkuBan` is the current export; `ban` is the deprecated alias, which
+    // configures exactly the same plugin and so must satisfy the check too.
+    if (
+      configuresPlugin(text, '@pikku/better-auth', 'pikkuBan') ||
+      configuresPlugin(text, '@pikku/better-auth', 'ban')
+    )
+      bansAnywhere = true
   }
 
   for (const file of adminFiles) {
@@ -168,11 +174,11 @@ export const runAuthPluginChecks = async (
         "better-auth's admin() plugin is not supported — it authorizes against a user.role column while pikku authorizes on scopes, so one has to be projected onto the other",
       path: file,
       fixHint: lines(
-        'Replace it with ban(), which keeps the one capability admin() had that',
-        'pikku cannot supply from outside better-auth — refusing a banned user a',
-        'session:',
-        "  import { ban } from '@pikku/better-auth'",
-        '  betterAuth({ plugins: [ban()] })',
+        'Replace it with pikkuBan(), which keeps the one capability admin() had',
+        'that pikku cannot supply from outside better-auth — refusing a banned',
+        'user a session:',
+        "  import { pikkuBan } from '@pikku/better-auth'",
+        '  betterAuth({ plugins: [pikkuBan()] })',
         'User management is already scoped RPCs in @pikku/addon-admin: list,',
         'create, ban, remove, revoke sessions and set password.'
       ),
@@ -189,11 +195,11 @@ export const runAuthPluginChecks = async (
           id: 'better-auth-no-ban-plugin',
           severity: 'warn',
           message:
-            'better-auth is configured without ban() — the banned/banReason/banExpires columns do not exist, so banning a user through @pikku/addon-admin has nothing to write and nothing refuses their next sign-in',
+            'better-auth is configured without pikkuBan() — the banned/banReason/banExpires columns do not exist, so banning a user through @pikku/addon-admin has nothing to write and nothing refuses their next sign-in',
           path: file,
           fixHint: lines(
-            "  import { ban } from '@pikku/better-auth'",
-            '  betterAuth({ plugins: [ban()] })',
+            "  import { pikkuBan } from '@pikku/better-auth'",
+            '  betterAuth({ plugins: [pikkuBan()] })',
             'Wire it wherever the rest of your plugins are, then run',
             '`pikku db migrate` to add the columns.'
           ),

--- a/packages/cli/src/functions/validate/persona-checks.test.ts
+++ b/packages/cli/src/functions/validate/persona-checks.test.ts
@@ -38,6 +38,14 @@ const writePersonaMeta = async (
 }
 
 const actorWiring = [
+  "import { pikkuActor } from '@pikku/better-auth'",
+  'export const auth = () => ({ plugins: [pikkuActor({ secret: undefined })] })',
+  '',
+].join('\n')
+
+// The name pikkuActor() shipped under before the plugins took a pikku prefix.
+// The alias is still exported, so wiring it still counts as actor sign-in.
+const deprecatedActorAliasWiring = [
   "import { actor } from '@pikku/better-auth'",
   'export const auth = () => ({ plugins: [actor({ secret: undefined })] })',
   '',
@@ -83,6 +91,18 @@ describe('persona checks', () => {
     try {
       await writeSource(tmp, 'personas.ts', personaDeclaration)
       await writeSource(tmp, 'auth.wiring.ts', actorWiring)
+      const findings = await runPersonaChecks(tmp, config)
+      assert.deepStrictEqual(ids(findings), [])
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('the deprecated actor() alias still counts as actor sign-in', async () => {
+    const tmp = await makeTmp()
+    try {
+      await writeSource(tmp, 'personas.ts', personaDeclaration)
+      await writeSource(tmp, 'auth.wiring.ts', deprecatedActorAliasWiring)
       const findings = await runPersonaChecks(tmp, config)
       assert.deepStrictEqual(ids(findings), [])
     } finally {

--- a/packages/cli/src/functions/validate/persona-checks.ts
+++ b/packages/cli/src/functions/validate/persona-checks.ts
@@ -106,17 +106,19 @@ const countPersonas = async (
 /**
  * Whether a persona can actually sign in.
  *
- * Two shapes count. `actor()` from `@pikku/better-auth` is the one the scaffold
- * wires, and a hand-rolled `/sign-in/actor` route is the one a project that does
- * not use better-auth ends up with. Both terminate at the same endpoint, so
- * either satisfies the check.
+ * Two shapes count. `pikkuActor()` from `@pikku/better-auth` is the one the
+ * scaffold wires, and a hand-rolled `/sign-in/actor` route is the one a project
+ * that does not use better-auth ends up with. Both terminate at the same
+ * endpoint, so either satisfies the check. The deprecated `actor()` alias is
+ * matched too — it is the same plugin under its old name.
  */
 const hasActorSignIn = async (sourceFiles: string[]): Promise<boolean> => {
   for (const file of sourceFiles) {
     const text = await readTextSafe(file)
     if (!text) continue
     const wiresPlugin =
-      /@pikku\/better-auth/.test(text) && /\bactor\s*\(/.test(text)
+      /@pikku\/better-auth/.test(text) &&
+      /(^|[^\w$.])(pikkuActor|actor)\s*\(/.test(text)
     if (wiresPlugin || /sign-in\/actor/.test(text)) return true
   }
   return false
@@ -181,8 +183,8 @@ export const runPersonaChecks = async (
       pikkuConfigPath,
       lines(
         'Wire the actor plugin where better-auth is configured:',
-        "  import { actor } from '@pikku/better-auth'",
-        '  plugins: [actor({ secret: SCENARIO_ACTOR_SECRET })]',
+        "  import { pikkuActor } from '@pikku/better-auth'",
+        '  plugins: [pikkuActor({ secret: SCENARIO_ACTOR_SECRET })]',
         '`pikku dev` turns the endpoint on and mints the secret itself, so there',
         'is nothing to configure locally. A deployed stage that must run',
         'scenarios opts in with',

--- a/packages/cli/src/functions/wirings/user-admin/pikku-command-user-admin-functions.ts
+++ b/packages/cli/src/functions/wirings/user-admin/pikku-command-user-admin-functions.ts
@@ -36,13 +36,19 @@ export const pikkuUserAdminFunctions = pikkuSessionlessFunc<void, boolean>({
     // Ban is the one capability with a schema requirement of its own, and it is
     // only one of the six — a warning rather than a failure, so an app that
     // never bans anyone is not forced to carry the columns.
-    if (!definition.plugins.includes('ban')) {
+    // The plugin ids here are the callee names read off the `plugins: [...]`
+    // array, so both the current `pikkuBan()` and the deprecated `ban()` alias
+    // have to count as wired.
+    const bansUsers =
+      definition.plugins.includes('pikkuBan') ||
+      definition.plugins.includes('ban')
+    if (!bansUsers) {
       logger.warn(
-        `"scaffold.userAdmin" is enabled but better-auth is configured without the ban() plugin, ` +
+        `"scaffold.userAdmin" is enabled but better-auth is configured without the pikkuBan() plugin, ` +
           `so the banned/banReason/banExpires columns do not exist and setUserBanned will fail.\n` +
-          `Fix: add ban() to the plugins array in ${definition.sourceFile}:\n` +
-          `  import { ban } from '@pikku/better-auth'\n` +
-          `  betterAuth({ plugins: [ban()] })`
+          `Fix: add pikkuBan() to the plugins array in ${definition.sourceFile}:\n` +
+          `  import { pikkuBan } from '@pikku/better-auth'\n` +
+          `  betterAuth({ plugins: [pikkuBan()] })`
       )
     }
 

--- a/packages/cli/src/functions/wirings/user-admin/serialize-user-admin-functions.ts
+++ b/packages/cli/src/functions/wirings/user-admin/serialize-user-admin-functions.ts
@@ -14,7 +14,7 @@ export interface UserAdminGenOutput {
  * codegen on conflicting declarations.
  *
  * Each function is gated on its own `admin:users:*` scope, and works through
- * better-auth's internal adapter. Banning additionally needs the `ban()` plugin
+ * better-auth's internal adapter. Banning additionally needs the `pikkuBan()` plugin
  * from `@pikku/better-auth` for the columns it writes to exist.
  *
  * Emitted as two files. The schemas are zod, and the inspector reads a zod
@@ -34,7 +34,7 @@ import { z } from 'zod'
 
 /**
  * A user, as the directory sees one. Ban state is optional because those
- * columns belong to the \`ban()\` plugin: a host without it reports no ban state
+ * columns belong to the \`pikkuBan()\` plugin: a host without it reports no ban state
  * at all, which a client can render as "unknown" rather than as a misleading
  * "not banned".
  */
@@ -232,7 +232,7 @@ export const pikkuAdminSetUserBanned = pikkuFunc({
   tags: ['pikku'],
   title: 'Ban or Unban User',
   description:
-    'Bans a user — revoking their sessions and blocking sign-in — or lifts an existing ban. An expiry lets the ban lapse on its own; without one it holds until it is lifted. Requires better-auth wired with the \`ban()\` plugin.',
+    'Bans a user — revoking their sessions and blocking sign-in — or lifts an existing ban. An expiry lets the ban lapse on its own; without one it holds until it is lifted. Requires better-auth wired with the \`pikkuBan()\` plugin.',
   expose: true,
   scopes: ['admin:users:ban'],
   input: SetUserBannedInput,

--- a/packages/cli/src/functions/wirings/user-admin/user-admin-functions.test.ts
+++ b/packages/cli/src/functions/wirings/user-admin/user-admin-functions.test.ts
@@ -13,7 +13,7 @@ const ADMIN_DEFINITION = {
   sourceFile: '/app/src/auth.ts',
   basePath: '/api/auth',
   hasCredentials: true,
-  plugins: ['bearer', 'ban'],
+  plugins: ['bearer', 'pikkuBan'],
 }
 
 const writeDir = mkdtempSync(join(tmpdir(), 'pikku-user-admin-'))
@@ -135,9 +135,9 @@ describe('pikkuUserAdminFunctions', () => {
     assert.equal(result, false)
   })
 
-  // Ban is one capability of six, so a missing ban() warns and generates the
+  // Ban is one capability of six, so a missing pikkuBan() warns and generates the
   // rest rather than refusing — but it must say so, naming the file to fix.
-  test('warns, and still generates, when ban() is not wired', async () => {
+  test('warns, and still generates, when pikkuBan() is not wired', async () => {
     const warnings: string[] = []
     const svc = services({ ...ADMIN_DEFINITION, plugins: ['bearer'] }, [])
     svc.logger.warn = (message: string) => warnings.push(message)
@@ -147,14 +147,31 @@ describe('pikkuUserAdminFunctions', () => {
       true
     )
     assert.equal(warnings.length, 1)
-    assert.match(warnings[0]!, /without the ban\(\) plugin/)
+    assert.match(warnings[0]!, /without the pikkuBan\(\) plugin/)
     assert.match(warnings[0]!, /\/app\/src\/auth\.ts/)
-    assert.match(warnings[0]!, /import \{ ban \} from '@pikku\/better-auth'/)
+    assert.match(
+      warnings[0]!,
+      /import \{ pikkuBan \} from '@pikku\/better-auth'/
+    )
   })
 
-  test('says nothing when ban() is wired', async () => {
+  test('says nothing when pikkuBan() is wired', async () => {
     const warnings: string[] = []
     const svc = services(ADMIN_DEFINITION, [])
+    svc.logger.warn = (message: string) => warnings.push(message)
+
+    await (pikkuUserAdminFunctions as any).func(svc, undefined, {})
+    assert.deepEqual(warnings, [])
+  })
+
+  // pikkuBan() was `ban()` until the plugins took a pikku prefix, and the alias
+  // is still exported — so a project on the old name still reads as banning.
+  test('says nothing when the deprecated ban() alias is wired', async () => {
+    const warnings: string[] = []
+    const svc = services(
+      { ...ADMIN_DEFINITION, plugins: ['bearer', 'ban'] },
+      []
+    )
     svc.logger.warn = (message: string) => warnings.push(message)
 
     await (pikkuUserAdminFunctions as any).func(svc, undefined, {})

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -607,8 +607,8 @@ export type PikkuCLIInput = {
     /**
      * List, create, ban, delete, session-revocation and set-password functions
      * driving better-auth's internal adapter. Requires better-auth to be wired —
-     * codegen fails if it is not — and banning additionally requires the ban()
-     * plugin from @pikku/better-auth.
+     * codegen fails if it is not — and banning additionally requires the
+     * pikkuBan() plugin from @pikku/better-auth.
      */
     userAdmin?: PikkuScaffoldFeature
     /**

--- a/packages/inspector/src/add/add-auth.test.ts
+++ b/packages/inspector/src/add/add-auth.test.ts
@@ -217,7 +217,7 @@ describe('addAuth inspector', () => {
     }
   })
 
-  test('refuses better-auth admin() and points at ban()', async () => {
+  test('refuses better-auth admin() and points at pikkuBan()', async () => {
     const rootDir = await mkdtemp(join(tmpdir(), 'pikku-add-auth-admin-'))
     const file = join(rootDir, 'auth.ts')
 
@@ -241,7 +241,7 @@ describe('addAuth inspector', () => {
         () => inspect(makeLogger(criticals), [file], { rootDir }),
         (error: Error) => {
           assert.match(error.message, /admin\(\) plugin is not supported/)
-          assert.match(error.message, /ban\(\)/)
+          assert.match(error.message, /pikkuBan\(\)/)
           assert.match(error.message, /@pikku\/addon-admin/)
           return true
         }

--- a/packages/inspector/src/add/add-auth.ts
+++ b/packages/inspector/src/add/add-auth.ts
@@ -128,7 +128,7 @@ const readPluginBindings = (source: ts.SourceFile): PluginBindings => {
 
 /**
  * Read a `plugins: [...]` entry. better-auth plugins are factory calls —
- * `bearer()`, `twoFactor({ ... })`, `ban()`, or `plugins.bearer()` through a
+ * `bearer()`, `twoFactor({ ... })`, `pikkuBan()`, or `plugins.bearer()` through a
  * namespace import; non-call entries are ignored. `betterAuthExport` is the
  * name better-auth exports the plugin under, and is absent for a plugin that
  * came from somewhere else, which no policy here applies to.
@@ -194,10 +194,10 @@ const isInsideGlobalMiddlewareRegistration = (node: ts.Node): boolean => {
  * every one of its endpoints underneath. Pikku dropped that projection: user
  * management is `@pikku/addon-admin`'s scoped RPCs, and the one capability
  * `admin()` had that nothing else did — refusing a session to a banned user —
- * is `ban()`.
+ * is `pikkuBan()`.
  *
  * Thrown rather than warned because the failure it prevents is silent. An app
- * that drops `admin()` without wiring `ban()` keeps its ban columns and its ban
+ * that drops `admin()` without wiring `pikkuBan()` keeps its ban columns and its
  * UI, and simply stops enforcing bans.
  */
 const UNSUPPORTED_ADMIN_PLUGIN = (sourceFile: string): string =>
@@ -207,12 +207,12 @@ It authorizes against a 'user.role' column, while pikku authorizes on scopes —
 wiring both means one has to be projected onto the other, and the projection is
 coarser than the scopes it stands in for.
 
-Use ban() instead:
+Use pikkuBan() instead:
 
-  import { ban } from '@pikku/better-auth'
-  betterAuth({ plugins: [ban()] })
+  import { pikkuBan } from '@pikku/better-auth'
+  betterAuth({ plugins: [pikkuBan()] })
 
-ban() keeps the part of admin() that pikku cannot supply from outside
+pikkuBan() keeps the part of admin() that pikku cannot supply from outside
 better-auth — the banned/banReason/banExpires columns and the session hook that
 refuses a banned user a session. Everything else admin() offered is already
 scoped RPCs in @pikku/addon-admin: list, create, ban, remove, revoke sessions

--- a/packages/services/better-auth/src/actor-plugin.test.ts
+++ b/packages/services/better-auth/src/actor-plugin.test.ts
@@ -5,7 +5,7 @@ import { memoryAdapter } from 'better-auth/adapters/memory'
 
 import { deriveActorSecret } from '@pikku/core/services'
 
-import { actor } from './actor-plugin.js'
+import { pikkuActor } from './actor-plugin.js'
 import {
   ACTOR_SIGN_IN_OPT_IN_ENV,
   ACTOR_SIGN_IN_OPT_IN_VALUE,
@@ -42,7 +42,9 @@ const makeAuth = (
     secret: 'better-auth-test-secret',
     database: memoryAdapter(db),
     emailAndPassword: { enabled: true },
-    plugins: [actor({ secret, logger: options.logger ?? recordingLogger() })],
+    plugins: [
+      pikkuActor({ secret, logger: options.logger ?? recordingLogger() }),
+    ],
   })
 
 const clearGateEnv = () => {
@@ -279,14 +281,14 @@ describe('actor sign-in gate', () => {
 
   test('a secret configured on a shut gate is a warning, not a silent no-op', () => {
     const logger = recordingLogger()
-    actor({ secret: ROOT, logger })
+    pikkuActor({ secret: ROOT, logger })
     assert.match(
       logger.lines.warn.join('\n'),
       /secret is configured but sign-in stays disabled/
     )
 
     const quiet = recordingLogger()
-    actor({ secret: undefined, logger: quiet })
+    pikkuActor({ secret: undefined, logger: quiet })
     assert.deepEqual(
       quiet.lines.warn,
       [],
@@ -297,7 +299,7 @@ describe('actor sign-in gate', () => {
   test('announces itself when it is open', () => {
     process.env[DEV_ACTOR_SIGN_IN_ENV] = 'true'
     const logger = recordingLogger()
-    actor({ secret: ROOT, logger })
+    pikkuActor({ secret: ROOT, logger })
     assert.match(
       logger.lines.info.join('\n'),
       new RegExp(DEV_ACTOR_SIGN_IN_ENV)
@@ -306,7 +308,7 @@ describe('actor sign-in gate', () => {
 
   test('still declares the actor column while disabled', () => {
     const logger = recordingLogger()
-    const plugin = actor({ secret: undefined, logger })
+    const plugin = pikkuActor({ secret: undefined, logger })
     assert.equal((plugin.schema as any).user.fields.actor.type, 'boolean')
   })
 })

--- a/packages/services/better-auth/src/actor-plugin.ts
+++ b/packages/services/better-auth/src/actor-plugin.ts
@@ -44,7 +44,7 @@ export interface ActorPluginOptions {
  * it verifies against the email being signed in as, so it opens that one
  * synthetic account and no other.
  */
-export const actor = (options: ActorPluginOptions): BetterAuthPlugin => {
+export const pikkuActor = (options: ActorPluginOptions): BetterAuthPlugin => {
   const logger = options.logger ?? console
   const gate = resolveActorSignIn()
 
@@ -173,3 +173,10 @@ export const actor = (options: ActorPluginOptions): BetterAuthPlugin => {
     },
   }
 }
+
+/**
+ * @deprecated Renamed to {@link pikkuActor}. The bare name is indistinguishable
+ * from better-auth's own plugin factories at the `plugins: [...]` call site.
+ * Still exported, and still the same plugin — the `id` is unchanged.
+ */
+export const actor = pikkuActor

--- a/packages/services/better-auth/src/ban-plugin.test.ts
+++ b/packages/services/better-auth/src/ban-plugin.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
-import { ban } from './ban-plugin.js'
+import { pikkuBan } from './ban-plugin.js'
 
 const hook = (plugin: any) =>
   plugin.init().options.databaseHooks.session.create.before
@@ -24,7 +24,7 @@ const contextFor = (user: any) => {
 
 describe('ban plugin', () => {
   test('declares the three columns a ban lives in, and no role', () => {
-    const fields = (ban().schema as any).user.fields
+    const fields = (pikkuBan().schema as any).user.fields
     assert.deepEqual(Object.keys(fields).sort(), [
       'banExpires',
       'banReason',
@@ -35,19 +35,19 @@ describe('ban plugin', () => {
 
   test('lets an unbanned user through', async () => {
     const { ctx, updates } = contextFor({ id: 'u1', banned: false })
-    await hook(ban())({ userId: 'u1' }, ctx)
+    await hook(pikkuBan())({ userId: 'u1' }, ctx)
     assert.deepEqual(updates, [])
   })
 
   test('refuses a session for a banned user', async () => {
     const { ctx } = contextFor({ id: 'u1', banned: true })
-    await assert.rejects(hook(ban())({ userId: 'u1' }, ctx), /banned/i)
+    await assert.rejects(hook(pikkuBan())({ userId: 'u1' }, ctx), /banned/i)
   })
 
   test('the refusal carries the configured message', async () => {
     const { ctx } = contextFor({ id: 'u1', banned: true })
     await assert.rejects(
-      hook(ban({ message: 'Talk to support' }))({ userId: 'u1' }, ctx),
+      hook(pikkuBan({ message: 'Talk to support' }))({ userId: 'u1' }, ctx),
       /Talk to support/
     )
   })
@@ -60,7 +60,7 @@ describe('ban plugin', () => {
       banned: true,
       banExpires: new Date(Date.now() - 1000),
     })
-    await hook(ban())({ userId: 'u1' }, ctx)
+    await hook(pikkuBan())({ userId: 'u1' }, ctx)
     assert.deepEqual(updates, [
       ['u1', { banned: false, banReason: null, banExpires: null }],
     ])
@@ -72,13 +72,13 @@ describe('ban plugin', () => {
       banned: true,
       banExpires: new Date(Date.now() + 60_000),
     })
-    await assert.rejects(hook(ban())({ userId: 'u1' }, ctx), /banned/i)
+    await assert.rejects(hook(pikkuBan())({ userId: 'u1' }, ctx), /banned/i)
     assert.deepEqual(updates, [])
   })
 
   // Without a request context there is nothing to read the user through, and a
   // server-minted session is not a sign-in to refuse.
   test('is inert without a context', async () => {
-    assert.equal(await hook(ban())({ userId: 'u1' }, undefined), undefined)
+    assert.equal(await hook(pikkuBan())({ userId: 'u1' }, undefined), undefined)
   })
 })

--- a/packages/services/better-auth/src/ban-plugin.ts
+++ b/packages/services/better-auth/src/ban-plugin.ts
@@ -34,7 +34,7 @@ const DEFAULT_MESSAGE =
  */
 export const BAN_PLUGIN_ID = 'pikku-ban'
 
-export const ban = (options: BanPluginOptions = {}): BetterAuthPlugin => ({
+export const pikkuBan = (options: BanPluginOptions = {}): BetterAuthPlugin => ({
   id: BAN_PLUGIN_ID,
   schema: {
     user: {
@@ -89,3 +89,10 @@ export const ban = (options: BanPluginOptions = {}): BetterAuthPlugin => ({
     }
   },
 })
+
+/**
+ * @deprecated Renamed to {@link pikkuBan}. The bare name is indistinguishable
+ * from better-auth's own plugin factories at the `plugins: [...]` call site.
+ * Still exported, and still the same plugin — the `id` is unchanged.
+ */
+export const ban = pikkuBan

--- a/packages/services/better-auth/src/credential-oauth.plugin.test.ts
+++ b/packages/services/better-auth/src/credential-oauth.plugin.test.ts
@@ -3,7 +3,10 @@ import { describe, test } from 'node:test'
 import { betterAuth } from 'better-auth'
 import { memoryAdapter } from 'better-auth/adapters/memory'
 
-import { credentialOAuth, PLATFORM_USER_ID } from './credential-oauth.plugin.js'
+import {
+  pikkuCredentialOAuth,
+  PLATFORM_USER_ID,
+} from './credential-oauth.plugin.js'
 import type { CredentialOAuthProvider } from './credential-oauth-providers.js'
 
 const provider = (
@@ -38,7 +41,7 @@ const makeAuth = (
     secret: 'better-auth-test-secret',
     database: memoryAdapter(db),
     emailAndPassword: { enabled: true },
-    plugins: [credentialOAuth({ config, ...options } as any)],
+    plugins: [pikkuCredentialOAuth({ config, ...options } as any)],
   })
 
 const emptyDb = (): Record<string, any[]> => ({

--- a/packages/services/better-auth/src/credential-oauth.plugin.ts
+++ b/packages/services/better-auth/src/credential-oauth.plugin.ts
@@ -76,7 +76,7 @@ export interface CredentialOAuthSession {
  * token exchange and the `refreshAccessToken` that `getAccessToken` calls. Only
  * the two identity-bound endpoints are replaced.
  */
-export const credentialOAuth = (options: CredentialOAuthOptions) => {
+export const pikkuCredentialOAuth = (options: CredentialOAuthOptions) => {
   const base = genericOAuth({ config: options.config })
   const findConfig = (providerId: string) =>
     options.config.find((provider) => provider.providerId === providerId)
@@ -290,3 +290,11 @@ export const credentialOAuth = (options: CredentialOAuthOptions) => {
     endpoints: { linkCredential: link, credentialOAuthCallback: callback },
   }
 }
+
+/**
+ * @deprecated Renamed to {@link pikkuCredentialOAuth}. The bare name is
+ * indistinguishable from better-auth's own plugin factories at the
+ * `plugins: [...]` call site. Still exported, and still the same plugin — the
+ * `id` is unchanged.
+ */
+export const credentialOAuth = pikkuCredentialOAuth

--- a/packages/services/better-auth/src/delegated-auth-plugin.test.ts
+++ b/packages/services/better-auth/src/delegated-auth-plugin.test.ts
@@ -3,9 +3,9 @@ import { describe, test } from 'node:test'
 import { betterAuth } from 'better-auth'
 import { memoryAdapter } from 'better-auth/adapters/memory'
 
-import { fabric } from './fabric-plugin.js'
+import { pikkuFabric } from './fabric-plugin.js'
 import {
-  delegatedAuth,
+  pikkuDelegatedAuth,
   DELEGATED_PROVIDER_ID,
   type DelegatedAuthOptions,
   type UpstreamIdentity,
@@ -42,9 +42,9 @@ const makeAuth = (
     database: memoryAdapter(db),
     emailAndPassword: { enabled: true },
     plugins: [
-      // fabric() declares the `fabric` flag the plugin refuses to sign in.
-      fabric({ publicKey: undefined }),
-      delegatedAuth({
+      // pikkuFabric() declares the `fabric` flag the plugin refuses to sign in.
+      pikkuFabric({ publicKey: undefined }),
+      pikkuDelegatedAuth({
         scopeService,
         authenticate: async ({ email, password, apiKey }) => {
           if (apiKey === 'good-key') return identityFor()
@@ -75,7 +75,7 @@ const signInDelegated = (
     })
   )
 
-describe('better-auth delegatedAuth plugin', () => {
+describe('better-auth pikkuDelegatedAuth plugin', () => {
   test('JIT-provisions the user, links the delegated account, stores the credential, mints a session', async () => {
     const db: Record<string, any[]> = { user: [], session: [], account: [] }
     const { auth, stored, roles } = makeAuth(db)

--- a/packages/services/better-auth/src/delegated-auth-plugin.ts
+++ b/packages/services/better-auth/src/delegated-auth-plugin.ts
@@ -111,7 +111,7 @@ const grantRole = async (
  * stored; the name is refreshed on every sign-in, and the resolved role is
  * re-granted through the {@link DelegatedAuthOptions.scopeService}.
  */
-export const delegatedAuth = (
+export const pikkuDelegatedAuth = (
   options: DelegatedAuthOptions
 ): BetterAuthPlugin => ({
   id: 'delegated-auth',
@@ -254,3 +254,11 @@ export const delegatedAuth = (
     ),
   },
 })
+
+/**
+ * @deprecated Renamed to {@link pikkuDelegatedAuth}. The bare name is
+ * indistinguishable from better-auth's own plugin factories at the
+ * `plugins: [...]` call site. Still exported, and still the same plugin — the
+ * `id` is unchanged.
+ */
+export const delegatedAuth = pikkuDelegatedAuth

--- a/packages/services/better-auth/src/fabric-plugin.test.ts
+++ b/packages/services/better-auth/src/fabric-plugin.test.ts
@@ -6,7 +6,7 @@ import { memoryAdapter } from 'better-auth/adapters/memory'
 
 import { hasScopes } from '@pikku/core/scope'
 
-import { fabric } from './fabric-plugin.js'
+import { pikkuFabric } from './fabric-plugin.js'
 
 const { publicKey, privateKey } = generateKeyPairSync('rsa', {
   modulusLength: 2048,
@@ -71,7 +71,7 @@ const makeAuth = (
     secret: 'better-auth-test-secret',
     database: memoryAdapter(db),
     emailAndPassword: { enabled: true },
-    plugins: [fabric({ publicKey: key, scopeService, audience })],
+    plugins: [pikkuFabric({ publicKey: key, scopeService, audience })],
   })
 
 const signInFabric = (auth: ReturnType<typeof makeAuth>, token: string) =>

--- a/packages/services/better-auth/src/fabric-plugin.ts
+++ b/packages/services/better-auth/src/fabric-plugin.ts
@@ -256,7 +256,7 @@ const resolveActAs = async (
  * Requires a {@link FabricPluginOptions.scopeService} for the grant to land.
  * Filter `fabric: true` rows out of any end-user listing.
  */
-export const fabric = (options: FabricPluginOptions): BetterAuthPlugin => {
+export const pikkuFabric = (options: FabricPluginOptions): BetterAuthPlugin => {
   const requiredPurpose = options.purpose ?? 'fabric-admin'
   return {
     id: 'fabric',
@@ -394,3 +394,11 @@ export const fabric = (options: FabricPluginOptions): BetterAuthPlugin => {
     },
   }
 }
+
+/**
+ * @deprecated Renamed to {@link pikkuFabric}. The bare name is
+ * indistinguishable from better-auth's own plugin factories at the
+ * `plugins: [...]` call site. Still exported, and still the same plugin — the
+ * `id` is unchanged.
+ */
+export const fabric = pikkuFabric

--- a/packages/services/better-auth/src/index.ts
+++ b/packages/services/better-auth/src/index.ts
@@ -22,9 +22,9 @@ export {
   setAuthUserPassword,
 } from './admin-users.js'
 export type { AuthGetter } from './admin-users.js'
-export { ban, BAN_PLUGIN_ID } from './ban-plugin.js'
+export { pikkuBan, ban, BAN_PLUGIN_ID } from './ban-plugin.js'
 export type { BanPluginOptions } from './ban-plugin.js'
-export { actor } from './actor-plugin.js'
+export { pikkuActor, actor } from './actor-plugin.js'
 export type { ActorPluginOptions } from './actor-plugin.js'
 export {
   ACTOR_NOT_PROVISIONED_MESSAGE,
@@ -45,9 +45,10 @@ export type {
   ProvisionPersonasResult,
   ProvisionPersonasServices,
 } from './provision-personas.js'
-export { fabric } from './fabric-plugin.js'
+export { pikkuFabric, fabric } from './fabric-plugin.js'
 export type { FabricPluginOptions } from './fabric-plugin.js'
 export {
+  pikkuDelegatedAuth,
   delegatedAuth,
   DELEGATED_PROVIDER_ID,
 } from './delegated-auth-plugin.js'
@@ -77,7 +78,11 @@ export type {
   CredentialOAuthProvider,
   CredentialOAuthSecretReader,
 } from './credential-oauth-providers.js'
-export { credentialOAuth, PLATFORM_USER_ID } from './credential-oauth.plugin.js'
+export {
+  pikkuCredentialOAuth,
+  credentialOAuth,
+  PLATFORM_USER_ID,
+} from './credential-oauth.plugin.js'
 export type { CredentialOAuthOptions } from './credential-oauth.plugin.js'
 export { PROVIDER_REGISTRY } from './provider-registry.js'
 export type { AuthProvider, AuthProviderDef } from './provider-registry.js'

--- a/packages/services/better-auth/src/plugin-registry.ts
+++ b/packages/services/better-auth/src/plugin-registry.ts
@@ -13,20 +13,30 @@ export interface AuthPluginDef {
  * kebab-case plugin directory names. Plugins not listed here still appear in the
  * meta — the CLI derives a Title Case display name from the id (see
  * {@link pluginDisplayName}).
+ *
+ * Pikku's own plugins are keyed under both names: `pikkuBan` and friends are
+ * what a call site says today, and the bare `ban` is what the deprecated alias
+ * still reads as. The derived fallback would render the prefixed names as
+ * "Pikku Ban", which is the package talking rather than the capability.
  */
 export const PLUGIN_REGISTRY: Record<string, AuthPluginDef> = {
   actor: { displayName: 'Actor' },
+  pikkuActor: { displayName: 'Actor' },
   anonymous: { displayName: 'Anonymous' },
   apiKey: { displayName: 'API Key' },
   ban: { displayName: 'Ban' },
+  pikkuBan: { displayName: 'Ban' },
   bearer: { displayName: 'Bearer' },
   captcha: { displayName: 'Captcha' },
   credentialOAuth: { displayName: 'Credential OAuth' },
+  pikkuCredentialOAuth: { displayName: 'Credential OAuth' },
   customSession: { displayName: 'Custom Session' },
   delegatedAuth: { displayName: 'Delegated Auth' },
+  pikkuDelegatedAuth: { displayName: 'Delegated Auth' },
   deviceAuthorization: { displayName: 'Device Authorization' },
   emailOTP: { displayName: 'Email OTP' },
   fabric: { displayName: 'Fabric' },
+  pikkuFabric: { displayName: 'Fabric' },
   genericOAuth: { displayName: 'Generic OAuth' },
   haveIBeenPwned: { displayName: 'Have I Been Pwned' },
   jwt: { displayName: 'JWT' },

--- a/packages/services/better-auth/src/plugins.test.ts
+++ b/packages/services/better-auth/src/plugins.test.ts
@@ -10,15 +10,29 @@ import { PLUGIN_REGISTRY, pluginDisplayName } from './plugin-registry.js'
  * off the callee and what {@link PLUGIN_REGISTRY} is keyed by, so it is the
  * identity that has to line up across the barrel, the registry, and the
  * generated meta — not the plugin's internal `id`, which differs for two of
- * them (`ban` is `pikku-ban`, `delegatedAuth` is `delegated-auth`).
+ * them (`pikkuBan` is `pikku-ban`, `pikkuDelegatedAuth` is `delegated-auth`).
  */
 const PIKKU_PLUGINS = [
-  'actor',
-  'ban',
-  'credentialOAuth',
-  'delegatedAuth',
-  'fabric',
+  'pikkuActor',
+  'pikkuBan',
+  'pikkuCredentialOAuth',
+  'pikkuDelegatedAuth',
+  'pikkuFabric',
 ] as const
+
+/**
+ * The names these factories shipped under before they took a `pikku` prefix, to
+ * tell them apart from better-auth's own at the call site. They are still
+ * exported, still the same functions, and still registry-keyed — an app that
+ * has not renamed its imports must keep working and keep its display names.
+ */
+const DEPRECATED_ALIASES: Record<string, (typeof PIKKU_PLUGINS)[number]> = {
+  actor: 'pikkuActor',
+  ban: 'pikkuBan',
+  credentialOAuth: 'pikkuCredentialOAuth',
+  delegatedAuth: 'pikkuDelegatedAuth',
+  fabric: 'pikkuFabric',
+}
 
 describe('pikku better-auth plugins', () => {
   // A factory reachable only from its own module is a plugin no app can wire:
@@ -38,8 +52,22 @@ describe('pikku better-auth plugins', () => {
   // missing entry costs only a worse label. A *stale* one is the real problem:
   // it advertises a plugin as supported in generated meta and in the console's
   // SSO page.
+  for (const [alias, current] of Object.entries(DEPRECATED_ALIASES)) {
+    test(`the deprecated ${alias}() alias still resolves to ${current}()`, () => {
+      const exports = barrel as Record<string, unknown>
+      assert.equal(exports[alias], exports[current])
+    })
+  }
+
   test('every shipped plugin has a registry entry', () => {
     const missing = PIKKU_PLUGINS.filter((name) => !PLUGIN_REGISTRY[name])
+    assert.deepEqual(missing, [])
+  })
+
+  test('every deprecated alias has a registry entry too', () => {
+    const missing = Object.keys(DEPRECATED_ALIASES).filter(
+      (name) => !PLUGIN_REGISTRY[name]
+    )
     assert.deepEqual(missing, [])
   })
 

--- a/packages/skills/skills/pikku-better-auth/SKILL.md
+++ b/packages/skills/skills/pikku-better-auth/SKILL.md
@@ -237,12 +237,12 @@ Banning is the one capability with a schema requirement, and it has its own
 small plugin:
 
 ```typescript
-import { ban } from '@pikku/better-auth'
+import { pikkuBan } from '@pikku/better-auth'
 
-betterAuth({ plugins: [ban()] })
+betterAuth({ plugins: [pikkuBan()] })
 ```
 
-`ban()` adds `banned`, `banReason` and `banExpires` to `user` and refuses to
+`pikkuBan()` adds `banned`, `banReason` and `banExpires` to `user` and refuses to
 create a session for a banned user, lapsing an expired ban as it goes. It makes
 no authorization decision — who may ban is decided by `admin:users:ban` — so it
 never needs to know about scopes or roles.
@@ -252,22 +252,28 @@ never needs to know about scopes or roles.
 Five, all imported from the package root and passed to `betterAuth({ plugins })`
 like any other. None is automatic — an app wires the ones it needs.
 
-| Plugin              | Plugin `id`        | Adds                                                                    | Use it when                                                   |
-| ------------------- | ------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `ban()`             | `pikku-ban`        | `user.banned/banReason/banExpires`                                      | You ban users (the schema + enforcement half of the above)    |
-| `actor()`           | `actor`            | `POST /sign-in/actor`, `user.actor`                                     | Scenarios or a dev switcher sign in as a persona              |
-| `credentialOAuth()` | `credential-oauth` | `POST /credential-oauth/link`, `/credential-oauth/callback/:providerId` | An app links OAuth2 **API credentials** for a user            |
-| `delegatedAuth()`   | `delegated-auth`   | `POST /sign-in/delegated`                                               | An imported upstream API is the system of record for identity |
-| `fabric()`          | `fabric`           | `POST /sign-in/fabric`                                                  | A Fabric-deployed app lets a control-plane operator in        |
+| Plugin                   | Plugin `id`        | Adds                                                                    | Use it when                                                   |
+| ------------------------ | ------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `pikkuBan()`             | `pikku-ban`        | `user.banned/banReason/banExpires`                                      | You ban users (the schema + enforcement half of the above)    |
+| `pikkuActor()`           | `actor`            | `POST /sign-in/actor`, `user.actor`                                     | Scenarios or a dev switcher sign in as a persona              |
+| `pikkuCredentialOAuth()` | `credential-oauth` | `POST /credential-oauth/link`, `/credential-oauth/callback/:providerId` | An app links OAuth2 **API credentials** for a user            |
+| `pikkuDelegatedAuth()`   | `delegated-auth`   | `POST /sign-in/delegated`                                               | An imported upstream API is the system of record for identity |
+| `pikkuFabric()`          | `fabric`           | `POST /sign-in/fabric`                                                  | A Fabric-deployed app lets a control-plane operator in        |
+
+Every one carries a `pikku` prefix, because a `plugins: [...]` array mixes these
+with better-auth's own and a bare `actor()` next to `organization()` says
+nothing about where it came from. The unprefixed names — `ban`, `actor`,
+`credentialOAuth`, `delegatedAuth`, `fabric` — are still exported as deprecated
+aliases, so existing apps keep working.
 
 The plugin's `id` is what better-auth stores; the **export name** is what the
 inspector reads off your `plugins` array and what generated metadata is keyed
-by, so the two differ for `ban` and `delegatedAuth`.
+by, so the two differ for every one of them.
 
-#### `credentialOAuth()` — link API credentials, not identities
+#### `pikkuCredentialOAuth()` — link API credentials, not identities
 
 ```typescript
-credentialOAuth({
+pikkuCredentialOAuth({
   config: [
     {
       providerId: 'github',
@@ -308,10 +314,10 @@ by construction. Tokens land in better-auth's `account` table, so
 An undeclared `providerId` is a 404; an anonymous caller a 401; a refused
 singleton a 403 that leaves no platform user behind.
 
-#### `delegatedAuth()` — the upstream API is the identity provider
+#### `pikkuDelegatedAuth()` — the upstream API is the identity provider
 
 ```typescript
-delegatedAuth({
+pikkuDelegatedAuth({
   authenticate: async ({ email, password, apiKey }) => upstream.login(...),
   storeCredential: (userId, identity) =>
     credentialService.set('acme', identity.credential, userId),
@@ -338,10 +344,10 @@ a warning and the user still gets in.
 `storeCredential` failing, by contrast, **fails the sign-in**: every proxied
 call would be dead anyway.
 
-#### `fabric()` — control-plane operator sign-in
+#### `pikkuFabric()` — control-plane operator sign-in
 
 ```typescript
-fabric({ publicKey: FABRIC_AUTH_PUBLIC_KEY, scopeService, logger })
+pikkuFabric({ publicKey: FABRIC_AUTH_PUBLIC_KEY, scopeService, logger })
 ```
 
 `POST /sign-in/fabric` verifies a short-lived RS256 token that the Fabric
@@ -468,9 +474,9 @@ someone" means **a particular kind of user** rather than one fixed admin.
 Register it explicitly — it is not automatic:
 
 ```typescript
-import { actor } from '@pikku/better-auth'
+import { pikkuActor } from '@pikku/better-auth'
 
-plugins: [actor({ secret: SCENARIO_ACTOR_SECRET })]
+plugins: [pikkuActor({ secret: SCENARIO_ACTOR_SECRET })]
 ```
 
 `POST ${basePath}/sign-in/actor` `{ email, secret, name? }` → 200 + the normal
@@ -585,7 +591,7 @@ await provisionPersonas(singletonServices, {
 ```
 
 It writes the same `banned` column the console's ban RPC writes (so it needs the
-`ban()` plugin wired, and says so if it isn't), revokes the account's sessions,
+`pikkuBan()` plugin wired, and says so if it isn't), revokes the account's sessions,
 and leaves the row, its grants and its history intact — provisioning lifts the
 ban again by itself if the persona comes back. Deleting is deliberately not
 offered: an actor row is referenced by whatever those scenarios did while it

--- a/packages/skills/skills/pikku-fabric/SKILL.md
+++ b/packages/skills/skills/pikku-fabric/SKILL.md
@@ -129,8 +129,8 @@ a stage whose pages return 200 — the shell renders fine — while its first da
 read throws `no result` or a foreign-key violation on a row the seed was
 silently supplying.
 
-A Better Auth app has a second constraint: the plugins you enable (`ban()`,
-`actor()`, …) each declare columns, and `pikku db migrate` refuses to run while
+A Better Auth app has a second constraint: the plugins you enable (`pikkuBan()`,
+`pikkuActor()`, …) each declare columns, and `pikku db migrate` refuses to run while
 the applied schema is missing any of them. `pikku db generate` writes the
 migration that closes the gap.
 

--- a/verifiers/db-schema/run.mjs
+++ b/verifiers/db-schema/run.mjs
@@ -362,7 +362,7 @@ for (const column of [
 ]) {
   contains(authSql, column, 'plugin column on an existing table')
 }
-// `ban()` replaced better-auth's `admin()`, which is no longer wired anywhere.
+// `pikkuBan()` replaced better-auth's `admin()`, which is no longer wired anywhere.
 // These are the columns it used to add. `user.role` is checked inside the user
 // statement rather than across the file, because `organization()` legitimately
 // puts a `role` on `member`.

--- a/verifiers/db-schema/src/auth.wiring.ts
+++ b/verifiers/db-schema/src/auth.wiring.ts
@@ -1,6 +1,6 @@
 import { betterAuth } from 'better-auth'
 import { organization, twoFactor } from 'better-auth/plugins'
-import { ban } from '@pikku/better-auth'
+import { pikkuBan } from '@pikku/better-auth'
 import { pikkuBetterAuth } from '#pikku/auth'
 
 /**
@@ -8,7 +8,7 @@ import { pikkuBetterAuth } from '#pikku/auth'
  *
  * A four-table core is easy to hardcode and would pass a test that only ever
  * saw one. `organization()` adds three tables of its own, `twoFactor()` a
- * fourth, and `ban()` adds columns to `user` rather than tables of its own — so a
+ * fourth, and `pikkuBan()` adds columns to `user` rather than tables of its own — so a
  * generator that special-cases table creation but not column addition fails
  * here. The auth source has to be the schema Better Auth materializes.
  *
@@ -47,6 +47,6 @@ export const auth = pikkuBetterAuth(async ({ secrets, kysely, config }) => {
     },
     emailAndPassword: { enabled: true },
     advanced: { database: { generateId: 'uuid' } },
-    plugins: [organization(), ban(), twoFactor()],
+    plugins: [organization(), pikkuBan(), twoFactor()],
   })
 })


### PR DESCRIPTION
`plugins: [actor(...), ban(), fabric(...), organization()]` reads as four plugins from one package when only the last is better-auth's own. This renames the five factories `@pikku/better-auth` exports so the call site says which package a plugin came from:

| was | now |
|---|---|
| `actor` | `pikkuActor` |
| `ban` | `pikkuBan` |
| `fabric` | `pikkuFabric` |
| `delegatedAuth` | `pikkuDelegatedAuth` |
| `credentialOAuth` | `pikkuCredentialOAuth` |

### Not a breaking change

The bare names stay exported as `@deprecated` aliases bound to the same functions, so no import has to change.

No plugin `id` moved — `pikku-ban`, `actor`, `fabric`, `delegated-auth` and `credential-oauth` are all unchanged, so **no deployed database or session is affected**.

Everything that reads a plugin's *export* name rather than its id accepts both spellings:

- `PLUGIN_REGISTRY` is keyed under each, mapping to one display name (the derived fallback would render `pikkuBan` as "Pikku Ban", which is the package talking rather than the capability).
- The `pikku validate` ban and actor checks (`auth-plugin-checks.ts`, `persona-checks.ts`) count either spelling as wired.
- The `scaffold.userAdmin` ban check (`pikku-command-user-admin-functions.ts`) does the same.

Their diagnostic messages now point at the new names.

### Tests

- `@pikku/better-auth` — 204/204
- `@pikku/cli` — 1574/1574
- `@pikku/inspector` — 745/745

### Note on how this got here

This first landed on `main` as 8f2e59845 without review, which is the wrong way in for a rename across a public export surface. That commit is reverted on `main` (d08fe2212) and re-opened here unchanged; the revert is procedural, not a judgement on the change.

Changeset: `patch` for `@pikku/better-auth`, `@pikku/inspector`, `@pikku/addon-admin`, `@pikku/skills`, `@pikku/cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Pikku-prefixed Better Auth plugin exports, including `pikkuBan`, `pikkuActor`, `pikkuFabric`, `pikkuDelegatedAuth`, and `pikkuCredentialOAuth`.
  * Existing plugin names remain available as deprecated aliases for backward compatibility.
  * Plugin identifiers and existing database and session behavior remain unchanged.

* **Documentation**
  * Updated guides, examples, validation messages, and setup instructions to recommend the new names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->