### PR TITLE
fix(skills): correct the `#pikku` subpaths the examples teach

### DIFF
--- a/.changeset/skill-import-specifiers.md
+++ b/.changeset/skill-import-specifiers.md
@@ -1,0 +1,23 @@
+---
+'@pikku/skills': patch
+---
+
+Fix the `#pikku` import specifiers the skills teach.
+
+Twenty-five examples across ten skills named a leaf that does not export the
+symbol — `pikkuAuth`/`pikkuPermission`/`addGlobalPermission` from `#pikku/function`
+(they are in `#pikku/auth`), `addHTTPMiddleware` from `#pikku/http` (`#pikku/middleware`),
+`pikkuServices`/`pikkuWireServices` from `#pikku/function` (`#pikku/setup`),
+`pikkuWorkflowFunc` from `#pikku/function` (`#pikku/workflow`), `pikkuScenario` and
+friends from `#pikku/scenario` and from `#pikku/workflow/pikku-workflow-types.gen.js`
+(`#pikku/scenarios`), and `defineSystemRole` from a bare `#pikku` (`#pikku/scopes`).
+
+`pikku-addon` also claimed an addon authors against `#pikku/addon/function` and
+`#pikku/addon/setup`. It does not: `pikku new addon` writes an `imports` map that
+points `#pikku/*` at the addon's own `.pikku/addon/` tree, so an addon uses the
+same subpaths an application does. The `addon` segment is the package's business,
+never part of a specifier.
+
+An agent following these wrote a file that took schema generation red —
+`Package import specifier "#pikku" is not defined in package .../packages/functions/package.json`
+— which is a failure the example, not the agent, was responsible for.

--- a/packages/skills/skills/pikku-addon/SKILL.md
+++ b/packages/skills/skills/pikku-addon/SKILL.md
@@ -146,7 +146,7 @@ second argument is always present — an addon never falls back to its own logge
 variables or secrets; the consuming app supplies them:
 
 ```typescript
-import { pikkuAddonServices } from '#pikku/addon/setup'
+import { pikkuAddonServices } from '#pikku/setup'
 
 export const createSingletonServices = pikkuAddonServices(
   async (config, { secrets, logger }) => {
@@ -167,7 +167,7 @@ config object.
 Define per-request services for an addon package (created fresh per HTTP request, queue job, etc.):
 
 ```typescript
-import { pikkuAddonWireServices } from '#pikku/addon/setup'
+import { pikkuAddonWireServices } from '#pikku/setup'
 
 export const createWireServices = pikkuAddonWireServices(
   async (singletonServices, wire) => {
@@ -195,7 +195,7 @@ This generates `package.json` (exports `.pikku/*` + `dist/`), `pikku.config.json
 
 ```typescript
 // src/services.ts
-import { pikkuAddonServices, pikkuAddonWireServices } from '#pikku/addon/setup'
+import { pikkuAddonServices, pikkuAddonWireServices } from '#pikku/setup'
 import { TodoStore } from './todo-store.service.js'
 
 export const createSingletonServices = pikkuAddonServices(async () => {
@@ -213,14 +213,15 @@ export const createWireServices = pikkuAddonWireServices(
 
 ### Functions
 
-An addon generates its whole tree under `#pikku/addon/*`, so it authors against
-`#pikku/addon/function`, `#pikku/addon/http` and so on. An application's leaves
-stay flat, which is what stops a linked addon resolving against its host.
+An addon's generated tree roots at `.pikku/addon/`, but its `imports` map points
+`#pikku/*` there, so it authors against the same subpaths an application does —
+`#pikku/function`, `#pikku/http`. The `addon` segment is the package's own
+business, never part of a specifier.
 
 ```typescript
 // src/functions/addTodo.function.ts
 import { z } from 'zod'
-import { pikkuSessionlessFunc } from '#pikku/addon/function'
+import { pikkuSessionlessFunc } from '#pikku/function'
 
 const AddTodoInput = z.object({ title: z.string() })
 const AddTodoOutput = z.object({ id: z.string(), title: z.string() })

--- a/packages/skills/skills/pikku-build-app/SKILL.md
+++ b/packages/skills/skills/pikku-build-app/SKILL.md
@@ -210,7 +210,7 @@ people the user named, and the roles they imply.
 
 ```typescript
 import { definePersonas } from '#pikku/scopes/pikku-personas.gen.js'
-import { defineSystemRole } from '#pikku'
+import { defineSystemRole } from '#pikku/scopes'
 
 defineSystemRole({
   owner: {
@@ -484,7 +484,7 @@ experiences it. Three ship in `packages/functions/test/scenarios/` — keep them
 green — and every milestone's gherkin block from §5 becomes one more.
 
 ```typescript
-import { pikkuScenario } from '#pikku/workflow/pikku-workflow-types.gen.js'
+import { pikkuScenario } from '#pikku/scenarios'
 
 export const tenantReportsAFaultScenario = pikkuScenario<void, { id: string }>({
   title: 'A tenant reports a fault and the owner sees it',

--- a/packages/skills/skills/pikku-build-quick/SKILL.md
+++ b/packages/skills/skills/pikku-build-quick/SKILL.md
@@ -85,7 +85,7 @@ named:
 
 ```typescript
 import { definePersonas } from '#pikku/scopes/pikku-personas.gen.js'
-import { defineSystemRole } from '#pikku'
+import { defineSystemRole } from '#pikku/scopes'
 
 defineSystemRole({
   owner: { displayName: 'Owner', description: 'Sees only their own rows', scopes: [] },
@@ -199,7 +199,7 @@ Not the full ladder — one journey, end to end, as a real persona, so the app h
 at least one thing that stays true.
 
 ```typescript
-import { pikkuScenario } from '#pikku/workflow/pikku-workflow-types.gen.js'
+import { pikkuScenario } from '#pikku/scenarios'
 
 export const ownerCreatesAndSeesItScenario = pikkuScenario<void, { id: string }>({
   title: 'An owner creates a thing and sees it',

--- a/packages/skills/skills/pikku-http/SKILL.md
+++ b/packages/skills/skills/pikku-http/SKILL.md
@@ -226,7 +226,7 @@ export const getBook = pikkuFunc({
 })
 
 // wirings/books.http.ts — same defineHTTPRoutes/wireHTTPRoutes shape as the Route Groups example above
-import { addHTTPMiddleware } from '#pikku/http'
+import { addHTTPMiddleware } from '#pikku/middleware'
 import { cors, authBearer } from '@pikku/core/middleware'
 
 addHTTPMiddleware('*', [cors(), authBearer()])

--- a/packages/skills/skills/pikku-middleware/SKILL.md
+++ b/packages/skills/skills/pikku-middleware/SKILL.md
@@ -23,7 +23,7 @@ installGroups: [core]
 ## The `pikkuMiddleware` Factory
 
 ```typescript
-import { pikkuMiddleware } from '#pikku/function'
+import { pikkuMiddleware } from '#pikku/middleware'
 
 // Simple: just a function
 const myMiddleware = pikkuMiddleware(async (services, wire, next) => {
@@ -139,7 +139,7 @@ Tags from the function definition and the wire object are merged — middleware 
 ### Registering Tag Middleware
 
 ```typescript
-import { addTagMiddleware } from '#pikku/function'
+import { addTagMiddleware } from '#pikku/middleware'
 
 addTagMiddleware('machine-agent', [machineAgentBearerAuth])
 ```
@@ -277,7 +277,7 @@ export const getToken = () => _token
 ```typescript
 // wirings/http.wiring.ts
 import { timingSafeEqual } from 'node:crypto'
-import { addTagMiddleware, pikkuMiddleware } from '#pikku/function'
+import { addTagMiddleware, pikkuMiddleware } from '#pikku/middleware'
 import { UnauthorizedError } from '#pikku/error'
 import { getToken } from '../lib/host-token.js'
 

--- a/packages/skills/skills/pikku-permissions/SKILL.md
+++ b/packages/skills/skills/pikku-permissions/SKILL.md
@@ -58,7 +58,7 @@ Use for checks that read the session but need no request data — and that asser
 something **beyond** merely having a session (a flag, a tier, a claim).
 
 ```typescript
-import { pikkuAuth } from '#pikku/function'
+import { pikkuAuth } from '#pikku/auth'
 
 // Good: a real gate on the session's contents, not just its existence.
 export const isVerified = pikkuAuth(
@@ -89,7 +89,7 @@ A permission answers "_may this user do this?_" (role, ownership, tier) — neve
 Use when authorization depends on the actual request data (e.g., resource ownership).
 
 ```typescript
-import { pikkuPermission } from '#pikku/function'
+import { pikkuPermission } from '#pikku/auth'
 
 export const isBookOwner = pikkuPermission(
   async ({ db }, { bookId }, { session }) => {
@@ -139,7 +139,7 @@ export const deleteBook = pikkuFunc({
 A global permission is an app-wide baseline that **every** function must additionally pass. It is an independent AND gate: it can only ever _narrow_ access — it never grants access a function's own `permissions` would deny.
 
 ```typescript
-import { addGlobalPermission } from '#pikku/function'
+import { addGlobalPermission } from '#pikku/auth'
 
 addGlobalPermission([isEmployee]) // every function now also requires an employee session
 ```
@@ -248,7 +248,7 @@ declared, inspectable, and reusable.
 
 ```typescript
 // src/permissions.ts
-import { pikkuAuth, pikkuPermission } from '#pikku/function'
+import { pikkuAuth, pikkuPermission } from '#pikku/auth'
 
 export const isVerified = pikkuAuth(
   async (_services, session) => !!session?.emailVerified

--- a/packages/skills/skills/pikku-scenario/SKILL.md
+++ b/packages/skills/skills/pikku-scenario/SKILL.md
@@ -46,7 +46,7 @@ Scenarios live in `srcDirectories` like any other function — by convention `*.
 `pikkuScenario` comes from the **generated** workflow types, not `@pikku/core`:
 
 ```typescript
-import { pikkuScenario } from '#pikku/scenario'
+import { pikkuScenario } from '#pikku/scenarios'
 
 export const orderSupportScenario = pikkuScenario<
   { value?: number },
@@ -175,7 +175,7 @@ Hooks are scenario-only. A `before`/`after` on a `pikkuWorkflowFunc` never runs 
 `pikkuFeature` groups scenarios the way gherkin's `Feature:` groups `Scenario:`. Scenarios are referenced by **imported identifier**, so a renamed or deleted scenario is a compile error rather than a silent skip:
 
 ```typescript
-import { pikkuFeature } from '#pikku/scenario'
+import { pikkuFeature } from '#pikku/scenarios'
 import {
   credentialLazyLoadScenario,
   credentialRoundTripScenario,
@@ -240,7 +240,7 @@ Utilities are **not steps**. They are plain exported functions, they take the br
 
 ```typescript
 // shop.browser.ts — shared actions. Not steps: nothing here is an intent.
-import type { PikkuBrowserWire } from '#pikku/scenario'
+import type { PikkuBrowserWire } from '#pikku/scenarios'
 import type {} from '@pikku/playwright'
 
 /** Arrive on the shop, from wherever the browser happens to be. */
@@ -462,7 +462,7 @@ Assertions with no possible browser witness are a different thing and should not
 `scenario.do` can only name an RPC. A **step** is a named, typed unit of scenario behaviour whose body is an ordinary pikku function — so it can call several RPCs as its actor, assert, or drive a browser.
 
 ```typescript
-import { pikkuScenarioStep } from '#pikku/scenario'
+import { pikkuScenarioStep } from '#pikku/scenarios'
 
 export const buysAnApple = pikkuScenarioStep<
   { qty: number },

--- a/packages/skills/skills/pikku-security/SKILL.md
+++ b/packages/skills/skills/pikku-security/SKILL.md
@@ -62,7 +62,7 @@ Apply these via `addHTTPMiddleware` in a wirings file:
 
 ```typescript
 import { authBearer, authCookie, authAPIKey } from '#pikku/middleware'
-import { addHTTPMiddleware } from '#pikku/http'
+import { addHTTPMiddleware } from '#pikku/middleware'
 
 // JWT bearer token — reads Authorization header
 addHTTPMiddleware('*', [authBearer()])
@@ -118,7 +118,7 @@ response.
 
 ```typescript
 // permissions.ts
-import { pikkuAuth, pikkuPermission } from '#pikku/function'
+import { pikkuAuth, pikkuPermission } from '#pikku/auth'
 
 export const isAuthenticated = pikkuAuth(
   async (_services, session) => !!session
@@ -129,7 +129,7 @@ export const isVerified = pikkuAuth(
 
 // wirings/auth.wiring.ts
 import { authCookie } from '#pikku/middleware'
-import { addHTTPMiddleware } from '#pikku/http'
+import { addHTTPMiddleware } from '#pikku/middleware'
 
 addHTTPMiddleware('*', [
   authCookie({

--- a/packages/skills/skills/pikku-services/SKILL.md
+++ b/packages/skills/skills/pikku-services/SKILL.md
@@ -38,7 +38,7 @@ pikku info tags --verbose        # Understand project organization
 ### `pikkuServices(factory)` — singleton services (created once at startup)
 
 ```typescript
-import { pikkuServices } from '#pikku/function'
+import { pikkuServices } from '#pikku/setup'
 import { ConsoleLogger } from '@pikku/core/services'
 import { JoseJWTService } from '@pikku/jose'
 
@@ -61,7 +61,7 @@ export const createSingletonServices = pikkuServices(
 ### `pikkuWireServices(factory)` — per-request services (fresh per HTTP request, queue job, CLI command, etc.)
 
 ```typescript
-import { pikkuWireServices } from '#pikku/function'
+import { pikkuWireServices } from '#pikku/setup'
 
 export const createWireServices = pikkuWireServices(
   async (singletonServices, wire) => {
@@ -240,7 +240,7 @@ const createSingletonServices = pikkuServices(async (config) => {
 
 ```typescript
 // services.ts
-import { pikkuServices, pikkuWireServices } from '#pikku/function'
+import { pikkuServices, pikkuWireServices } from '#pikku/setup'
 import { ConsoleLogger } from '@pikku/core/services'
 import { JoseJWTService } from '@pikku/jose'
 

--- a/packages/skills/skills/pikku-workflow/SKILL.md
+++ b/packages/skills/skills/pikku-workflow/SKILL.md
@@ -65,7 +65,7 @@ import {
 } from '#pikku/workflow/pikku-workflow-types.gen.js'
 
 // WRONG — the function leaf does not re-export them (TS2305)
-import { pikkuWorkflowFunc } from '#pikku/function'
+import { pikkuWorkflowFunc } from '#pikku/workflow'
 ```
 
 ## Defining a workflow


### PR DESCRIPTION
Found while debugging why a generated app's schema generation went red:

```
Could not convert Zod schema 'SignInWithBackboneInput': Package import specifier
"#pikku" is not defined in package .../packages/functions/package.json
imported from .../src/permissions/allow-anybody.permission.ts
```

The agent had followed a permissions example verbatim. The example was wrong.

### What was wrong

Twenty-five examples across ten skills imported a symbol from a leaf that does not export it:

| symbol | said | actually |
|---|---|---|
| `pikkuAuth`, `pikkuPermission`, `addGlobalPermission` | `#pikku/function` | `#pikku/auth` |
| `addHTTPMiddleware` | `#pikku/http` | `#pikku/middleware` |
| `pikkuMiddleware`, `addTagMiddleware` | `#pikku/function` | `#pikku/middleware` |
| `pikkuServices`, `pikkuWireServices` | `#pikku/function` | `#pikku/setup` |
| `pikkuWorkflowFunc` | `#pikku/function` | `#pikku/workflow` |
| `pikkuScenario`, `pikkuFeature`, `pikkuScenarioStep`, `PikkuBrowserWire` | `#pikku/scenario` (no such leaf) and `#pikku/workflow/pikku-workflow-types.gen.js` | `#pikku/scenarios` |
| `defineSystemRole` | bare `#pikku` | `#pikku/scopes` |

`pikku-addon` additionally claimed an addon "generates its whole tree under `#pikku/addon/*`, so it authors against `#pikku/addon/function`, `#pikku/addon/http`". It does not. `pikku new addon` writes an `imports` map pointing `#pikku/*` at the addon's own `.pikku/addon/` tree — the comment in `new-addon.ts` says so directly ("a consumer reaches it by the same subpath an application would") — and a real addon's source is 20 × `#pikku/function`, 1 × `#pikku/setup`, 1 × `#pikku/workflow`, with zero `#pikku/addon/*`.

### How it was verified

Every `#pikku/*` import in all 84 skill markdown files was checked against a symbol index built from a real generated tree (1802 symbols, 29 leaves), and each rewrite was applied only where every named symbol on the line agreed on a single leaf. After the change the checker reports zero unresolvable specifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)