### PR TITLE
feat(core): add file attachments to EmailService

### DIFF
--- a/.changeset/email-attachments.md
+++ b/.changeset/email-attachments.md
@@ -1,0 +1,27 @@
+---
+'@pikku/core': patch
+'@pikku/skills': patch
+---
+
+Add file attachments to `EmailService`.
+
+`BaseSendEmailInput` gains an optional `attachments: EmailAttachment[]`, so it is
+available on all three input variants — text, HTML and template. The new
+`EmailAttachment` type is exported from `@pikku/core/services` alongside the
+input types, and is shaped so that mapping it onto Resend, SendGrid, Nodemailer
+or SES v2 is a straight field rename rather than a translation.
+
+`content` is `Uint8Array | string`, where a string is always read as base64.
+Both forms are accepted because both are what callers already hold: bytes come
+out of a fetch or a file read, and base64 comes out of a database column or a
+provider API. `Buffer` is deliberately absent from the type — it is a subclass
+of `Uint8Array`, so Node callers can still pass one, while the type stays usable
+in Cloudflare Workers, where `Buffer` does not exist.
+
+`LocalEmailService` now logs attachment metadata — filename, content type,
+content id, disposition and content length — instead of dropping the field
+silently. The content itself is deliberately not logged.
+
+The template-rendering wrapper documented in the emails skill rebuilt its
+delegate payload field by field and therefore dropped `attachments`; it now
+forwards them.

--- a/.claude/agents/pikku-email-templates.md
+++ b/.claude/agents/pikku-email-templates.md
@@ -293,6 +293,7 @@ export class GeneratedTemplateEmailService implements EmailService {
       cc: input.cc,
       bcc: input.bcc,
       replyTo: input.replyTo,
+      attachments: input.attachments,
       headers: {
         ...(input.headers ?? {}),
         'x-pikku-email-template': String(input.template.name),

--- a/examples/online-shop/src/lib/email-service.ts
+++ b/examples/online-shop/src/lib/email-service.ts
@@ -42,6 +42,7 @@ export class GeneratedTemplateEmailService implements EmailService {
       cc: input.cc,
       bcc: input.bcc,
       replyTo: input.replyTo,
+      attachments: input.attachments,
       headers: {
         ...(input.headers ?? {}),
         'x-pikku-email-template': String(input.template.name),

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,8 +5,8 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2871 observable things**: 912 exported names, plus
-1959 members on the classes and interfaces among them, reachable
+**2877 observable things**: 913 exported names, plus
+1964 members on the classes and interfaces among them, reachable
 through 53 entry points.
 
 An entry point whose exports are mostly *exclusive* is a self-contained
@@ -14,7 +14,7 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 
 | entry point | exports | exclusive | members on those |
 | --- | ---: | ---: | ---: |
-| `./services` | 147 | 115 | 413 |
+| `./services` | 148 | 116 | 418 |
 | `./virtual-user` | 66 | 66 | 212 |
 | `./scenario` | 45 | 45 | 134 |
 | `./workflow` | 84 | 35 | 140 |
@@ -4475,6 +4475,13 @@ export interface EmailAssets {
   locales: Record<string, Record<string, unknown>>
   partials: Record<string, string>
   templates: Record<string, EmailTemplateAssets>
+}
+export interface EmailAttachment {
+  filename: string
+  content: Uint8Array | string
+  contentType?: string
+  contentId?: string
+  disposition?: 'attachment' | 'inline'
 }
 export interface EmailService {
   send<T extends SendEmailInput>(input: Safe<T>): Promise<SendEmailResult>

--- a/packages/core/src/services/email-service.test.ts
+++ b/packages/core/src/services/email-service.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import type {
+  EmailAttachment,
+  EmailService,
+  SendEmailInput,
+  SendEmailResult,
+  SendHTMLEmailInput,
+  SendTemplateEmailInput,
+  SendTextEmailInput,
+} from './email-service.js'
+
+const receipt: EmailAttachment = {
+  filename: 'receipt.pdf',
+  content: new Uint8Array([1, 2, 3]),
+  contentType: 'application/pdf',
+}
+
+const logo: EmailAttachment = {
+  filename: 'logo.png',
+  content: 'aGVsbG8=',
+  contentType: 'image/png',
+  contentId: 'logo',
+  disposition: 'inline',
+}
+
+test('a text email carries attachments', () => {
+  const input: SendTextEmailInput = {
+    to: 'user@example.com',
+    text: 'Your receipt is attached',
+    attachments: [receipt],
+  }
+
+  assert.deepEqual(input.attachments, [receipt])
+})
+
+test('an html email carries attachments', () => {
+  const input: SendHTMLEmailInput = {
+    to: 'user@example.com',
+    html: '<img src="cid:logo" />',
+    attachments: [logo],
+  }
+
+  assert.equal(input.attachments?.[0]?.disposition, 'inline')
+  assert.equal(input.attachments?.[0]?.contentId, 'logo')
+})
+
+test('a template email carries attachments', () => {
+  const input: SendTemplateEmailInput = {
+    to: 'user@example.com',
+    template: { name: 'receipt', locale: 'en', data: { total: 10 } },
+    attachments: [receipt, logo],
+  }
+
+  assert.equal(input.attachments?.length, 2)
+})
+
+test('attachments are optional on every variant', () => {
+  const inputs: SendEmailInput[] = [
+    { to: 'user@example.com', text: 'hello' },
+    { to: 'user@example.com', html: '<p>hello</p>' },
+    { to: 'user@example.com', template: { name: 'welcome' } },
+  ]
+
+  for (const input of inputs) {
+    assert.equal(input.attachments, undefined)
+  }
+})
+
+test('a wrapping service forwards attachments to its delegate', async () => {
+  const sent: SendEmailInput[] = []
+  const delegate: EmailService = {
+    async send(input): Promise<SendEmailResult> {
+      sent.push(input as SendEmailInput)
+      return { messageId: 'delegated' }
+    },
+  }
+
+  const wrapper: EmailService = {
+    async send(input): Promise<SendEmailResult> {
+      const { template, ...rest } = input as SendTemplateEmailInput
+      return delegate.send({
+        ...rest,
+        subject: `rendered:${template.name}`,
+        html: '<p>rendered</p>',
+      })
+    },
+  }
+
+  const result = await wrapper.send({
+    to: 'user@example.com',
+    template: { name: 'receipt' },
+    attachments: [receipt],
+  })
+
+  assert.equal(result.messageId, 'delegated')
+  assert.equal(sent.length, 1)
+  assert.deepEqual(sent[0]!.attachments, [receipt])
+})

--- a/packages/core/src/services/email-service.ts
+++ b/packages/core/src/services/email-service.ts
@@ -6,6 +6,19 @@ export interface EmailTemplateReference {
   data?: Record<string, unknown>
 }
 
+export interface EmailAttachment {
+  filename: string
+  /**
+   * Raw bytes, or the content already base64-encoded. A `string` is always
+   * read as base64 — never as a plain-text body — so text attachments must be
+   * encoded by the caller.
+   */
+  content: Uint8Array | string
+  contentType?: string
+  contentId?: string
+  disposition?: 'attachment' | 'inline'
+}
+
 export interface BaseSendEmailInput {
   to: string | string[]
   from?: string
@@ -14,6 +27,7 @@ export interface BaseSendEmailInput {
   replyTo?: string | string[]
   headers?: Record<string, string>
   subject?: string
+  attachments?: EmailAttachment[]
 }
 
 export interface SendTextEmailInput extends BaseSendEmailInput {

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -46,6 +46,7 @@ export type {
 // knowledge: decisions/internals/the-persona-runtime-is-exported-from-the-persona-entry-point.md
 export type { JWTService } from './jwt-service.js'
 export type {
+  EmailAttachment,
   EmailService,
   SendEmailInput,
   SendEmailResult,

--- a/packages/core/src/services/local-email-service.test.ts
+++ b/packages/core/src/services/local-email-service.test.ts
@@ -106,3 +106,77 @@ test('LocalEmailService logs null textLength for HTML email without plain text',
   assert.equal(payload.htmlLength, '<p>Hello</p>'.length)
   assert.equal(payload.textLength, null)
 })
+
+test('LocalEmailService logs attachment metadata without the content', async () => {
+  const service = new LocalEmailService()
+  const writes: string[] = []
+  const originalInfo = console.info
+  console.info = (value?: unknown) => {
+    writes.push(String(value))
+  }
+
+  try {
+    await service.send({
+      to: 'user@example.com',
+      html: '<img src="cid:logo" />',
+      attachments: [
+        {
+          filename: 'receipt.pdf',
+          content: new Uint8Array([1, 2, 3, 4]),
+          contentType: 'application/pdf',
+        },
+        {
+          filename: 'logo.png',
+          content: 'aGVsbG8=',
+          contentType: 'image/png',
+          contentId: 'logo',
+          disposition: 'inline',
+        },
+      ],
+    })
+  } finally {
+    console.info = originalInfo
+  }
+
+  const payload = JSON.parse(writes[0])
+  assert.deepEqual(payload.attachments, [
+    {
+      filename: 'receipt.pdf',
+      contentType: 'application/pdf',
+      contentId: null,
+      disposition: 'attachment',
+      contentLength: 4,
+    },
+    {
+      filename: 'logo.png',
+      contentType: 'image/png',
+      contentId: 'logo',
+      disposition: 'inline',
+      contentLength: 8,
+    },
+  ])
+  assert.equal(writes[0].includes('aGVsbG8='), false)
+})
+
+test('LocalEmailService omits attachments when there are none', async () => {
+  const service = new LocalEmailService()
+  const writes: string[] = []
+  const originalInfo = console.info
+  console.info = (value?: unknown) => {
+    writes.push(String(value))
+  }
+
+  try {
+    await service.send({ to: 'user@example.com', text: 'no files' })
+    await service.send({
+      to: 'user@example.com',
+      text: 'no files',
+      attachments: [],
+    })
+  } finally {
+    console.info = originalInfo
+  }
+
+  assert.equal(JSON.parse(writes[0]).attachments, undefined)
+  assert.equal(JSON.parse(writes[1]).attachments, undefined)
+})

--- a/packages/core/src/services/local-email-service.ts
+++ b/packages/core/src/services/local-email-service.ts
@@ -27,6 +27,15 @@ export class LocalEmailService implements EmailService {
     if ('text' in input && typeof input.text === 'string') {
       payload.textLength = input.text.length
     }
+    if (input.attachments?.length) {
+      payload.attachments = input.attachments.map((attachment) => ({
+        filename: attachment.filename,
+        contentType: attachment.contentType ?? null,
+        contentId: attachment.contentId ?? null,
+        disposition: attachment.disposition ?? 'attachment',
+        contentLength: attachment.content.length,
+      }))
+    }
 
     console.info(JSON.stringify(payload))
     return {}

--- a/packages/core/tsconfig.type-tests.json
+++ b/packages/core/tsconfig.type-tests.json
@@ -8,6 +8,7 @@
   },
   "files": [
     "src/classification/secret-value.test.ts",
+    "src/services/email-service.test.ts",
     "src/types/typed-credentials.test.ts",
     "src/wirings/agent/agent-middleware.types.test.ts"
   ]

--- a/packages/skills/skills/pikku-emails/SKILL.md
+++ b/packages/skills/skills/pikku-emails/SKILL.md
@@ -187,6 +187,7 @@ async send(input: SendEmailInput) {
   const r = renderEmailTemplate(input.template as RenderEmailInput<EmailTemplateName>)
   return this.delegate.send({
     to: input.to, from: input.from, subject: r.subject, html: r.html,
+    attachments: input.attachments,
     ...(r.text ? { text: r.text } : {}),
   })
 }


### PR DESCRIPTION
## What

`BaseSendEmailInput` gains an optional `attachments: EmailAttachment[]`, so it is available on all three input variants — text, HTML and template — through the one base. `EmailAttachment` is exported from `@pikku/core/services` alongside the input types.

```ts
export interface EmailAttachment {
  filename: string
  content: Uint8Array | string
  contentType?: string
  contentId?: string
  disposition?: 'attachment' | 'inline'
}
```

The shape is the intersection of what Resend, SendGrid, Nodemailer and SES v2 accept, so an adapter is a field rename rather than a translation.

## The `content` type

`Uint8Array | string`, where a string is **always** read as base64 — never as a plain-text body. That ambiguity is the one thing here a caller could get wrong, so it carries a short JSDoc.

Both forms are accepted because both are what callers already hold: bytes come out of a `fetch` or a file read, base64 comes out of a database column or a provider API. Normalising to either one forces a decode or an encode on half of all callers, and Workers has no standard base64 helper for the bytes-to-string direction.

`Buffer` is deliberately absent from the type. It is a subclass of `Uint8Array`, so Node callers can still pass one and it structurally satisfies the field, while the type itself stays valid on Cloudflare Workers.

`Safe<T>` already lists `ArrayBufferView` in its `Passthrough` union, so a `Uint8Array` survives the classification mapped type intact — no change needed there.

## Implementations and consumers

- **`LocalEmailService`** logged nothing for attachments and dropped them silently. It now records `filename`, `contentType`, `contentId`, `disposition` and `contentLength` per attachment. The content itself is deliberately not logged.
- **The template-rendering wrapper** rebuilds its delegate payload field by field and therefore dropped `attachments`. Fixed in the `online-shop` example and in both places that teach the pattern (`packages/skills/skills/pikku-emails/SKILL.md`, `.claude/agents/pikku-email-templates.md`) so copies of it do not reintroduce the bug.

There are **no Resend/SES/SMTP/Nodemailer adapter packages in this repo** — `LocalEmailService` is the only `implements EmailService` in `packages/`. (`verifiers/treeshaking/src/services/email.service.ts` is an unrelated class with a `send(to, subject, body)` signature, and the e2e `sendEmail` function is its own zod schema; neither touches this interface.)

## Tests

New `packages/core/src/services/email-service.test.ts` covers attachments on each of the three variants, that the field stays optional, and that a wrapping service forwards attachments to its delegate. It is registered in `tsconfig.type-tests.json`, so the per-variant coverage is enforced at compile time — removing the field from the interface produces 8 type errors in that file.

`local-email-service.test.ts` adds two cases: metadata is logged without the content, and the key is omitted for both a missing and an empty array.

`packages/core`: **2482 tests / 2471 pass / 0 fail** before → **2489 / 2478 / 0 fail** after (11 skipped both ways). No pre-existing failures.

`api-report.md` regenerated after building the package, per the usual ordering requirement.