### PR TITLE
feat(cli): add `pikku dist`, and build generated addons with it

### DIFF
--- a/.changeset/pikku-dist.md
+++ b/.changeset/pikku-dist.md
@@ -1,0 +1,21 @@
+---
+'@pikku/cli': patch
+---
+
+Add `pikku dist`, and use it as the generated addon's build step.
+
+`tsc` compiles the `.ts` under the pikku out dir, but it never carries the
+`*.gen.json` meta written beside them, and it never re-emits a hand-authored
+`.d.ts`. Both are needed at runtime — `MetaService` opens the meta off disk by
+path — so a package that ships only tsc's output answers every meta lookup with
+nothing.
+
+Every generated addon papered over this with `tsc && cp -r .pikku types dist/`,
+which copied two whole directories: it dragged 52 raw `.ts` sources into the
+published output alongside the compiled ones, and needed a POSIX shell. Since
+the script comes from the CLI, every project carried the same line.
+
+`pikku dist` copies exactly what tsc could not emit, to where tsc would have put
+it, reading the layout from `pikku.config.json` and the destination from the
+tsconfig's `outDir` (or `--dist-dir`). The generated build script is now
+`tsc && pikku dist`.

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -12,6 +12,7 @@ import { pikkuCLICommand, wireCLI } from '../.pikku/cli/pikku-cli-types.gen.js'
 import { fabricCommands } from './fabric/fabric-commands.js'
 import { all } from './functions/commands/all.js'
 import { bootstrap } from './functions/commands/bootstrap.js'
+import { pikkuDist } from './functions/commands/dist.js'
 import { watch } from './functions/commands/watch.js'
 import { login, logout, whoami } from './functions/commands/login.js'
 import { dev } from './functions/commands/dev.js'
@@ -301,6 +302,18 @@ wireCLI({
     bootstrap: pikkuCLICommand({
       func: bootstrap,
       description: 'Generate only type files (setup phase only)',
+    }),
+    dist: pikkuCLICommand({
+      func: pikkuDist,
+      description:
+        "Copy the generated files tsc cannot emit — the .gen.json meta, and hand-authored .d.ts — into the build output. Run it after tsc, as a package's build script",
+      options: {
+        distDir: {
+          description:
+            "Where to copy to. Defaults to the tsconfig's compilerOptions.outDir",
+          type: 'string',
+        },
+      },
     }),
     audit: pikkuCLICommand({
       func: pikkuAudit,

--- a/packages/cli/src/functions/commands/dist.test.ts
+++ b/packages/cli/src/functions/commands/dist.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert'
-import { join } from 'node:path'
+import { join, relative } from 'node:path'
 import { describe, test } from 'node:test'
 import { planDistCopies } from './dist.js'
 
@@ -7,59 +7,57 @@ describe('planDistCopies', () => {
   const root = join('/repo', 'addon')
   const dist = join(root, 'dist')
 
+  const plan = (...files: string[]) =>
+    planDistCopies(root, dist, files).map(({ from, to }) => [
+      relative(root, from),
+      relative(root, to),
+    ])
+
   test('carries the generated json and leaves the compiled sources behind', () => {
-    const copies = planDistCopies(root, dist, {
-      pikku: [
+    assert.deepEqual(
+      plan(
         join(root, '.pikku', 'function', 'pikku-functions-meta.gen.json'),
         join(root, '.pikku', 'function', 'index.ts'),
-        join(root, '.pikku', 'pikku-bootstrap.gen.ts'),
-      ],
-      src: [],
-    })
-
-    assert.deepEqual(copies, [
-      {
-        from: join(root, '.pikku', 'function', 'pikku-functions-meta.gen.json'),
-        to: join(dist, '.pikku', 'function', 'pikku-functions-meta.gen.json'),
-      },
-    ])
+        join(root, '.pikku', 'pikku-bootstrap.gen.ts')
+      ),
+      [
+        [
+          join('.pikku', 'function', 'pikku-functions-meta.gen.json'),
+          join(
+            '',
+            'dist',
+            '.pikku',
+            'function',
+            'pikku-functions-meta.gen.json'
+          ),
+        ],
+      ]
+    )
   })
 
-  test('carries a hand-authored declaration but not a source tsc compiles', () => {
-    const copies = planDistCopies(root, dist, {
-      pikku: [],
-      src: [
+  test('carries a declaration file, wherever it sits', () => {
+    assert.deepEqual(
+      plan(
+        join(root, '.pikku', 'agent', 'pikku-agent-map.gen.d.ts'),
         join(root, 'types', 'application-types.d.ts'),
-        join(root, 'src', 'hello.function.ts'),
-      ],
-    })
-
-    assert.deepEqual(copies, [
-      {
-        from: join(root, 'types', 'application-types.d.ts'),
-        to: join(dist, 'types', 'application-types.d.ts'),
-      },
-    ])
-  })
-
-  test('mirrors the tree under the out dir', () => {
-    const copies = planDistCopies(root, dist, {
-      pikku: [join(root, '.pikku', 'scopes', 'pikku-roles-meta.gen.json')],
-      src: [],
-    })
-
-    assert.equal(
-      copies[0]!.to,
-      join(dist, '.pikku', 'scopes', 'pikku-roles-meta.gen.json')
+        join(root, 'src', 'hello.function.ts')
+      ),
+      [
+        [
+          join('.pikku', 'agent', 'pikku-agent-map.gen.d.ts'),
+          join('dist', '.pikku', 'agent', 'pikku-agent-map.gen.d.ts'),
+        ],
+        [
+          join('types', 'application-types.d.ts'),
+          join('dist', 'types', 'application-types.d.ts'),
+        ],
+      ]
     )
   })
 
   test('copies nothing when tsc already emitted everything', () => {
     assert.deepEqual(
-      planDistCopies(root, dist, {
-        pikku: [join(root, '.pikku', 'index.ts')],
-        src: [join(root, 'src', 'a.ts')],
-      }),
+      plan(join(root, '.pikku', 'index.ts'), join(root, 'src', 'a.ts')),
       []
     )
   })

--- a/packages/cli/src/functions/commands/dist.test.ts
+++ b/packages/cli/src/functions/commands/dist.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert'
+import { join } from 'node:path'
+import { describe, test } from 'node:test'
+import { planDistCopies } from './dist.js'
+
+describe('planDistCopies', () => {
+  const root = join('/repo', 'addon')
+  const dist = join(root, 'dist')
+
+  test('carries the generated json and leaves the compiled sources behind', () => {
+    const copies = planDistCopies(root, dist, {
+      pikku: [
+        join(root, '.pikku', 'function', 'pikku-functions-meta.gen.json'),
+        join(root, '.pikku', 'function', 'index.ts'),
+        join(root, '.pikku', 'pikku-bootstrap.gen.ts'),
+      ],
+      src: [],
+    })
+
+    assert.deepEqual(copies, [
+      {
+        from: join(root, '.pikku', 'function', 'pikku-functions-meta.gen.json'),
+        to: join(dist, '.pikku', 'function', 'pikku-functions-meta.gen.json'),
+      },
+    ])
+  })
+
+  test('carries a hand-authored declaration but not a source tsc compiles', () => {
+    const copies = planDistCopies(root, dist, {
+      pikku: [],
+      src: [
+        join(root, 'types', 'application-types.d.ts'),
+        join(root, 'src', 'hello.function.ts'),
+      ],
+    })
+
+    assert.deepEqual(copies, [
+      {
+        from: join(root, 'types', 'application-types.d.ts'),
+        to: join(dist, 'types', 'application-types.d.ts'),
+      },
+    ])
+  })
+
+  test('mirrors the tree under the out dir', () => {
+    const copies = planDistCopies(root, dist, {
+      pikku: [join(root, '.pikku', 'scopes', 'pikku-roles-meta.gen.json')],
+      src: [],
+    })
+
+    assert.equal(
+      copies[0]!.to,
+      join(dist, '.pikku', 'scopes', 'pikku-roles-meta.gen.json')
+    )
+  })
+
+  test('copies nothing when tsc already emitted everything', () => {
+    assert.deepEqual(
+      planDistCopies(root, dist, {
+        pikku: [join(root, '.pikku', 'index.ts')],
+        src: [join(root, 'src', 'a.ts')],
+      }),
+      []
+    )
+  })
+})

--- a/packages/cli/src/functions/commands/dist.ts
+++ b/packages/cli/src/functions/commands/dist.ts
@@ -1,0 +1,98 @@
+import { existsSync } from 'node:fs'
+import { cp, mkdir, readdir } from 'node:fs/promises'
+import { dirname, join, relative, resolve } from 'node:path'
+import ts from 'typescript'
+import { pikkuSessionlessFunc } from '#pikku/function'
+
+/**
+ * Carry into the build output the files `tsc` compiles around but never emits.
+ *
+ * `tsc` turns the generated `.ts` under the pikku out dir into JavaScript, so
+ * that half arrives on its own. Two kinds of file do not:
+ *
+ *  - the `*.gen.json` meta pikku writes beside them. `resolveJsonModule` lets
+ *    TypeScript *read* a json, it never copies one to `outDir`, and the meta is
+ *    read off disk at runtime — `MetaService` opens it by path — so a package
+ *    that ships only tsc's output answers every meta lookup with nothing.
+ *  - a hand-authored `.d.ts` such as `types/application-types.d.ts`. A
+ *    declaration file is an input, and `declaration: true` does not re-emit it.
+ *
+ * Packages used to do this with `cp -r .pikku types dist/`, which also dumped
+ * every `.ts` source into the published output and needed a POSIX shell.
+ */
+export type DistCopy = { from: string; to: string }
+
+const walk = async (dir: string): Promise<string[]> => {
+  if (!existsSync(dir)) {
+    return []
+  }
+  const entries = await readdir(dir, { withFileTypes: true })
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(dir, entry.name)
+      return entry.isDirectory() ? walk(path) : [path]
+    })
+  )
+  return files.flat()
+}
+
+export const planDistCopies = (
+  rootDir: string,
+  distDir: string,
+  files: { pikku: string[]; src: string[] }
+): DistCopy[] => {
+  const carried = [
+    // Everything tsc did not compile: the generated json, and any other asset
+    // sitting in the out dir.
+    ...files.pikku.filter((file) => !file.endsWith('.ts')),
+    // A declaration file is an input to tsc, never an output of it.
+    ...files.src.filter((file) => file.endsWith('.d.ts')),
+  ]
+  return carried.map((from) => ({
+    from,
+    to: join(distDir, relative(rootDir, from)),
+  }))
+}
+
+const readTsOutDir = (tsconfig: string): string | undefined => {
+  const parsed = ts.getParsedCommandLineOfConfigFile(tsconfig, {}, {
+    ...ts.sys,
+    onUnRecoverableConfigFileDiagnostic: () => {},
+  } as ts.ParseConfigFileHost)
+  return parsed?.options.outDir
+}
+
+export const pikkuDist = pikkuSessionlessFunc<{ distDir?: string }, void>({
+  func: async ({ logger, config }, data) => {
+    const { rootDir, outDir, srcDirectories, tsconfig } = config as any
+
+    const distDir = data.distDir
+      ? resolve(rootDir, data.distDir)
+      : readTsOutDir(resolve(rootDir, tsconfig))
+
+    if (!distDir) {
+      logger.error(
+        `${tsconfig} sets no compilerOptions.outDir, so there is nowhere to copy to. Set one, or pass --dist-dir.`
+      )
+      process.exit(1)
+    }
+
+    const copies = planDistCopies(rootDir, distDir, {
+      pikku: await walk(outDir),
+      src: (
+        await Promise.all(
+          srcDirectories.map((dir: string) => walk(resolve(rootDir, dir)))
+        )
+      ).flat(),
+    })
+
+    for (const { from, to } of copies) {
+      await mkdir(dirname(to), { recursive: true })
+      await cp(from, to)
+    }
+
+    logger.info(
+      `Copied ${copies.length} generated file(s) into ${relative(rootDir, distDir) || distDir}`
+    )
+  },
+})

--- a/packages/cli/src/functions/commands/dist.ts
+++ b/packages/cli/src/functions/commands/dist.ts
@@ -22,6 +22,14 @@ import { pikkuSessionlessFunc } from '#pikku/function'
  */
 export type DistCopy = { from: string; to: string }
 
+/**
+ * `tsc` compiles a `.ts` and emits it. Everything else it either reads without
+ * emitting — a `.d.ts` is an input, `declaration: true` does not re-emit one —
+ * or ignores entirely, like the generated json.
+ */
+const tscEmitsIt = (file: string) =>
+  file.endsWith('.ts') && !file.endsWith('.d.ts')
+
 const walk = async (dir: string): Promise<string[]> => {
   if (!existsSync(dir)) {
     return []
@@ -39,19 +47,14 @@ const walk = async (dir: string): Promise<string[]> => {
 export const planDistCopies = (
   rootDir: string,
   distDir: string,
-  files: { pikku: string[]; src: string[] }
+  files: string[]
 ): DistCopy[] => {
-  const carried = [
-    // Everything tsc did not compile: the generated json, and any other asset
-    // sitting in the out dir.
-    ...files.pikku.filter((file) => !file.endsWith('.ts')),
-    // A declaration file is an input to tsc, never an output of it.
-    ...files.src.filter((file) => file.endsWith('.d.ts')),
-  ]
-  return carried.map((from) => ({
-    from,
-    to: join(distDir, relative(rootDir, from)),
-  }))
+  return files
+    .filter((file) => !tscEmitsIt(file))
+    .map((from) => ({
+      from,
+      to: join(distDir, relative(rootDir, from)),
+    }))
 }
 
 const readTsOutDir = (tsconfig: string): string | undefined => {
@@ -77,14 +80,14 @@ export const pikkuDist = pikkuSessionlessFunc<{ distDir?: string }, void>({
       process.exit(1)
     }
 
-    const copies = planDistCopies(rootDir, distDir, {
-      pikku: await walk(outDir),
-      src: (
+    const copies = planDistCopies(rootDir, distDir, [
+      ...(await walk(outDir)),
+      ...(
         await Promise.all(
           srcDirectories.map((dir: string) => walk(resolve(rootDir, dir)))
         )
       ).flat(),
-    })
+    ])
 
     for (const { from, to } of copies) {
       await mkdir(dirname(to), { recursive: true })

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -209,7 +209,7 @@ export function getAddonFiles(
       scripts: {
         prepublishOnly: 'yarn build',
         prebuild: 'pikku all',
-        build: 'tsc && cp -r .pikku types dist/',
+        build: 'tsc && pikku dist',
         pikku: 'pikku all',
       },
       peerDependencies: {

--- a/templates/function-addon/package.json
+++ b/templates/function-addon/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "prebuild": "pikku all",
-    "build": "tsc && cp -r .pikku types dist/",
+    "build": "tsc && pikku dist",
     "pikku": "pikku all"
   },
   "peerDependencies": {


### PR DESCRIPTION
`tsc` compiles the `.ts` under the pikku out dir, but it never carries the `*.gen.json` meta written beside them, and it never re-emits a hand-authored `.d.ts`. Both are read at runtime — `MetaService` opens the meta off disk by path — so a package that ships only tsc's output answers every meta lookup with nothing.

Generated addons papered over this with `tsc && cp -r .pikku types dist/`. Against `templates/function-addon` that copies the 28 files it needs and also drags **52 raw `.ts` sources** into the published output, and it needs a POSIX shell. The line is written by the CLI, so every project carries it.

`pikku dist` copies exactly what tsc could not emit, to where tsc would have put it — layout from `pikku.config.json`, destination from the tsconfig's `outDir` (or `--dist-dir`). Verified against `templates/function-addon`: 28 copies, every one landing on a path the old `cp -r` already produced, and none of the 52 `.ts`.

The generated build script becomes `tsc && pikku dist`; `templates/function-addon` moves with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)