### PR TITLE
fix(better-auth): export provisionPersonas again

### DIFF
--- a/.changeset/restore-provision-personas-export.md
+++ b/.changeset/restore-provision-personas-export.md
@@ -1,0 +1,9 @@
+---
+'@pikku/better-auth': patch
+---
+
+Export `provisionPersonas` again.
+
+Moving provisioning into the fabric plugin was right for a deployed stage, but un-exporting the function left an app that boots its own server through `pikku serve` — where `afterStart` genuinely runs — with no way to provision at all.
+
+The plugin remains the arrangement to reach for: it is the only one that works on Workers or a serverless target. `provisionPersonas` is for the server case, and its documentation now says which is which.

--- a/packages/services/better-auth/src/index.ts
+++ b/packages/services/better-auth/src/index.ts
@@ -39,7 +39,13 @@ export type {
   ActorSignInReason,
 } from './actor-sign-in-gate.js'
 
-export type { PersonaOrphanPolicy } from './provision-personas.js'
+export { provisionPersonas } from './provision-personas.js'
+export type {
+  PersonaOrphanPolicy,
+  ProvisionPersonasOptions,
+  ProvisionPersonasResult,
+  ProvisionPersonasServices,
+} from './provision-personas.js'
 export { pikkuFabric } from './fabric-plugin.js'
 export type { FabricPluginOptions } from './fabric-plugin.js'
 export {

--- a/packages/services/better-auth/src/provision-personas.ts
+++ b/packages/services/better-auth/src/provision-personas.ts
@@ -86,12 +86,16 @@ type ActorUser = {
  * could open — true of a local stage and of nothing else. A running stage has
  * that connection by definition, so provisioning happens there.
  *
- * Not exported, and not something an app calls. The fabric plugin runs it on an
- * operator handshake that names an address the stage has no account for, which
- * is the only moment the work is both needed and cheap to detect. The obvious
- * home — `pikkuServerLifecycle`'s `afterStart` — is a trap: that hook is
- * invoked by `pikku serve` and `pikku dev` and by nothing else, so every stage
- * deployed to Workers or a serverless target provisioned nothing at all.
+ * Prefer handing the personas to `pikkuFabric` and letting the plugin call this
+ * on an operator handshake that names an address the stage has no account for:
+ * that is the only moment the work is both needed and cheap to detect, and it
+ * is the only arrangement that works on a deployed stage.
+ *
+ * Calling it directly is for a server the app itself boots, where
+ * `pikkuServerLifecycle`'s `afterStart` genuinely runs. Reach for that hook only
+ * if you know the process starts through `pikku serve` or `pikku dev` — nothing
+ * else invokes it, so an app on Workers or a serverless target that provisions
+ * from `afterStart` provisions nothing at all.
  *
  * Accounts are created through better-auth's internal adapter — the same call
  * the actor endpoint makes — rather than by inserting a `user` row directly, so

--- a/packages/skills/skills/pikku-better-auth/SKILL.md
+++ b/packages/skills/skills/pikku-better-auth/SKILL.md
@@ -578,6 +578,19 @@ invoked by `pikku serve` and `pikku dev` and by nothing else — no deploy runti
 calls it — so a stage on Workers or a serverless target that provisioned from
 `afterStart` provisioned nothing, and every persona signed in holding no roles.
 
+An app that boots its own server through `pikku serve` is the one case where
+that hook does run, and it can call `provisionPersonas` from `@pikku/better-auth`
+directly:
+
+```ts
+import { provisionPersonas } from '@pikku/better-auth'
+
+await provisionPersonas(
+  { auth, scopeService, logger },
+  { personas: personaConfigs, environments: personaEnvironments }
+)
+```
+
 Provisioning runs where the database already is, which is the point: the CLI has
 no connection to a deployed environment's database — it resolves one from the
 local project config — so a `pikku persona sync staging` that wrote rows would


### PR DESCRIPTION
#1531 moved persona provisioning into the fabric plugin, which is right for a deployed stage — `afterStart` never fires on Workers or a serverless target, so that was the only arrangement that could work there.

It also un-exported `provisionPersonas`, and that went too far. An app that boots its own server through `pikku serve` *does* run `afterStart`, and fabric's own backend is exactly that: it provisions its own personas at boot so `/admin/virtual-users` has actor accounts to sign in as. With the export gone it has no API at all.

This restores `provisionPersonas` and its three types, and rewrites the doc block to say which arrangement is for which case rather than describing the direct call as a trap.

`@pikku/better-auth` — 206 tests, 0 fail; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)