### PR TITLE
docs(skills): cover `pikku persona run` and inventory the CLI commands

### DIFF
--- a/.changeset/persona-run-command-inventory.md
+++ b/.changeset/persona-run-command-inventory.md
@@ -1,0 +1,21 @@
+---
+'@pikku/skills': patch
+---
+
+Cover `pikku persona run`, and give the corpus a CLI command inventory.
+
+`pikku doc` computes the `#pikku/*` API surface and lists no CLI commands, so
+for anything invoked as `pikku <cmd>` the skills corpus is the only place it
+exists. Two things were missing from it.
+
+`pikku-scenario` covered declaring personas but not running one. Its new
+`references/persona-run.md` covers the virtual-user run: the seven dispositions
+and what each one is for, the three credentials and which wins, the budget and
+`--seed` replay, why production takes only `accountable` and why that rule is
+checked at build time and again at sign-in, the role check that happens before
+the first step, and `sync` / `list` / `secret`.
+
+`pikku-concepts` gains a one-line-per-command inventory of the CLI, grouped by
+what you are doing and pointing at the skill that teaches each one. A dash means
+no skill covers it beyond that line, which is a reason to read `--help` rather
+than assume the command does what its name suggests.

--- a/packages/skills/skills/pikku-concepts/SKILL.md
+++ b/packages/skills/skills/pikku-concepts/SKILL.md
@@ -98,14 +98,15 @@ flags; the "Read" column is the skill that teaches the thing, where one does.
 
 **Running**
 
-| Command                           | What it does                                                      | Read                                    |
-| --------------------------------- | ----------------------------------------------------------------- | --------------------------------------- |
-| `dev`                             | Local dev server, all services wired, watch + HMR                 | `pikku-build`                           |
-| `serve`                           | Bundled bun/node runner — no watch, no codegen                    | `pikku-deploy`                          |
-| `watch`                           | Regenerate on file change, without a server                       | —                                       |
-| `scenario list\|run`              | Scenarios as e2e tests and health checks                          | `pikku-scenario`                        |
-| `persona run\|list\|sync\|secret` | A declared persona as a model-driven virtual user against a stage | `pikku-scenario`, persona-run reference |
-| `db`                              | Local development database                                        | `pikku-kysely`                          |
+| Command                      | What it does                                                                   | Read                                    |
+| ---------------------------- | ------------------------------------------------------------------------------ | --------------------------------------- |
+| `dev`                        | Local dev server, all services wired, watch + HMR                              | `pikku-build`                           |
+| `serve`                      | Bundled bun/node runner — no watch, no codegen                                 | `pikku-deploy`                          |
+| `watch`                      | Regenerate on file change, without a server                                    | —                                       |
+| `scenario list\|run`         | Scenarios as e2e tests and health checks                                       | `pikku-scenario`                        |
+| `persona run`                | A declared persona as a model-driven virtual user against a stage              | `pikku-scenario`, persona-run reference |
+| `persona list\|sync\|secret` | Who is declared; what an environment will provision; minting their credentials | `pikku-scenario`, persona-run reference |
+| `db`                         | Local development database                                                     | `pikku-kysely`                          |
 
 **Inspecting and evolving**
 
@@ -130,6 +131,9 @@ flags; the "Read" column is the skill that teaches the thing, where one does.
 | `dist`                        | Copy what `tsc` cannot emit — `.gen.json` meta, hand-authored `.d.ts` — into the build output. Run it after `tsc`, as a package's build script | —              |
 | `login` / `logout` / `whoami` | The CLI's session against a pikku server                                                                                                       | —              |
 | `skills`                      | Install these skills into an agent (Claude Code, opencode, pi)                                                                                 | —              |
+
+`-c/--config`, `--log-level`, `--json` and the filter flags are **global
+options**, not commands — they attach to the generating commands above.
 
 A dash means no skill covers it beyond this line. `--help` is then the whole of
 it — which is a reason to read `--help` rather than to assume the command does

--- a/packages/skills/skills/pikku-concepts/SKILL.md
+++ b/packages/skills/skills/pikku-concepts/SKILL.md
@@ -74,6 +74,67 @@ which is what decides whether a thrown error becomes a 409 or a 500.
 `pikku doc` needs `@pikku/cli` 0.12.115 or newer. On an older pin, fall back to the door's
 skill and `pikku meta --json`, and do not guess at names the doc would have given you.
 
+## The CLI commands
+
+`pikku doc` is the API surface — the `#pikku/*` exports. It does **not** list
+commands, so this table is where they exist. `pikku <command> --help` has the
+flags; the "Read" column is the skill that teaches the thing, where one does.
+
+**Generating**
+
+| Command                                    | What it does                                         | Read                          |
+| ------------------------------------------ | ---------------------------------------------------- | ----------------------------- |
+| `all`                                      | Everything: types, schemas, wirings, clients         | this skill                    |
+| `bootstrap`                                | Type files only (the setup phase)                    | this skill                    |
+| `schemas`                                  | JSON Schemas for function input/output types         | this skill                    |
+| `fetch` / `websocket` / `rpc` / `realtime` | One client each, when you do not want `all`          | `pikku-wiring`, `pikku-react` |
+| `react-query` / `tanstack-start`           | React Query hooks; the TanStack Start `makeApi` shim | `pikku-react`                 |
+| `queue-service`                            | The queue service wrapper                            | `pikku-wiring`                |
+| `openapi`                                  | An OpenAPI spec from the HTTP routes                 | —                             |
+| `nextjs`                                   | Next.js backend and HTTP wrappers                    | `pikku-deploy`                |
+| `new`                                      | Scaffold a function or wiring                        | `pikku-wiring`                |
+| `enable`                                   | Turn a Pikku feature on                              | `pikku-build`                 |
+| `import`                                   | Import workflows from another system                 | `pikku-n8n-import`            |
+
+**Running**
+
+| Command                           | What it does                                                      | Read                                    |
+| --------------------------------- | ----------------------------------------------------------------- | --------------------------------------- |
+| `dev`                             | Local dev server, all services wired, watch + HMR                 | `pikku-build`                           |
+| `serve`                           | Bundled bun/node runner — no watch, no codegen                    | `pikku-deploy`                          |
+| `watch`                           | Regenerate on file change, without a server                       | —                                       |
+| `scenario list\|run`              | Scenarios as e2e tests and health checks                          | `pikku-scenario`                        |
+| `persona run\|list\|sync\|secret` | A declared persona as a model-driven virtual user against a stage | `pikku-scenario`, persona-run reference |
+| `db`                              | Local development database                                        | `pikku-kysely`                          |
+
+**Inspecting and evolving**
+
+| Command               | What it does                                                            | Read                         |
+| --------------------- | ----------------------------------------------------------------------- | ---------------------------- |
+| `doc`                 | The installed API surface                                               | this skill                   |
+| `meta` / `info`       | What the project declares, machine- and human-readable                  | `pikku-meta`                 |
+| `validate`            | Every check that applies — app structure, an addon's published file set | `pikku-build`, `pikku-addon` |
+| `versions` / `semver` | Contract hashes, breaking-change detection, the release semver          | `pikku-meta`                 |
+| `audit` / `update`    | Advisories; which `@pikku/*` can move and what peers that needs         | `pikku-meta`                 |
+| `scopes` / `roles`    | Declared authorization scopes; roles from `defineSystemRole`            | `pikku-auth`                 |
+| `knowledge`           | The knowledge base — what this app is, in its users' language           | `pikku-knowledge`            |
+| `emails`              | Email template generation                                               | `pikku-emails`               |
+
+**Shipping, and the CLI itself**
+
+| Command                       | What it does                                                                                                                                   | Read           |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `deploy`                      | Deploy to cloud infrastructure                                                                                                                 | `pikku-deploy` |
+| `fabric`                      | PikkuFabric: login, link, deploy, domains, secrets, logs                                                                                       | `pikku-fabric` |
+| `binary`                      | Compile an entrypoint to a native binary (`bun build --compile`)                                                                               | —              |
+| `dist`                        | Copy what `tsc` cannot emit — `.gen.json` meta, hand-authored `.d.ts` — into the build output. Run it after `tsc`, as a package's build script | —              |
+| `login` / `logout` / `whoami` | The CLI's session against a pikku server                                                                                                       | —              |
+| `skills`                      | Install these skills into an agent (Claude Code, opencode, pi)                                                                                 | —              |
+
+A dash means no skill covers it beyond this line. `--help` is then the whole of
+it — which is a reason to read `--help` rather than to assume the command does
+what its name suggests.
+
 ## Core Mental Model
 
 ```text

--- a/packages/skills/skills/pikku-scenario/SKILL.md
+++ b/packages/skills/skills/pikku-scenario/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: pikku-scenario
 description: >-
-  Use when writing or running Pikku scenarios, or when asked to test Pikku functions or improve
-  test coverage. A scenario (pikkuScenario) drives the app the way users do — steps run as actors
-  over the real transport against a running server — so a flow doubles as an e2e test and a
-  staged/production health check. Covers scenario.do / expectEventually / expectError /
-  expectService / expectScore, declared steps via pikkuScenarioStep (including browser steps driven by
-  @pikku/playwright) written as intent rather than as clicks, with the actions factored into
-  shared browser utilities, actors and environments in pikku.config.json, SCENARIO_ACTOR_SECRET, the
-  `pikku scenario list|run` commands, live function coverage via `pikku dev --coverage`, and
-  plain unit tests for pure function logic. TRIGGER when: user asks about scenarios, testing a
-  Pikku function, test coverage, end-to-end flows, browser/UI e2e, or health checks. DO NOT
-  TRIGGER when: user asks about running an existing test suite (use Bash) or CI configuration.
+  Use when writing or running Pikku scenarios, running a persona as a virtual user, or when
+  asked to test Pikku functions or improve coverage. A scenario (pikkuScenario) drives the app
+  the way users do — steps run as actors over the real transport against a running server — so a
+  flow doubles as an e2e test and a staged/production health check. Covers scenario.do /
+  expectEventually / expectError / expectService / expectScore, declared steps via
+  pikkuScenarioStep (browser steps driven by @pikku/playwright) written as intent rather than
+  clicks, personas / actors / environments in pikku.config.json, SCENARIO_ACTOR_SECRET, the
+  `pikku scenario list|run` and `pikku persona run|list|sync|secret` commands, and live coverage
+  via `pikku dev --coverage`. TRIGGER when: user asks about scenarios, testing a Pikku function,
+  coverage, e2e flows, browser/UI e2e, health checks, personas, virtual users, or adversarial
+  runs against a stage. DO NOT TRIGGER when: user asks about running an existing suite (use
+  Bash) or CI config.
 installGroups: [core]
 ---
 
@@ -28,6 +29,13 @@ Use this skill as an execution checklist, not reference material.
 5. If validation fails, fix the source cause and rerun. Do not paper over generated errors by editing generated files.
 
 **`pikku tests` does not exist.** It was removed in #865 — scenarios own coverage now. Any reference you find to it is stale.
+
+## Pick the reference
+
+| You are…                                                         | Read                        |
+| ---------------------------------------------------------------- | --------------------------- |
+| Writing or running scenarios                                     | this skill                  |
+| Running a persona as a model-driven virtual user against a stage | `references/persona-run.md` |
 
 ## What a scenario is
 
@@ -379,10 +387,13 @@ identifier is an API, and it is read by the toolchain.
 
 ```typescript
 // pikku.config.json: { "metaLocale": "de" }
-export const buysAnApple = pikkuScenarioStep<{ qty: number }, { orderId: string }>({
-  name: 'buysAnApple',          // identifier — English, always
-  description: 'kauft einen Apfel',  // prose — follows locale
-  template: 'kauft {qty} Äpfel',     // prose — follows locale
+export const buysAnApple = pikkuScenarioStep<
+  { qty: number },
+  { orderId: string }
+>({
+  name: 'buysAnApple', // identifier — English, always
+  description: 'kauft einen Apfel', // prose — follows locale
+  template: 'kauft {qty} Äpfel', // prose — follows locale
   actor: true,
   default: async (_services, { qty }, { actor }) =>
     await actor.invoke('placeOrder', { qty }),
@@ -548,7 +559,7 @@ Two consequences follow, and both shape how steps get written:
   as an RPC — which usually improves the product, since a client debugging the
   same problem needed it too.
 - **`agentRunner` is conditional.** It is built only when the project declares
-  agents, and `createDevAgentRunner` needs a base URL *and* a key together
+  agents, and `createDevAgentRunner` needs a base URL _and_ a key together
   (`OPENAI_BASE_URL` + `OPENAI_API_KEY`, or the LiteLLM pair). With a key alone
   it returns nothing and `agentRunner` is `undefined`, so `actor.converse`
   fails before the persona says anything. A suite that would rather own its own
@@ -596,12 +607,16 @@ import type messages from '../../../../apps/web/messages/en.json'
 
 export type MessageKey = keyof typeof messages
 
-export const t = (key: MessageKey, locale = baseLocale): string => { /* … */ }
+export const t = (key: MessageKey, locale = baseLocale): string => {
+  /* … */
+}
 ```
 
 ```typescript
 await page.getByLabel(t('jobs_apply_fullname')).fill(identity.name)
-await page.getByRole('button', { name: t('jobs_apply_submit'), exact: true }).click()
+await page
+  .getByRole('button', { name: t('jobs_apply_submit'), exact: true })
+  .click()
 ```
 
 - Type off `messages/<baseLocale>.json`, **not** the generated Paraglide output — `i18n/paraglide/` is build output, so typing against it makes the tests unbuildable until the app has been built. The JSON is the tracked source.
@@ -676,11 +691,11 @@ Generated files are exempt and never claim the slot.
 What that admits and what it does not:
 
 ```typescript
-personality: 'Wound up and short with it.'      // read
+personality: 'Wound up and short with it.' // read
 personality: `Wound up and short with it.
-  Says what she wants in a few blunt words.`    // read — no ${} in it
-personality: 'Wound up. ' + 'Short with it.'    // dropped, silently
-personality: TEMPERAMENTS.impatient             // dropped, silently
+  Says what she wants in a few blunt words.` // read — no ${} in it
+personality: 'Wound up. ' + 'Short with it.' // dropped, silently
+personality: TEMPERAMENTS.impatient // dropped, silently
 ```
 
 A no-substitution template literal is a string literal as far as the reader is
@@ -825,22 +840,22 @@ Services are plain objects — a Pikku function is pure business logic, so a moc
 
 ## Red flags
 
-| Smell                                               | Why it's wrong                                                                                                              |
-| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `pikku tests …`                                     | Removed in #865. Use `pikku scenario`.                                                                                      |
-| `.feature` files / Gherkin for function tests       | Scenarios are TypeScript, not Gherkin. The in-process cucumber function world was deleted.                                  |
-| `scenario.do(...)` with no `{ actor }`              | Throws. Every step runs as somebody.                                                                                        |
-| A scenario per function                             | Scenarios are user flows. One flow covers many functions; that is the point.                                                |
-| Assuming a clean database                           | There is no state reset — it may be a staging server. Scope what you create.                                                |
-| `sleep()` before asserting                          | Use `expectEventually`.                                                                                                     |
-| A step named `clicksAddToBasket` / `opensThePage`   | That is an action, not an intent. Name the step for what the actor wanted; put the clicking in a utility.                   |
-| A step named `kauftEinenApfel` / a `vorgang` table   | Identifiers are English in every project. The German belongs in `description` / `template`, and only when `pikku.config.json` sets `metaLocale`.  |
-| A browser step that assumes it is already on a page | It can then only run mid-flow. Arrive first — check the URL, navigate if needed.                                            |
-| `getByLabel('Full Name')` in a translated app        | Passes only in the base locale, and a copy edit breaks it as an unexplained timeout. Locate by message key.                 |
-| A `browser` binding guarding `if (!browser)`        | The binding guarantees it. The guard hides the real error, which is a missing actor (`PKU677`).                             |
-| A step with a `func:` instead of a surface binding  | There is no `func` on a step. Bodies live under `default` / `browser` / `cli`; a step with none throws at load.             |
-| `expectEventually` in a `pikkuWorkflowFunc`         | `PKU675` — scenario-only.                                                                                                   |
-| Coverage silently 0                                 | Server not run with `--coverage`, verbose functions meta not deployed, `scaffold.scenarios` unset, or no actors configured. |
+| Smell                                               | Why it's wrong                                                                                                                                   |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pikku tests …`                                     | Removed in #865. Use `pikku scenario`.                                                                                                           |
+| `.feature` files / Gherkin for function tests       | Scenarios are TypeScript, not Gherkin. The in-process cucumber function world was deleted.                                                       |
+| `scenario.do(...)` with no `{ actor }`              | Throws. Every step runs as somebody.                                                                                                             |
+| A scenario per function                             | Scenarios are user flows. One flow covers many functions; that is the point.                                                                     |
+| Assuming a clean database                           | There is no state reset — it may be a staging server. Scope what you create.                                                                     |
+| `sleep()` before asserting                          | Use `expectEventually`.                                                                                                                          |
+| A step named `clicksAddToBasket` / `opensThePage`   | That is an action, not an intent. Name the step for what the actor wanted; put the clicking in a utility.                                        |
+| A step named `kauftEinenApfel` / a `vorgang` table  | Identifiers are English in every project. The German belongs in `description` / `template`, and only when `pikku.config.json` sets `metaLocale`. |
+| A browser step that assumes it is already on a page | It can then only run mid-flow. Arrive first — check the URL, navigate if needed.                                                                 |
+| `getByLabel('Full Name')` in a translated app       | Passes only in the base locale, and a copy edit breaks it as an unexplained timeout. Locate by message key.                                      |
+| A `browser` binding guarding `if (!browser)`        | The binding guarantees it. The guard hides the real error, which is a missing actor (`PKU677`).                                                  |
+| A step with a `func:` instead of a surface binding  | There is no `func` on a step. Bodies live under `default` / `browser` / `cli`; a step with none throws at load.                                  |
+| `expectEventually` in a `pikkuWorkflowFunc`         | `PKU675` — scenario-only.                                                                                                                        |
+| Coverage silently 0                                 | Server not run with `--coverage`, verbose functions meta not deployed, `scaffold.scenarios` unset, or no actors configured.                      |
 
 `@pikku/cucumber` is a **browser/e2e** harness (`Actor`, `BrowserWorld`, `PersonaData`, `DbUtils`) — out of scope here.
 

--- a/packages/skills/skills/pikku-scenario/references/persona-run.md
+++ b/packages/skills/skills/pikku-scenario/references/persona-run.md
@@ -1,0 +1,135 @@
+# Running a persona as a virtual user
+
+`pikku persona run <environment> <persona>` signs a declared persona in over the
+app's real auth and works the API in character, driven by a model. A persona
+while running **is** the virtual user — there is no second declaration for it.
+
+**It is not a test runner.** It asserts nothing, and a green run proves nothing:
+what it produces is _findings_, and their absence is only ever "not this time,
+not with this seed". Findings set exit code 1, so a run can gate a pipeline;
+giving up on a goal does not, because that is a user being a user.
+
+Everything it needs is already in the project — the catalogue is the function
+meta, the intents are the scenarios' own prose, the identity is the persona
+signing in, the scopes come from their declared roles. The only new input is
+which person to be.
+
+Declaring personas — persona versus actor, `definePersonas`, materialised
+actors — is in the skill itself, under **Personas and actors**. This is the
+running half.
+
+## The shape of a run
+
+```bash
+SCENARIO_ACTOR_SECRET=… pikku persona run local shopper
+SCENARIO_ACTOR_SECRET=… pikku persona run local shopper -d careless --seed 42
+SCENARIO_ACTOR_SECRET=… pikku persona run staging auditor \
+  --goals "reconcile the order totals" --steps 80 --out runs/auditor.json
+```
+
+Both arguments are required positionals: the environment key from
+`environments`, then the persona id. A run needs a model — `--model`, or
+`scenarios.model` in `pikku.config.json` — and an AI provider in the
+environment (`OPENAI_BASE_URL` + `OPENAI_API_KEY`, or `LITELLM_PROXY_URL` +
+`LITELLM_API_KEY`).
+
+| Flag                   | Effect                                                                                                                |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `--disposition` / `-d` | How they behave. Overrides the persona's own                                                                          |
+| `--goals`              | Comma-separated, in your words — run _alongside_ the persona's own and the ones derived from scenarios                |
+| `--steps`              | Model turns before it stops (default 40)                                                                              |
+| `--mutations`          | Non-read calls before it stops                                                                                        |
+| `--duration`           | Wall clock before it stops, e.g. `30m`                                                                                |
+| `--seed`               | Replay — the same seed schedules the same run                                                                         |
+| `--model`              | The model they think with                                                                                             |
+| `--allow-approval`     | Offer the endpoints the app marked as needing a human's approval. Off by default: those are the ones that spend money |
+| `--skip-role-check`    | Start without verifying declared roles against the stage                                                              |
+| `--api-url`            | Override the environment's `apiUrl`, for a target that only exists at run time                                        |
+| `--out`                | Write the whole run — every step, response and finding — as JSON                                                      |
+
+## The dispositions
+
+A disposition is a bundle of instructions and mechanical dials (move weights,
+temperature, repeat and re-read rates). `tuning` on the persona adjusts those
+dials without replacing the character — a tuned `careless` user is still
+careless. Passing `--disposition` drops the persona's `tuning`, because you
+asked to run them differently rather than to bend their dials into another
+shape.
+
+| Disposition   | Who that is                                                                                                                   |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `realistic`   | The default. A competent user reading schemas and entering plausible values                                                   |
+| `careless`    | Busy, interrupted, half-remembering; submits twice, enters odd-but-legal values. **Where most production bugs actually live** |
+| `newcomer`    | First time here, holds no ids in their head, must find a path from the lists that exist (`emptyMemory`)                       |
+| `stale`       | Working from old notes — reaches for ids that may no longer resolve, to see how the product says so                           |
+| `auditor`     | Reconciling, not achieving: reads one fact from every endpoint claiming to know it and reports disagreement. Read-only        |
+| `adversarial` | Probing whether the boundaries are enforced. Inverted oracle — a 2xx from something it should not reach is the finding        |
+| `accountable` | Doing the job for real. The **only** disposition production accepts                                                           |
+
+## Credentials, and which one wins
+
+Three variables, checked in this order. None of them belongs in
+`pikku.config.json`.
+
+1. **`FABRIC_OPERATOR_TOKEN`** — what a deployed stage accepts. Asymmetric, and
+   it needs no account the target would not otherwise have, so it wins over the
+   other two when both are present.
+2. **`PIKKU_PERSONA_SECRETS`** — `id=secret,id=secret`, already-derived
+   per-persona credentials. Hand a run only the personas it should be able to
+   be; asking for one outside the list is refused by name rather than falling
+   through to the root. Mint them with `pikku persona secret [personas...]` —
+   naming none mints all.
+3. **`SCENARIO_ACTOR_SECRET`** — the root secret, which derives every persona's
+   credential and is therefore entitled to all of them. Only `pikku dev` serves
+   the endpoint it opens.
+
+## Production is opt-in, twice
+
+A persona's `environments` omitted means every configured environment **except**
+those flagged `production: true` — nothing reaches production by being
+forgotten. Naming one requires `disposition: 'accountable'`.
+
+That rule is checked twice on purpose: the inspector checks the declaration at
+build time, and sign-in re-checks the **effective** disposition against the
+environment actually resolved at run time. So `--disposition adversarial`
+cannot point an accountable persona at production. The build check trusts the
+file; the run check does not trust which artifact got deployed.
+
+## The role check happens before the first step
+
+A run reads its own roles back from the stage and compares them to what the
+persona declared. It refuses on a mismatch, before anything runs — findings
+from a persona whose roles drifted are about the seed, and reading them as
+product bugs is how a whole run gets thrown away. A stage that reports no roles
+warns and runs unverified. `--skip-role-check` is for a target whose auth
+reports roles somewhere pikku cannot read; findings from such a run may be seed
+drift.
+
+## The other subcommands
+
+| Command                              | What it answers                                                                            |
+| ------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `pikku persona list`                 | Who is declared — who each one is, what they may do, what they want                        |
+| `pikku persona sync <environment>`   | Which personas that environment will provision, with which roles, and why any were skipped |
+| `pikku persona secret [personas...]` | Mint per-persona credentials from the root secret                                          |
+
+`sync` **reports**; it does not provision. The CLI has no connection to a
+deployed environment's database, so the provisioning happens in the deployment —
+pass the generated personas to `pikkuFabric` from `@pikku/better-auth`.
+
+## What NOT to do
+
+- **Do not treat a clean run as a pass.** Nothing was asserted. Use scenarios
+  for the things that must hold.
+- **Do not run a persona declared `runnable: false`**, or one whose `account`
+  names a provider. The first is someone who exists to be acted upon — running
+  her races the scenario that bans her — and the second needs a human at a
+  consent screen. Both are refused before sign-in rather than partway through.
+- **Do not put any of the three credentials in `pikku.config.json`.** They are
+  environment variables.
+- **Do not pass `--allow-approval` casually.** The endpoints behind it are the
+  ones the app marked as needing a human because they spend money.
+- **Do not read a finding from a run started with `--skip-role-check` as a
+  product bug** until the roles are confirmed some other way.
+- **Do not expect `--goals` to replace the persona's goals.** They are appended;
+  a run that replaces Susan's goals is not Susan.

--- a/packages/skills/skills/pikku-scenario/references/persona-run.md
+++ b/packages/skills/skills/pikku-scenario/references/persona-run.md
@@ -33,19 +33,19 @@ Both arguments are required positionals: the environment key from
 environment (`OPENAI_BASE_URL` + `OPENAI_API_KEY`, or `LITELLM_PROXY_URL` +
 `LITELLM_API_KEY`).
 
-| Flag                   | Effect                                                                                                                |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `--disposition` / `-d` | How they behave. Overrides the persona's own                                                                          |
-| `--goals`              | Comma-separated, in your words — run _alongside_ the persona's own and the ones derived from scenarios                |
-| `--steps`              | Model turns before it stops (default 40)                                                                              |
-| `--mutations`          | Non-read calls before it stops                                                                                        |
-| `--duration`           | Wall clock before it stops, e.g. `30m`                                                                                |
-| `--seed`               | Replay — the same seed schedules the same run                                                                         |
-| `--model`              | The model they think with                                                                                             |
-| `--allow-approval`     | Offer the endpoints the app marked as needing a human's approval. Off by default: those are the ones that spend money |
-| `--skip-role-check`    | Start without verifying declared roles against the stage                                                              |
-| `--api-url`            | Override the environment's `apiUrl`, for a target that only exists at run time                                        |
-| `--out`                | Write the whole run — every step, response and finding — as JSON                                                      |
+| Flag                   | Effect                                                                                                                                                |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--disposition` / `-d` | How they behave. Overrides the persona's own                                                                                                          |
+| `--goals`              | Comma-separated, in your words — run _alongside_ the persona's own and the ones derived from scenarios                                                |
+| `--steps`              | Model turns before it stops (default 40)                                                                                                              |
+| `--mutations`          | Non-read calls before it stops                                                                                                                        |
+| `--duration`           | Wall clock before it stops, e.g. `30m`                                                                                                                |
+| `--seed`               | Replay — the same seed schedules the same run                                                                                                         |
+| `--model`              | The model they think with                                                                                                                             |
+| `--allow-approval`     | Offer the endpoints the app marked as needing a human's approval. Off by default: those are the ones that spend money                                 |
+| `--skip-role-check`    | Start without verifying declared roles against the stage                                                                                              |
+| `--api-url`            | Override the environment's `apiUrl`, for a target that only exists at run time. It replaces the url, not the environment's classification — see below |
+| `--out`                | Write the whole run — every step, response and finding — as JSON                                                                                      |
 
 ## The dispositions
 
@@ -90,10 +90,20 @@ those flagged `production: true` — nothing reaches production by being
 forgotten. Naming one requires `disposition: 'accountable'`.
 
 That rule is checked twice on purpose: the inspector checks the declaration at
-build time, and sign-in re-checks the **effective** disposition against the
-environment actually resolved at run time. So `--disposition adversarial`
-cannot point an accountable persona at production. The build check trusts the
-file; the run check does not trust which artifact got deployed.
+build time, and sign-in re-checks the **effective** disposition — the persona's
+own, or whatever `--disposition` replaced it with — before the run starts. So
+`--disposition adversarial` cannot point an accountable persona at production.
+The build check trusts the file; the run check does not trust which artifact got
+deployed.
+
+**That rule is keyed on the environment's name, not its url.** `production:
+true` is a label a person wrote in `pikku.config.json`; nothing can tell from a
+url whether real customers are behind it. `--api-url` replaces the url and keeps
+the classification, so a non-production environment repointed at a production
+host is still treated as non-production, and an adversarial persona will happily
+run against it. The flag is for a target that only exists at run time — a
+freshly provisioned sandbox. Point it anywhere else and the guard above is not
+protecting you.
 
 ## The role check happens before the first step
 
@@ -125,6 +135,9 @@ pass the generated personas to `pikkuFabric` from `@pikku/better-auth`.
   names a provider. The first is someone who exists to be acted upon — running
   her races the scenario that bans her — and the second needs a human at a
   consent screen. Both are refused before sign-in rather than partway through.
+- **Do not use `--api-url` to reach a production host from a non-production
+  environment.** The disposition guard reads the named environment's
+  `production` flag, not the url you pointed it at, so nothing will stop you.
 - **Do not put any of the three credentials in `pikku.config.json`.** They are
   environment variables.
 - **Do not pass `--allow-approval` casually.** The endpoints behind it are the


### PR DESCRIPTION
Closes #1542.

`pikku doc` computes the `#pikku/*` API surface (20 doors, 174 exports) and lists **no CLI commands**, so for anything invoked as `pikku <cmd>` the skills corpus is the only place it exists. Two gaps were left after the 63→21 consolidation (#1541).

## `pikku persona run`

`pikku-scenario` covered declaring personas — persona versus actor, `definePersonas`, materialised actors — but not running one. The new `pikku-scenario/references/persona-run.md` covers the virtual-user run:

- the seven dispositions and what each is *for*, including that `careless` is where most production bugs live and that `accountable` is the only one production accepts
- `FABRIC_OPERATOR_TOKEN` / `PIKKU_PERSONA_SECRETS` / `SCENARIO_ACTOR_SECRET`, the order they are checked and why the operator token wins
- the `--steps` / `--mutations` / `--duration` budget, `--seed` replay, `--allow-approval`, `--out`
- why the production rule is checked twice — inspector at build time, sign-in against the *effective* disposition at run time, so `--disposition` cannot point an accountable persona at production
- the role check that runs before the first step, and what `--skip-role-check` costs you
- `persona sync` reports, it does not provision
- that findings set exit code 1 and a green run proves nothing

## The command inventory

`pikku-concepts` gains a one-line-per-command table of the whole CLI, grouped by what you are doing (generating / running / inspecting / shipping) and pointing at the skill that teaches each one. A dash means no skill covers it beyond that line — `binary`, `dist`, `watch`, `openapi`, `skills`, `login`/`logout`/`whoami` — which is a reason to read `--help` rather than assume the command does what its name suggests.

## Verification

`packages/skills` 10/10, and the CLI's `build-surface-doc` + `surface-editorial` suites 10/10. Manifest re-embedded (95 files, 21 skills).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a CLI command inventory covering project generation, execution, inspection, evolution, shipping, and management.
  * Added guidance for running personas as virtual users, including supported dispositions, credentials, budgets, replay seeds, production safeguards, and role checks.
  * Documented `persona run`, `list`, `sync`, and `secret`, including available options and expected findings.
  * Clarified how to select relevant scenario references and interpret run results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->