### PR TITLE
fix(inspector): prune a filtered workflow's file entry, not just its meta

### DIFF
--- a/.changeset/prune-workflow-files-when-filtering.md
+++ b/.changeset/prune-workflow-files-when-filtering.md
@@ -1,0 +1,7 @@
+---
+'@pikku/inspector': patch
+---
+
+Prune a filtered-out workflow's file entry, not just its meta.
+
+`filterInspectorState` deleted a pruned workflow from `workflows.graphMeta` and `workflows.meta` but left it in `workflows.files`, which is what the wiring generator iterates. Per-unit deploy codegen therefore registered every workflow in the project into every unit, and — because a scenario is told apart from an app workflow by `graphMeta[name].source === 'scenario'`, which the same prune had just removed — each scenario was reclassified as an app workflow. That pulled scenario bodies, their steps, and whatever those import into deployed bundles; on Cloudflare a step reading a fixture off disk failed the whole publish with `No such module "node:fs"`.

--- a/packages/inspector/src/utils/filter-inspector-state.test.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.test.ts
@@ -2010,3 +2010,56 @@ describe('invokedFunctionsByFile serialization', () => {
     assert.strictEqual(restored.rpc.invokedFunctionsByFile.size, 0)
   })
 })
+
+describe('Workflow file pruning', () => {
+  const workflowState = () => {
+    const state = createMockInspectorState()
+    state.workflows.meta = {
+      moveOut: { pikkuFuncId: 'getUsers' } as any,
+      theMoveOutScenario: { pikkuFuncId: 'createUser' } as any,
+    }
+    state.workflows.graphMeta = {
+      moveOut: { pikkuFuncId: 'getUsers' } as any,
+      theMoveOutScenario: {
+        pikkuFuncId: 'createUser',
+        source: 'scenario',
+      } as any,
+    }
+    state.workflows.files = new Map([
+      [
+        'moveOut',
+        {
+          path: '/test/project/src/wirings/move-out.workflow.ts',
+          exportedName: 'moveOut',
+        },
+      ],
+      [
+        'theMoveOutScenario',
+        {
+          path: '/test/project/test/scenarios/the-move-out.scenario.ts',
+          exportedName: 'theMoveOutScenario',
+        },
+      ],
+    ])
+    return state
+  }
+
+  test('drops the file entry of a pruned workflow', () => {
+    const result = filterInspectorState(
+      workflowState(),
+      { names: ['getUsers'] },
+      mockLogger
+    )
+
+    assert.deepEqual(Object.keys(result.workflows.graphMeta), ['moveOut'])
+    assert.deepEqual([...result.workflows.files.keys()], ['moveOut'])
+  })
+
+  test('leaves the original state untouched', () => {
+    const state = workflowState()
+    filterInspectorState(state, { names: ['getUsers'] }, mockLogger)
+
+    assert.equal(state.workflows.files.size, 2)
+    assert.equal(Object.keys(state.workflows.graphMeta).length, 2)
+  })
+})

--- a/packages/inspector/src/utils/filter-inspector-state.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.ts
@@ -21,6 +21,28 @@ type DeployFilter = {
   has(pikkuFuncId: string): boolean
 }
 
+/**
+ * Drop a workflow from every map that describes it. `files` and `graphFiles`
+ * are what the wiring generator iterates, and `graphMeta` is what tells a
+ * scenario apart from an app workflow — leaving a pruned workflow's file entry
+ * behind registers it anyway, and a scenario whose graphMeta has gone reads as
+ * an app workflow, which is how scenario steps reached deployed bundles.
+ */
+const pruneWorkflow = (
+  workflows: InspectorState['workflows'],
+  name: string,
+  pikkuFuncId: string | undefined
+) => {
+  delete workflows.graphMeta[name]
+  delete workflows.meta[name]
+  workflows.files.delete(name)
+  workflows.graphFiles.delete(name)
+  if (pikkuFuncId) {
+    workflows.files.delete(pikkuFuncId)
+    workflows.graphFiles.delete(pikkuFuncId)
+  }
+}
+
 // Module-level Set to track warned groups across multiple filter calls
 const globalWarnedGroups = new Set<string>()
 
@@ -449,6 +471,8 @@ export function filterInspectorState(
       ...state.workflows,
       graphMeta: JSON.parse(JSON.stringify(state.workflows?.graphMeta ?? {})),
       meta: JSON.parse(JSON.stringify(state.workflows?.meta ?? {})),
+      files: new Map(state.workflows?.files ?? []),
+      graphFiles: new Map(state.workflows?.graphFiles ?? []),
     },
     channels: {
       ...state.channels,
@@ -1098,12 +1122,10 @@ export function filterInspectorState(
         pikkuFuncId &&
         !filteredState.serviceAggregation.usedFunctions.has(pikkuFuncId)
       ) {
-        delete filteredState.workflows.graphMeta[name]
-        delete filteredState.workflows.meta[name]
+        pruneWorkflow(filteredState.workflows, name, pikkuFuncId)
       } else if (!pikkuFuncId) {
         // No function ID found — prune it
-        delete filteredState.workflows.graphMeta[name]
-        delete filteredState.workflows.meta[name]
+        pruneWorkflow(filteredState.workflows, name, pikkuFuncId)
       }
     }
 


### PR DESCRIPTION
## The bug

`filterInspectorState` deleted a pruned workflow from `workflows.graphMeta` and `workflows.meta` but left it in `workflows.files` — which is what `serializeWorkflowRegistration` actually iterates.

Two things fall out of that in per-unit deploy codegen:

1. Every workflow in the project is registered into every unit, regardless of `--names`.
2. `partitionScenarioWorkflows` tells a scenario apart from an app workflow by `graphMeta[name].source === 'scenario'` — and the prune had just deleted that entry. So every scenario was reclassified as an app workflow and registered too.

The registration is a top-level `addWorkflow('x', x)` with the binding passed as an argument, so nothing is tree-shakeable: esbuild keeps the import and its whole transitive graph. Scenario bodies, their steps, and whatever those import all land in the deployed bundle.

Found on a real project, where two scenarios import a helper that `readFileSync`s a message catalogue. Cloudflare rejected the publish outright:

```
CF 400: Uncaught Error: No such module "node:fs". imported from "worker.js"
```

## The fix

Prune the file maps alongside the meta, via a `pruneWorkflow` helper, and clone `files`/`graphFiles` into the filtered state so the caller's state is not mutated.

## Verification

`pikku deploy plan --provider cloudflare` on that project:

| | before | after |
|---|---|---|
| workers carrying `node:fs` | 10 of 74 | 0 |
| `addWorkflow` calls in the `wf-move-out` unit | 31 | 1 (`moveOut`) |
| units importing anything under `test/` | 10 | 0 |

Two regression tests added; the first fails on `main`. The 7 pre-existing addon/ref failures in `packages/inspector` are unchanged by this commit (verified by diffing the failure list against a stashed tree).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filtered workflow deployments so excluded workflows and their associated files are no longer included in generated unit bundles.
  * Prevented scenario code and unsupported imports from being incorrectly packaged, avoiding related Cloudflare publishing failures.
  * Preserved the original inspector state when applying workflow filters.

* **Tests**
  * Added coverage for workflow file metadata removal during filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->