### PR TITLE
fix(better-auth): drop the bare plugin-factory aliases

### DIFF
--- a/.changeset/drop-better-auth-plugin-aliases.md
+++ b/.changeset/drop-better-auth-plugin-aliases.md
@@ -1,0 +1,15 @@
+---
+'@pikku/better-auth': patch
+---
+
+Remove the bare aliases for the five better-auth plugin factories.
+
+`actor`, `ban`, `credentialOAuth`, `delegatedAuth` and `fabric` were kept beside
+`pikkuActor`, `pikkuBan`, `pikkuCredentialOAuth`, `pikkuDelegatedAuth` and
+`pikkuFabric` when the factories were renamed. Two exported names for one value
+is what the rename set out to end — a bare `fabric()` or `actor()` in a
+`plugins: [...]` list is indistinguishable from better-auth's own factories —
+and it left the repo failing its own duplicate-export check.
+
+Rename any remaining call: `actor(...)` becomes `pikkuActor(...)`, and so on.
+The plugins and their ids are unchanged.

--- a/packages/cli/src/functions/validate/auth-plugin-checks.ts
+++ b/packages/cli/src/functions/validate/auth-plugin-checks.ts
@@ -157,8 +157,9 @@ export const runAuthPluginChecks = async (
     if (!text) continue
     if (configuresPlugin(text, 'better-auth/plugins', 'admin'))
       adminFiles.push(file)
-    // `pikkuBan` is the current export; `ban` is the deprecated alias, which
-    // configures exactly the same plugin and so must satisfy the check too.
+    // `pikkuBan` is the export. `ban` was its alias until it was removed, and
+    // an app written against an older version still configures exactly the same
+    // plugin under that name, so it must satisfy the check too.
     if (
       configuresPlugin(text, '@pikku/better-auth', 'pikkuBan') ||
       configuresPlugin(text, '@pikku/better-auth', 'ban')

--- a/packages/cli/src/functions/validate/persona-checks.ts
+++ b/packages/cli/src/functions/validate/persona-checks.ts
@@ -110,7 +110,8 @@ const countPersonas = async (
  * scaffold wires, and a hand-rolled `/sign-in/actor` route is the one a project
  * that does not use better-auth ends up with. Both terminate at the same
  * endpoint, so either satisfies the check. The deprecated `actor()` alias is
- * matched too — it is the same plugin under its old name.
+ * matched too — an app on an older version wires the same plugin under that
+ * name, which was removed from the library.
  */
 const hasActorSignIn = async (sourceFiles: string[]): Promise<boolean> => {
   for (const file of sourceFiles) {

--- a/packages/services/better-auth/src/actor-plugin.ts
+++ b/packages/services/better-auth/src/actor-plugin.ts
@@ -173,10 +173,3 @@ export const pikkuActor = (options: ActorPluginOptions): BetterAuthPlugin => {
     },
   }
 }
-
-/**
- * @deprecated Renamed to {@link pikkuActor}. The bare name is indistinguishable
- * from better-auth's own plugin factories at the `plugins: [...]` call site.
- * Still exported, and still the same plugin — the `id` is unchanged.
- */
-export const actor = pikkuActor

--- a/packages/services/better-auth/src/ban-plugin.ts
+++ b/packages/services/better-auth/src/ban-plugin.ts
@@ -89,10 +89,3 @@ export const pikkuBan = (options: BanPluginOptions = {}): BetterAuthPlugin => ({
     }
   },
 })
-
-/**
- * @deprecated Renamed to {@link pikkuBan}. The bare name is indistinguishable
- * from better-auth's own plugin factories at the `plugins: [...]` call site.
- * Still exported, and still the same plugin — the `id` is unchanged.
- */
-export const ban = pikkuBan

--- a/packages/services/better-auth/src/credential-oauth.plugin.ts
+++ b/packages/services/better-auth/src/credential-oauth.plugin.ts
@@ -290,11 +290,3 @@ export const pikkuCredentialOAuth = (options: CredentialOAuthOptions) => {
     endpoints: { linkCredential: link, credentialOAuthCallback: callback },
   }
 }
-
-/**
- * @deprecated Renamed to {@link pikkuCredentialOAuth}. The bare name is
- * indistinguishable from better-auth's own plugin factories at the
- * `plugins: [...]` call site. Still exported, and still the same plugin — the
- * `id` is unchanged.
- */
-export const credentialOAuth = pikkuCredentialOAuth

--- a/packages/services/better-auth/src/delegated-auth-plugin.ts
+++ b/packages/services/better-auth/src/delegated-auth-plugin.ts
@@ -254,11 +254,3 @@ export const pikkuDelegatedAuth = (
     ),
   },
 })
-
-/**
- * @deprecated Renamed to {@link pikkuDelegatedAuth}. The bare name is
- * indistinguishable from better-auth's own plugin factories at the
- * `plugins: [...]` call site. Still exported, and still the same plugin — the
- * `id` is unchanged.
- */
-export const delegatedAuth = pikkuDelegatedAuth

--- a/packages/services/better-auth/src/fabric-plugin.ts
+++ b/packages/services/better-auth/src/fabric-plugin.ts
@@ -449,11 +449,3 @@ export const pikkuFabric = (options: FabricPluginOptions): BetterAuthPlugin => {
     },
   }
 }
-
-/**
- * @deprecated Renamed to {@link pikkuFabric}. The bare name is
- * indistinguishable from better-auth's own plugin factories at the
- * `plugins: [...]` call site. Still exported, and still the same plugin — the
- * `id` is unchanged.
- */
-export const fabric = pikkuFabric

--- a/packages/services/better-auth/src/index.ts
+++ b/packages/services/better-auth/src/index.ts
@@ -22,9 +22,9 @@ export {
   setAuthUserPassword,
 } from './admin-users.js'
 export type { AuthGetter } from './admin-users.js'
-export { pikkuBan, ban, BAN_PLUGIN_ID } from './ban-plugin.js'
+export { pikkuBan, BAN_PLUGIN_ID } from './ban-plugin.js'
 export type { BanPluginOptions } from './ban-plugin.js'
-export { pikkuActor, actor } from './actor-plugin.js'
+export { pikkuActor } from './actor-plugin.js'
 export type { ActorPluginOptions } from './actor-plugin.js'
 export {
   ACTOR_NOT_PROVISIONED_MESSAGE,
@@ -45,11 +45,10 @@ export type {
   ProvisionPersonasResult,
   ProvisionPersonasServices,
 } from './provision-personas.js'
-export { pikkuFabric, fabric } from './fabric-plugin.js'
+export { pikkuFabric } from './fabric-plugin.js'
 export type { FabricPluginOptions } from './fabric-plugin.js'
 export {
   pikkuDelegatedAuth,
-  delegatedAuth,
   DELEGATED_PROVIDER_ID,
 } from './delegated-auth-plugin.js'
 export type {
@@ -80,7 +79,6 @@ export type {
 } from './credential-oauth-providers.js'
 export {
   pikkuCredentialOAuth,
-  credentialOAuth,
   PLATFORM_USER_ID,
 } from './credential-oauth.plugin.js'
 export type { CredentialOAuthOptions } from './credential-oauth.plugin.js'


### PR DESCRIPTION
`main` currently fails its own `knip` duplicate-export rule, which reds `Lint & Format` on every open PR:

```
Duplicate exports (5)
pikkuActor|actor                      packages/services/better-auth/src/actor-plugin.ts
pikkuBan|ban                          packages/services/better-auth/src/ban-plugin.ts
pikkuCredentialOAuth|credentialOAuth  packages/services/better-auth/src/credential-oauth.plugin.ts
pikkuDelegatedAuth|delegatedAuth      packages/services/better-auth/src/delegated-auth-plugin.ts
pikkuFabric|fabric                    packages/services/better-auth/src/fabric-plugin.ts
```

#1523 renamed the five factories and kept the bare names as deprecated aliases. Two exported names for one value is the thing that rename set out to end — a bare `fabric()` or `actor()` in a `plugins: [...]` list is indistinguishable from better-auth's own factories — so this removes them rather than teaching knip to ignore them.

Every consumer in this repo already imports the prefixed names; the only remaining references were CHANGELOG history. The two CLI validators still *recognise* the old names, since they read app source that may predate the rename, and their comments now say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)