### PR TITLE
fix(inspector): derive an addon's parent services from its functions

### DIFF
--- a/.changeset/addon-parent-services-from-usage.md
+++ b/.changeset/addon-parent-services-from-usage.md
@@ -1,0 +1,27 @@
+---
+'@pikku/inspector': patch
+---
+
+Derive an addon's required parent services from what its functions actually use.
+
+An addon's functions are its published surface — a consumer calls them, nothing
+wires them locally — so `usedFunctions` was empty for an addon's own build and no
+function services were ever aggregated. The generated services map came out
+claiming the addon needed nothing beyond the framework defaults, and
+`requiredParentServices` was derived only from the second parameter of
+`pikkuAddonServices`, which names what the factory reads rather than what its
+functions destructure.
+
+The visible cost was an addon that consumed `kysely` in all fifteen of its
+functions and declared it nowhere: the consuming project was never told to supply
+it, the addon lost it at runtime, and every query failed on the first call. The
+only way out was to list the missing names under `forceRequiredServices`, which
+is a detection escape hatch and was never meant to carry a contract.
+
+An addon build now aggregates services from every declared function, and treats
+as parent-provided whatever it uses but does not build itself. What the factory
+builds is read from the object literals it returns, minus anything it took off
+the parent bag first — a forwarded service is not a created one, which is how
+`@pikku/addon-admin` returns `scopeService` and friends without claiming to own
+them. Names destructured from the second parameter in the function body, rather
+than in the parameter list, are picked up too.

--- a/packages/inspector/src/add/add-file-with-factory.test.ts
+++ b/packages/inspector/src/add/add-file-with-factory.test.ts
@@ -1,0 +1,134 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { inspect } from '../inspector.js'
+import type { ErrorCode } from '../error-codes.js'
+import type { InspectorLogger } from '../types.js'
+import {
+  serializeInspectorState,
+  deserializeInspectorState,
+} from '../utils/serialize-inspector-state.js'
+
+const makeLogger = (criticals: Array<{ code: ErrorCode; message: string }>) =>
+  ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    diagnostic: ({ severity, code, message }) => {
+      if (severity !== 'warn') {
+        criticals.push({ code, message })
+      }
+    },
+    critical: (code: ErrorCode, message: string) => {
+      criticals.push({ code, message })
+    },
+    hasCriticalErrors: () => criticals.length > 0,
+  }) satisfies InspectorLogger
+
+const inspectSource = async (prefix: string, source: string) => {
+  const rootDir = await mkdtemp(join(tmpdir(), prefix))
+  const file = join(rootDir, 'services.ts')
+  await writeFile(file, source)
+  const criticals: Array<{ code: ErrorCode; message: string }> = []
+  try {
+    const state = await inspect(makeLogger(criticals), [file], { rootDir })
+    return { state, criticals }
+  } finally {
+    await rm(rootDir, { recursive: true, force: true })
+  }
+}
+
+describe('pikkuAddonServices — what an addon takes from its parent', () => {
+  test('a name destructured in the body, not the parameter list, is still forwarded', async () => {
+    const { state } = await inspectSource(
+      'pikku-addon-body-destructure-',
+      [
+        "import { pikkuAddonServices } from '#pikku/addon/setup'",
+        'export const createSingletonServices = pikkuAddonServices(',
+        '  async (_config, existingServices) => {',
+        '    const { kysely, secrets } = existingServices',
+        '    return { ...existingServices, stripeApi: makeStripe(secrets) }',
+        '  }',
+        ')',
+      ].join('\n')
+    )
+
+    assert.ok(
+      state.addonRequiredParentServices.includes('kysely'),
+      'kysely is read off the parent bag and must be declared as required'
+    )
+    assert.deepEqual(state.addonCreatedServices, ['stripeApi'])
+    assert.equal(state.addonServicesFactorySeen, true)
+  })
+
+  test('an object rest is a binding name, not a service', async () => {
+    const { state } = await inspectSource(
+      'pikku-addon-object-rest-',
+      [
+        "import { pikkuAddonServices } from '#pikku/addon/setup'",
+        'export const createSingletonServices = pikkuAddonServices(',
+        '  async (_config, { kysely, ...parentServices }) => ({',
+        '    ...parentServices,',
+        '    kysely,',
+        '    stripeApi: makeStripe(),',
+        '  })',
+        ')',
+      ].join('\n')
+    )
+
+    assert.deepEqual(state.addonRequiredParentServices, ['kysely'])
+    assert.ok(
+      !state.addonRequiredParentServices.includes('parentServices'),
+      'a rest binding names the leftover bag, not a service the parent provides'
+    )
+  })
+
+  test('a parenthesised return still yields its created services', async () => {
+    const { state } = await inspectSource(
+      'pikku-addon-parenthesised-return-',
+      [
+        "import { pikkuAddonServices } from '#pikku/addon/setup'",
+        'export const createSingletonServices = pikkuAddonServices(',
+        '  async (_config, existingServices) => {',
+        '    return ({ ...existingServices, stripeApi: makeStripe() })',
+        '  }',
+        ')',
+      ].join('\n')
+    )
+
+    assert.deepEqual(state.addonCreatedServices, ['stripeApi'])
+    assert.ok(
+      !state.addonRequiredParentServices.includes('stripeApi'),
+      'a service the factory builds is not one the parent has to supply'
+    )
+  })
+
+  test('the addon contract survives a serialize/deserialize round trip', async () => {
+    const { state } = await inspectSource(
+      'pikku-addon-round-trip-',
+      [
+        "import { pikkuAddonServices } from '#pikku/addon/setup'",
+        'export const createSingletonServices = pikkuAddonServices(',
+        '  async (_config, existingServices) => {',
+        '    const { kysely } = existingServices',
+        '    return { ...existingServices, stripeApi: makeStripe(kysely) }',
+        '  }',
+        ')',
+      ].join('\n')
+    )
+
+    const restored = deserializeInspectorState(
+      JSON.parse(JSON.stringify(serializeInspectorState(state)))
+    )
+
+    assert.deepEqual(
+      restored.addonRequiredParentServices,
+      state.addonRequiredParentServices
+    )
+    assert.deepEqual(restored.addonCreatedServices, ['stripeApi'])
+    assert.equal(restored.addonServicesFactorySeen, true)
+  })
+})

--- a/packages/inspector/src/add/add-file-with-factory.ts
+++ b/packages/inspector/src/add/add-file-with-factory.ts
@@ -13,6 +13,102 @@ const wrapperFunctionMap: Record<string, string> = {
   pikkuServerLifecycle: 'ServerLifecycle',
 }
 
+/**
+ * What an addon's `pikkuAddonServices` factory takes from the parent: the names
+ * destructured off its second parameter, either in the parameter list or from a
+ * `const { … } = existingServices` in the body.
+ */
+const extractForwardedServices = (
+  functionNode: ts.ArrowFunction | ts.FunctionExpression
+): string[] => {
+  const forwarded: string[] = []
+  const secondParam = functionNode.parameters[1]
+  if (!secondParam) return forwarded
+
+  const collectBinding = (pattern: ts.ObjectBindingPattern) => {
+    for (const elem of pattern.elements) {
+      const name =
+        elem.propertyName && ts.isIdentifier(elem.propertyName)
+          ? elem.propertyName.text
+          : ts.isIdentifier(elem.name)
+            ? elem.name.text
+            : undefined
+      if (name) forwarded.push(name)
+    }
+  }
+
+  if (ts.isObjectBindingPattern(secondParam.name)) {
+    collectBinding(secondParam.name)
+    return forwarded
+  }
+
+  if (!ts.isIdentifier(secondParam.name)) return forwarded
+  const paramName = secondParam.name.text
+  const body = functionNode.body
+  if (!ts.isBlock(body)) return forwarded
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isObjectBindingPattern(node.name) &&
+      node.initializer &&
+      ts.isIdentifier(node.initializer) &&
+      node.initializer.text === paramName
+    ) {
+      collectBinding(node.name)
+    }
+    ts.forEachChild(node, visit)
+  }
+  ts.forEachChild(body, visit)
+
+  return forwarded
+}
+
+/**
+ * The service names the factory's returned object literals name. A spread is
+ * skipped — it carries the parent's bag through rather than naming anything —
+ * and a name the factory took off the parent is a forward, not a creation.
+ */
+const extractReturnedServices = (
+  functionNode: ts.ArrowFunction | ts.FunctionExpression
+): string[] => {
+  const returned: string[] = []
+
+  const collect = (expression: ts.Expression) => {
+    if (!ts.isObjectLiteralExpression(expression)) return
+    for (const property of expression.properties) {
+      if (ts.isSpreadAssignment(property)) continue
+      const name = property.name
+      if (name && (ts.isIdentifier(name) || ts.isStringLiteral(name))) {
+        returned.push(name.text)
+      }
+    }
+  }
+
+  const body = functionNode.body
+  if (!ts.isBlock(body)) {
+    collect(ts.isParenthesizedExpression(body) ? body.expression : body)
+    return returned
+  }
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node)
+    ) {
+      return
+    }
+    if (ts.isReturnStatement(node) && node.expression) {
+      collect(node.expression)
+    }
+    ts.forEachChild(node, visit)
+  }
+  ts.forEachChild(body, visit)
+
+  return returned
+}
+
 export const addFileWithFactory = (
   node: ts.Node,
   checker: ts.TypeChecker,
@@ -77,23 +173,15 @@ export const addFileWithFactory = (
 
             // Extract existing services an addon needs from the parent
             // (second parameter of pikkuAddonServices callback)
-            if (
-              wrapperFunctionName === 'pikkuAddonServices' &&
-              functionNode &&
-              functionNode.parameters.length >= 2
-            ) {
-              const secondParam = functionNode.parameters[1]
-              if (secondParam && ts.isObjectBindingPattern(secondParam.name)) {
-                for (const elem of secondParam.name.elements) {
-                  const name =
-                    elem.propertyName && ts.isIdentifier(elem.propertyName)
-                      ? elem.propertyName.text
-                      : ts.isIdentifier(elem.name)
-                        ? elem.name.text
-                        : undefined
-                  if (name) {
-                    state.addonRequiredParentServices.push(name)
-                  }
+            if (wrapperFunctionName === 'pikkuAddonServices' && functionNode) {
+              state.addonServicesFactorySeen = true
+              const forwarded = new Set(extractForwardedServices(functionNode))
+              for (const name of forwarded) {
+                state.addonRequiredParentServices.push(name)
+              }
+              for (const name of extractReturnedServices(functionNode)) {
+                if (!forwarded.has(name)) {
+                  state.addonCreatedServices.push(name)
                 }
               }
             }

--- a/packages/inspector/src/add/add-file-with-factory.ts
+++ b/packages/inspector/src/add/add-file-with-factory.ts
@@ -27,6 +27,7 @@ const extractForwardedServices = (
 
   const collectBinding = (pattern: ts.ObjectBindingPattern) => {
     for (const elem of pattern.elements) {
+      if (elem.dotDotDotToken) continue
       const name =
         elem.propertyName && ts.isIdentifier(elem.propertyName)
           ? elem.propertyName.text
@@ -75,6 +76,9 @@ const extractReturnedServices = (
   const returned: string[] = []
 
   const collect = (expression: ts.Expression) => {
+    while (ts.isParenthesizedExpression(expression)) {
+      expression = expression.expression
+    }
     if (!ts.isObjectLiteralExpression(expression)) return
     for (const property of expression.properties) {
       if (ts.isSpreadAssignment(property)) continue
@@ -87,7 +91,7 @@ const extractReturnedServices = (
 
   const body = functionNode.body
   if (!ts.isBlock(body)) {
-    collect(ts.isParenthesizedExpression(body) ? body.expression : body)
+    collect(body)
     return returned
   }
 

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -83,6 +83,8 @@ export function getInitialInspectorState(rootDir: string): InspectorState {
     wireServicesFactories: new Map(),
     wireServicesMeta: new Map(),
     addonRequiredParentServices: [],
+    addonCreatedServices: [],
+    addonServicesFactorySeen: false,
     addonServerlessIncompatible: new Map(),
     configFactories: new Map(),
     serverLifecycleFactories: new Map(),

--- a/packages/inspector/src/types.ts
+++ b/packages/inspector/src/types.ts
@@ -526,6 +526,8 @@ export interface InspectorState {
   wireServicesFactories: PathToNameAndType
   wireServicesMeta: Map<string, string[]> // variable name -> singleton services consumed
   addonRequiredParentServices: string[] // services an addon needs from the parent (extracted from pikkuAddonServices 2nd param)
+  addonCreatedServices: string[] // services an addon's own pikkuAddonServices factory builds itself
+  addonServicesFactorySeen: boolean // this project declares a pikkuAddonServices factory, i.e. it is an addon
   addonServerlessIncompatible: Map<string, string[]> // namespace → service names that are serverless-incompatible (scoped per addon)
   configFactories: PathToNameAndType
   serverLifecycleFactories: PathToNameAndType

--- a/packages/inspector/src/utils/post-process.ts
+++ b/packages/inspector/src/utils/post-process.ts
@@ -381,6 +381,35 @@ export function aggregateRequiredServices(
       requiredServices.add(service)
     }
   }
+
+  // 8. When this project IS an addon, what it needs from its parent is whatever
+  // its functions use minus whatever its own factory builds. Reading only the
+  // factory's second parameter missed everything the functions destructure and
+  // the factory never names — `kysely` above all — which left the contract empty
+  // and let a consumer omit it and fail at the first query instead of at build.
+  if (state.addonServicesFactorySeen) {
+    // Every function an addon declares is part of its published surface — a
+    // consumer calls it — so none of them are reachable from a local wiring and
+    // `usedFunctions` is empty. Aggregating only from wirings left the services
+    // map claiming an addon needs nothing, which is what drove addons to list
+    // their own services under `forceRequiredServices` by hand.
+    for (const funcMeta of Object.values(state.functions.meta)) {
+      addServices(funcMeta?.services)
+    }
+
+    const createdSet = new Set(state.addonCreatedServices ?? [])
+    const parentServices = new Set(parentDeclared)
+    for (const service of requiredServices) {
+      if (
+        !createdSet.has(service) &&
+        !internalServices.has(service) &&
+        !defaultServices.has(service)
+      ) {
+        parentServices.add(service)
+      }
+    }
+    state.addonRequiredParentServices = [...parentServices]
+  }
 }
 
 export function validateSecretOverrides(

--- a/packages/inspector/src/utils/serialize-inspector-state.ts
+++ b/packages/inspector/src/utils/serialize-inspector-state.ts
@@ -51,6 +51,8 @@ export interface SerializableInspectorState {
   >
   wireServicesMeta: Array<[string, string[]]>
   addonRequiredParentServices: string[]
+  addonCreatedServices: string[]
+  addonServicesFactorySeen: boolean
   addonServerlessIncompatible: Array<[string, string[]]>
   configFactories: Array<
     [
@@ -335,6 +337,8 @@ export function serializeInspectorState(
     wireServicesFactories: Array.from(state.wireServicesFactories.entries()),
     wireServicesMeta: Array.from(state.wireServicesMeta.entries()),
     addonRequiredParentServices: state.addonRequiredParentServices,
+    addonCreatedServices: state.addonCreatedServices,
+    addonServicesFactorySeen: state.addonServicesFactorySeen,
     addonServerlessIncompatible: Array.from(
       state.addonServerlessIncompatible.entries()
     ),
@@ -544,6 +548,8 @@ export function deserializeInspectorState(
     wireServicesFactories: new Map(data.wireServicesFactories),
     wireServicesMeta: new Map(data.wireServicesMeta),
     addonRequiredParentServices: data.addonRequiredParentServices || [],
+    addonCreatedServices: data.addonCreatedServices || [],
+    addonServicesFactorySeen: data.addonServicesFactorySeen ?? false,
     addonServerlessIncompatible: new Map(
       data.addonServerlessIncompatible || []
     ),


### PR DESCRIPTION
## The problem

Service aggregation is driven by `usedFunctions`, which is populated from wirings. An addon's functions are its published surface — a consumer calls them, nothing wires them locally — so `usedFunctions` is empty during an addon's own build and **no function services were aggregated at all**.

`requiredParentServices` was then derived solely from the second parameter of `pikkuAddonServices`: what the factory *reads*, not what its functions *use*.

The visible cost: an addon consuming `kysely` in all fifteen of its functions declared it nowhere. The generated map said `'kysely': false`, the consuming project was never told to supply it, the addon lost it at runtime, and every query failed on the first call. The only way out was listing the missing names under `forceRequiredServices` — a detection escape hatch (`usedServices.add`), never meant to carry a contract.

## The change

An addon build now:

1. **aggregates services from every declared function**, not just wired ones;
2. **treats what it uses but does not build as parent-provided.**

"Builds" is read from the object literals the factory returns, minus anything it took off the parent bag first — a forwarded service is not a created one, which is how `@pikku/addon-admin` returns `scopeService`, `credentialService`, `audit` and `auth` without claiming to own them. Names destructured from the second parameter *in the function body* are recognised alongside parameter destructuring.

Two new `InspectorState` fields carry this: `addonCreatedServices` and `addonServicesFactorySeen`.

## Effect

On an addon whose functions all use `kysely`:

```diff
-export const requiredParentServices = ["secrets","variables"] as const
+export const requiredParentServices = ["secrets","variables","kysely"] as const
-  'kysely': false,
+  'kysely': true,
```

and its `forceRequiredServices` entry becomes redundant — output is identical with and without it.

## Verification

- 745/745 inspector tests pass.
- Regenerating `@pikku/addon-admin`, `@pikku/addon-console` and `@pikku/addon-graph` leaves their tracked `.pikku` output **unchanged** — the forwarded-vs-created distinction is what keeps `addon-admin` stable.
- The addon that surfaced this now builds and passes its own 184 tests against the corrected contract.

Note: the local `@pikku/cli` build fails on 18 pre-existing errors in stale generated `.pikku/*.gen.ts` files, unrelated to any file in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of services provided by add-ons and those required from their parent applications.
  * Add-on functions now correctly contribute to required service calculations.
  * Improved support for services accessed through destructuring and returned service objects.
  * Preserved compatibility when restoring previously saved inspection data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->