### PR TITLE
fix(better-auth): drop the tests that asserted the deleted aliases

### DIFF
--- a/packages/services/better-auth/src/plugins.test.ts
+++ b/packages/services/better-auth/src/plugins.test.ts
@@ -21,18 +21,18 @@ const PIKKU_PLUGINS = [
 ] as const
 
 /**
- * The names these factories shipped under before they took a `pikku` prefix, to
- * tell them apart from better-auth's own at the call site. They are still
- * exported, still the same functions, and still registry-keyed — an app that
- * has not renamed its imports must keep working and keep its display names.
+ * The names these factories shipped under before they took a `pikku` prefix.
+ * The exports are gone, but the registry still has to answer for them: the
+ * inspector reads the name off the call site, and an app pinned to an older
+ * @pikku/better-auth still writes the bare spelling.
  */
-const DEPRECATED_ALIASES: Record<string, (typeof PIKKU_PLUGINS)[number]> = {
-  actor: 'pikkuActor',
-  ban: 'pikkuBan',
-  credentialOAuth: 'pikkuCredentialOAuth',
-  delegatedAuth: 'pikkuDelegatedAuth',
-  fabric: 'pikkuFabric',
-}
+const FORMER_NAMES = [
+  'actor',
+  'ban',
+  'credentialOAuth',
+  'delegatedAuth',
+  'fabric',
+] as const
 
 describe('pikku better-auth plugins', () => {
   // A factory reachable only from its own module is a plugin no app can wire:
@@ -48,14 +48,9 @@ describe('pikku better-auth plugins', () => {
     })
   }
 
-  // Absent keys still render — `pluginDisplayName` Title-Cases the id — so a
-  // missing entry costs only a worse label. A *stale* one is the real problem:
-  // it advertises a plugin as supported in generated meta and in the console's
-  // SSO page.
-  for (const [alias, current] of Object.entries(DEPRECATED_ALIASES)) {
-    test(`the deprecated ${alias}() alias still resolves to ${current}()`, () => {
-      const exports = barrel as Record<string, unknown>
-      assert.equal(exports[alias], exports[current])
+  for (const name of FORMER_NAMES) {
+    test(`${name}() is no longer exported`, () => {
+      assert.equal((barrel as Record<string, unknown>)[name], undefined)
     })
   }
 
@@ -64,10 +59,11 @@ describe('pikku better-auth plugins', () => {
     assert.deepEqual(missing, [])
   })
 
-  test('every deprecated alias has a registry entry too', () => {
-    const missing = Object.keys(DEPRECATED_ALIASES).filter(
-      (name) => !PLUGIN_REGISTRY[name]
-    )
+  // Absent keys still render — `pluginDisplayName` Title-Cases the id — so a
+  // missing entry costs only a worse label. But source written against an
+  // older release still says `ban()`, and that should keep its display name.
+  test('every former name has a registry entry too', () => {
+    const missing = FORMER_NAMES.filter((name) => !PLUGIN_REGISTRY[name])
     assert.deepEqual(missing, [])
   })
 


### PR DESCRIPTION
#1528 removed the five bare plugin-factory aliases but left `plugins.test.ts` asserting that each still resolves to its prefixed factory. Main is red on those five.

They now assert the opposite — the bare names are gone from the barrel. `PLUGIN_REGISTRY` keeps their keys on purpose: the inspector reads the plugin name off the call site, and an app pinned to an older `@pikku/better-auth` still writes `ban()`, which should keep its display name.

My miss on #1528 — sorry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)