### PR TITLE
chore(core): regenerate api-report after the persona change

### DIFF
--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,8 +5,8 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2872 observable things**: 912 exported names, plus
-1960 members on the classes and interfaces among them, reachable
+**2871 observable things**: 912 exported names, plus
+1959 members on the classes and interfaces among them, reachable
 through 53 entry points.
 
 An entry point whose exports are mostly *exclusive* is a self-contained
@@ -22,7 +22,7 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | `./channel` | 32 | 32 | 84 |
 | `./types` | 23 | 20 | 73 |
 | `./queue` | 22 | 22 | 71 |
-| `./persona` | 45 | 39 | 49 |
+| `./persona` | 45 | 39 | 48 |
 | `./http` | 25 | 25 | 49 |
 | `./errors` | 49 | 49 | 20 |
 | `./services/local-meta` | 22 | 2 | 38 |


### PR DESCRIPTION
Main is red on `Unit Tests` → `the API report matches the code` → `regenerating produces no diff`:

```
committed:   **2872 observable things**: 912 exported names, plus
regenerated: **2871 observable things**: 912 exported names, plus
```

#1531 removed a member from a `./persona` type and the report was not regenerated. Regenerated against a built core — the counts are the only change, and `api-report.test.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)