### PR TITLE
fix: register agents invoked from a function body in the calling unit

### DIFF
--- a/.changeset/register-body-invoked-agents.md
+++ b/.changeset/register-body-invoked-agents.md
@@ -1,0 +1,11 @@
+---
+'@pikku/inspector': patch
+'@pikku/cli': patch
+'@pikku/deploy': patch
+---
+
+Register an agent invoked from a function body in the calling deployment unit.
+
+`runAgent('houseAssistant', ...)` and `rpc.agent.run('houseAssistant', ...)` resolve against the in-process agent registry, but the deploy analyzer only ever put an agent's registration in its own `agent-*` unit. A function calling one landed in a separate unit whose bootstrap never registered it, so the deployed worker threw `AI agent not found: houseAssistant`.
+
+The inspector now records a string-literal agent name passed to `runAgent` / `streamAgent` / `rpc.agent.run` / `rpc.agent.stream` in a function body under `agents.invokedAgentsByFile`, mirroring what it already does for `rpc.invoke` targets. The analyzer carries those names on the calling unit as `invokedAgents` and adds the `ai-model` / `ai-storage` service requirements, and per-unit codegen puts the agent — and its tools — into that unit's filter names so its wiring is generated there too. A dynamic (template-literal) agent name is warned about, as it is for `rpc.invoke`.

--- a/packages/cli/src/deploy/analyzer/analyzer.test.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.test.ts
@@ -444,3 +444,100 @@ describe('analyzeDeployment - globalHTTPPrefix', () => {
     assert.deepEqual(routesOf(manifest, 'get-me'), ['/rpc/getMe'])
   })
 })
+
+/**
+ * A function wired to HTTP whose body calls `runAgent('houseAssistant', ...)`,
+ * alongside the agent that call names.
+ */
+function stateWithFunctionInvokingAgent(
+  invoked: string[] = ['houseAssistant']
+): InspectorState {
+  return {
+    functions: {
+      meta: {
+        askTheHouse: {
+          pikkuFuncId: 'askTheHouse',
+          name: 'askTheHouse',
+          services: { services: ['kysely'] },
+        },
+      },
+      files: new Map([
+        [
+          'askTheHouse',
+          {
+            path: '/project/src/assistant/ask-the-house.function.ts',
+            exportedName: 'askTheHouse',
+          },
+        ],
+      ]),
+    },
+    http: {
+      meta: {
+        post: {
+          '/ask': {
+            pikkuFuncId: 'askTheHouse',
+            method: 'post',
+            route: '/ask',
+          },
+        },
+      },
+    },
+    agents: {
+      agentsMeta: {
+        houseAssistant: {
+          name: 'house-assistant',
+          model: 'deepseek/deepseek-v4-flash',
+          tools: ['listChores'],
+          tags: [],
+        },
+      },
+      invokedAgentsByFile: new Map([
+        ['/project/src/assistant/ask-the-house.function.ts', new Set(invoked)],
+      ]),
+    },
+    mcpEndpoints: { toolsMeta: {}, resourcesMeta: {}, promptsMeta: {} },
+    channels: { meta: {} },
+    queueWorkers: { meta: {} },
+    scheduledTasks: { meta: {} },
+    workflows: { graphMeta: {} },
+    secrets: { definitions: [] },
+    variables: { definitions: [] },
+  } as unknown as InspectorState
+}
+
+describe('analyzeDeployment - agents invoked from a function body', () => {
+  // `runAgent(...)` resolves against the in-process registry, so the calling
+  // unit has to register the agent itself — the agent gateway unit is a
+  // different worker.
+  const unitOf = (state: InspectorState) =>
+    analyzeDeployment(state, { projectId: 'test' }).units.find(
+      (u) => u.name === 'ask-the-house'
+    )!
+
+  test('the calling unit records the agent', () => {
+    assert.deepEqual(unitOf(stateWithFunctionInvokingAgent()).invokedAgents, [
+      'houseAssistant',
+    ])
+  })
+
+  test('the calling unit gains the AI service requirements', () => {
+    const capabilities = unitOf(stateWithFunctionInvokingAgent()).services.map(
+      (s) => s.capability
+    )
+    assert.ok(capabilities.includes('ai-model'))
+    assert.ok(capabilities.includes('ai-storage'))
+  })
+
+  test("the function's own services survive", () => {
+    const capabilities = unitOf(stateWithFunctionInvokingAgent()).services.map(
+      (s) => s.capability
+    )
+    assert.ok(capabilities.includes('database'))
+  })
+
+  test('a name that is not a declared agent is ignored', () => {
+    const unit = unitOf(stateWithFunctionInvokingAgent(['notAnAgent']))
+    assert.equal(unit.invokedAgents, undefined)
+    assert.ok(!unit.services.some((s) => s.capability === 'ai-model'))
+  })
+})

--- a/packages/cli/src/deploy/analyzer/analyzer.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.ts
@@ -214,6 +214,8 @@ export function analyzeDeployment(
       continue
     }
 
+    const invokedAgents = collectInvokedAgents(state, funcId)
+
     units.push({
       name: toSafeKebab(funcId),
       role: 'function',
@@ -224,10 +226,14 @@ export function analyzeDeployment(
         defaultTarget
       ),
       functionIds: [funcId],
-      services: collectServicesForFunction(funcMeta),
+      services: withAgentServices(
+        collectServicesForFunction(funcMeta),
+        invokedAgents
+      ),
       dependsOn: [],
       handlers,
       tags: funcMeta.tags ?? [],
+      ...(invokedAgents.length > 0 && { invokedAgents }),
     })
   }
 
@@ -244,10 +250,7 @@ export function analyzeDeployment(
     )
 
     // Agent needs AI services
-    const agentServices: ServiceRequirement[] = [
-      { capability: 'ai-model', sourceServiceName: 'agentRunner' },
-      { capability: 'ai-storage', sourceServiceName: 'agentStorage' },
-    ]
+    const agentServices: ServiceRequirement[] = agentServiceRequirements()
 
     // Concrete routes for this agent via catch-all
     const agentRoutes = [
@@ -405,6 +408,7 @@ export function analyzeDeployment(
         const funcId = fromKebab(dep)
         const funcMeta = functionsMeta[funcId]
         if (funcMeta) {
+          const invokedAgents = collectInvokedAgents(state, funcId)
           units.push({
             name: dep,
             role: 'function',
@@ -415,10 +419,14 @@ export function analyzeDeployment(
               defaultTarget
             ),
             functionIds: [funcId],
-            services: collectServicesForFunction(funcMeta),
+            services: withAgentServices(
+              collectServicesForFunction(funcMeta),
+              invokedAgents
+            ),
             dependsOn: [],
             handlers: [{ type: 'fetch', routes: [] }],
             tags: funcMeta.tags ?? [],
+            ...(invokedAgents.length > 0 && { invokedAgents }),
           })
           existingUnitNames.add(dep)
         }
@@ -767,6 +775,44 @@ function mapServiceToRequirement(
   const capability = SERVICE_CAPABILITY_MAP[serviceName]
   if (!capability) return null
   return { capability, sourceServiceName: serviceName }
+}
+
+function agentServiceRequirements(): ServiceRequirement[] {
+  return [
+    { capability: 'ai-model', sourceServiceName: 'agentRunner' },
+    { capability: 'ai-storage', sourceServiceName: 'agentStorage' },
+  ]
+}
+
+/**
+ * Agents named by a `runAgent`/`rpc.agent.run` call inside a function body.
+ *
+ * The inspector attributes those calls to the source FILE, so every function
+ * declared alongside the caller inherits them. That is deliberate: the unit
+ * bundles the file either way, and registering an agent the caller never
+ * reaches is cheaper than the run-time "AI agent not found" a missed one
+ * causes.
+ */
+function collectInvokedAgents(state: InspectorState, funcId: string): string[] {
+  const path = state.functions?.files?.get(funcId)?.path
+  if (!path) return []
+  const invoked = state.agents?.invokedAgentsByFile?.get(path)
+  if (!invoked) return []
+  return [...invoked].filter((name) => Boolean(state.agents?.agentsMeta[name]))
+}
+
+function withAgentServices(
+  services: ServiceRequirement[],
+  invokedAgents: string[]
+): ServiceRequirement[] {
+  if (invokedAgents.length === 0) return services
+  const merged = [...services]
+  for (const requirement of agentServiceRequirements()) {
+    if (!merged.some((s) => s.capability === requirement.capability)) {
+      merged.push(requirement)
+    }
+  }
+  return merged
 }
 
 function collectServicesForFunction(

--- a/packages/cli/src/deploy/codegen/per-unit-codegen.test.ts
+++ b/packages/cli/src/deploy/codegen/per-unit-codegen.test.ts
@@ -1,0 +1,65 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { collectFilterNames } from './per-unit-codegen.js'
+import type { InspectorState } from '@pikku/inspector'
+import type { DeploymentManifest, DeploymentUnit } from '@pikku/deploy'
+
+function manifestWithAgent(): DeploymentManifest {
+  return {
+    agents: [
+      {
+        name: 'houseAssistant',
+        unitName: 'agent-house-assistant',
+        toolFunctionIds: ['listChores'],
+        subAgentNames: [],
+        model: 'deepseek/deepseek-v4-flash',
+      },
+    ],
+    channels: [],
+    mcpEndpoints: [],
+    workflows: [],
+    units: [],
+  } as unknown as DeploymentManifest
+}
+
+function callingUnit(invokedAgents?: string[]): DeploymentUnit {
+  return {
+    name: 'ask-the-house',
+    role: 'function',
+    target: 'serverless',
+    functionIds: ['askTheHouse'],
+    services: [],
+    dependsOn: [],
+    handlers: [{ type: 'fetch', routes: [] }],
+    tags: [],
+    ...(invokedAgents && { invokedAgents }),
+  }
+}
+
+const inspectorState = {
+  functions: { meta: { askTheHouse: { pikkuFuncId: 'askTheHouse' } } },
+} as unknown as InspectorState
+
+describe('collectFilterNames - agents invoked from a function body', () => {
+  // Without the agent name in the filter, per-unit codegen emits no
+  // `addAgent(...)` for this unit and the in-process lookup fails at run time
+  // with "AI agent not found".
+  const names = (unit: DeploymentUnit) =>
+    collectFilterNames(unit, manifestWithAgent(), inspectorState, true)
+
+  test('the agent name joins the filter', () => {
+    assert.ok(names(callingUnit(['houseAssistant'])).includes('houseAssistant'))
+  })
+
+  test("the agent's tools join the filter", () => {
+    assert.ok(names(callingUnit(['houseAssistant'])).includes('listChores'))
+  })
+
+  test('the RPC catch-all joins the filter, for tool dispatch', () => {
+    assert.ok(names(callingUnit(['houseAssistant'])).includes('/rpc/:rpcName'))
+  })
+
+  test('a unit invoking no agent is unchanged', () => {
+    assert.deepEqual(names(callingUnit()), ['askTheHouse'])
+  })
+})

--- a/packages/cli/src/deploy/codegen/per-unit-codegen.ts
+++ b/packages/cli/src/deploy/codegen/per-unit-codegen.ts
@@ -77,7 +77,7 @@ function resolvePikkuBin(): string {
  * include both the function IDs and any wiring-level names (e.g. agent
  * names, channel names) that reference those functions.
  */
-function collectFilterNames(
+export function collectFilterNames(
   unit: DeploymentUnit,
   manifest: DeploymentManifest,
   inspectorState: InspectorState,
@@ -146,6 +146,16 @@ function collectFilterNames(
       for (const handler of unit.handlers) {
         if (handler.type === 'queue') names.add(handler.queueName)
         if (handler.type === 'scheduled') names.add(handler.taskName)
+      }
+      // `runAgent(...)` / `rpc.agent.run(...)` look the agent up in the
+      // in-process registry, so a function that calls one needs the agent's
+      // wiring — and its tools — bundled into its OWN unit, not just into
+      // the agent gateway unit.
+      for (const agentName of unit.invokedAgents ?? []) {
+        names.add(agentName)
+        const agentDef = manifest.agents.find((a) => a.name === agentName)
+        for (const id of agentDef?.toolFunctionIds ?? []) names.add(id)
+        names.add('/rpc/:rpcName')
       }
       // Function units with workflow-state capability (workflow-starter,
       // workflow-runner, workflow-status-checker) call rpc.startWorkflow

--- a/packages/deploy/deploy-core/src/manifest.ts
+++ b/packages/deploy/deploy-core/src/manifest.ts
@@ -53,6 +53,12 @@ export interface DeploymentUnit {
   /** What runtime handlers this unit needs to export */
   handlers: DeploymentHandler[]
   tags: string[]
+  /**
+   * Agents named by a `runAgent`/`rpc.agent.run` call in one of this unit's
+   * function bodies. The lookup is in-process, so the agent has to be
+   * registered here as well as in its own gateway unit.
+   */
+  invokedAgents?: string[]
   /** SHA-256 of final bundled artifact (set by build pipeline) */
   bundleHash?: string
   /** Final bundle size in bytes (set by build pipeline) */

--- a/packages/inspector/src/add/add-rpc-invocations.test.ts
+++ b/packages/inspector/src/add/add-rpc-invocations.test.ts
@@ -161,3 +161,127 @@ export async function doWork() {
     }
   })
 })
+
+describe('add-rpc-invocations — invokedAgentsByFile', () => {
+  test('a body-level runAgent() is attributed to its source file', async () => {
+    const { state, dir } = await inspectFiles({
+      'caller.ts': `
+declare const runAgent: (name: string, input: unknown) => Promise<unknown>
+export async function askTheHouse() {
+  return runAgent('houseAssistant', { message: 'hi' })
+}
+`,
+      'other.ts': `
+export const unrelated = () => 'no agents here'
+`,
+    })
+    try {
+      const byFile = state.agents.invokedAgentsByFile
+      assert.strictEqual(byFile.size, 1)
+      const [file, agents] = [...byFile.entries()][0]!
+      assert.ok(file.endsWith('caller.ts'))
+      assert.deepStrictEqual([...agents], ['houseAssistant'])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('rpc.agent.run() is an agent invocation too', async () => {
+    const { state, dir } = await inspectFiles({
+      'caller.ts': `
+declare const rpc: { agent: { run: (name: string, input: unknown) => Promise<unknown> } }
+export async function askTheHouse() {
+  return rpc.agent.run('houseAssistant', { message: 'hi' })
+}
+`,
+    })
+    try {
+      const agents = [...state.agents.invokedAgentsByFile.values()][0]!
+      assert.deepStrictEqual([...agents], ['houseAssistant'])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('a non-null assertion on the rpc receiver is still an invocation', async () => {
+    const { state, dir } = await inspectFiles({
+      'caller.ts': `
+declare const rpc: { agent: { stream: (name: string, input: unknown) => Promise<unknown> } } | undefined
+export async function askTheHouse() {
+  return rpc!.agent.stream('houseAssistant', { message: 'hi' })
+}
+`,
+    })
+    try {
+      const agents = [...state.agents.invokedAgentsByFile.values()][0]!
+      assert.deepStrictEqual([...agents], ['houseAssistant'])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('multiple agent calls in one file accumulate under that file', async () => {
+    const { state, dir } = await inspectFiles({
+      'caller.ts': `
+declare const runAgent: (name: string, input: unknown) => Promise<unknown>
+declare const rpc: { agent: { run: (name: string, input: unknown) => Promise<unknown> } }
+export async function askEveryone() {
+  await runAgent('houseAssistant', {})
+  return rpc.agent.run('gardenAssistant', {})
+}
+`,
+    })
+    try {
+      const agents = [...state.agents.invokedAgentsByFile.values()][0]!
+      assert.deepStrictEqual([...agents].sort(), [
+        'gardenAssistant',
+        'houseAssistant',
+      ])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('a dynamic agent name is warned about, not recorded', async () => {
+    const warnings: string[] = []
+    const dir = await mkdtemp(join(tmpdir(), 'pikku-agent-invocations-test-'))
+    const path = join(dir, 'caller.ts')
+    await writeFile(
+      path,
+      `
+declare const runAgent: (name: string, input: unknown) => Promise<unknown>
+declare const suffix: string
+export async function askTheHouse() {
+  return runAgent(\`house-\${suffix}\`, {})
+}
+`
+    )
+    const logger = makeLogger()
+    logger.warn = (message: string) => {
+      warnings.push(message)
+    }
+    try {
+      const state = await inspect(logger, [path], { rootDir: dir })
+      assert.strictEqual(state.agents.invokedAgentsByFile.size, 0)
+      assert.ok(warnings.some((w) => w.includes('dynamic agent invocation')))
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('run() on some other receiver is left alone', async () => {
+    const { state, dir } = await inspectFiles({
+      'caller.ts': `
+declare const client: { agent: { run: (name: string, input: unknown) => Promise<unknown> } }
+export async function doWork() {
+  return client.agent.run('notAnAgentCall', {})
+}
+`,
+    })
+    try {
+      assert.strictEqual(state.agents.invokedAgentsByFile.size, 0)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/inspector/src/add/add-rpc-invocations.ts
+++ b/packages/inspector/src/add/add-rpc-invocations.ts
@@ -51,6 +51,33 @@ function extractNamespace(functionRef: string): string | null {
   return null
 }
 
+function agentInvocationName(
+  expression: ts.Expression
+): 'runAgent' | 'streamAgent' | 'rpc.agent.run' | 'rpc.agent.stream' | null {
+  if (ts.isIdentifier(expression)) {
+    if (expression.text === 'runAgent') return 'runAgent'
+    if (expression.text === 'streamAgent') return 'streamAgent'
+    return null
+  }
+  if (!ts.isPropertyAccessExpression(expression)) return null
+  const method = expression.name.text
+  if (method !== 'run' && method !== 'stream') return null
+  const agentReceiver = invocationReceiver(expression.expression)
+  if (
+    !ts.isPropertyAccessExpression(agentReceiver) ||
+    agentReceiver.name.text !== 'agent'
+  ) {
+    return null
+  }
+  const rpcReceiver = invocationReceiver(agentReceiver.expression)
+  const isRpc = ts.isIdentifier(rpcReceiver)
+    ? rpcReceiver.text === 'rpc'
+    : ts.isPropertyAccessExpression(rpcReceiver) &&
+      rpcReceiver.name.text === 'rpc'
+  if (!isRpc) return null
+  return method === 'run' ? 'rpc.agent.run' : 'rpc.agent.stream'
+}
+
 /**
  * Scan for rpc.invoke() calls to track which functions are actually being invoked
  * Also detects addon usage via:
@@ -96,6 +123,31 @@ export function addRPCInvocations(
         const workflowName = firstArg.text
         logger.debug(`• Found ${expression.text}() call: ${workflowName}`)
         state.workflows.invokedWorkflows.add(workflowName)
+      }
+    }
+
+    const agentCall = agentInvocationName(expression)
+    if (agentCall) {
+      const [firstArg] = args
+      if (firstArg && ts.isStringLiteral(firstArg)) {
+        const agentName = firstArg.text
+        logger.debug(`• Found ${agentCall}() call: ${agentName}`)
+        const sourceFileName = node.getSourceFile().fileName
+        let byFile = state.agents.invokedAgentsByFile.get(sourceFileName)
+        if (!byFile) {
+          byFile = new Set()
+          state.agents.invokedAgentsByFile.set(sourceFileName, byFile)
+        }
+        byFile.add(agentName)
+      } else if (
+        firstArg &&
+        (ts.isTemplateExpression(firstArg) ||
+          ts.isNoSubstitutionTemplateLiteral(firstArg))
+      ) {
+        logger.warn(`• Found dynamic agent invocation: ${firstArg.getText()}`)
+        logger.warn(
+          `\tYou can only use string literals for agent names, with ' or " and not \``
+        )
       }
     }
 

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -163,6 +163,7 @@ export function getInitialInspectorState(rootDir: string): InspectorState {
     agents: {
       agentsMeta: {},
       files: new Map(),
+      invokedAgentsByFile: new Map(),
     },
     scorers: {
       scorersMeta: {},

--- a/packages/inspector/src/types.ts
+++ b/packages/inspector/src/types.ts
@@ -634,6 +634,16 @@ export interface InspectorState {
   agents: {
     agentsMeta: AgentsMeta
     files: Map<string, { path: string; exportedName: string }>
+    /**
+     * Agent registry keys named by a `runAgent`/`rpc.agent.run` call in a
+     * function body, keyed by the file the call was written in.
+     *
+     * The lookup those calls perform is in-process, so the agent has to be
+     * registered in the same deployment unit as its caller. Without this the
+     * deploy analyzer only ever saw an agent as its own unit, and a caller in
+     * another unit failed at run time with "AI agent not found".
+     */
+    invokedAgentsByFile: Map<string, Set<string>>
   }
   scorers: {
     scorersMeta: ScorerMeta

--- a/packages/inspector/src/utils/filter-inspector-state.test.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.test.ts
@@ -2063,3 +2063,82 @@ describe('Workflow file pruning', () => {
     assert.equal(Object.keys(state.workflows.graphMeta).length, 2)
   })
 })
+
+describe('invokedAgentsByFile', () => {
+  test('round-trips through serialize/deserialize', () => {
+    const state = getInitialInspectorState('/test/project')
+    state.agents.invokedAgentsByFile = new Map([
+      ['/test/project/src/api/users.ts', new Set(['houseAssistant'])],
+      [
+        '/test/project/src/api/tasks.ts',
+        new Set(['houseAssistant', 'gardenAssistant']),
+      ],
+    ])
+    const restored = deserializeInspectorState(
+      JSON.parse(JSON.stringify(serializeInspectorState(state as any)))
+    )
+    assert.ok(restored.agents.invokedAgentsByFile instanceof Map)
+    assert.strictEqual(restored.agents.invokedAgentsByFile.size, 2)
+    assert.deepStrictEqual(
+      [
+        ...restored.agents.invokedAgentsByFile.get(
+          '/test/project/src/api/tasks.ts'
+        )!,
+      ].sort(),
+      ['gardenAssistant', 'houseAssistant']
+    )
+  })
+
+  test('deserializing legacy state without the field yields an empty Map', () => {
+    const serialized = JSON.parse(
+      JSON.stringify(
+        serializeInspectorState(
+          getInitialInspectorState('/test/project') as any
+        )
+      )
+    )
+    delete serialized.agents.invokedAgentsByFile
+    const restored = deserializeInspectorState(serialized)
+    assert.ok(restored.agents.invokedAgentsByFile instanceof Map)
+    assert.strictEqual(restored.agents.invokedAgentsByFile.size, 0)
+  })
+
+  test('the filtered map is a clone, not the original', () => {
+    const state = createMockInspectorState()
+    state.agents = {
+      agentsMeta: {},
+      files: new Map(),
+      invokedAgentsByFile: new Map([
+        ['/test/project/src/api/users.ts', new Set(['houseAssistant'])],
+      ]),
+    }
+    const filtered = filterInspectorState(
+      state,
+      { names: ['getUsers'] },
+      mockLogger
+    )
+    filtered.agents.invokedAgentsByFile.clear()
+    assert.strictEqual(state.agents.invokedAgentsByFile.size, 1)
+  })
+
+  test('keeps the entry of a kept function file and prunes the rest', () => {
+    const state = createMockInspectorState()
+    state.agents = {
+      agentsMeta: {},
+      files: new Map(),
+      invokedAgentsByFile: new Map([
+        ['/test/project/src/api/users.ts', new Set(['houseAssistant'])],
+        ['/test/project/src/admin/settings.ts', new Set(['adminAssistant'])],
+      ]),
+    }
+    const filtered = filterInspectorState(
+      state,
+      { names: ['getUsers'] },
+      mockLogger
+    )
+    assert.deepStrictEqual(
+      [...filtered.agents.invokedAgentsByFile.keys()],
+      ['/test/project/src/api/users.ts']
+    )
+  })
+})

--- a/packages/inspector/src/utils/filter-inspector-state.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.ts
@@ -507,6 +507,15 @@ export function filterInspectorState(
       ...state.agents,
       agentsMeta: JSON.parse(JSON.stringify(state.agents?.agentsMeta ?? {})),
       files: new Map(),
+      invokedAgentsByFile: new Map(
+        [
+          ...(state.agents?.invokedAgentsByFile ??
+            new Map<string, Set<string>>()),
+        ].map(([file, agents]): [string, Set<string>] => [
+          file,
+          new Set(agents),
+        ])
+      ),
     },
     // Scorers carry through every filter. They are named by the agents that
     // survive it, and a deployment that quietly stopped grading would look
@@ -1208,6 +1217,16 @@ export function filterInspectorState(
     filteredState.serviceAggregation.requiredServices.has('workflowService')
   ) {
     filteredState.serviceAggregation.requiredServices.add('queueService')
+  }
+
+  const keptFunctionFiles = new Set<string>()
+  for (const file of filteredState.functions.files.values()) {
+    if (file?.path) keptFunctionFiles.add(file.path)
+  }
+  for (const file of filteredState.agents.invokedAgentsByFile.keys()) {
+    if (!keptFunctionFiles.has(file)) {
+      filteredState.agents.invokedAgentsByFile.delete(file)
+    }
   }
 
   if ((filteredState.rpc.wireAddonDeclarations?.size ?? 0) > 0) {

--- a/packages/inspector/src/utils/serialize-inspector-state.ts
+++ b/packages/inspector/src/utils/serialize-inspector-state.ts
@@ -186,6 +186,7 @@ export interface SerializableInspectorState {
     files: string[]
   }
   agents: {
+    invokedAgentsByFile?: Array<[string, string[]]>
     agentsMeta: InspectorState['agents']['agentsMeta']
     files: [string, { path: string; exportedName: string }][]
   }
@@ -417,6 +418,11 @@ export function serializeInspectorState(
     agents: {
       agentsMeta: state.agents?.agentsMeta ?? {},
       files: Array.from(state.agents?.files?.entries() ?? []),
+      invokedAgentsByFile: Array.from(
+        (
+          state.agents?.invokedAgentsByFile ?? new Map<string, Set<string>>()
+        ).entries()
+      ).map(([file, agents]): [string, string[]] => [file, Array.from(agents)]),
     },
     scorers: {
       scorersMeta: state.scorers?.scorersMeta ?? {},
@@ -626,6 +632,11 @@ export function deserializeInspectorState(
     agents: {
       agentsMeta: data.agents?.agentsMeta || {},
       files: new Map(data.agents?.files || []),
+      invokedAgentsByFile: new Map(
+        (data.agents?.invokedAgentsByFile || []).map(
+          ([file, agents]): [string, Set<string>] => [file, new Set(agents)]
+        )
+      ),
     },
     scorers: {
       scorersMeta: data.scorers?.scorersMeta || {},


### PR DESCRIPTION
## Symptom

Deployed to Cloudflare, houseshare's `askTheHouse` returns:

```
AI agent not found: houseAssistant
```

thrown from `packages/core/src/wirings/agent/agent-prepare.ts`. The function body is a plain `runAgent('houseAssistant', { … }, { sessionService })`.

## Cause

`runAgent` is an **in-process registry lookup**, and so is `rpc.agent.run(...)` — it delegates to the same function, it is not a remote dispatch. The deploy analyzer put the agent's registration in its own unit (`agent-house-assistant`), while `askTheHouse` landed in a separate `function` unit whose per-unit bootstrap imports only `agent/pikku-model-aliases.gen.js`. The agent was never registered in that worker, so the lookup failed at run time on code that type-checked.

## Fix

Mirrors the existing `rpc.invoke` body-target tracking:

- **inspector** — `addRPCInvocations` now also records a string-literal agent name passed to `runAgent` / `streamAgent` / `rpc.agent.run` / `rpc.agent.stream` in a function body, into `state.agents.invokedAgentsByFile` (keyed by source file, like `rpc.invokedFunctionsByFile`). Receivers are unwrapped through `!` and parens via the existing `invocationReceiver`. A template-literal name is `logger.warn`ed, as it is for `rpc.invoke`. The map is serialized/deserialized (per-unit codegen passes state through `--stateInput`, so anything unserialized is silently lost) and is cloned — not shared through the object spread — and pruned in `filterInspectorState`.
- **analyzer** — a `function` unit whose function's file invokes a declared agent now carries `invokedAgents` and gains the `ai-model` / `ai-storage` service requirements. Names that are not declared agents are ignored.
- **per-unit codegen** — `collectFilterNames`' `function` arm adds those agent names, their tool function ids, and the RPC catch-all, which is the existing hook that makes agent wirings generate for a unit.

## Tests

- `packages/inspector/src/add/add-rpc-invocations.test.ts` — new `invokedAgentsByFile` suite (6 tests: `runAgent`, `rpc.agent.run`, `rpc!.agent.stream`, accumulation, dynamic-name warning, non-agent receiver). 5 of 6 fail without the change.
- `packages/inspector/src/utils/filter-inspector-state.test.ts` — serialize round-trip, legacy state, clone-not-shared, prune-by-kept-file. All 4 fail without the change.
- `packages/cli/src/deploy/analyzer/analyzer.test.ts` — the calling unit records the agent and gains the AI services; its own services survive; an undeclared name is ignored.
- `packages/cli/src/deploy/codegen/per-unit-codegen.test.ts` (new) — `collectFilterNames` for a calling unit.

Suites: `packages/inspector` 757/757 pass (was 747/747). `packages/cli` 1249 pass / 21 fail — the same 21 pre-existing failures as on `main`, verified file-by-file before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployments where agents invoked from function bodies could not be found at runtime.
  * Ensured invoked agents and their tools are included in the calling deployment unit.
  * Added support for direct and RPC-based agent invocation patterns.
  * Added warnings for dynamic agent names that cannot be resolved automatically.
* **Tests**
  * Added coverage for agent detection, deployment wiring, state persistence, filtering, and service requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->