### PR TITLE
feat(cli): give `pikku dev` a credential store

### DIFF
--- a/.changeset/dev-local-credential-service.md
+++ b/.changeset/dev-local-credential-service.md
@@ -1,0 +1,19 @@
+---
+'@pikku/cli': patch
+---
+
+Give `pikku dev` a credential store.
+
+Wiring a `credentialService` is the deployment's job — the values are per-user
+secrets, and where they are encrypted and who holds the key is a decision only
+the host can make. But that left `pikku dev` with none at all: `credentialService`
+was `undefined`, so an addon imported with `--auth per-user` or `--auth delegated`
+could not be exercised locally. The delegated sign-in a project is told to wire
+threw on its first call, and projects were reaching for their own credential
+tables to get past it.
+
+`pikku dev` now builds a `LocalCredentialService` alongside the rest of its
+in-memory services — the queue, the trigger service, the workflow service — and
+hands it to `createSingletonServices` as an existing service. A project that
+wants a real store overrides it there the same way it overrides any of the
+others: `existingServices.credentialService ?? new OwnCredentialService()`.

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -12,6 +12,7 @@ import { InMemoryQueueService, QueueWebhookService } from '@pikku/core/services'
 import {
   ConsoleLogger,
   LocalEmailService,
+  LocalCredentialService,
   spy,
   InMemoryAgentRunStateService,
 } from '@pikku/core/services'
@@ -342,6 +343,7 @@ export const dev = pikkuSessionlessFunc<
       workflowService,
       workflowRunService: workflowService,
       triggerService: new InMemoryTriggerService(),
+      credentialService: new LocalCredentialService(),
       agentStorage,
       agentRunState,
       agentRunService,


### PR DESCRIPTION
### The gap

Wiring a `credentialService` is the deployment's job — the values are per-user secrets, and where they are encrypted and who holds the key is a decision only the host can make.

But that left `pikku dev` with none at all. `@pikku/core`'s addon runner only *uses* `existingServices.credentialService` when one is present, and nothing in `@pikku/cli` ever constructs one, so under `pikku dev` it is simply `undefined`. An addon imported with `--auth per-user` or `--auth delegated` therefore cannot be exercised locally: the delegated sign-in the toolchain instructs a project to wire (`credentialService.set(...)`) throws on its first call. Projects were reaching for their own hand-rolled credential tables to get past it.

### The change

`pikku dev` now builds a `LocalCredentialService` alongside the rest of its in-memory services — the queue, the trigger service, the workflow service, the meta service — and passes it into `createSingletonServices` as an existing service.

That means a project that wants a real store overrides it exactly the way it overrides any of the others, in its own `services.ts`:

```ts
credentialService: existingServices.credentialService ?? new OwnCredentialService(...)
```

`LocalCredentialService` is the class core already shipped and nothing wired. In-memory is the honest shape for a dev run: credentials it stores are meant to die with it, and anything durable would need a key the CLI has no way to obtain.

### Scope

Two lines in `packages/cli/src/functions/commands/dev.ts` — an import and one entry in `inMemoryServices`. No change to `@pikku/core`; no new public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)