### PR TITLE
feat(cli): build the addon that `new addon` generates

### DIFF
--- a/.changeset/addon-build-after-generate.md
+++ b/.changeset/addon-build-after-generate.md
@@ -1,0 +1,14 @@
+---
+'@pikku/cli': patch
+---
+
+`pikku new addon` now installs and builds the addon it generates.
+
+The generated package exports `./dist/...`, which is what an installed consumer
+resolves and what the app's own `pikku-bootstrap.gen.ts` imports. Until `build`
+had run, that path did not exist: the app failed at boot with PKU340 and an
+ERR_MODULE_NOT_FOUND on a dist file nobody had written, and every
+`ref('<addon>:…')` resolved to nothing. Nothing about the generated files showed
+the problem, so a generated addon looked complete and was dead at runtime.
+
+Pass `--no-build` to keep the previous write-only behaviour.

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -981,6 +981,11 @@ wireCLI({
                 'Convert snake_case property names to camelCase in generated Zod schemas',
               default: false,
             },
+            build: {
+              description:
+                'Install and build the generated addon (an unbuilt addon exports a dist/ that does not exist yet, so every ref() into it is dead at runtime)',
+              default: true,
+            },
           },
         }),
       },

--- a/packages/cli/src/functions/commands/new-addon.test.ts
+++ b/packages/cli/src/functions/commands/new-addon.test.ts
@@ -8,6 +8,7 @@ import { readFileSync } from 'node:fs'
 import ts from 'typescript'
 import {
   buildGeneratedAddon,
+  workspaceCovers,
   getAddonFiles,
   getTestFiles,
   resolveAddonDepProtocol,
@@ -359,7 +360,7 @@ describe('buildGeneratedAddon', () => {
     )
   })
 
-  test('installs in the addon itself when it is not a workspace member', async () => {
+  test('installs in the addon itself when the root declares no workspaces', async () => {
     const root = await makeTmp()
     await writeJson(join(root, 'package.json'), { name: 'app' })
     await writeFile(join(root, 'package-lock.json'), '', 'utf8')
@@ -374,6 +375,29 @@ describe('buildGeneratedAddon', () => {
       [
         ['npm', 'install', addonDir],
         ['npm', 'run build', addonDir],
+      ]
+    )
+  })
+
+  test("installs in the addon itself when the root's patterns exclude it", async () => {
+    const root = await makeTmp()
+    await writeJson(join(root, 'package.json'), {
+      name: 'root',
+      private: true,
+      workspaces: ['packages/*'],
+    })
+    await writeFile(join(root, 'yarn.lock'), '', 'utf8')
+    const addonDir = join(root, 'addons', 'addon-crm')
+    await mkdir(addonDir, { recursive: true })
+
+    const { calls, run } = recorder()
+    const { logger } = logs()
+    assert.equal(buildGeneratedAddon(addonDir, logger, run), true)
+    assert.deepEqual(
+      calls.map((c) => [c.command, c.args.join(' '), c.cwd]),
+      [
+        ['yarn', 'install', addonDir],
+        ['yarn', 'run build', addonDir],
       ]
     )
   })
@@ -421,5 +445,48 @@ describe('buildGeneratedAddon', () => {
     assert.equal(buildGeneratedAddon(addonDir, logger, run), false)
     assert.deepEqual(calls, [])
     assert.match(error.join('\n'), /Could not tell which package manager/)
+  })
+})
+
+describe('workspaceCovers', () => {
+  test('matches a single-segment pattern', async () => {
+    const root = await makeTmp()
+    await writeJson(join(root, 'package.json'), { workspaces: ['packages/*'] })
+    assert.equal(workspaceCovers(root, join(root, 'packages', 'crm')), true)
+    assert.equal(workspaceCovers(root, join(root, 'addons', 'crm')), false)
+    assert.equal(
+      workspaceCovers(root, join(root, 'packages', 'group', 'crm')),
+      false
+    )
+  })
+
+  test('matches a deep pattern at any depth', async () => {
+    const root = await makeTmp()
+    await writeJson(join(root, 'package.json'), { workspaces: ['packages/**'] })
+    assert.equal(workspaceCovers(root, join(root, 'packages', 'crm')), true)
+    assert.equal(
+      workspaceCovers(root, join(root, 'packages', 'group', 'crm')),
+      true
+    )
+    assert.equal(workspaceCovers(root, join(root, 'addons', 'crm')), false)
+  })
+
+  test('reads the object form, and covers nothing without workspaces', async () => {
+    const object = await makeTmp()
+    await writeJson(join(object, 'package.json'), {
+      workspaces: { packages: ['packages/*'] },
+    })
+    assert.equal(workspaceCovers(object, join(object, 'packages', 'crm')), true)
+
+    const plain = await makeTmp()
+    await writeJson(join(plain, 'package.json'), { name: 'app' })
+    assert.equal(workspaceCovers(plain, join(plain, 'packages', 'crm')), false)
+  })
+
+  test('covers neither the root itself nor a dir outside it', async () => {
+    const root = await makeTmp()
+    await writeJson(join(root, 'package.json'), { workspaces: ['packages/*'] })
+    assert.equal(workspaceCovers(root, root), false)
+    assert.equal(workspaceCovers(root, join(root, '..', 'elsewhere')), false)
   })
 })

--- a/packages/cli/src/functions/commands/new-addon.test.ts
+++ b/packages/cli/src/functions/commands/new-addon.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url'
 import { readFileSync } from 'node:fs'
 import ts from 'typescript'
 import {
+  buildGeneratedAddon,
   getAddonFiles,
   getTestFiles,
   resolveAddonDepProtocol,
@@ -308,5 +309,117 @@ describe('getAddonFiles', () => {
       /describe\("Bob's CRM API key"\)/,
       'the display name and the words around it are one literal'
     )
+  })
+})
+
+describe('buildGeneratedAddon', () => {
+  function recorder(statuses: Array<number | null> = []) {
+    const calls: Array<{ command: string; args: string[]; cwd: string }> = []
+    const run = (command: string, args: string[], cwd: string) => {
+      calls.push({ command, args, cwd })
+      return { status: statuses[calls.length - 1] ?? 0 }
+    }
+    return { calls, run }
+  }
+
+  function logs() {
+    const info: string[] = []
+    const error: string[] = []
+    return {
+      info,
+      error,
+      logger: {
+        info: (m: string) => info.push(m),
+        error: (m: string) => error.push(m),
+      },
+    }
+  }
+
+  test('installs at the workspace root, then builds in the addon', async () => {
+    const root = await makeTmp()
+    await writeJson(join(root, 'package.json'), {
+      name: 'root',
+      private: true,
+      workspaces: ['packages/*'],
+    })
+    await writeFile(join(root, 'yarn.lock'), '', 'utf8')
+    const addonDir = join(root, 'packages', 'addon-crm')
+    await mkdir(addonDir, { recursive: true })
+
+    const { calls, run } = recorder()
+    const { logger, error } = logs()
+    assert.equal(buildGeneratedAddon(addonDir, logger, run), true)
+    assert.deepEqual(error, [])
+    assert.deepEqual(
+      calls.map((c) => [c.command, c.args.join(' '), c.cwd]),
+      [
+        ['yarn', 'install', root],
+        ['yarn', 'run build', addonDir],
+      ]
+    )
+  })
+
+  test('installs in the addon itself when it is not a workspace member', async () => {
+    const root = await makeTmp()
+    await writeJson(join(root, 'package.json'), { name: 'app' })
+    await writeFile(join(root, 'package-lock.json'), '', 'utf8')
+    const addonDir = join(root, 'addons', 'addon-crm')
+    await mkdir(addonDir, { recursive: true })
+
+    const { calls, run } = recorder()
+    const { logger } = logs()
+    assert.equal(buildGeneratedAddon(addonDir, logger, run), true)
+    assert.deepEqual(
+      calls.map((c) => [c.command, c.args.join(' '), c.cwd]),
+      [
+        ['npm', 'install', addonDir],
+        ['npm', 'run build', addonDir],
+      ]
+    )
+  })
+
+  test('stops at a failed install and never runs the build', async () => {
+    const root = await makeTmp()
+    await writeJson(join(root, 'package.json'), {
+      name: 'root',
+      private: true,
+      workspaces: ['packages/*'],
+    })
+    await writeFile(join(root, 'yarn.lock'), '', 'utf8')
+    const addonDir = join(root, 'packages', 'addon-crm')
+    await mkdir(addonDir, { recursive: true })
+
+    const { calls, run } = recorder([1])
+    const { logger, error } = logs()
+    assert.equal(buildGeneratedAddon(addonDir, logger, run), false)
+    assert.equal(calls.length, 1)
+    assert.match(error.join('\n'), /yarn install failed/)
+  })
+
+  test('reports a failed build', async () => {
+    const root = await makeTmp()
+    await writeJson(join(root, 'package.json'), {
+      name: 'root',
+      private: true,
+      workspaces: ['packages/*'],
+    })
+    await writeFile(join(root, 'yarn.lock'), '', 'utf8')
+    const addonDir = join(root, 'packages', 'addon-crm')
+    await mkdir(addonDir, { recursive: true })
+
+    const { calls, run } = recorder([0, 1])
+    const { logger, error } = logs()
+    assert.equal(buildGeneratedAddon(addonDir, logger, run), false)
+    assert.equal(calls.length, 2)
+    assert.match(error.join('\n'), /yarn run build failed/)
+  })
+
+  test('runs nothing when no package manager owns the tree', async () => {
+    const addonDir = await makeTmp()
+    const { calls, run } = recorder()
+    const { logger, error } = logs()
+    assert.equal(buildGeneratedAddon(addonDir, logger, run), false)
+    assert.deepEqual(calls, [])
+    assert.match(error.join('\n'), /Could not tell which package manager/)
   })
 })

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -957,9 +957,25 @@ async function writeFiles(
  * generator finishes the job: install at the root that owns the lockfile, then
  * run the addon's own `build` script (whose `prebuild` is `pikku all`).
  */
-const buildGeneratedAddon = (
+export type AddonBuildRunner = (
+  command: string,
+  args: string[],
+  cwd: string
+) => { status: number | null; error?: Error }
+
+const spawnAddonBuildStep: AddonBuildRunner = (command, args, cwd) => {
+  const { status, error } = spawnSync(command, args, {
+    cwd,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  })
+  return { status, error }
+}
+
+export const buildGeneratedAddon = (
   addonDir: string,
-  logger: { info: (message: string) => void; error: (message: string) => void }
+  logger: { info: (message: string) => void; error: (message: string) => void },
+  run: AddonBuildRunner = spawnAddonBuildStep
 ): boolean => {
   const { dir: installDir, packageManager } = findInstallRoot(addonDir)
   if (packageManager === 'unknown') {
@@ -969,17 +985,20 @@ const buildGeneratedAddon = (
     return false
   }
 
+  // A root install only reaches the addon when the addon is a workspace member.
+  // Outside a workspace the root owns a lockfile but not this package, so its
+  // devDependencies — `@pikku/cli` and `typescript`, which the build script
+  // needs — would never be installed.
+  const installIn =
+    resolveAddonDepProtocol(addonDir) === 'workspace:*' ? installDir : addonDir
+
   const steps: Array<[string, string[]]> = [
-    [installDir, ['install']],
+    [installIn, ['install']],
     [addonDir, ['run', 'build']],
   ]
   for (const [cwd, args] of steps) {
     logger.info(`${packageManager} ${args.join(' ')} (${cwd})`)
-    const result = spawnSync(packageManager, args, {
-      cwd,
-      stdio: 'inherit',
-      shell: process.platform === 'win32',
-    })
+    const result = run(packageManager, args, cwd)
     if (result.status !== 0) {
       logger.error(
         `${packageManager} ${args.join(' ')} failed in ${cwd}: ${result.error?.message ?? `exit ${result.status}`}`

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'fs'
-import { dirname, join } from 'path'
+import { dirname, join, relative as relativePath, sep } from 'path'
 import { mkdir, writeFile } from 'fs/promises'
 import { spawnSync } from 'node:child_process'
 import { findInstallRoot } from './update.js'
@@ -947,6 +947,50 @@ async function writeFiles(
 }
 
 /**
+ * Does `root`'s `workspaces` field cover `dir`?
+ *
+ * Declaring workspaces is not enough — a root with `packages/*` does not own an
+ * addon written to `addons/crm`, and yarn, npm and pnpm all skip a nested
+ * package they were never told about.
+ */
+export function workspaceCovers(root: string, dir: string): boolean {
+  const relative = relativePath(root, dir).split(sep).join('/')
+  if (relative === '' || relative.startsWith('..')) {
+    return false
+  }
+
+  let patterns: unknown
+  try {
+    const manifest = JSON.parse(
+      readFileSync(join(root, 'package.json'), 'utf8')
+    )
+    patterns = Array.isArray(manifest.workspaces)
+      ? manifest.workspaces
+      : manifest.workspaces?.packages
+  } catch {
+    return false
+  }
+  if (!Array.isArray(patterns)) {
+    return false
+  }
+
+  return patterns.some((pattern) => {
+    if (typeof pattern !== 'string') {
+      return false
+    }
+    const source = pattern
+      .split('/')
+      .map((segment) =>
+        segment === '**'
+          ? '.*'
+          : segment.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*')
+      )
+      .join('/')
+    return new RegExp(`^${source}$`).test(relative)
+  })
+}
+
+/**
  * An addon that has not been built is dead at runtime.
  *
  * The generated package exports `./dist/...` — that is what an installed
@@ -985,12 +1029,13 @@ export const buildGeneratedAddon = (
     return false
   }
 
-  // A root install only reaches the addon when the addon is a workspace member.
-  // Outside a workspace the root owns a lockfile but not this package, so its
-  // devDependencies — `@pikku/cli` and `typescript`, which the build script
-  // needs — would never be installed.
-  const installIn =
-    resolveAddonDepProtocol(addonDir) === 'workspace:*' ? installDir : addonDir
+  // A root install only reaches the addon when the root's workspace patterns
+  // cover it. A root that owns the lockfile but not this package installs
+  // nothing for it, so its devDependencies — `@pikku/cli` and `typescript`,
+  // which the build script needs — would never arrive.
+  const installIn = workspaceCovers(installDir, addonDir)
+    ? installDir
+    : addonDir
 
   const steps: Array<[string, string[]]> = [
     [installIn, ['install']],

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync } from 'fs'
 import { dirname, join } from 'path'
 import { mkdir, writeFile } from 'fs/promises'
+import { spawnSync } from 'node:child_process'
+import { findInstallRoot } from './update.js'
 import {
   createEmptyManifest,
   saveManifest,
@@ -944,6 +946,50 @@ async function writeFiles(
   return written
 }
 
+/**
+ * An addon that has not been built is dead at runtime.
+ *
+ * The generated package exports `./dist/...` — that is what an installed
+ * consumer resolves, and what the app's own `pikku-bootstrap.gen.ts` imports.
+ * Until `build` has run, every `ref('<addon>:...')` resolves to nothing and the
+ * app fails at boot with PKU340 plus an ERR_MODULE_NOT_FOUND on a dist path
+ * nobody wrote. Nothing about the generated files shows the problem, so the
+ * generator finishes the job: install at the root that owns the lockfile, then
+ * run the addon's own `build` script (whose `prebuild` is `pikku all`).
+ */
+const buildGeneratedAddon = (
+  addonDir: string,
+  logger: { info: (message: string) => void; error: (message: string) => void }
+): boolean => {
+  const { dir: installDir, packageManager } = findInstallRoot(addonDir)
+  if (packageManager === 'unknown') {
+    logger.error(
+      `Could not tell which package manager owns ${addonDir} — the addon is generated but NOT built. Run install, then the addon's build script, in ${addonDir} before using it.`
+    )
+    return false
+  }
+
+  const steps: Array<[string, string[]]> = [
+    [installDir, ['install']],
+    [addonDir, ['run', 'build']],
+  ]
+  for (const [cwd, args] of steps) {
+    logger.info(`${packageManager} ${args.join(' ')} (${cwd})`)
+    const result = spawnSync(packageManager, args, {
+      cwd,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    })
+    if (result.status !== 0) {
+      logger.error(
+        `${packageManager} ${args.join(' ')} failed in ${cwd}: ${result.error?.message ?? `exit ${result.status}`}`
+      )
+      return false
+    }
+  }
+  return true
+}
+
 export const pikkuNewAddon = pikkuSessionlessFunc<
   {
     name: string
@@ -960,6 +1006,7 @@ export const pikkuNewAddon = pikkuSessionlessFunc<
     authConfig?: string
     mcp?: boolean
     camelCase?: boolean
+    build?: boolean
   },
   void
 >({
@@ -980,6 +1027,7 @@ export const pikkuNewAddon = pikkuSessionlessFunc<
       authConfig,
       mcp = false,
       camelCase = false,
+      build = true,
     }
   ) => {
     name = sanitizeAddonName(name)
@@ -1101,6 +1149,10 @@ export const pikkuNewAddon = pikkuSessionlessFunc<
     logger.info(`Created addon at ${addonDir}`)
     for (const f of written) {
       logger.debug({ message: `  ${f}`, type: 'success' })
+    }
+
+    if (build && !buildGeneratedAddon(addonDir, logger)) {
+      process.exit(1)
     }
 
     console.log(addonDir)


### PR DESCRIPTION
`pikku new addon` wrote the files and stopped. The generated package exports `./dist/...` — what an installed consumer resolves, and what the app's own `pikku-bootstrap.gen.ts` imports — so until `build` had run that path did not exist.

The app then failed at boot with:

```
[PKU340] Addon 'backbone' is wired with wireAddon but cannot be resolved
Cannot find module '@pikku/addon-backbone/dist/.pikku/addon/pikku-bootstrap.gen.js'
```

and every `ref('<addon>:…')` resolved to nothing. Nothing about the files on disk showed the problem: the addon looked complete and was dead at runtime. Found on a Fabric run that generated a 300-operation addon from an OpenAPI spec, deployed green, and had a scenario runner exit 1 before running a single scenario.

The generator now finishes the job — install at the root that owns the lockfile (`findInstallRoot`, reused from `update.ts`), then the addon's own `build` script, whose `prebuild` is `pikku all`. `--no-build` keeps the previous write-only behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated addons are now automatically installed and built, ensuring compiled exports are available when the app starts.
  * Added a `--no-build` option for write-only scaffolding.

* **Bug Fixes**
  * Prevented startup failures caused by missing generated addon files and unresolved addon references.
  * Improved error handling when installation or building fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->