### PR TITLE
feat: the milestone plan format, and `pikku knowledge plan`

### DIFF
--- a/.changeset/knowledge-plan-command.md
+++ b/.changeset/knowledge-plan-command.md
@@ -1,0 +1,24 @@
+---
+'@pikku/knowledge': patch
+'@pikku/cli': patch
+---
+
+Add `pikku knowledge plan` — read and write a milestone's technical plan.
+
+    pikku knowledge plan schema
+    pikku knowledge plan show <milestone> [--for-build]
+    pikku knowledge plan set <milestone> <file>
+    pikku knowledge plan defer <milestone> <item> --reason "..."
+
+`set` is the point of it. It runs the schema, then `checkFirstPass`,
+`checkPlanInternals` and `checkAgainstMilestone` against the milestone note's
+own surface and personas, and writes nothing unless all of them pass — a plan
+validated at gate time instead has already cost the build it was measured
+against. A shape refusal carries the schema with it, so a writer told a field
+is invalid does not have to go looking for what the valid options are.
+
+`defer` moves ONE first-pass item to the next pass with its reason recorded,
+which is the only sanctioned way for something planned to stop blocking the
+milestone. The runners live in `@pikku/knowledge` as
+`runKnowledgePlanSchema`/`Show`/`Set`/`Defer`, so anything else driving a build
+gets the same order of checks without reimplementing it.

--- a/.changeset/knowledge-plan-format.md
+++ b/.changeset/knowledge-plan-format.md
@@ -1,0 +1,32 @@
+---
+'@pikku/knowledge': patch
+---
+
+Add the milestone plan format to `@pikku/knowledge`.
+
+A milestone says what to build; a plan says what building it consists of —
+which functions, wires, roles, scopes, screens and scenarios a pass owes, and
+what was deferred to the next one. The two halves were split across two repos:
+this package owned the note format, `MILESTONE_TYPE` and `runKnowledgeValidate`,
+while the plan lived downstream. Anything that wanted to write a plan had to
+reimplement the schema from an example.
+
+`PlanSchema` and `PLAN_VERSION` are the format. `readPlan`/`writePlan` are the
+only readers and writers. `checkFirstPass`, `checkAgainstMilestone` and
+`checkPlanInternals` are deterministic gates over a plan and its milestone —
+they judge whether the plan holds, never whether it is a good plan, which stays
+a matter for whatever wrote it. `planSchemaJson` emits the schema as JSON Schema
+so an agent can be handed the shape rather than made to infer it.
+
+`plan-meta` reads a generated `.pikku` meta directory and reports which planned
+items the code actually discharges: `planProgress`, `planShortfall`,
+`cascadeProblems`. `hollow-scenarios` classifies a scenario by what it proves,
+so a plan cannot be satisfied by scenarios that assert nothing.
+
+`readPlan` refuses a plan whose `version` this reader does not know, naming the
+version, rather than reporting the mismatch as a scatter of field errors. That
+is what lets the format change later without a stale reader spending its turn
+editing fields to satisfy a schema it cannot satisfy.
+
+`notes` also gains `MILESTONES_DIR`, `MILESTONE_SURFACES`, `listOf` and
+`noteHash`, which the plan reads and which belong with the note vocabulary.

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -41,6 +41,16 @@ import {
   knowledgeIndex,
   renderKnowledgeIndex,
 } from './functions/commands/knowledge-index.js'
+import {
+  knowledgePlanDefer,
+  knowledgePlanSchema,
+  knowledgePlanSet,
+  knowledgePlanShow,
+  renderKnowledgePlanDefer,
+  renderKnowledgePlanSchema,
+  renderKnowledgePlanSet,
+  renderKnowledgePlanShow,
+} from './functions/commands/knowledge-plan.js'
 import { scenarioRun, scenarioList } from './functions/commands/scenario.js'
 import {
   personaList,
@@ -635,6 +645,51 @@ wireCLI({
             },
           },
         }),
+        plan: {
+          description:
+            "Read and write a milestone's technical plan — the shape of the work, checked before it is built rather than after",
+          subcommands: {
+            schema: pikkuCLICommand({
+              func: knowledgePlanSchema,
+              render: renderKnowledgePlanSchema,
+              description:
+                'Print the plan schema, so a plan is written against what is enforced rather than guessed at',
+            }),
+            show: pikkuCLICommand({
+              func: knowledgePlanShow,
+              render: renderKnowledgePlanShow,
+              description: "Print a milestone's plan",
+              parameters: '<milestone>',
+              options: {
+                forBuild: {
+                  description:
+                    'Render it as the ordered list of work a build follows, rather than as stored',
+                  default: false,
+                },
+              },
+            }),
+            set: pikkuCLICommand({
+              func: knowledgePlanSet,
+              render: renderKnowledgePlanSet,
+              description:
+                'Validate a plan against its milestone note and write it, or write nothing and say what is wrong',
+              parameters: '<milestone> <file>',
+            }),
+            defer: pikkuCLICommand({
+              func: knowledgePlanDefer,
+              render: renderKnowledgePlanDefer,
+              description:
+                'Move one first-pass item to the next pass, with the reason on the record',
+              parameters: '<milestone> <item>',
+              options: {
+                reason: {
+                  description: 'Why this item cannot land in the first pass',
+                  short: 'r',
+                },
+              },
+            }),
+          },
+        },
       },
     },
     validate: pikkuCLICommand({

--- a/packages/cli/src/functions/commands/knowledge-plan.ts
+++ b/packages/cli/src/functions/commands/knowledge-plan.ts
@@ -1,0 +1,64 @@
+import { pikkuSessionlessFunc } from '#pikku/function'
+import {
+  runKnowledgePlanDefer,
+  runKnowledgePlanSchema,
+  runKnowledgePlanSet,
+  runKnowledgePlanShow,
+} from '@pikku/knowledge'
+import {
+  renderKnowledgePlanDefer,
+  renderKnowledgePlanSchema,
+  renderKnowledgePlanSet,
+  renderKnowledgePlanShow,
+} from '../knowledge/render.js'
+import {
+  KnowledgePlanDeferInputSchema,
+  KnowledgePlanDeferOutputSchema,
+  KnowledgePlanSchemaInputSchema,
+  KnowledgePlanSchemaOutputSchema,
+  KnowledgePlanSetInputSchema,
+  KnowledgePlanSetOutputSchema,
+  KnowledgePlanShowInputSchema,
+  KnowledgePlanShowOutputSchema,
+} from '../knowledge/schemas.js'
+
+export const knowledgePlanSchema = pikkuSessionlessFunc({
+  description:
+    'Print the plan schema, so a plan is written against what is actually enforced rather than guessed at.',
+  input: KnowledgePlanSchemaInputSchema,
+  output: KnowledgePlanSchemaOutputSchema,
+  func: async () => runKnowledgePlanSchema(),
+})
+
+export const knowledgePlanShow = pikkuSessionlessFunc({
+  description:
+    "Print a milestone's plan, either as it is stored or as the ordered list of work a build follows.",
+  input: KnowledgePlanShowInputSchema,
+  output: KnowledgePlanShowOutputSchema,
+  func: async ({ config }, input) =>
+    runKnowledgePlanShow(config.rootDir, input),
+})
+
+export const knowledgePlanSet = pikkuSessionlessFunc({
+  description:
+    'Validate a plan against its milestone note and write it, or write nothing and say what is wrong.',
+  input: KnowledgePlanSetInputSchema,
+  output: KnowledgePlanSetOutputSchema,
+  func: async ({ config }, input) => runKnowledgePlanSet(config.rootDir, input),
+})
+
+export const knowledgePlanDefer = pikkuSessionlessFunc({
+  description:
+    'Move one first-pass item to the next pass with the reason on the record, so it stops blocking the milestone.',
+  input: KnowledgePlanDeferInputSchema,
+  output: KnowledgePlanDeferOutputSchema,
+  func: async ({ config }, input) =>
+    runKnowledgePlanDefer(config.rootDir, input),
+})
+
+export {
+  renderKnowledgePlanDefer,
+  renderKnowledgePlanSchema,
+  renderKnowledgePlanSet,
+  renderKnowledgePlanShow,
+}

--- a/packages/cli/src/functions/knowledge/render.ts
+++ b/packages/cli/src/functions/knowledge/render.ts
@@ -1,5 +1,9 @@
 import type {
   KnowledgeIndexResult,
+  KnowledgePlanDeferResult,
+  KnowledgePlanSchemaResult,
+  KnowledgePlanSetResult,
+  KnowledgePlanShowResult,
   KnowledgeValidateResult,
 } from '@pikku/knowledge'
 import { added, changed, dim, removed } from '../../fabric/lib/output.js'
@@ -84,4 +88,53 @@ export const renderKnowledgeIndex = (
     )
     if (!ok) process.exitCode = 1
   }
+}
+
+export const renderKnowledgePlanSchema = (
+  _services: unknown,
+  { schema }: KnowledgePlanSchemaResult
+): void => {
+  console.log(schema)
+}
+
+export const renderKnowledgePlanShow = (
+  _services: unknown,
+  { ok, path, body }: KnowledgePlanShowResult
+): void => {
+  if (!ok) {
+    console.log(`${removed('✗')}  ${body}`)
+    process.exitCode = 1
+    return
+  }
+  console.log(dim(path))
+  console.log(body)
+}
+
+export const renderKnowledgePlanSet = (
+  _services: unknown,
+  { ok, path, problems, schema }: KnowledgePlanSetResult
+): void => {
+  if (ok) {
+    console.log(`${added('✓')}  plan written to ${path}`)
+    console.log(dim('the build is measured against it'))
+    return
+  }
+  console.log(`${removed('✗')}  not written:`)
+  for (const problem of problems) {
+    console.log(`   ${problem}`)
+  }
+  if (schema) {
+    console.log()
+    console.log(dim('the schema, in full — build the plan to match it:'))
+    console.log(schema)
+  }
+  process.exitCode = 1
+}
+
+export const renderKnowledgePlanDefer = (
+  _services: unknown,
+  { ok, message }: KnowledgePlanDeferResult
+): void => {
+  console.log(`${ok ? added('✓') : removed('✗')}  ${message}`)
+  if (!ok) process.exitCode = 1
 }

--- a/packages/cli/src/functions/knowledge/schemas.ts
+++ b/packages/cli/src/functions/knowledge/schemas.ts
@@ -1,6 +1,14 @@
 import {
   KnowledgeIndexInput,
   KnowledgeIndexOutput,
+  KnowledgePlanDeferInput,
+  KnowledgePlanDeferOutput,
+  KnowledgePlanSchemaInput,
+  KnowledgePlanSchemaOutput,
+  KnowledgePlanSetInput,
+  KnowledgePlanSetOutput,
+  KnowledgePlanShowInput,
+  KnowledgePlanShowOutput,
   KnowledgeValidateInput,
   KnowledgeValidateOutput,
 } from '@pikku/knowledge'
@@ -29,3 +37,11 @@ export const KnowledgeIndexInputSchema = KnowledgeIndexInput
 export const KnowledgeIndexOutputSchema = KnowledgeIndexOutput
 export const KnowledgeValidateInputSchema = KnowledgeValidateInput
 export const KnowledgeValidateOutputSchema = KnowledgeValidateOutput
+export const KnowledgePlanSchemaInputSchema = KnowledgePlanSchemaInput
+export const KnowledgePlanSchemaOutputSchema = KnowledgePlanSchemaOutput
+export const KnowledgePlanShowInputSchema = KnowledgePlanShowInput
+export const KnowledgePlanShowOutputSchema = KnowledgePlanShowOutput
+export const KnowledgePlanSetInputSchema = KnowledgePlanSetInput
+export const KnowledgePlanSetOutputSchema = KnowledgePlanSetOutput
+export const KnowledgePlanDeferInputSchema = KnowledgePlanDeferInput
+export const KnowledgePlanDeferOutputSchema = KnowledgePlanDeferOutput

--- a/packages/knowledge/src/hollow-scenarios.test.ts
+++ b/packages/knowledge/src/hollow-scenarios.test.ts
@@ -1,0 +1,191 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { classifyScenario, scenarioDepths } from './hollow-scenarios.js'
+
+type Node = {
+  rpcName: string
+  scenarioStepPhase?: string
+  input?: Record<string, unknown>
+  next?: string
+}
+
+/** Build a linear scenario meta the way codegen writes one: nodes chained by `next`. */
+const scenario = (name: string, steps: Node[]) => {
+  const nodes: Record<string, Node> = {}
+  steps.forEach((step, index) => {
+    nodes[`n${index}`] = {
+      ...step,
+      ...(steps[index + 1] ? { next: `n${index + 1}` } : {}),
+    }
+  })
+  return {
+    name,
+    source: 'scenario',
+    nodes,
+    entryNodeIds: steps.length ? ['n0'] : [],
+  }
+}
+
+const opens = (path: string): Node => ({
+  rpcName: 'opensPage',
+  scenarioStepPhase: 'when',
+  input: { path },
+})
+const restsOn = (path: string): Node => ({
+  rpcName: 'restsOnPath',
+  scenarioStepPhase: 'then',
+  input: { path },
+})
+const sees = (text: string): Node => ({
+  rpcName: 'seesText',
+  scenarioStepPhase: 'then',
+  input: { text },
+})
+
+// The measured case: this passed 5/5 having proved only that the router left the browser
+// on the page the scenario itself opened.
+test('opens a page then asserts it is on that page → reachability-only', () => {
+  assert.equal(
+    classifyScenario(
+      scenario('renWritesHowTheDayFelt', [opens('/app'), restsOn('/app')])
+    ),
+    'reachability-only'
+  )
+})
+
+// The trailing-slash form is the same route — the step compares them that way, so the
+// classifier must too, or the shape escapes by typing `/app/`.
+test('the same route with a trailing slash is still reachability-only', () => {
+  assert.equal(
+    classifyScenario(scenario('slash', [opens('/app'), restsOn('/app/')])),
+    'reachability-only'
+  )
+})
+
+// The case restsOnPath was written for: `/app` bounces to `/app/login` when the session
+// cookie does not carry. Different path → a fact the scenario could not have assumed.
+test('a redirect assertion is a real assertion', () => {
+  assert.equal(
+    classifyScenario(scenario('guard', [opens('/app'), restsOn('/app/login')])),
+    'asserts'
+  )
+})
+
+test('any content assertion is a real assertion', () => {
+  assert.equal(
+    classifyScenario(
+      scenario('journal', [
+        opens('/app'),
+        restsOn('/app'),
+        sees('How the day felt'),
+      ])
+    ),
+    'asserts'
+  )
+})
+
+// Reachability is about what it DID, not only what it checked: a scenario that submits a
+// form and then confirms it stayed put has driven real work.
+test('a non-navigation action makes it a real assertion even with a restating check', () => {
+  const submits: Node = {
+    rpcName: 'submitsEntry',
+    scenarioStepPhase: 'when',
+    input: {},
+  }
+  assert.equal(
+    classifyScenario(
+      scenario('writes', [opens('/app'), submits, restsOn('/app')])
+    ),
+    'asserts'
+  )
+})
+
+test('acts and asserts nothing at all', () => {
+  assert.equal(
+    classifyScenario(scenario('silent', [opens('/app')])),
+    'no-assertion'
+  )
+})
+
+// A pure `given` ladder (a fixture) has nothing to prove and must not be judged.
+test('a scenario that never acts is not judged', () => {
+  const given: Node = {
+    rpcName: 'signsIn',
+    scenarioStepPhase: 'given',
+    input: {},
+  }
+  assert.equal(classifyScenario(scenario('fixture', [given])), 'not-judged')
+})
+
+// Backend scenarios reach their assertions through a different vocabulary; the
+// reachability shape is browser-specific and must not touch them.
+test('a backend assertion step is a real assertion', () => {
+  const call: Node = {
+    rpcName: 'callsOrchestratorRpc',
+    scenarioStepPhase: 'when',
+    input: {},
+  }
+  const expects: Node = {
+    rpcName: 'expectsOrchestratorResponse',
+    scenarioStepPhase: 'then',
+    input: { outcome: 'succeeds' },
+  }
+  assert.equal(
+    classifyScenario(scenario('authCheck', [call, expects])),
+    'asserts'
+  )
+})
+
+// Order comes from the `next` chain, not key order: asserting a path opened LATER is not
+// restating anything the scenario could have known.
+test('a rest assertion before the page is opened is a real assertion', () => {
+  assert.equal(
+    classifyScenario({
+      name: 'outOfOrder',
+      source: 'scenario',
+      entryNodeIds: ['a'],
+      nodes: { a: { ...restsOn('/app'), next: 'b' }, b: opens('/app') },
+    }),
+    'asserts'
+  )
+})
+
+test('non-scenario meta (a workflow) is never judged', () => {
+  assert.equal(
+    classifyScenario({
+      ...scenario('wf', [opens('/app')]),
+      source: 'workflow',
+    }),
+    'not-judged'
+  )
+})
+
+test('reads every scenario in the generated meta dir, skipping the verbose twin', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'depths-'))
+  const dir = join(cwd, '.pikku/scenarios/meta')
+  mkdirSync(dir, { recursive: true })
+  const shallow = scenario('shallowOne', [opens('/app'), restsOn('/app')])
+  writeFileSync(join(dir, 'shallowOne.gen.json'), JSON.stringify(shallow))
+  writeFileSync(
+    join(dir, 'shallowOne-verbose.gen.json'),
+    JSON.stringify(shallow)
+  )
+  writeFileSync(
+    join(dir, 'realOne.gen.json'),
+    JSON.stringify(scenario('realOne', [opens('/app'), sees('Today')]))
+  )
+
+  const depths = scenarioDepths(cwd)
+  assert.equal(depths.size, 2)
+  assert.equal(depths.get('shallowOne'), 'reachability-only')
+  assert.equal(depths.get('realOne'), 'asserts')
+})
+
+// Every gate that reads codegen output fails open: no meta means codegen has not run,
+// which is not evidence that the app proves nothing.
+test('missing meta reports nothing rather than blocking', () => {
+  assert.equal(scenarioDepths(mkdtempSync(join(tmpdir(), 'empty-'))).size, 0)
+})

--- a/packages/knowledge/src/hollow-scenarios.ts
+++ b/packages/knowledge/src/hollow-scenarios.ts
@@ -1,0 +1,146 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+// How much a scenario PROVES, read statically off pikku's generated step meta — one JSON
+// read per scenario, no browser, no dev server, no instrumentation. Cheap enough for
+// `fabric verify` rather than only the closing gate.
+//
+// `scenario-rpc-coverage.ts` answers which mutations a journey drives. It is blind to a
+// browser journey twice over: the scenario drives no RPC, so it contributes nothing there
+// and nothing there can judge it. Measured on the journal fixture,
+// `renWritesHowTheDayFeltScenario` reduced to `opens /app` → `is on /app` and passed 5/5
+// while RPC coverage stayed green (the backend scenario already covered `saveEntry`).
+//
+// The trap this walked into first: that shape is NOT hollow by itself. `opensPage` reports
+// where the browser LANDED rather than forcing it, so `is on /app` genuinely asserts that
+// the route guard did not bounce a signed-in actor to `/app/login` — it is precisely the
+// starter template's `signedInActorReachesTheAppScenario`, which is honest work. The two
+// scenarios are structurally identical and differ only in what they CLAIM, so depth is
+// reported here and judged against the plan's claim in `plan-meta.ts`, never alone.
+
+/** Where per-scenario step meta lands; mirrors scenario-rpc-coverage.ts. */
+const SCENARIO_META_DIRS = ['.pikku/scenarios/meta', '.pikku/workflow/meta']
+
+const metaDirs = (cwd: string): string[] =>
+  [process.env.PIKKU_DEV_DIR, join(cwd, 'packages/functions'), cwd].filter(
+    (d): d is string => !!d
+  )
+
+/** Steps that only move the browser. Landing somewhere is not evidence of doing anything. */
+const NAVIGATION_STEPS = new Set(['opensPage'])
+
+type ScenarioNode = {
+  rpcName?: string
+  scenarioStepPhase?: string
+  input?: Record<string, unknown>
+  next?: string
+}
+type ScenarioMeta = {
+  name?: string
+  source?: string
+  nodes?: Record<string, ScenarioNode>
+  entryNodeIds?: string[]
+}
+
+/**
+ * What a scenario is capable of proving.
+ *
+ * - `asserts` — it drives something and checks a fact it could not have assumed.
+ * - `reachability-only` — it navigates, then asserts it is on a page it opened. Real proof
+ *   that a guard let the actor through, and nothing more. Legitimate for an auth scenario,
+ *   a lie when it stands in for a user doing something.
+ * - `no-assertion` — it acts and checks nothing. pikku fails this at inspection (PKU680,
+ *   critical as of inspector 0.12.52); reported anyway because that severity is a property
+ *   of the CLI version in the sandbox, not of this build.
+ * - `not-judged` — no acting step (a `given`-only fixture), or not a scenario.
+ */
+export type ScenarioDepth =
+  'asserts' | 'reachability-only' | 'no-assertion' | 'not-judged'
+
+/** `/app/` and `/app` are the same route — the step itself compares them this way. */
+const normalisePath = (path: string) => path.replace(/\/+$/, '') || '/'
+
+/**
+ * Walk from the entry node so "already opened" means what it says. Key order happens to
+ * match today, but nodes are a linked graph and an order-dependent test would quietly
+ * invert on any codegen change.
+ */
+function orderedNodes(meta: ScenarioMeta): ScenarioNode[] {
+  const nodes = meta.nodes ?? {}
+  const ordered: ScenarioNode[] = []
+  const seen = new Set<string>()
+  let id = meta.entryNodeIds?.[0]
+  while (id && nodes[id] && !seen.has(id)) {
+    seen.add(id)
+    ordered.push(nodes[id]!)
+    id = nodes[id]!.next
+  }
+  // Branching graphs (and any node the chain misses) still get judged — a scenario must
+  // never be assessed on a fraction of itself.
+  for (const [key, node] of Object.entries(nodes))
+    if (!seen.has(key)) ordered.push(node)
+  return ordered
+}
+
+export function classifyScenario(meta: ScenarioMeta): ScenarioDepth {
+  if (meta.source !== 'scenario') return 'not-judged'
+  const nodes = orderedNodes(meta)
+  const acting = nodes.filter((node) => node.scenarioStepPhase === 'when')
+  if (acting.length === 0) return 'not-judged'
+
+  const opened = new Set<string>()
+  let assertions = 0
+  let beyondReachability = 0
+
+  for (const node of nodes) {
+    if (node.rpcName && NAVIGATION_STEPS.has(node.rpcName)) {
+      const path = node.input?.['path']
+      if (typeof path === 'string') opened.add(normalisePath(path))
+    }
+    if (node.scenarioStepPhase !== 'then') continue
+    assertions += 1
+    const path = node.input?.['path']
+    const restatesOpenedPage =
+      node.rpcName === 'restsOnPath' &&
+      typeof path === 'string' &&
+      opened.has(normalisePath(path))
+    if (!restatesOpenedPage) beyondReachability += 1
+  }
+
+  if (assertions === 0) return 'no-assertion'
+  if (beyondReachability > 0) return 'asserts'
+  // Only meaningful when navigation is ALSO all it did — a scenario that submits a form and
+  // then checks it stayed put has driven real work, whatever its assertion looks like.
+  const onlyNavigated = acting.every(
+    (node) => node.rpcName && NAVIGATION_STEPS.has(node.rpcName)
+  )
+  return onlyNavigated ? 'reachability-only' : 'asserts'
+}
+
+/**
+ * Every scenario in the project by `pikkuScenario` export id → what it can prove.
+ *
+ * Fails OPEN on missing or unreadable meta, like every gate that reads codegen output: an
+ * absent file means codegen has not run, not that the app proves nothing.
+ */
+export function scenarioDepths(cwd: string): Map<string, ScenarioDepth> {
+  const depths = new Map<string, ScenarioDepth>()
+  const dirs = metaDirs(cwd)
+    .flatMap((dir) => SCENARIO_META_DIRS.map((rel) => join(dir, rel)))
+    .filter((dir) => existsSync(dir))
+  for (const dir of dirs) {
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith('.gen.json') || file.endsWith('-verbose.gen.json'))
+        continue
+      let meta: ScenarioMeta
+      try {
+        meta = JSON.parse(readFileSync(join(dir, file), 'utf8'))
+      } catch {
+        continue
+      }
+      const depth = classifyScenario(meta)
+      if (meta.name && depth !== 'not-judged') depths.set(meta.name, depth)
+    }
+  }
+  return depths
+}

--- a/packages/knowledge/src/index.ts
+++ b/packages/knowledge/src/index.ts
@@ -3,9 +3,6 @@ export {
   type KnowledgeNote,
   type ProfileNote,
   MILESTONE_TYPE,
-  MILESTONES_DIR,
-  MILESTONE_SURFACES,
-  type MilestoneSurface,
   listOf,
   noteHash,
   readKnowledgeNotes,
@@ -99,6 +96,17 @@ export {
   cascadeProblems,
   planShortfall,
 } from './plan-meta.js'
+
+export {
+  MILESTONES_DIR,
+  MILESTONE_SURFACES,
+  type MilestoneSurface,
+  inMilestonesDir,
+  surfaceOf,
+  readMilestones,
+  gherkinOf,
+  personasIn,
+} from './milestone.js'
 
 export {
   type ScenarioDepth,

--- a/packages/knowledge/src/index.ts
+++ b/packages/knowledge/src/index.ts
@@ -3,6 +3,11 @@ export {
   type KnowledgeNote,
   type ProfileNote,
   MILESTONE_TYPE,
+  MILESTONES_DIR,
+  MILESTONE_SURFACES,
+  type MilestoneSurface,
+  listOf,
+  noteHash,
   readKnowledgeNotes,
   resourceIds,
 } from './notes.js'
@@ -48,3 +53,55 @@ export {
   type KnowledgeIndexResult,
   runKnowledgeIndex,
 } from './reindex.js'
+
+export {
+  PLAN_VERSION,
+  FIRST_PASS,
+  MAX_DEFERRALS,
+  CLASSIFICATIONS,
+  WireTransport,
+  PlanSchema,
+  type Plan,
+  type PlanSlot,
+  type PlanRead,
+  type PlanDefer,
+  type Deferral,
+  type CoverageState,
+  type NoteCoverage,
+  planSchemaJson,
+  itemsOf,
+  scenarioPass,
+  plannedApps,
+  planPathFor,
+  planIdFor,
+  milestonePathForPlanId,
+  readPlan,
+  writePlan,
+  renderPlanForBuild,
+  deferPlanItem,
+  deferOutstandingItems,
+  checkFirstPass,
+  checkAgainstMilestone,
+  checkPlanInternals,
+  knowledgeCoverage,
+} from './plan.js'
+
+export {
+  type PikkuMeta,
+  type PlannedTransport,
+  type PlanChecklistItem,
+  type PlanProgress,
+  type PlanShortfallResult,
+  functionsDirFor,
+  readPikkuMeta,
+  planProgress,
+  shallowScenarioProblems,
+  cascadeProblems,
+  planShortfall,
+} from './plan-meta.js'
+
+export {
+  type ScenarioDepth,
+  classifyScenario,
+  scenarioDepths,
+} from './hollow-scenarios.js'

--- a/packages/knowledge/src/index.ts
+++ b/packages/knowledge/src/index.ts
@@ -113,3 +113,24 @@ export {
   classifyScenario,
   scenarioDepths,
 } from './hollow-scenarios.js'
+
+export {
+  KnowledgePlanSchemaInput,
+  KnowledgePlanSchemaOutput,
+  type KnowledgePlanSchemaResult,
+  runKnowledgePlanSchema,
+  KnowledgePlanShowInput,
+  KnowledgePlanShowOutput,
+  type KnowledgePlanShowResult,
+  runKnowledgePlanShow,
+  KnowledgePlanSetInput,
+  KnowledgePlanSetOutput,
+  type KnowledgePlanSetResult,
+  runKnowledgePlanSet,
+  KnowledgePlanDeferInput,
+  KnowledgePlanDeferOutput,
+  type KnowledgePlanDeferResult,
+  runKnowledgePlanDefer,
+} from './plan-command.js'
+
+export { type MilestoneNote, MILESTONE_SCALARS } from './milestone.js'

--- a/packages/knowledge/src/milestone.test.ts
+++ b/packages/knowledge/src/milestone.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, test } from 'node:test'
+import {
+  gherkinOf,
+  inMilestonesDir,
+  personasIn,
+  readMilestones,
+  surfaceOf,
+} from './milestone.js'
+import { parseNote } from './notes.js'
+import { MILESTONE_SCALARS } from './milestone.js'
+
+const note = (body: string) =>
+  parseNote('knowledge/milestones/01-a.md', body, MILESTONE_SCALARS)
+
+describe('surfaceOf', () => {
+  test('an unset surface is an app', () => {
+    assert.equal(surfaceOf(note('---\ntype: milestone\n---\n')), 'app')
+  })
+
+  test('a surface nobody declared falls back rather than throwing', () => {
+    assert.equal(
+      surfaceOf(note('---\ntype: milestone\nsurface: hologram\n---\n')),
+      'app'
+    )
+  })
+
+  test('a declared surface is read case-insensitively', () => {
+    assert.equal(
+      surfaceOf(note('---\ntype: milestone\nsurface: CLI\n---\n')),
+      'cli'
+    )
+  })
+})
+
+describe('personasIn', () => {
+  test('a single-quoted subject is a persona', () => {
+    assert.deepEqual(personasIn("Given 'owner' has an entry"), ['owner'])
+  })
+
+  test('a double-quoted value is the product speaking, not a person', () => {
+    // Reading both quote styles as personas made a checklist item called
+    // "Took my meds" a gate failure.
+    assert.deepEqual(personasIn('When \'owner\' saves "Took my meds"'), [
+      'owner',
+    ])
+  })
+
+  test('the same persona named twice is named once', () => {
+    assert.deepEqual(
+      personasIn("Given 'owner' has an entry\nThen 'owner' sees it"),
+      ['owner']
+    )
+  })
+})
+
+describe('gherkinOf', () => {
+  test('a note with no fence has none', () => {
+    assert.equal(gherkinOf(note('---\ntype: milestone\n---\nprose only')), null)
+  })
+
+  test('the fenced block comes back trimmed', () => {
+    const body = '---\ntype: milestone\n---\n```gherkin\nGiven a thing\n```\n'
+    assert.equal(gherkinOf(note(body)), 'Given a thing')
+  })
+})
+
+describe('readMilestones', () => {
+  test('only milestone notes under milestones/ come back, with their own scalars', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'milestone-'))
+    try {
+      await mkdir(join(cwd, 'knowledge/milestones'), { recursive: true })
+      await mkdir(join(cwd, 'knowledge/entities'), { recursive: true })
+      await writeFile(
+        join(cwd, 'knowledge/milestones/01-a.md'),
+        '---\ntype: milestone\nsurface: cli\n---\nbody\n'
+      )
+      await writeFile(
+        join(cwd, 'knowledge/entities/entry.md'),
+        '---\ntype: entity\n---\nbody\n'
+      )
+      const milestones = await readMilestones(cwd)
+      assert.deepEqual(
+        milestones.map((m) => m.path),
+        ['knowledge/milestones/01-a.md']
+      )
+      assert.equal(surfaceOf(milestones[0]!), 'cli')
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('inMilestonesDir', () => {
+  test('the directory itself is not a note in it', () => {
+    assert.equal(inMilestonesDir('knowledge/milestones'), false)
+    assert.equal(inMilestonesDir('knowledge/milestones/01-a.md'), true)
+    assert.equal(inMilestonesDir('knowledge/entities/entry.md'), false)
+  })
+})

--- a/packages/knowledge/src/milestone.ts
+++ b/packages/knowledge/src/milestone.ts
@@ -1,0 +1,73 @@
+import { KNOWLEDGE_DIR, MILESTONE_TYPE, readKnowledgeNotes } from './notes.js'
+import type { KnowledgeNote, ProfileNote } from './notes.js'
+
+export const MILESTONES_DIR = `${KNOWLEDGE_DIR}/milestones`
+
+/**
+ * What a milestone is judged as. Holding every milestone to `screens:` refused one for
+ * lacking a page it was never going to have — a CLI does not get a route, and an MCP
+ * tool is used by a machine. What the surface changes is WHICH proof a first pass owes,
+ * never whether it owes one.
+ */
+export const MILESTONE_SURFACES = [
+  'app',
+  'cli',
+  'mcp',
+  'agent',
+  'backend',
+] as const
+export type MilestoneSurface = (typeof MILESTONE_SURFACES)[number]
+
+/**
+ * The frontmatter keys a milestone carries on top of the base profile.
+ *
+ * `surface:` is what the milestone reaches its person THROUGH, and it lives on the note
+ * rather than in the plan: a milestone that is a CLI is a fact about the milestone, not
+ * about the document written from it. `requires:` is what it cannot be built without.
+ */
+export const MILESTONE_SCALARS = ['surface', 'requires'] as const
+export type MilestoneNote = ProfileNote<(typeof MILESTONE_SCALARS)[number]>
+
+export const inMilestonesDir = (path: string): boolean =>
+  path.startsWith(`${MILESTONES_DIR}/`)
+
+const isSurface = (raw: string): raw is MilestoneSurface =>
+  (MILESTONE_SURFACES as readonly string[]).includes(raw)
+
+export function surfaceOf(note: MilestoneNote): MilestoneSurface {
+  const raw = (note.surface ?? '').trim().toLowerCase()
+  return isSurface(raw) ? raw : 'app'
+}
+
+export async function readMilestones(cwd: string): Promise<MilestoneNote[]> {
+  return (await readKnowledgeNotes(cwd, MILESTONE_SCALARS)).filter(
+    (note) =>
+      inMilestonesDir(note.path) &&
+      !note.reserved &&
+      note.type === MILESTONE_TYPE
+  )
+}
+
+/** The ```gherkin block in a milestone note's body, or null if it has none. */
+export function gherkinOf(note: KnowledgeNote): string | null {
+  const fenced = /```gherkin\r?\n([\s\S]*?)```/i.exec(note.body)
+  return fenced ? fenced[1]!.trim() || null : null
+}
+
+/**
+ * Every persona a Gherkin body names in SUBJECT position — `Given 'owner' has …`
+ * → `owner`. This is what answers "who does this scenario run as".
+ *
+ * Single quotes mean a persona; double quotes are the product's own words and are
+ * never read as a person. Treating both alike made a checklist item called "Took my
+ * meds" a gate failure — one quote style has to stay free for domain values.
+ */
+export function personasIn(gherkin: string): string[] {
+  const names = new Set<string>()
+  for (const [, , name] of gherkin.matchAll(
+    /^\s*(given|when|then|and|but)\s+'([A-Za-z][A-Za-z0-9]*)'/gim
+  )) {
+    names.add(name!)
+  }
+  return [...names]
+}

--- a/packages/knowledge/src/notes.ts
+++ b/packages/knowledge/src/notes.ts
@@ -63,23 +63,6 @@ export type ProfileNote<Key extends string = never> = KnowledgeNote &
 /** The `type:` a milestone note carries. */
 export const MILESTONE_TYPE = 'milestone'
 
-export const MILESTONES_DIR = `${KNOWLEDGE_DIR}/milestones`
-
-/**
- * What a milestone is judged as. Holding every milestone to `screens:` refused one for
- * lacking a page it was never going to have — a CLI does not get a route, and an MCP
- * tool is used by a machine. What the surface changes is WHICH proof a first pass owes,
- * never whether it owes one.
- */
-export const MILESTONE_SURFACES = [
-  'app',
-  'cli',
-  'mcp',
-  'agent',
-  'backend',
-] as const
-export type MilestoneSurface = (typeof MILESTONE_SURFACES)[number]
-
 /** Read a frontmatter scalar that carries a list, written either bare or bracketed. */
 export const listOf = (value: string | undefined): string[] =>
   (value ?? '')

--- a/packages/knowledge/src/notes.ts
+++ b/packages/knowledge/src/notes.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { readFile, readdir, stat } from 'node:fs/promises'
 import { basename, join, posix, relative, sep } from 'node:path'
@@ -61,6 +62,40 @@ export type ProfileNote<Key extends string = never> = KnowledgeNote &
 
 /** The `type:` a milestone note carries. */
 export const MILESTONE_TYPE = 'milestone'
+
+export const MILESTONES_DIR = `${KNOWLEDGE_DIR}/milestones`
+
+/**
+ * What a milestone is judged as. Holding every milestone to `screens:` refused one for
+ * lacking a page it was never going to have — a CLI does not get a route, and an MCP
+ * tool is used by a machine. What the surface changes is WHICH proof a first pass owes,
+ * never whether it owes one.
+ */
+export const MILESTONE_SURFACES = [
+  'app',
+  'cli',
+  'mcp',
+  'agent',
+  'backend',
+] as const
+export type MilestoneSurface = (typeof MILESTONE_SURFACES)[number]
+
+/** Read a frontmatter scalar that carries a list, written either bare or bracketed. */
+export const listOf = (value: string | undefined): string[] =>
+  (value ?? '')
+    .replace(/^\s*\[/, '')
+    .replace(/\]\s*$/, '')
+    .split(',')
+    .map((item) => item.trim().replace(/^['"]|['"]$/g, ''))
+    .filter(Boolean)
+
+/**
+ * Identifies a note's body, so a plan can say which revision it was written against
+ * and a later read can tell that the note moved underneath it.
+ */
+export function noteHash(body: string): string {
+  return createHash('sha256').update(body).digest('hex').slice(0, 12)
+}
 
 /**
  * The scalars this profile reads. A caller's own keys are passed to `parseNote`

--- a/packages/knowledge/src/plan-command.test.ts
+++ b/packages/knowledge/src/plan-command.test.ts
@@ -1,0 +1,231 @@
+import assert from 'node:assert'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, test } from 'node:test'
+import { basePlan } from './plan-fixture.js'
+import {
+  runKnowledgePlanDefer,
+  runKnowledgePlanSchema,
+  runKnowledgePlanSet,
+  runKnowledgePlanShow,
+} from './plan-command.js'
+
+const MILESTONE = 'knowledge/milestones/01-the-daily-entry.md'
+
+const NOTE = `---
+type: milestone
+entities: entry
+---
+The daily entry.
+
+\`\`\`gherkin
+Given 'owner' has today free
+When 'owner' writes an entry
+Then 'owner' reads it back
+\`\`\`
+`
+
+const project = async (): Promise<string> => {
+  const cwd = await mkdtemp(join(tmpdir(), 'plan-cmd-'))
+  await mkdir(join(cwd, 'knowledge/milestones'), { recursive: true })
+  await mkdir(join(cwd, 'knowledge/entities'), { recursive: true })
+  await writeFile(join(cwd, MILESTONE), NOTE)
+  await writeFile(
+    join(cwd, 'knowledge/entities/entry.md'),
+    '---\ntype: entity\n---\nentry body\n'
+  )
+  return cwd
+}
+
+const planFile = async (cwd: string, plan: unknown): Promise<string> => {
+  const file = join(cwd, 'draft.json')
+  await writeFile(file, JSON.stringify(plan))
+  return file
+}
+
+describe('plan schema', () => {
+  test('the schema comes back as JSON Schema, not as prose about it', () => {
+    const { schema } = runKnowledgePlanSchema()
+    const parsed = JSON.parse(schema)
+    assert.ok(parsed.properties.version)
+    assert.ok(parsed.properties.scenarios)
+  })
+})
+
+describe('plan set', () => {
+  test('a plan that holds against its milestone is written', async () => {
+    const cwd = await project()
+    try {
+      const result = await runKnowledgePlanSet(cwd, {
+        milestone: '01-the-daily-entry',
+        file: await planFile(cwd, basePlan()),
+      })
+      assert.deepEqual(result.problems, [])
+      assert.equal(result.ok, true)
+      assert.equal(
+        result.path,
+        'knowledge/milestones/01-the-daily-entry.plan.json'
+      )
+      const written = JSON.parse(await readFile(join(cwd, result.path), 'utf8'))
+      assert.equal(written.milestone, MILESTONE)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('the milestone can be named by path as well as by id', async () => {
+    const cwd = await project()
+    try {
+      const result = await runKnowledgePlanSet(cwd, {
+        milestone: MILESTONE,
+        file: await planFile(cwd, basePlan()),
+      })
+      assert.equal(result.ok, true)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('a plan that fails a check writes NOTHING', async () => {
+    // The whole property: the only writer validates, so a plan cannot reach disk
+    // unvalidated and a gate cannot be the first thing to read it.
+    const cwd = await project()
+    try {
+      const plan = basePlan()
+      plan.ui = { kind: 'n/a', description: 'Later.' }
+      const result = await runKnowledgePlanSet(cwd, {
+        milestone: '01-the-daily-entry',
+        file: await planFile(cwd, plan),
+      })
+      assert.equal(result.ok, false)
+      assert.match(result.problems.join('\n'), /no `ui` item/)
+      await assert.rejects(() => readFile(join(cwd, result.path), 'utf8'))
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('a shape refusal carries the schema, so the writer does not go looking', async () => {
+    const cwd = await project()
+    try {
+      const plan = basePlan() as unknown as Record<string, unknown>
+      delete plan.covers
+      const result = await runKnowledgePlanSet(cwd, {
+        milestone: '01-the-daily-entry',
+        file: await planFile(cwd, plan),
+      })
+      assert.equal(result.ok, false)
+      assert.match(result.problems.join('\n'), /covers/)
+      assert.ok(result.schema)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('a milestone nobody wrote is said so, not guessed at', async () => {
+    const cwd = await project()
+    try {
+      const result = await runKnowledgePlanSet(cwd, {
+        milestone: '99-nothing',
+        file: await planFile(cwd, basePlan()),
+      })
+      assert.equal(result.ok, false)
+      assert.match(result.problems[0]!, /No milestone note matching/)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('plan show', () => {
+  test('without --for-build it is the document as stored', async () => {
+    const cwd = await project()
+    try {
+      await runKnowledgePlanSet(cwd, {
+        milestone: '01-the-daily-entry',
+        file: await planFile(cwd, basePlan()),
+      })
+      const shown = await runKnowledgePlanShow(cwd, {
+        milestone: '01-the-daily-entry',
+      })
+      assert.equal(shown.ok, true)
+      assert.equal(JSON.parse(shown.body).milestone, MILESTONE)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('--for-build is the same plan rendered for a reader', async () => {
+    const cwd = await project()
+    try {
+      await runKnowledgePlanSet(cwd, {
+        milestone: '01-the-daily-entry',
+        file: await planFile(cwd, basePlan()),
+      })
+      const shown = await runKnowledgePlanShow(cwd, {
+        milestone: '01-the-daily-entry',
+        forBuild: true,
+      })
+      assert.equal(shown.ok, true)
+      assert.match(shown.body, /createEntry/)
+      assert.throws(() => JSON.parse(shown.body))
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('a milestone with no plan says so rather than showing nothing', async () => {
+    const cwd = await project()
+    try {
+      const shown = await runKnowledgePlanShow(cwd, {
+        milestone: '01-the-daily-entry',
+      })
+      assert.equal(shown.ok, false)
+      assert.match(shown.body, /No plan at/)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('plan defer', () => {
+  test('a deferred item is recorded with its reason and the plan is rewritten', async () => {
+    const cwd = await project()
+    try {
+      await runKnowledgePlanSet(cwd, {
+        milestone: '01-the-daily-entry',
+        file: await planFile(cwd, basePlan()),
+      })
+      const result = await runKnowledgePlanDefer(cwd, {
+        milestone: '01-the-daily-entry',
+        item: 'function:createEntry',
+        reason: 'The table it writes is not migrated yet.',
+      })
+      assert.equal(result.ok, true)
+      const written = JSON.parse(await readFile(join(cwd, result.path), 'utf8'))
+      assert.equal(written.deferrals.length, 1)
+      assert.match(written.deferrals[0].why, /not migrated/)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('an item the plan does not have is refused', async () => {
+    const cwd = await project()
+    try {
+      await runKnowledgePlanSet(cwd, {
+        milestone: '01-the-daily-entry',
+        file: await planFile(cwd, basePlan()),
+      })
+      const result = await runKnowledgePlanDefer(cwd, {
+        milestone: '01-the-daily-entry',
+        item: 'function:noSuchThing',
+        reason: 'Because.',
+      })
+      assert.equal(result.ok, false)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/knowledge/src/plan-command.ts
+++ b/packages/knowledge/src/plan-command.ts
@@ -1,0 +1,197 @@
+import { readFileSync } from 'node:fs'
+import { z } from 'zod'
+import {
+  gherkinOf,
+  personasIn,
+  readMilestones,
+  surfaceOf,
+  type MilestoneNote,
+} from './milestone.js'
+import {
+  PlanSchema,
+  checkAgainstMilestone,
+  checkFirstPass,
+  checkPlanInternals,
+  deferPlanItem,
+  planIdFor,
+  planPathFor,
+  planSchemaJson,
+  readPlan,
+  renderPlanForBuild,
+  writePlan,
+} from './plan.js'
+
+/**
+ * The plan commands, as one module so the CLI binds four thin wrappers rather than
+ * reimplementing the order the checks run in.
+ *
+ * `set` is the only writer, and that is the property worth protecting: schema, then the
+ * first-pass shape, then the plan against its own milestone — and nothing reaches disk
+ * unless all three pass. A plan validated at gate time instead has already cost the
+ * build it was measured against.
+ *
+ * What is deliberately absent is any judgement of whether a plan is a GOOD plan. That
+ * needs a model, a budget and a seat, and it belongs to whatever is driving the build,
+ * not to a command that must run offline.
+ */
+const NO_MILESTONE = (milestone: string) =>
+  `No milestone note matching "${milestone}". Pass the note's id (its filename stem) or its path under knowledge/milestones/.`
+
+const resolve = async (
+  root: string,
+  milestone: string
+): Promise<MilestoneNote | null> => {
+  const notes = await readMilestones(root)
+  return (
+    notes.find((note) => note.path === milestone) ??
+    notes.find((note) => planIdFor(note.path) === milestone) ??
+    null
+  )
+}
+
+const problemsFor = (
+  plan: z.infer<typeof PlanSchema>,
+  note: MilestoneNote
+): string[] => {
+  const surface = surfaceOf(note)
+  const gherkin = gherkinOf(note)
+  return [
+    ...checkFirstPass(plan, surface),
+    ...checkPlanInternals(plan),
+    ...checkAgainstMilestone(
+      plan,
+      note,
+      gherkin ? personasIn(gherkin) : [],
+      surface
+    ),
+  ]
+}
+
+export const KnowledgePlanSchemaInput = z.object({})
+
+export const KnowledgePlanSchemaOutput = z.object({
+  schema: z.string(),
+})
+
+export type KnowledgePlanSchemaResult = z.infer<
+  typeof KnowledgePlanSchemaOutput
+>
+
+export const runKnowledgePlanSchema = (): KnowledgePlanSchemaResult => ({
+  schema: planSchemaJson(),
+})
+
+export const KnowledgePlanShowInput = z.object({
+  milestone: z.string().min(1),
+  forBuild: z.boolean().optional(),
+})
+
+export const KnowledgePlanShowOutput = z.object({
+  ok: z.boolean(),
+  path: z.string(),
+  body: z.string(),
+})
+
+export type KnowledgePlanShowResult = z.infer<typeof KnowledgePlanShowOutput>
+
+export const runKnowledgePlanShow = async (
+  root: string,
+  { milestone, forBuild }: z.infer<typeof KnowledgePlanShowInput>
+): Promise<KnowledgePlanShowResult> => {
+  const note = await resolve(root, milestone)
+  if (!note) return { ok: false, path: '', body: NO_MILESTONE(milestone) }
+  const read = readPlan(root, note.path)
+  if (!read.ok) return { ok: false, path: read.path, body: read.reason }
+  return {
+    ok: true,
+    path: read.path,
+    body: forBuild
+      ? renderPlanForBuild(read.plan)
+      : `${JSON.stringify(read.plan, null, 2)}\n`,
+  }
+}
+
+export const KnowledgePlanSetInput = z.object({
+  milestone: z.string().min(1),
+  file: z.string().min(1),
+})
+
+export const KnowledgePlanSetOutput = z.object({
+  ok: z.boolean(),
+  path: z.string(),
+  problems: z.array(z.string()),
+  schema: z.string().optional(),
+})
+
+export type KnowledgePlanSetResult = z.infer<typeof KnowledgePlanSetOutput>
+
+export const runKnowledgePlanSet = async (
+  root: string,
+  { milestone, file }: z.infer<typeof KnowledgePlanSetInput>
+): Promise<KnowledgePlanSetResult> => {
+  const note = await resolve(root, milestone)
+  if (!note) return { ok: false, path: '', problems: [NO_MILESTONE(milestone)] }
+  const path = planPathFor(note.path)
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(file, 'utf8'))
+  } catch (err) {
+    return { ok: false, path, problems: [`${file}: ${String(err)}`] }
+  }
+  const parsed = PlanSchema.safeParse(raw)
+  if (!parsed.success) {
+    // The schema rides along with a shape refusal. Naming the bad field is not enough on
+    // its own: a writer told `transport` is invalid, with no way to ask what the options
+    // ARE, goes looking instead of editing.
+    return {
+      ok: false,
+      path,
+      problems: parsed.error.issues
+        .slice(0, 10)
+        .map(
+          (issue) => `${issue.path.join('.') || '(root)'} — ${issue.message}`
+        ),
+      schema: planSchemaJson(),
+    }
+  }
+  const problems = problemsFor(parsed.data, note)
+  if (problems.length > 0) return { ok: false, path, problems }
+  return {
+    ok: true,
+    path: writePlan(root, note.path, parsed.data),
+    problems: [],
+  }
+}
+
+export const KnowledgePlanDeferInput = z.object({
+  milestone: z.string().min(1),
+  item: z.string().min(1),
+  reason: z.string().min(1),
+})
+
+export const KnowledgePlanDeferOutput = z.object({
+  ok: z.boolean(),
+  path: z.string(),
+  message: z.string(),
+})
+
+export type KnowledgePlanDeferResult = z.infer<typeof KnowledgePlanDeferOutput>
+
+export const runKnowledgePlanDefer = async (
+  root: string,
+  { milestone, item, reason }: z.infer<typeof KnowledgePlanDeferInput>
+): Promise<KnowledgePlanDeferResult> => {
+  const note = await resolve(root, milestone)
+  if (!note) return { ok: false, path: '', message: NO_MILESTONE(milestone) }
+  const read = readPlan(root, note.path)
+  if (!read.ok) return { ok: false, path: read.path, message: read.reason }
+  const deferred = deferPlanItem(read.plan, item, reason)
+  if (!deferred.ok) {
+    return { ok: false, path: read.path, message: deferred.reason }
+  }
+  return {
+    ok: true,
+    path: writePlan(root, note.path, deferred.plan),
+    message: `${deferred.label} moved to the next pass.`,
+  }
+}

--- a/packages/knowledge/src/plan-fixture.ts
+++ b/packages/knowledge/src/plan-fixture.ts
@@ -1,0 +1,108 @@
+import { PLAN_VERSION, type Plan } from './plan.js'
+import { noteHash } from './notes.js'
+
+/**
+ * One plan that passes every check, as the thing tests vary from.
+ *
+ * Shared rather than copied because two suites now need a plan the reader accepts, and a
+ * second hand-written one drifts the moment a schema rule changes — the failure would show
+ * as an unrelated suite going red for a plan that was never the point of it.
+ */
+export const basePlan = (
+  milestone = 'knowledge/milestones/01-the-daily-entry.md'
+): Plan => ({
+  version: PLAN_VERSION,
+  deferrals: [],
+  milestone,
+  description: 'One person writes one entry a day and reads their own back.',
+  covers: [
+    {
+      note: 'entities/entry.md',
+      hash: noteHash('entry body'),
+      complete: true,
+    },
+  ],
+  model: {
+    kind: 'built',
+    description: 'One table.',
+    items: [
+      {
+        table: 'entry',
+        description: 'One row per person per day.',
+        fields: [
+          { name: 'id', type: 'uuid', classification: 'internal' },
+          { name: 'body', type: 'text', classification: 'personal' },
+        ],
+        relationships: [],
+      },
+    ],
+  },
+  functions: {
+    kind: 'built',
+    description: 'Write and read.',
+    items: [
+      {
+        name: 'createEntry',
+        description: "Creates today's entry on the entry table.",
+        pass: 1,
+        wire: { transport: 'http', route: 'POST /entry' },
+        scopes: [],
+        permission: 'Only the signed-in person can write their own entry',
+      },
+    ],
+  },
+  roles: {
+    kind: 'built',
+    description: 'One role.',
+    items: [{ name: 'member', description: 'In the org.', app: 'journal' }],
+  },
+  scopes: { kind: 'n/a', description: 'No third-party access yet.' },
+  ui: {
+    kind: 'built',
+    description: 'One screen.',
+    items: [
+      {
+        route: '/app/today',
+        description: "Write today's entry.",
+        pass: 1,
+        scenarios: ['features/today.feature#Writing today'],
+      },
+    ],
+  },
+  scenarios: {
+    backend: {
+      kind: 'built',
+      description: 'The one-per-day rule.',
+      items: [
+        {
+          feature: 'features/entry.feature',
+          scenario: 'A second entry for today is refused',
+          name: 'secondEntryRefusedScenario',
+        },
+      ],
+    },
+    browser: {
+      kind: 'built',
+      description: 'Writing it.',
+      items: [
+        {
+          feature: 'features/today.feature',
+          scenario: "'owner' writes today's entry",
+          name: 'ownerWritesTodayScenario',
+        },
+      ],
+    },
+    permission: {
+      kind: 'built',
+      description: 'Someone else cannot.',
+      items: [
+        {
+          fn: 'createEntry',
+          feature: 'features/entry-perms.feature',
+          scenario: 'Another member is refused',
+          name: 'anotherMemberRefusedScenario',
+        },
+      ],
+    },
+  },
+})

--- a/packages/knowledge/src/plan-meta.test.ts
+++ b/packages/knowledge/src/plan-meta.test.ts
@@ -1,0 +1,851 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PLAN_VERSION, renderPlanForBuild, type Plan } from './plan.js'
+import { noteHash } from './notes.js'
+import { cascadeProblems, planShortfall, readPikkuMeta } from './plan-meta.js'
+
+// This is the half of the gate the build agent cannot edit. Everything here reconciles
+// the plan against pikku's GENERATED meta, so the interesting cases are the ones where
+// the agent could otherwise certify itself: a function that was planned and never
+// written, a wire that was never made, a rule the plan calls restricted that the code
+// leaves wide open.
+
+const plan = (): Plan => ({
+  version: PLAN_VERSION,
+  deferrals: [],
+  milestone: 'knowledge/milestones/01-the-daily-entry.md',
+  description: 'One person writes one entry a day and reads their own back.',
+  covers: [
+    {
+      note: 'entities/entry.md',
+      hash: noteHash('entry body'),
+      complete: true,
+    },
+  ],
+  model: {
+    kind: 'built',
+    description: 'One table.',
+    items: [
+      {
+        table: 'entry',
+        description: 'One row per person per day.',
+        fields: [{ name: 'body', type: 'text', classification: 'personal' }],
+        relationships: [],
+      },
+    ],
+  },
+  functions: {
+    kind: 'built',
+    description: 'Write and read.',
+    items: [
+      {
+        name: 'createEntry',
+        description: "Creates today's entry.",
+        pass: 1,
+        wire: { transport: 'http', route: 'POST /entry' },
+        scopes: [],
+        permission: 'Only the signed-in person can write their own entry',
+      },
+      {
+        name: 'listEntries',
+        description: 'Their own entries, newest first.',
+        pass: 2,
+        wire: { transport: 'http', route: 'GET /entry' },
+        scopes: [],
+        permission: 'Only your own entries come back',
+      },
+    ],
+  },
+  roles: {
+    kind: 'built',
+    description: 'One role.',
+    items: [{ name: 'member', description: 'In the org.', app: 'journal' }],
+  },
+  scopes: { kind: 'n/a', description: 'No third-party access yet.' },
+  ui: {
+    kind: 'built',
+    description: 'One screen.',
+    items: [
+      {
+        route: '/app/today',
+        description: "Write today's entry.",
+        pass: 1,
+        scenarios: ['features/today.feature#Writing today'],
+      },
+    ],
+  },
+  scenarios: {
+    backend: {
+      kind: 'built',
+      description: 'The one-per-day rule.',
+      items: [
+        {
+          feature: 'features/entry.feature',
+          scenario: 'A second entry for today is refused',
+          name: 'secondEntryRefusedScenario',
+        },
+      ],
+    },
+    browser: {
+      kind: 'built',
+      description: 'Writing it.',
+      items: [
+        {
+          feature: 'features/today.feature',
+          scenario: "'owner' writes today's entry",
+          name: 'ownerWritesTodayScenario',
+        },
+      ],
+    },
+    permission: {
+      kind: 'built',
+      description: 'Someone else cannot.',
+      items: [
+        {
+          fn: 'createEntry',
+          feature: 'features/entry-perms.feature',
+          scenario: 'Another member is refused',
+          name: 'anotherMemberRefusedScenario',
+        },
+      ],
+    },
+  },
+})
+
+/** A functionsDir whose `.pikku` holds exactly the generated files named. */
+function project(files: Record<string, unknown>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'plan-meta-'))
+  for (const [rel, body] of Object.entries(files)) {
+    const full = join(dir, '.pikku', rel)
+    mkdirSync(join(full, '..'), { recursive: true })
+    writeFileSync(full, JSON.stringify(body))
+  }
+  return dir
+}
+
+/**
+ * Everything the shared `plan()` promises, as codegen would report it. The scenario meta is
+ * part of "built" because the plan names three scenarios; without it every test focused on
+ * functions or wires would also carry three outstanding scenarios.
+ */
+const bothBuilt = {
+  'function/pikku-functions-meta.gen.json': {
+    createEntry: { auth: true },
+    listEntries: { auth: true },
+  },
+  'http/pikku-http-wirings-meta.gen.json': {
+    POST: { '/entry': {} },
+    GET: { '/entry': {} },
+  },
+  'scenarios/pikku-scenario-functions-meta.gen.json': {
+    secondEntryRefusedScenario: {},
+    ownerWritesTodayScenario: {},
+    anotherMemberRefusedScenario: {},
+  },
+}
+
+test('a plan whose every function and wire exists has nothing outstanding', () => {
+  const dir = project(bothBuilt)
+  try {
+    const { missing, problems, done } = planShortfall(
+      plan(),
+      readPikkuMeta(dir)
+    )
+    assert.deepEqual(missing, [])
+    assert.deepEqual(problems, [])
+    // Two functions and the plan's three scenarios.
+    assert.equal(done.length, 5)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// Completion asks whether the milestone's WALKING SKELETON is done. A later pass is real
+// work the next milestone picks up, and blocking on it is what made plan size fatal.
+test('a function planned for a later pass is deferred, not blocking', () => {
+  const dir = project({
+    ...bothBuilt,
+    'function/pikku-functions-meta.gen.json': { createEntry: { auth: true } },
+    'http/pikku-http-wirings-meta.gen.json': { POST: { '/entry': {} } },
+  })
+  try {
+    const { missing, deferred } = planShortfall(plan(), readPikkuMeta(dir))
+    assert.deepEqual(missing, [])
+    assert.deepEqual(deferred, ['function listEntries'])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// The console renders `Done` beside `10 of 17`, and the seven were the permission
+// scenarios a plan defaults to pass 2 — so a row has to say which pass owes it or the two
+// numbers read as a lie.
+test('a later-pass row is tagged deferred, and a pass-1 row is not', () => {
+  const dir = project({
+    ...bothBuilt,
+    'function/pikku-functions-meta.gen.json': { createEntry: { auth: true } },
+    'http/pikku-http-wirings-meta.gen.json': { POST: { '/entry': {} } },
+  })
+  try {
+    const { items } = planShortfall(plan(), readPikkuMeta(dir))
+    const byId = new Map(items.map((item) => [item.id, item]))
+    assert.equal(byId.get('function:createEntry')?.deferred, false)
+    assert.equal(byId.get('function:listEntries')?.deferred, true)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a function that exists but was never wired is missing its wire, not itself', () => {
+  const dir = project({
+    ...bothBuilt,
+    'http/pikku-http-wirings-meta.gen.json': { POST: { '/entry': {} } },
+  })
+  try {
+    const { missing, deferred, done } = planShortfall(
+      plan(),
+      readPikkuMeta(dir)
+    )
+    assert.deepEqual(missing, [])
+    assert.deepEqual(deferred, ['wire GET /entry'])
+    assert.ok(done.includes('function listEntries'))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// A path parameter is camelCase by convention, and the matcher used to lowercase only the
+// plan's side — so a wire that WAS generated read as missing, and the only way for the agent
+// to discharge it was to rename the parameter to something no codebase writes.
+test('a wire whose route carries a camelCase path parameter matches the generated meta', () => {
+  const withParam = plan()
+  if (withParam.functions.kind === 'built') {
+    withParam.functions.items[1]!.wire = {
+      transport: 'http',
+      route: 'POST /entry/:entryId/stage',
+    }
+  }
+  const dir = project({
+    ...bothBuilt,
+    'http/pikku-http-wirings-meta.gen.json': {
+      POST: { '/entry': {}, '/entry/:entryId/stage': {} },
+    },
+  })
+  try {
+    const { missing } = planShortfall(withParam, readPikkuMeta(dir))
+    assert.deepEqual(missing, [])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// The plan states a permission as prose, which nothing can compare against the rule the
+// code enforces. Meta knows whether the function is gated AT ALL, so the one mechanical
+// question — planned restricted, shipped open — is still answerable.
+test('a function planned as restricted but shipped with auth off is reported', () => {
+  const dir = project({
+    ...bothBuilt,
+    'function/pikku-functions-meta.gen.json': {
+      createEntry: { auth: false },
+      listEntries: { auth: true },
+    },
+  })
+  try {
+    const { problems } = planShortfall(plan(), readPikkuMeta(dir))
+    assert.equal(problems.length, 1)
+    assert.match(problems[0]!, /createEntry.*auth: false/s)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a feature declaring scenarios that were never written is reported', () => {
+  const dir = project({
+    ...bothBuilt,
+    'scenarios/features.gen.json': {
+      'features/today.feature': { entries: [], unresolvedEntries: 2 },
+    },
+  })
+  try {
+    const { problems } = planShortfall(plan(), readPikkuMeta(dir))
+    assert.equal(problems.length, 1)
+    assert.match(problems[0]!, /2 scenario\(s\) that do not exist/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// Fail-open on absent codegen would certify a plan against nothing; every planned item is
+// simply missing until the meta says otherwise.
+test('a project with no generated meta has everything outstanding', () => {
+  const dir = project({})
+  try {
+    const { missing, deferred, done } = planShortfall(
+      plan(),
+      readPikkuMeta(dir)
+    )
+    assert.deepEqual(done, [])
+    assert.deepEqual(missing, [
+      'function createEntry',
+      'backend scenario secondEntryRefusedScenario ("A second entry for today is refused")',
+      `browser scenario ownerWritesTodayScenario ("'owner' writes today's entry")`,
+    ])
+    assert.deepEqual(deferred, [
+      'function listEntries',
+      'permission scenario anotherMemberRefusedScenario ("Another member is refused")',
+    ])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('the rendered plan carries the reason an empty slot is empty', () => {
+  const text = renderPlanForBuild(plan())
+  assert.match(text, /SCOPES: none — No third-party access yet\./)
+  assert.match(text, /`createEntry`.*pass 1/)
+  assert.match(
+    text,
+    /permission: Only the signed-in person can write their own entry/
+  )
+  assert.match(text, /body: text \[personal\]/)
+})
+
+// The gate's whole point after the journal runs: a milestone whose scenarios were never
+// written must not certify. deepseek-v4-pro delivered 0 of 6 planned scenarios and kimi-k2.6
+// delivered 1, and both were marked complete, because nothing compared the plan's scenario
+// list against what codegen found.
+test('a planned scenario that was never written is missing', () => {
+  const dir = project({
+    ...bothBuilt,
+    // Overrides bothBuilt's scenario meta: only the template's own scenario exists.
+    'scenarios/pikku-scenario-functions-meta.gen.json': {
+      sessionHealthScenario: {},
+    },
+  })
+  try {
+    const { missing, deferred } = planShortfall(plan(), readPikkuMeta(dir))
+    assert.ok(missing.some((m) => m.includes('secondEntryRefusedScenario')))
+    assert.ok(missing.some((m) => m.includes('ownerWritesTodayScenario')))
+    assert.ok(deferred.some((d) => d.includes('anotherMemberRefusedScenario')))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('planned scenarios that were written are done, not missing', () => {
+  const dir = project({
+    ...bothBuilt,
+    'scenarios/pikku-scenario-functions-meta.gen.json': {
+      secondEntryRefusedScenario: {},
+      ownerWritesTodayScenario: {},
+      anotherMemberRefusedScenario: {},
+    },
+  })
+  try {
+    const { missing, done } = planShortfall(plan(), readPikkuMeta(dir))
+    assert.ok(!missing.some((m) => m.includes('scenario')))
+    assert.ok(done.includes('scenario secondEntryRefusedScenario'))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// Prose alone cannot be checked against codegen, so a nameless scenario is a hole in the
+// plan rather than a silent pass.
+test('a scenario with no name is reported as a problem', () => {
+  const p = plan()
+  if (p.scenarios.backend.kind === 'built')
+    delete (p.scenarios.backend.items[0] as { name?: string }).name
+  const dir = project(bothBuilt)
+  try {
+    const { problems } = planShortfall(p, readPikkuMeta(dir))
+    assert.ok(problems.some((x) => /names no `pikkuScenario` export/.test(x)))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+/** A repo whose `db/` holds exactly the migrations named. */
+function migrations(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'plan-cascade-'))
+  for (const [rel, body] of Object.entries(files)) {
+    const full = join(dir, 'db', rel)
+    mkdirSync(join(full, '..'), { recursive: true })
+    writeFileSync(full, body)
+  }
+  return dir
+}
+
+const cascadingPlan = (): Plan => {
+  const p = plan()
+  if (p.model.kind === 'built') {
+    p.model.items[0]!.fields.push({
+      name: 'user_id',
+      type: 'uuid',
+      classification: 'internal',
+    })
+    p.model.items[0]!.relationships = [
+      {
+        column: 'user_id',
+        references: 'user',
+        onDelete: 'cascade',
+        provedBy: 'secondEntryRefusedScenario',
+      },
+    ]
+  }
+  return p
+}
+
+test('a cascade the migrations never declare is reported', () => {
+  const dir = migrations({
+    'sqlite/0003-entry.sql':
+      'create table "entry" ("id" text primary key, "user_id" text references "user" ("id"));',
+  })
+  try {
+    const problems = cascadeProblems(cascadingPlan(), dir)
+    assert.equal(problems.length, 1)
+    assert.match(
+      problems[0]!,
+      /no migration declares `on delete cascade` on `entry`/
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// The architect cannot know the migration NUMBER — it depends on what already shipped —
+// so the check searches every migration rather than the path the plan guessed.
+test('a cascade declared under a different migration number still counts', () => {
+  const dir = migrations({
+    'sqlite/0007-entry.sql':
+      'create table "entry" ("id" text primary key, "user_id" text not null references "user" ("id") on delete cascade);',
+  })
+  try {
+    assert.deepEqual(cascadeProblems(cascadingPlan(), dir), [])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a camelCase plan table finds its snake_case migration', () => {
+  const dir = migrations({
+    'sqlite/0006-class-bookings.sql':
+      'create table "class_bookings" ("id" text primary key, "class_id" text not null references "classes" ("id") on delete cascade);',
+  })
+  try {
+    const p = plan()
+    if (p.model.kind === 'built') {
+      p.model.items[0]!.table = 'classBookings'
+      p.model.items[0]!.relationships = [
+        {
+          column: 'classId',
+          references: 'classes',
+          onDelete: 'cascade',
+          provedBy: 'someScenario',
+        },
+      ]
+    }
+    assert.deepEqual(cascadeProblems(p, dir), [])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a cascade on a DIFFERENT table does not answer for this one', () => {
+  const dir = migrations({
+    'postgres/0003-tables.sql': [
+      'create table "comment" ("id" text primary key, "entry_id" text references "entry" ("id") on delete cascade);',
+      'create table "entry" ("id" text primary key, "user_id" text references "user" ("id"));',
+    ].join('\n'),
+  })
+  try {
+    assert.equal(cascadeProblems(cascadingPlan(), dir).length, 1)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('the SQLite rebuild-and-rename dance declares the cascade', () => {
+  const dir = migrations({
+    'sqlite/0003-entry.sql':
+      'create table "entry" ("id" text primary key, "user_id" text references "user" ("id"));',
+    'sqlite/0007-entry-cascade.sql': [
+      'create table "entry_new" ("id" text primary key, "user_id" text references "user" ("id") on delete cascade);',
+      'insert into "entry_new" select * from "entry";',
+      'drop table "entry";',
+      'alter table "entry_new" rename to "entry";',
+    ].join('\n'),
+  })
+  try {
+    assert.deepEqual(cascadeProblems(cascadingPlan(), dir), [])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a rebuild renamed onto a DIFFERENT table does not answer for this one', () => {
+  const dir = migrations({
+    'sqlite/0003-entry.sql':
+      'create table "entry" ("id" text primary key, "user_id" text references "user" ("id"));',
+    'sqlite/0007-comment-cascade.sql': [
+      'create table "comment_new" ("id" text primary key, "entry_id" text references "entry" ("id") on delete cascade);',
+      'alter table "comment_new" rename to "comment";',
+    ].join('\n'),
+  })
+  try {
+    assert.equal(cascadeProblems(cascadingPlan(), dir).length, 1)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a relationship that is not a cascade asserts nothing about the SQL', () => {
+  const p = cascadingPlan()
+  if (p.model.kind === 'built')
+    p.model.items[0]!.relationships[0]!.onDelete = 'orphan'
+  const dir = migrations({
+    'sqlite/0003-entry.sql': 'create table "entry" ("id" text primary key);',
+  })
+  try {
+    assert.deepEqual(cascadeProblems(p, dir), [])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+/**
+ * Generated step meta for one scenario, as `pikku scenarios` writes it: nodes chained by
+ * `next`, each carrying the phase and the step's resolved input.
+ */
+const steps = (
+  name: string,
+  nodes: Array<[string, string, Record<string, unknown>]>
+) => {
+  const built: Record<string, unknown> = {}
+  nodes.forEach(([rpcName, scenarioStepPhase, input], i) => {
+    built[`n${i}`] = {
+      rpcName,
+      scenarioStepPhase,
+      input,
+      ...(nodes[i + 1] ? { next: `n${i + 1}` } : {}),
+    }
+  })
+  return { name, source: 'scenario', nodes: built, entryNodeIds: ['n0'] }
+}
+
+const opensThenRests = (name: string) =>
+  steps(name, [
+    ['opensPage', 'when', { path: '/app/today' }],
+    ['restsOnPath', 'then', { path: '/app/today' }],
+  ])
+
+// The gap the existence check is blind to: the scenario was written, so it ticks its row
+// and passes its run, while the journey it names was never driven.
+test('a browser scenario that only proves the page loads is called out', () => {
+  const dir = project({
+    ...bothBuilt,
+    'scenarios/meta/ownerWritesTodayScenario.gen.json': opensThenRests(
+      'ownerWritesTodayScenario'
+    ),
+  })
+  try {
+    const { missing, problems } = planShortfall(plan(), readPikkuMeta(dir))
+    assert.deepEqual(
+      missing,
+      [],
+      'it exists — this is not an existence failure'
+    )
+    assert.equal(problems.length, 1)
+    assert.match(problems[0]!, /ownerWritesTodayScenario/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// The same shape, honestly used. A permission scenario's whole claim is that the guard let
+// this actor through (or bounced them), which is exactly what landing somewhere proves —
+// judging it by the browser rule would fail the starter template's own auth scenario.
+test('the identical shape is fine when the plan only claimed a permission', () => {
+  const dir = project({
+    ...bothBuilt,
+    'scenarios/meta/anotherMemberRefusedScenario.gen.json': opensThenRests(
+      'anotherMemberRefusedScenario'
+    ),
+  })
+  try {
+    assert.deepEqual(planShortfall(plan(), readPikkuMeta(dir)).problems, [])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a browser scenario that asserts what the user would see raises nothing', () => {
+  const dir = project({
+    ...bothBuilt,
+    'scenarios/meta/ownerWritesTodayScenario.gen.json': steps(
+      'ownerWritesTodayScenario',
+      [
+        ['opensPage', 'when', { path: '/app/today' }],
+        ['writesEntry', 'when', { body: 'a good day' }],
+        ['seesText', 'then', { text: 'a good day' }],
+      ]
+    ),
+  })
+  try {
+    assert.deepEqual(planShortfall(plan(), readPikkuMeta(dir)).problems, [])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// The generated scopes meta nests by segment while a plan (and a function's `scopes: [...]`)
+// names the colon-joined id, so reading the top-level keys alone made every nested scope
+// unsatisfiable — the shape that refused run hmt2p3w7z six times for scopes codegen had
+// already produced.
+test('readPikkuMeta flattens nested scope ids, not just the roots', () => {
+  const dir = project({
+    'scopes/pikku-scopes-meta.gen.json': {
+      tutor: {
+        name: 'tutor',
+        description: 'Tutor capabilities',
+        scopes: {
+          week: {
+            description: 'The week',
+            scopes: { read: { description: 'Read the week' } },
+          },
+          practice: {
+            description: 'Practice',
+            scopes: { manage: { description: 'Manage' } },
+          },
+        },
+      },
+      family: {
+        description: 'Family',
+        scopes: { practice: { description: 'Their practice' } },
+      },
+    },
+  })
+  try {
+    const { scopes } = readPikkuMeta(dir)
+    assert.ok(scopes.has('tutor:week:read'))
+    assert.ok(scopes.has('tutor:practice:manage'))
+    assert.ok(scopes.has('family:practice'))
+    assert.ok(scopes.has('tutor'), 'the root is still a grantable scope')
+    assert.ok(!scopes.has('read'), 'a leaf segment is not an id on its own')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// The failure this split exists for: run hmt3fz3c0's first milestone planned ten permission
+// scenarios against four other items, and the union meant a deployed, rendering, signed-in
+// app with 15 passing scenarios could never be marked complete.
+test('a cross product of permission scenarios does not block the walking skeleton', () => {
+  const crossProduct = plan()
+  crossProduct.scenarios.permission = {
+    kind: 'built',
+    description: 'Nobody reaches anybody else.',
+    items: Array.from({ length: 10 }, (_, i) => ({
+      feature: 'features/perms.feature',
+      scenario: `Refusal ${i}`,
+      name: `refusal${i}Scenario`,
+    })),
+  }
+  const dir = project(bothBuilt)
+  try {
+    const { missing, deferred } = planShortfall(
+      crossProduct,
+      readPikkuMeta(dir)
+    )
+    assert.deepEqual(missing, [])
+    assert.equal(deferred.length, 10)
+    assert.ok(deferred.every((d) => d.startsWith('permission scenario')))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a permission scenario explicitly placed in pass 1 still blocks', () => {
+  const explicit = plan()
+  if (explicit.scenarios.permission.kind === 'built') {
+    explicit.scenarios.permission.items[0]!.pass = 1
+  }
+  const dir = project({
+    ...bothBuilt,
+    'scenarios/pikku-scenario-functions-meta.gen.json': {
+      secondEntryRefusedScenario: {},
+      ownerWritesTodayScenario: {},
+    },
+  })
+  try {
+    const { missing } = planShortfall(explicit, readPikkuMeta(dir))
+    assert.ok(missing.some((m) => m.includes('anotherMemberRefusedScenario')))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// A plan states a wire only when the function is reached some way other than its RPC, and
+// only `http` was ever checked back. So a plan could promise a scheduled task, the build
+// could ship the bare function, and the gate certified the milestone complete — which is
+// why `transports: ["http", "scheduler"]` was planned in run hmt7o76ws and never built.
+test('a function planned on a non-http transport is missing until that transport reaches it', () => {
+  const scheduled = plan()
+  if (scheduled.functions.kind === 'built') {
+    scheduled.functions.items[0].wire = { transport: 'scheduler' }
+  }
+  const dir = project({
+    ...bothBuilt,
+    'http/pikku-http-wirings-meta.gen.json': { GET: { '/entry': {} } },
+  })
+  try {
+    const { missing } = planShortfall(scheduled, readPikkuMeta(dir))
+    assert.deepEqual(missing, ['scheduler wire for createEntry'])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a workflow meta left behind by a rename no longer discharges a wire', () => {
+  const dir = project({
+    ...bothBuilt,
+    'workflow/meta/deletedSweep.gen.json': {
+      name: 'deletedSweep',
+      pikkuFuncId: 'deletedSweep',
+      source: 'dsl',
+      nodes: { step_0: { nodeId: 'step_0', rpcName: 'goneStep', next: null } },
+    },
+  })
+  try {
+    const wired = readPikkuMeta(dir).wired.workflow
+    assert.equal(wired.has('deletedSweep'), false)
+    assert.equal(wired.has('goneStep'), false)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("a meta tree's own vocabulary is not read as a wired function", () => {
+  const dir = project({
+    ...bothBuilt,
+    'function/pikku-functions-meta.gen.json': {
+      createEntry: { auth: true },
+      listEntries: { auth: true },
+      nightlySweep: { auth: false },
+      sweepEntries: { auth: false },
+    },
+    'workflow/meta/nightlySweep.gen.json': {
+      name: 'nightlySweep',
+      pikkuFuncId: 'nightlySweep',
+      source: 'dsl',
+      context: { attempts: { type: 'number', default: 1 } },
+      nodes: {
+        step_0: { nodeId: 'step_0', rpcName: 'sweepEntries', next: null },
+      },
+    },
+  })
+  try {
+    const wired = readPikkuMeta(dir).wired.workflow
+    assert.ok(wired.has('nightlySweep'))
+    assert.ok(wired.has('sweepEntries'))
+    for (const vocabulary of [
+      'nodes',
+      'source',
+      'dsl',
+      'context',
+      'attempts',
+      'number',
+      'step_0',
+    ]) {
+      assert.equal(
+        wired.has(vocabulary),
+        false,
+        `${vocabulary} is schema, not a function`
+      )
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a scheduled task codegen recorded discharges the wire it was planned with', () => {
+  const scheduled = plan()
+  if (scheduled.functions.kind === 'built') {
+    scheduled.functions.items[0].wire = { transport: 'scheduler' }
+  }
+  const dir = project({
+    ...bothBuilt,
+    'http/pikku-http-wirings-meta.gen.json': { GET: { '/entry': {} } },
+    'scheduler/pikku-schedulers-wirings-meta.gen.json': {
+      nightlyEntrySweep: {
+        pikkuFuncId: 'createEntry',
+        name: 'nightlyEntrySweep',
+        schedule: '0 2 * * *',
+      },
+    },
+  })
+  try {
+    const { missing, done } = planShortfall(scheduled, readPikkuMeta(dir))
+    assert.deepEqual(missing, [])
+    assert.ok(done.includes('function createEntry'))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// Checked against real generated meta, not a guess at its shape: a scheduler records
+// `{pikkuFuncId, name, schedule}`, a queue worker's `pikkuFuncId` can carry a namespace
+// (`pikkuWorkflowOrchestrator:allWorkflow`), and a workflow is a `nodes` tree whose steps
+// name the rpcs they call.
+test('the shapes codegen really writes discharge the wire they were planned with', () => {
+  const cases: Array<[string, Record<string, unknown>]> = [
+    [
+      'queue/pikku-queue-workers-wirings-meta.gen.json',
+      {
+        'wf-createEntry': {
+          name: 'wf-createEntry',
+          pikkuFuncId: 'pikkuWorkflowOrchestrator:createEntry',
+        },
+      },
+    ],
+    [
+      'workflow/meta/entryWorkflow.gen.json',
+      {
+        name: 'entryWorkflow',
+        pikkuFuncId: 'entryWorkflow',
+        nodes: {
+          'Write it': {
+            nodeId: 'Write it',
+            rpcName: 'createEntry',
+            stepHash: '94d48581c462',
+          },
+        },
+      },
+    ],
+  ]
+  for (const [file, meta] of cases) {
+    const transport = file.startsWith('queue') ? 'queue' : 'workflow'
+    const wired = plan()
+    if (wired.functions.kind === 'built') {
+      wired.functions.items[0].wire = { transport }
+    }
+    const dir = project({
+      ...bothBuilt,
+      'http/pikku-http-wirings-meta.gen.json': { GET: { '/entry': {} } },
+      [file]: meta,
+    })
+    try {
+      const { missing } = planShortfall(wired, readPikkuMeta(dir))
+      assert.deepEqual(
+        missing,
+        [],
+        `${transport} did not discharge createEntry`
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})

--- a/packages/knowledge/src/plan-meta.ts
+++ b/packages/knowledge/src/plan-meta.ts
@@ -1,0 +1,669 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { z } from 'zod'
+import { FIRST_PASS, scenarioPass, type Plan, type WireTransport } from './plan.js'
+import { scenarioDepths, type ScenarioDepth } from './hollow-scenarios.js'
+
+/**
+ * A planned scenario that exists but cannot prove its own claim.
+ *
+ * Only `browser`-level claims are judged, and only against `reachability-only`. A
+ * `permission` scenario proving a guard let an actor through is doing exactly its job with
+ * that shape — the starter template's `signedInActorReachesTheAppScenario` is one, and
+ * failing it would be wrong. A `browser` scenario says a PERSON did something on screen, so
+ * navigating to a page and confirming the router left you there does not answer it.
+ *
+ * This is the gap the existence check cannot see: the scenario was written, so it counts as
+ * delivered, and it passes its run, so the scenario gate is green — measured on the journal
+ * fixture, `renWritesHowTheDayFeltScenario` shipped as `opens /app` → `is on /app`, passed
+ * 5/5, and the milestone was certified with the entry-writing journey never once driven.
+ */
+function shallowScenarioProblem(
+  level: string,
+  name: string,
+  claim: string,
+  depths: Map<string, ScenarioDepth>
+): string[] {
+  if (!name) return []
+  if (level !== 'browser') return []
+  const depth = depths.get(name)
+  if (depth === 'reachability-only') {
+    return [
+      `Browser scenario \`${name}\` ("${claim}") only opens a page and asserts it is still on it. That proves the route loads, not that anyone did the thing — drive the actual steps and assert what the user would see afterwards.`,
+    ]
+  }
+  if (depth === 'no-assertion') {
+    return [
+      `Browser scenario \`${name}\` ("${claim}") acts and asserts nothing, so it can only fail by throwing. Assert the outcome the user would see.`,
+    ]
+  }
+  return []
+}
+
+/**
+ * Every planned scenario that exists but proves less than its level claims.
+ *
+ * Exported so `fabric verify` can say it as a warning mid-build without re-deriving the
+ * whole shortfall — the finding is worth hearing while scenarios are still being written,
+ * and `fabric build-complete` refuses on the same list at the end.
+ */
+export function shallowScenarioProblems(plan: Plan, meta: PikkuMeta): string[] {
+  const problems: string[] = []
+  for (const [level, slot] of [
+    ['backend', plan.scenarios.backend],
+    ['browser', plan.scenarios.browser],
+    ['permission', plan.scenarios.permission],
+  ] as const) {
+    if (slot.kind !== 'built') continue
+    for (const item of slot.items) {
+      problems.push(
+        ...shallowScenarioProblem(
+          level,
+          item.name ?? '',
+          item.scenario,
+          meta.depths
+        )
+      )
+    }
+  }
+  return problems
+}
+
+/**
+ * What the app ACTUALLY has, read from pikku's generated metadata rather than from the
+ * source tree.
+ *
+ * Codegen already inventories eight of the nine things a plan declares — functions,
+ * wires, scopes, roles, workflows, agents, personas and features — keyed by the same
+ * ids the plan uses. So "did the engineer build `updateEntry`" is a set membership
+ * test against a JSON file the drive already regenerates every turn, not a glob over
+ * the tree and not a scenario run. Scenario PASS/FAIL still needs a run; existence
+ * does not, and existence is what a pass needs at its start to know what is left.
+ */
+export type PikkuMeta = {
+  functions: Record<string, { auth?: boolean }>
+  httpRoutes: Set<string>
+  scopes: Set<string>
+  roles: Set<string>
+  features: Record<
+    string,
+    { entries: Array<{ scenario: string }>; unresolvedEntries?: number }
+  >
+  /** Every `pikkuScenario` export codegen found, by id — what proves a planned scenario was written. */
+  scenarios: Set<string>
+  /** What each scenario is capable of proving, by id. See lib/hollow-scenarios.ts. */
+  depths: Map<string, ScenarioDepth>
+  /**
+   * The functions codegen found behind a NON-http transport, by transport.
+   *
+   * A plan states a wire only when the function is reached some way other than its RPC,
+   * and until now only `http` was ever checked back. So a plan could promise a scheduled
+   * task or a workflow entry point, the build could ship the bare function, and the gate
+   * would certify the milestone complete — which is why `transports: ["http",
+   * "scheduler"]` has been planned and never once built.
+   */
+  wired: Record<PlannedTransport, Set<string>>
+}
+
+/** The transports a plan can state, minus `http`, which is checked by route. */
+export type PlannedTransport = Exclude<z.infer<typeof WireTransport>, 'http'>
+
+const WIRE_META: Record<PlannedTransport, string> = {
+  queue: 'queue/pikku-queue-workers-wirings-meta.gen.json',
+  channel: 'channel/pikku-channels-meta.gen.json',
+  scheduler: 'scheduler/pikku-schedulers-wirings-meta.gen.json',
+  workflow: 'workflow/meta',
+}
+
+/**
+ * Where codegen writes its meta — the functions package when the project has one, the
+ * repo root otherwise. Every caller of `readPikkuMeta` needs this same resolution, and
+ * getting it wrong reads as "nothing was built" rather than as an error.
+ */
+export function functionsDirFor(cwd: string): string {
+  return existsSync(join(cwd, 'packages/functions'))
+    ? join(cwd, 'packages/functions')
+    : cwd
+}
+
+const readJson = (path: string): unknown => {
+  if (!existsSync(path)) return null
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'))
+  } catch (err) {
+    console.warn(`[plan-meta] unreadable ${path}: ${String(err)}`)
+    return null
+  }
+}
+
+const keysOf = (value: unknown): string[] =>
+  value && typeof value === 'object'
+    ? Object.keys(value as Record<string, unknown>)
+    : []
+
+/**
+ * Every scope id the generated tree declares, colon-joined — the spelling a plan and a
+ * function's `scopes: [...]` both use.
+ *
+ * The meta NESTS (`{admin: {scopes: {invoices: {scopes: {void: {}}}}}}`) while an id is
+ * flat, so reading only the top-level keys left every nested scope permanently missing and
+ * the gate unsatisfiable: run hmt2p3w7z declared its tree, cleared 15 of its 21 planned
+ * items, then was refused six times for six scopes codegen had already generated — four of
+ * those refusals identical — until the drive was killed.
+ */
+const flattenScopes = (tree: unknown, prefix = ''): string[] => {
+  if (!tree || typeof tree !== 'object') return []
+  const out: string[] = []
+  for (const [name, node] of Object.entries(
+    tree as Record<string, { scopes?: unknown }>
+  )) {
+    const id = prefix ? `${prefix}:${name}` : name
+    out.push(id, ...flattenScopes(node?.scopes, id))
+  }
+  return out
+}
+
+/** The generated meta for a project, tolerating anything codegen has not produced yet. */
+export function readPikkuMeta(functionsDir: string): PikkuMeta {
+  const pikku = join(functionsDir, '.pikku')
+  const functions = (readJson(
+    join(pikku, 'function/pikku-functions-meta.gen.json')
+  ) ?? {}) as Record<string, { auth?: boolean }>
+  const http = readJson(
+    join(pikku, 'http/pikku-http-wirings-meta.gen.json')
+  ) as Record<string, Record<string, unknown>> | null
+  const httpRoutes = new Set<string>()
+  for (const [method, routes] of Object.entries(http ?? {})) {
+    for (const route of keysOf(routes))
+      httpRoutes.add(`${method.toLowerCase()} ${route}`)
+  }
+  return {
+    functions,
+    httpRoutes,
+    scopes: new Set(
+      flattenScopes(readJson(join(pikku, 'scopes/pikku-scopes-meta.gen.json')))
+    ),
+    roles: new Set(
+      keysOf(readJson(join(pikku, 'scopes/pikku-roles-meta.gen.json')))
+    ),
+    features: (readJson(join(pikku, 'scenarios/features.gen.json')) ??
+      {}) as PikkuMeta['features'],
+    scenarios: new Set(
+      keysOf(
+        readJson(
+          join(pikku, 'scenarios/pikku-scenario-functions-meta.gen.json')
+        )
+      )
+    ),
+    depths: scenarioDepths(functionsDir),
+    wired: wiredFunctions(pikku, new Set(Object.keys(functions))),
+  }
+}
+
+/**
+ * Which functions each non-http transport actually reaches.
+ *
+ * Each meta names its functions differently — a queue worker and a scheduled task record
+ * the function they call, a channel records its handlers, a workflow gets a file per
+ * workflow — so what is collected is every function name any of them mentions. The test
+ * is "does this transport reach this function at all", which is what a plan states.
+ */
+function wiredFunctions(
+  pikku: string,
+  live: ReadonlySet<string>
+): Record<PlannedTransport, Set<string>> {
+  const out = {} as Record<PlannedTransport, Set<string>>
+  for (const [transport, rel] of Object.entries(WIRE_META) as [
+    PlannedTransport,
+    string,
+  ][]) {
+    const names = new Set<string>()
+    const path = join(pikku, rel)
+    const perFile = !rel.endsWith('.gen.json')
+    const files = perFile
+      ? existsSync(path)
+        ? readdirSync(path)
+            .filter((f) => f.endsWith('.gen.json'))
+            .map((f) => join(path, f))
+        : []
+      : [path]
+    for (const file of files) collectNames(readJson(file), names)
+    /**
+     * A directory of one file per workflow is never CLEARED before codegen rewrites it,
+     * so a renamed or deleted workflow leaves its meta behind forever — verified by
+     * adding a workflow to the starter template and removing it again: the orphan
+     * survived `pikku all`. Left alone it discharges a wire nothing implements any more,
+     * the same way `.pikku/scenarios/meta` fed dead scenario names to a run until
+     * `unknownScenarios` started dropping them. The single-file metas are rewritten
+     * whole, so only the per-file ones can go stale — and the functions meta is itself
+     * rewritten whole, which makes it the authority on what still exists.
+     */
+    out[transport] = perFile
+      ? new Set([...names].filter((n) => live.has(n)))
+      : names
+  }
+  return out
+}
+
+/**
+ * The function names a meta tree names, read from the keys that carry one.
+ *
+ * Every string in the tree is the wrong net: a workflow meta holds its own schema
+ * vocabulary (`name`, `source`, `complex`, `nodes`) and a channel meta holds its route,
+ * so a function called `events` or `input` would discharge a wire it never got — the gate
+ * failing lax in exactly the way the http one used to. `name`, `pikkuFuncId` and `rpcName`
+ * are the three keys pikku writes a function name under, across all four transports.
+ *
+ * A `pikkuFuncId` can carry a namespace (`pikkuWorkflowOrchestrator:allWorkflow`), so the
+ * last segment goes in too: a plan names the function, never the id that wraps it. Under
+ * `rpcName` a channel nests an object keyed by the names, so its keys count as well.
+ */
+const NAME_KEYS = new Set(['name', 'pikkuFuncId', 'rpcName'])
+
+function addName(value: unknown, into: Set<string>): void {
+  if (typeof value === 'string') {
+    into.add(value)
+    if (value.includes(':')) into.add(value.slice(value.lastIndexOf(':') + 1))
+    return
+  }
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    for (const key of Object.keys(value)) into.add(key)
+  }
+}
+
+function collectNames(node: unknown, into: Set<string>): void {
+  if (Array.isArray(node)) {
+    for (const child of node) collectNames(child, into)
+    return
+  }
+  if (!node || typeof node !== 'object') return
+  for (const [key, child] of Object.entries(node)) {
+    if (NAME_KEYS.has(key)) addName(child, into)
+    collectNames(child, into)
+  }
+}
+
+/**
+ * Whether a planned HTTP wire exists, comparing METHOD and path.
+ *
+ * The method is half the wire: `GET /entry` and `POST /entry` are different routes doing
+ * different things, and a check that matched on path alone let a plan's read endpoint be
+ * discharged by its write one — the plan would read as fully built with the list route
+ * never wired. A plan may name the route bare (`/entry`), in which case any method
+ * answers it, because that is genuinely all the plan asked for.
+ *
+ * Both sides are lowercased, which matters for the path and not just the method: a path
+ * parameter is camelCase by convention (`/deal/:dealId/stage`), so comparing a lowercased
+ * plan entry against the meta's verbatim route made EVERY parameterised wire unmatchable.
+ * Measured on a crm build — the route was in the generated meta and the gate still reported
+ * it missing, and the agent spent its last two turns inventing a pikku codegen fault to
+ * explain a wire it had already written correctly.
+ */
+function isWired(planned: string, routes: Set<string>): boolean {
+  const path = (r: string) => r.trim().toLowerCase().replace(/\/+$/, '') || '/'
+  const declared = planned.trim().toLowerCase()
+  const [head, ...rest] = declared.split(/\s+/)
+  if (
+    rest.length > 0 &&
+    /^(get|post|put|patch|delete|head|options)$/.test(head ?? '')
+  ) {
+    const wanted = `${head} ${path(rest.join(' '))}`
+    return [...routes].some((r) => {
+      const [m, ...p] = r.split(/\s+/)
+      return `${(m ?? '').toLowerCase()} ${path(p.join(' '))}` === wanted
+    })
+  }
+  return [...routes].some((r) => path(r.split(' ')[1] ?? '') === path(declared))
+}
+
+/**
+ * One row of the build checklist the console renders.
+ *
+ * `done` is a set-membership test against codegen's meta, never a status anything types.
+ * That is the whole reason this replaced the agent's own todo list: a task the agent
+ * marks `completed` says only that it claimed to finish, and run 10 is the case against
+ * it — refused with four of six tasks unfinished, all four flipped to `completed` nine
+ * seconds later with nothing built.
+ */
+export type PlanChecklistItem = {
+  /** Stable across turns so the console can keep row identity as items land. */
+  id: string
+  /** What the plan called it — the description a reader recognises, not the symbol. */
+  label: string
+  kind: 'function' | 'wire' | 'scope' | 'scenario'
+  done: boolean
+  /**
+   * Promised by a later pass, so `fabric build-complete` never asks for it.
+   *
+   * Set by `planShortfall`, which is the only caller that can see every pass at once —
+   * `planProgress` works one pass at a time and leaves it false.
+   */
+  deferred: boolean
+}
+
+export type PlanProgress = {
+  pass: number
+  done: string[]
+  missing: string[]
+  problems: string[]
+  /** The same reconcile as `done`/`missing`, structured for the console checklist. */
+  items: PlanChecklistItem[]
+}
+
+/**
+ * What is left to build in one pass, and what the meta says is wrong with what landed.
+ *
+ * The `auth` cross-check is the sharp one: the plan states a permission rule in prose,
+ * which no checker can compare against the rule the function enforces — but meta knows
+ * whether the function is gated AT ALL, so "the plan says this is restricted and the
+ * function is wide open" is caught mechanically. Only the rule's meaning needs a human.
+ */
+export function planProgress(
+  plan: Plan,
+  meta: PikkuMeta,
+  pass: number
+): PlanProgress {
+  const done: string[] = []
+  const missing: string[] = []
+  const problems: string[] = []
+  const items: PlanChecklistItem[] = []
+
+  const fns = plan.functions.kind === 'built' ? plan.functions.items : []
+  for (const fn of fns.filter((f) => f.pass === pass)) {
+    const built = meta.functions[fn.name]
+    items.push({
+      id: `function:${fn.name}`,
+      label: fn.description,
+      kind: 'function',
+      done: !!built,
+      deferred: false,
+    })
+    if (fn.wire && fn.wire.transport === 'http' && fn.wire.route) {
+      items.push({
+        id: `wire:${fn.wire.route}`,
+        label: fn.wire.route,
+        kind: 'wire',
+        done: isWired(fn.wire.route, meta.httpRoutes),
+        deferred: false,
+      })
+    } else if (fn.wire && fn.wire.transport !== 'http') {
+      items.push({
+        id: `wire:${fn.wire.transport}:${fn.name}`,
+        label: `${fn.name} on ${fn.wire.transport}`,
+        kind: 'wire',
+        done: meta.wired[fn.wire.transport]?.has(fn.name) ?? false,
+        deferred: false,
+      })
+    }
+    if (!built) {
+      missing.push(`function ${fn.name}`)
+      continue
+    }
+    done.push(`function ${fn.name}`)
+    if (fn.permission !== null && built.auth === false) {
+      problems.push(
+        `\`${fn.name}\` is planned as restricted — "${fn.permission}" — but its meta says \`auth: false\`, so anyone can call it.`
+      )
+    }
+    if (fn.wire && fn.wire.transport === 'http' && fn.wire.route) {
+      if (!isWired(fn.wire.route, meta.httpRoutes))
+        missing.push(`wire ${fn.wire.route}`)
+    } else if (fn.wire && fn.wire.transport !== 'http') {
+      if (!meta.wired[fn.wire.transport]?.has(fn.name)) {
+        missing.push(`${fn.wire.transport} wire for ${fn.name}`)
+      }
+    }
+  }
+
+  const scopes = plan.scopes.kind === 'built' ? plan.scopes.items : []
+  for (const scope of scopes) {
+    items.push({
+      id: `scope:${scope.name}`,
+      label: scope.description,
+      kind: 'scope',
+      done: meta.scopes.has(scope.name),
+      deferred: false,
+    })
+    if (!meta.scopes.has(scope.name)) missing.push(`scope ${scope.name}`)
+  }
+
+  /**
+   * The scenarios the plan promised, checked for existence.
+   *
+   * Without this the plan bound the build as intent but not as obligation: the gate certified
+   * functions, wires, permissions and scopes, and a model that skipped the scenarios section
+   * entirely lost nothing. Measured on the journal fixture — deepseek-v4-pro delivered 0 of 6
+   * planned scenarios and kimi-k2.6 delivered 1, and BOTH were marked complete, because the
+   * only scenario-adjacent check asked whether declared features had unwritten entries rather
+   * than whether the planned scenarios were written at all.
+   *
+   * Deliberately existence, not pass/fail: a run answers pass/fail, and the scenario gate
+   * already does that. What was missing is that a scenario nobody wrote cannot fail, so its
+   * absence read as success.
+   */
+  for (const [level, slot] of [
+    ['backend', plan.scenarios.backend],
+    ['browser', plan.scenarios.browser],
+    ['permission', plan.scenarios.permission],
+  ] as const) {
+    if (slot.kind !== 'built') continue
+    for (const item of slot.items.filter(
+      (i) => scenarioPass(level, i) === pass
+    )) {
+      if (!item.name) {
+        problems.push(
+          `The ${level} scenario "${item.scenario}" names no \`pikkuScenario\` export, so nothing can check it was written. Add \`name\` to it in the plan.`
+        )
+        continue
+      }
+      items.push({
+        id: `scenario:${item.name}`,
+        label: item.scenario,
+        kind: 'scenario',
+        done: meta.scenarios.has(item.name),
+        deferred: false,
+      })
+      if (meta.scenarios.has(item.name)) done.push(`scenario ${item.name}`)
+      else missing.push(`${level} scenario ${item.name} ("${item.scenario}")`)
+    }
+  }
+  problems.push(...shallowScenarioProblems(plan, meta))
+
+  for (const [id, feature] of Object.entries(meta.features)) {
+    if ((feature.unresolvedEntries ?? 0) > 0) {
+      problems.push(
+        `Feature \`${id}\` declares ${feature.unresolvedEntries} scenario(s) that do not exist. A declared-but-unwritten scenario passes nothing.`
+      )
+    }
+  }
+
+  return { pass, done, missing, problems, items }
+}
+
+const sqlFiles = (dir: string): string[] => {
+  if (!existsSync(dir)) return []
+  return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const full = join(dir, e.name)
+    if (e.isDirectory()) return sqlFiles(full)
+    return e.name.endsWith('.sql') ? [full] : []
+  })
+}
+
+const TABLE_STATEMENT =
+  /(create|alter)\s+table\s+(?:if\s+not\s+exists\s+)?["`[]?([A-Za-z0-9_]+)["`\]]?/i
+
+/**
+ * One table under either spelling.
+ *
+ * A plan names its tables in camelCase, because that is what every line of TypeScript
+ * that touches them uses; a migration names the same table in snake_case, because that
+ * is what a column name is. Matched literally, `classBookings` never finds
+ * `class_bookings`, so the cascade gate refused every table whose name is more than one
+ * word — plan-probe-105130 died there, and "fixed" it by DELETING the cascade the
+ * migration already had.
+ */
+const sameTable = (name: string): string => name.replace(/_/g, '').toLowerCase()
+
+const RENAME_STATEMENT =
+  /alter\s+table\s+["`[]?([A-Za-z0-9_]+)["`\]]?\s+rename\s+to\s+["`\]]?([A-Za-z0-9_]+)["`\]]?/i
+
+/**
+ * Every table name that a later migration renames, mapped to the name it ends up with.
+ *
+ * SQLite cannot add a foreign key to an existing table, so the only correct way to
+ * introduce a cascade after the fact is the rebuild: create a replacement carrying the
+ * constraint, copy the rows, drop the original, rename the replacement into its place.
+ * That leaves the `on delete cascade` sitting in a `create table` for the TEMPORARY name,
+ * which the plan never mentions — so a literal match reads the migration as absent and
+ * the gate refuses a build that did exactly the right thing. Run hmt09oj7q died there,
+ * rewriting the same migration on every `fabric build-complete` until it was killed.
+ *
+ * Chains are followed to the end so a rebuild done twice still lands on the real table.
+ */
+function finalTableNames(files: string[]): Map<string, string> {
+  const direct = new Map<string, string>()
+  for (const file of files) {
+    for (const statement of readFileSync(file, 'utf8').split(';')) {
+      const renamed = RENAME_STATEMENT.exec(statement)
+      if (renamed) direct.set(sameTable(renamed[1]!), sameTable(renamed[2]!))
+    }
+  }
+  const resolved = new Map<string, string>()
+  for (const from of direct.keys()) {
+    let to = from
+    const seen = new Set<string>([from])
+    while (direct.has(to)) {
+      const next = direct.get(to)!
+      if (seen.has(next)) break
+      seen.add(next)
+      to = next
+    }
+    resolved.set(from, to)
+  }
+  return resolved
+}
+
+/**
+ * Whether the migrations declare a delete cascade on a table.
+ *
+ * Deliberately searched across every `db/**\/*.sql` rather than read from the path the
+ * plan names. Migration filenames are numbered by what is already in the repo, which the
+ * architect cannot know when writing the plan — the journal plan said `0001-entry.sql`
+ * and the two builds correctly wrote `0003-` and `0004-`. Holding the build to a guessed
+ * filename would fail every plan that got the ordering right.
+ *
+ * Statement-scoped, because a file that creates two tables would otherwise let a cascade
+ * on one answer for the other.
+ */
+function declaresCascade(cwd: string, table: string): boolean {
+  const wanted = sameTable(table)
+  const files = sqlFiles(join(cwd, 'db'))
+  const renames = finalTableNames(files)
+  for (const file of files) {
+    for (const statement of readFileSync(file, 'utf8').split(';')) {
+      const named = TABLE_STATEMENT.exec(statement)
+      if (!named) continue
+      const declared = sameTable(named[2]!)
+      if (declared !== wanted && renames.get(declared) !== wanted) continue
+      if (/on\s+delete\s+cascade/i.test(statement)) return true
+    }
+  }
+  return false
+}
+
+/**
+ * Cascades the plan promised that the migrations do not declare.
+ *
+ * Separate from `planShortfall` because it reads the repo rather than codegen meta —
+ * pikku's generated metadata inventories functions, wires, scopes and scenarios, but
+ * nothing in it says what happens to a child row when its parent is deleted. The
+ * scenario half of the promise (`provedBy`) needs no separate check: it is a planned
+ * scenario like any other, so the existence check already covers it.
+ */
+export function cascadeProblems(plan: Plan, cwd: string): string[] {
+  const problems: string[] = []
+  const tables = plan.model.kind === 'built' ? plan.model.items : []
+  for (const table of tables) {
+    for (const rel of table.relationships) {
+      if (rel.onDelete !== 'cascade') continue
+      if (!declaresCascade(cwd, table.table)) {
+        problems.push(
+          `The plan says a \`${table.table}\` is deleted with its \`${rel.references}\` (${table.table}.${rel.column}), but no migration declares \`on delete cascade\` on \`${table.table}\`. Deleting a ${rel.references} will fail or leave the rows behind.`
+        )
+      }
+    }
+  }
+  return problems
+}
+
+export type PlanShortfallResult = Omit<PlanProgress, 'pass'> & {
+  /** Promised by a later pass and not built. Reported, never blocking. */
+  deferred: string[]
+}
+
+/**
+ * Everything the plan promised that the meta cannot find — `missing` is what BLOCKS,
+ * `deferred` is what a later milestone picks up.
+ *
+ * `planProgress` answers "what is left in THIS pass", which is what a build turn needs
+ * while it works. Completion used to be the union of every pass, so that a plan could not
+ * discharge itself by declaring the unbuilt half a later pass. That defence was written
+ * when the BUILD agent authored its own plan and was therefore both author and examiner;
+ * the architect/builder split closed the vector, and `checkFirstPass` independently
+ * requires pass 1 to be a walking skeleton that reaches a screen with a function behind it.
+ *
+ * What the union cost instead: a milestone ships only when every pass is done, so plan SIZE
+ * became fatal. Run hmt3fz3c0 planned 14 items whose 10 permission scenarios were the role x
+ * resource cross product, refused `fabric build-complete` thirteen times, and surrendered
+ * with a deployed, rendering, signed-in app carrying 15 passing scenarios. Blocking on pass 1
+ * alone makes an over-large plan slow rather than fatal, which is the only durable answer
+ * when the budget cannot be expressed as a number of items.
+ *
+ * Deliberately meta-only. The ui slot has no counterpart in codegen, and the existing
+ * completion gates already refuse an unrendered or unlooked-at route far better than a
+ * file-exists check would; adding a weaker duplicate here would only produce a second
+ * opinion to argue with.
+ */
+export function planShortfall(
+  plan: Plan,
+  meta: PikkuMeta
+): PlanShortfallResult {
+  const passes = new Set<number>([FIRST_PASS])
+  if (plan.functions.kind === 'built')
+    for (const f of plan.functions.items) passes.add(f.pass)
+  for (const [level, slot] of [
+    ['backend', plan.scenarios.backend],
+    ['browser', plan.scenarios.browser],
+    ['permission', plan.scenarios.permission],
+  ] as const) {
+    if (slot.kind === 'built')
+      for (const i of slot.items) passes.add(scenarioPass(level, i))
+  }
+
+  const done = new Set<string>()
+  const missing = new Set<string>()
+  const problems = new Set<string>()
+  // Keyed by id so a function declared in two passes contributes ONE checklist row —
+  // the console renders these as the build's progress, and the same row twice reads as
+  // two things to build.
+  const items = new Map<string, PlanChecklistItem>()
+  const first = planProgress(plan, meta, FIRST_PASS)
+  const firstPassIds = new Set(first.items.map((item) => item.id))
+  for (const pass of passes) {
+    const progress = planProgress(plan, meta, pass)
+    for (const d of progress.done) done.add(d)
+    for (const m of progress.missing) missing.add(m)
+    for (const p of progress.problems) problems.add(p)
+    for (const item of progress.items) {
+      items.set(item.id, { ...item, deferred: !firstPassIds.has(item.id) })
+    }
+  }
+  const blocking = new Set(first.missing)
+  return {
+    done: [...done],
+    missing: [...blocking],
+    deferred: [...missing].filter((m) => !blocking.has(m)),
+    problems: [...problems],
+    items: [...items.values()],
+  }
+}

--- a/packages/knowledge/src/plan-meta.ts
+++ b/packages/knowledge/src/plan-meta.ts
@@ -1,7 +1,12 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { z } from 'zod'
-import { FIRST_PASS, scenarioPass, type Plan, type WireTransport } from './plan.js'
+import {
+  FIRST_PASS,
+  scenarioPass,
+  type Plan,
+  type WireTransport,
+} from './plan.js'
 import { scenarioDepths, type ScenarioDepth } from './hollow-scenarios.js'
 
 /**

--- a/packages/knowledge/src/plan.test.ts
+++ b/packages/knowledge/src/plan.test.ts
@@ -1,0 +1,620 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  MAX_DEFERRALS,
+  PLAN_VERSION,
+  checkAgainstMilestone,
+  deferPlanItem,
+  itemsOf,
+  checkFirstPass,
+  checkPlanInternals,
+  deferOutstandingItems,
+  knowledgeCoverage,
+  planPathFor,
+  planSchemaJson,
+  plannedApps,
+  readPlan,
+  renderPlanForBuild,
+} from './plan.js'
+import { noteHash } from './notes.js'
+import { basePlan } from './plan-fixture.js'
+
+// The plan is the denominator the build agent does not own. Every check here is one
+// the agent could otherwise satisfy by lowering the bar — so a gap that lets a plan
+// through is worth more than a false refusal.
+
+test('a well-formed plan passes every check', () => {
+  const plan = basePlan()
+  assert.deepEqual(checkFirstPass(plan), [])
+  assert.deepEqual(checkPlanInternals(plan), [])
+  assert.deepEqual(
+    checkAgainstMilestone(
+      plan,
+      { entities: 'entry', path: 'knowledge/milestones/01.md' },
+      ['owner']
+    ),
+    []
+  )
+})
+
+test('pass 1 without a screen is refused — the cap this replaces let that through', () => {
+  const plan = basePlan()
+  plan.ui = { kind: 'n/a', description: 'Later.' }
+  const problems = checkFirstPass(plan)
+  assert.equal(problems.length, 1)
+  assert.match(problems[0]!, /no `ui` item/)
+})
+
+test('a cli milestone passes pass 1 with no ui at all', () => {
+  // The `ui` slot's whole reason for existing is that "not needed, and here's why" can
+  // be said out loud — and `checkFirstPass` used to make that legal to write and
+  // impossible to pass, for a CLI as much as for an app.
+  const plan = basePlan()
+  plan.ui = { kind: 'n/a', description: 'A command, not a page.' }
+  if (plan.scenarios.backend.kind === 'built')
+    plan.scenarios.backend.items[0]!.fn = 'createEntry'
+  assert.deepEqual(checkFirstPass(plan, 'cli'), [])
+})
+
+test('a cli milestone with nothing driving what it wires is refused', () => {
+  // The obligation does not disappear with the surface, only the level it is met at:
+  // an app is proved in the browser, a command at the backend.
+  const plan = basePlan()
+  plan.ui = { kind: 'n/a', description: 'A command, not a page.' }
+  const problems = checkFirstPass(plan, 'cli')
+  assert.equal(problems.length, 1)
+  assert.match(problems[0]!, /"fn": "createEntry"/)
+})
+
+test('a pass-1 route with no browser scenario is refused', () => {
+  const plan = basePlan()
+  if (plan.ui.kind === 'built') plan.ui.items[0]!.scenarios = []
+  plan.scenarios.browser = { kind: 'n/a', description: 'Skipped.' }
+  const problems = checkFirstPass(plan)
+  assert.ok(problems.some((p) => /no browser scenario/.test(p)))
+})
+
+test('a permission rule with no refusal scenario is refused', () => {
+  const plan = basePlan()
+  plan.scenarios.permission = { kind: 'n/a', description: 'None needed.' }
+  const problems = checkPlanInternals(plan)
+  assert.ok(problems.some((p) => /createEntry.*no scenario proving/s.test(p)))
+})
+
+test('a function touching personal data with no permission rule is flagged', () => {
+  const plan = basePlan()
+  if (plan.functions.kind === 'built')
+    plan.functions.items[0]!.permission = null
+  plan.scenarios.permission = { kind: 'n/a', description: 'None needed.' }
+  const problems = checkPlanInternals(plan)
+  assert.ok(problems.some((p) => /personal data/.test(p)))
+})
+
+// The refusal above has to be answerable, and the only answer it can accept is this one.
+// It used to offer a second: say in the `description` that anyone signed in may call it.
+// Nothing read the description for that, and the trigger IS the description naming the
+// table — so following the advice could only keep the refusal firing. The architect spent
+// its whole attempt budget on it, the milestone got no plan, and every later
+// `fabric build-milestone` refused with "has no plan and one could not be written".
+test('an open function touching personal data clears once a scenario names it', () => {
+  const plan = basePlan()
+  if (plan.functions.kind === 'built')
+    plan.functions.items[0]!.permission = null
+  assert.deepEqual(checkPlanInternals(plan), [])
+})
+
+test('a declared scope that gates nothing is flagged', () => {
+  const plan = basePlan()
+  plan.scopes = {
+    kind: 'built',
+    description: 'One.',
+    items: [{ name: 'entry:write', description: 'Write.' }],
+  }
+  const problems = checkPlanInternals(plan)
+  assert.ok(problems.some((p) => /entry:write.*gates no function/.test(p)))
+})
+
+test('a milestone entity no function or table mentions is flagged', () => {
+  const plan = basePlan()
+  const problems = checkAgainstMilestone(
+    plan,
+    { entities: 'entry, reminder', path: 'knowledge/milestones/01.md' },
+    []
+  )
+  assert.equal(problems.length, 1)
+  assert.match(problems[0]!, /reminder/)
+})
+
+test('a persona nobody drives through the UI is flagged', () => {
+  const plan = basePlan()
+  const problems = checkAgainstMilestone(
+    plan,
+    { entities: 'entry', path: 'x.md' },
+    ['owner', 'admin']
+  )
+  assert.ok(problems.some((p) => /'admin'/.test(p)))
+})
+
+test('coverage separates built from merely claimed', () => {
+  const notes = [
+    { path: 'entities/entry.md', body: 'entry body' },
+    { path: 'decisions/privacy.md', body: 'privacy body' },
+    { path: 'entities/tag.md', body: 'tag body' },
+  ]
+  const built = basePlan()
+  const claimed = basePlan()
+  claimed.milestone = 'knowledge/milestones/02-tags.md'
+  claimed.covers = [
+    {
+      note: 'decisions/privacy.md',
+      hash: noteHash('privacy body'),
+      complete: true,
+    },
+  ]
+  const coverage = knowledgeCoverage(notes, [
+    { plan: built, status: 'built' },
+    { plan: claimed, status: 'proposed' },
+  ])
+  assert.deepEqual(
+    coverage.map((c) => [c.note, c.state]),
+    [
+      ['entities/entry.md', 'covered'],
+      ['decisions/privacy.md', 'claimed'],
+      ['entities/tag.md', 'uncovered'],
+    ]
+  )
+})
+
+test('a partial claim never discharges the note', () => {
+  const plan = basePlan()
+  plan.covers = [
+    {
+      note: 'entities/entry.md',
+      hash: noteHash('entry body'),
+      complete: false,
+    },
+  ]
+  const coverage = knowledgeCoverage(
+    [{ path: 'entities/entry.md', body: 'entry body' }],
+    [{ plan, status: 'built' }]
+  )
+  assert.equal(coverage[0]!.state, 'claimed')
+})
+
+test('a milestone that landed with deferrals leaves its note part-built', () => {
+  const plan = basePlan()
+  plan.deferrals = [
+    {
+      item: 'scenario:ownerWritesTodayScenario',
+      why: 'the clock ran out',
+      at: '2026-08-29T00:00:00.000Z',
+    },
+  ]
+  const coverage = knowledgeCoverage(
+    [{ path: 'entities/entry.md', body: 'entry body' }],
+    [{ plan, status: 'built' }]
+  )
+  assert.equal(coverage[0]!.state, 'partial')
+  assert.deepEqual(
+    coverage[0]!.leftBehind.map((d) => d.item),
+    ['scenario:ownerWritesTodayScenario']
+  )
+})
+
+// The termination property: the librarian is told once, writes the milestone, and the
+// note stops being backlog. Without it the same directive fires on every planner turn.
+test('a follow-up milestone claiming the note takes it out of the backlog', () => {
+  const built = basePlan()
+  built.deferrals = [
+    {
+      item: 'scenario:ownerWritesTodayScenario',
+      why: 'the clock ran out',
+      at: '2026-08-29T00:00:00.000Z',
+    },
+  ]
+  const followUp = basePlan('knowledge/milestones/02-writing-it.md')
+  const coverage = knowledgeCoverage(
+    [{ path: 'entities/entry.md', body: 'entry body' }],
+    [
+      { plan: built, status: 'built' },
+      { plan: followUp, status: 'proposed' },
+    ]
+  )
+  assert.equal(coverage[0]!.state, 'claimed')
+})
+
+test('a killed milestone defers everything pass 1 still owed, past the voluntary limit', () => {
+  const plan = basePlan()
+  const { plan: after, deferred } = deferOutstandingItems(
+    plan,
+    [
+      'function:createEntry',
+      'scenario:secondEntryRefusedScenario',
+      'scenario:ownerWritesTodayScenario',
+      'wire:POST /entry',
+    ],
+    'the milestone was stopped at its cap'
+  )
+  assert.deepEqual(deferred, [
+    'function:createEntry',
+    'scenario:secondEntryRefusedScenario',
+    'scenario:ownerWritesTodayScenario',
+  ])
+  assert.equal(after.deferrals.length, 3)
+  assert.equal(itemsOf(after.functions)[0]!.pass, 2)
+  assert.deepEqual(plan.deferrals, [])
+})
+
+// The ledger's honesty over time depends on this one: the interview keeps running, and
+// a sentence added to a note that shipped months ago is the commonest way a new
+// requirement arrives. Keyed on path alone it would read `covered` forever.
+test('a note edited after it was built goes back to the backlog', () => {
+  const plan = basePlan()
+  const coverage = knowledgeCoverage(
+    [
+      {
+        path: 'entities/entry.md',
+        body: 'entry body, plus a rule added later',
+      },
+    ],
+    [{ plan, status: 'built' }]
+  )
+  assert.equal(coverage[0]!.state, 'changed')
+  assert.deepEqual(coverage[0]!.by, [
+    'knowledge/milestones/01-the-daily-entry.md',
+  ])
+})
+
+test('a schema failure names the field path so the reader can fix it in one edit', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'plan-'))
+  try {
+    mkdirSync(join(cwd, 'knowledge/milestones'), { recursive: true })
+    const plan = basePlan() as unknown as Record<string, unknown>
+    delete (plan.functions as Record<string, unknown>).description
+    writeFileSync(
+      join(cwd, planPathFor('knowledge/milestones/01.md')),
+      JSON.stringify(plan)
+    )
+    const read = readPlan(cwd, 'knowledge/milestones/01.md')
+    assert.equal(read.ok, false)
+    if (!read.ok) assert.match(read.reason, /functions/)
+  } finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+test('a plan from a version this reader does not know is refused as a version', () => {
+  // Published, the format is a contract with readers that shipped before it changed.
+  // Parsing optimistically reports a version bump as a scattering of field errors, and
+  // the reader spends its turn editing fields to match a schema it cannot satisfy.
+  const cwd = mkdtempSync(join(tmpdir(), 'plan-'))
+  try {
+    mkdirSync(join(cwd, 'knowledge/milestones'), { recursive: true })
+    const plan = { ...basePlan(), version: PLAN_VERSION + 1 }
+    writeFileSync(
+      join(cwd, planPathFor('knowledge/milestones/01.md')),
+      JSON.stringify(plan)
+    )
+    const read = readPlan(cwd, 'knowledge/milestones/01.md')
+    assert.equal(read.ok, false)
+    if (!read.ok) assert.match(read.reason, /only understands 1/)
+  } finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+test('a missing plan says so rather than passing silently', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'plan-'))
+  try {
+    const read = readPlan(cwd, 'knowledge/milestones/01.md')
+    assert.equal(read.ok, false)
+    if (!read.ok) assert.match(read.reason, /No plan at/)
+  } finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+test('a cascade with no scenario proving it is refused', () => {
+  const plan = basePlan()
+  if (plan.model.kind === 'built') {
+    plan.model.items[0]!.relationships = [
+      { column: 'id', references: 'user', onDelete: 'cascade' },
+    ]
+  }
+  const problems = checkPlanInternals(plan)
+  assert.ok(
+    problems.some((p) =>
+      /cascades when a `user` is deleted, with no scenario/.test(p)
+    )
+  )
+})
+
+test('a cascade proved by a scenario the plan never promises is refused', () => {
+  const plan = basePlan()
+  if (plan.model.kind === 'built') {
+    plan.model.items[0]!.relationships = [
+      {
+        column: 'id',
+        references: 'user',
+        onDelete: 'cascade',
+        provedBy: 'noSuchScenario',
+      },
+    ]
+  }
+  const problems = checkPlanInternals(plan)
+  assert.ok(
+    problems.some((p) => /no scenario in this plan has that name/.test(p))
+  )
+})
+
+test('a cascade proved by a planned scenario passes', () => {
+  const plan = basePlan()
+  if (plan.model.kind === 'built') {
+    plan.model.items[0]!.relationships = [
+      {
+        column: 'id',
+        references: 'user',
+        onDelete: 'cascade',
+        provedBy: 'secondEntryRefusedScenario',
+      },
+    ]
+  }
+  assert.deepEqual(checkPlanInternals(plan), [])
+})
+
+test('a relationship on a column the table does not have is refused', () => {
+  const plan = basePlan()
+  if (plan.model.kind === 'built') {
+    plan.model.items[0]!.relationships = [
+      { column: 'owner_id', references: 'user', onDelete: 'restrict' },
+    ]
+  }
+  const problems = checkPlanInternals(plan)
+  assert.ok(problems.some((p) => /is not one of the table's fields/.test(p)))
+})
+
+// Two audiences is the ordinary case, not the exception — a bike shop has mechanics and
+// the customer booking the repair, a landlord app has the landlord and the tenant. The
+// plan is written before either app exists, so nothing but the plan can say there are two.
+test('the apps a plan calls for are read off its roles, in order', () => {
+  const plan = basePlan()
+  plan.roles = {
+    kind: 'built',
+    description: 'Two sides of a counter.',
+    items: [
+      { name: 'mechanic', description: 'Works the bench.', app: 'workshop' },
+      {
+        name: 'counter',
+        description: 'Takes the booking in.',
+        app: 'workshop',
+      },
+      {
+        name: 'rider',
+        description: 'Books their bike in and checks on it.',
+        app: 'storefront',
+      },
+    ],
+  }
+  assert.deepEqual(plannedApps(plan), ['workshop', 'storefront'])
+
+  const rendered = renderPlanForBuild(plan)
+  assert.match(rendered, /APPS: 2/)
+  assert.match(rendered, /`workshop` — mechanic, counter/)
+  assert.match(rendered, /`storefront` — rider/)
+  assert.match(rendered, /fabric new-app/)
+  assert.match(rendered, /`mechanic` \[workshop\]/)
+})
+
+// A project where everyone is a colleague is a real answer and often the right one — it
+// just has to be SAID. Every role names its app, so one app is one slug repeated rather
+// than a field left off, and the build gets no APPS block and no nudge.
+test('a single-audience plan is one named app, not a silence', () => {
+  const plan = basePlan()
+  const rendered = renderPlanForBuild(plan)
+  assert.deepEqual(plannedApps(plan), ['journal'])
+  assert.equal(rendered.includes('APPS:'), false)
+  assert.equal(rendered.includes('fabric new-app'), false)
+})
+
+test('a screen names the app it belongs to', () => {
+  const plan = basePlan()
+  plan.ui = {
+    kind: 'built',
+    description: 'One screen each side.',
+    items: [
+      {
+        route: '/jobs',
+        description: 'The bench queue.',
+        pass: 1,
+        app: 'workshop',
+        scenarios: [],
+      },
+      {
+        route: '/',
+        description: 'Book a bike in.',
+        pass: 1,
+        app: 'storefront',
+        scenarios: [],
+      },
+    ],
+  }
+  const rendered = renderPlanForBuild(plan)
+  assert.match(rendered, /`\/jobs` \[workshop\] \(pass 1\)/)
+  assert.match(rendered, /`\/` \[storefront\] \(pass 1\)/)
+})
+
+// Two audiences and a screen that does not say whose it is builds one app with both
+// sides' pages jumbled into it — the single-app outcome three runs in a row produced,
+// and the reason `app` stopped being optional.
+test('a two-app plan is refused if a screen does not say which app it is on', () => {
+  const plan = basePlan()
+  plan.roles = {
+    kind: 'built',
+    description: 'Two sides of a counter.',
+    items: [
+      { name: 'mechanic', description: 'Works the bench.', app: 'workshop' },
+      { name: 'rider', description: 'Books the bike in.', app: 'storefront' },
+    ],
+  }
+  plan.ui = {
+    kind: 'built',
+    description: 'One screen each side, one unassigned.',
+    items: [
+      {
+        route: '/jobs',
+        description: 'The bench queue.',
+        pass: 1,
+        app: 'workshop',
+        scenarios: [],
+      },
+      { route: '/', description: 'Book a bike in.', pass: 1, scenarios: [] },
+    ],
+  }
+  const problems = checkPlanInternals(plan)
+  assert.equal(problems.length, 1)
+  assert.match(problems[0]!, /`\/` does not say which one/)
+})
+
+test('a screen on an app nobody signs into is refused', () => {
+  const plan = basePlan()
+  plan.roles = {
+    kind: 'built',
+    description: 'Two sides of a counter.',
+    items: [
+      { name: 'mechanic', description: 'Works the bench.', app: 'workshop' },
+      { name: 'rider', description: 'Books the bike in.', app: 'storefront' },
+    ],
+  }
+  plan.ui = {
+    kind: 'built',
+    description: 'One screen on an app no role uses.',
+    items: [
+      {
+        route: '/admin',
+        description: 'The back office.',
+        pass: 1,
+        app: 'backoffice',
+        scenarios: [],
+      },
+    ],
+  }
+  assert.match(checkPlanInternals(plan)[0]!, /which no role signs into/)
+})
+
+test('the architect is told what `app` means on a role, not just on a screen', () => {
+  const schema = JSON.parse(planSchemaJson())
+  const role = schema.properties.roles.oneOf
+    .flatMap((variant: any) =>
+      variant.properties?.items ? [variant.properties.items.items] : []
+    )
+    .at(0)
+  assert.ok(role, 'roles slot exposes its item shape')
+  const described = role.properties.app.description
+  assert.match(described, /counter, not the org chart/)
+  assert.match(described, /fabric new-app/)
+  assert.match(described, /REQUIRED on every role/)
+  assert.ok(
+    role.required.includes('app'),
+    'app is required, so one app is a decision the architect states rather than an omission'
+  )
+})
+
+test('a milestone requiring a workflow is refused a plan that wires none', () => {
+  const plan = basePlan()
+  const problems = checkAgainstMilestone(
+    plan,
+    {
+      entities: 'entry',
+      path: 'knowledge/milestones/01.md',
+      requires: 'transport:workflow',
+    },
+    ['owner']
+  )
+  assert.equal(problems.length, 1)
+  assert.match(problems[0]!, /requires `transport:workflow`/)
+  assert.match(problems[0]!, /not a token to drop from/)
+})
+
+test('wiring the transport the milestone asked for satisfies it', () => {
+  const plan = basePlan()
+  if (plan.functions.kind === 'built')
+    plan.functions.items[0]!.wire = { transport: 'workflow' }
+  assert.deepEqual(
+    checkAgainstMilestone(
+      plan,
+      {
+        entities: 'entry',
+        path: 'knowledge/milestones/01.md',
+        requires: 'transport:workflow',
+      },
+      ['owner']
+    ),
+    []
+  )
+})
+
+// The librarian is taught `transport:sse` and the plan schema has no field that can carry
+// it, so demanding it would refuse every plan for a live board with no way to comply.
+test('a transport the plan cannot express is not demanded', () => {
+  const plan = basePlan()
+  assert.deepEqual(
+    checkAgainstMilestone(
+      plan,
+      {
+        entities: 'entry',
+        path: 'knowledge/milestones/01.md',
+        requires: '[transport:sse]',
+      },
+      ['owner']
+    ),
+    []
+  )
+})
+
+test('a build defers one impossible pass-1 item, and only within its budget', () => {
+  const plan = basePlan()
+  assert.equal(deferPlanItem(plan, 'scope:read', 'no').ok, false)
+  assert.equal(deferPlanItem(plan, 'wire:POST /entry', 'no').ok, false)
+  assert.equal(deferPlanItem(plan, 'function:noSuchThing', 'no').ok, false)
+  assert.equal(deferPlanItem(plan, 'entity:entry', 'no').ok, false)
+  assert.equal(deferPlanItem(plan, 'createEntry', 'no').ok, false)
+
+  const first = deferPlanItem(
+    plan,
+    'function:createEntry',
+    'the provider has no write API'
+  )
+  assert.equal(first.ok, true)
+  if (!first.ok) return
+  assert.equal(itemsOf(plan.functions)[0]!.pass, 1)
+  assert.equal(itemsOf(first.plan.functions)[0]!.pass, 2)
+  assert.deepEqual(
+    first.plan.deferrals.map((d) => d.item),
+    ['function:createEntry']
+  )
+  assert.equal(
+    deferPlanItem(first.plan, 'function:createEntry', 'again').ok,
+    false
+  )
+
+  const second = deferPlanItem(
+    first.plan,
+    'scenario:ownerWritesTodayScenario',
+    'nothing to drive'
+  )
+  assert.equal(second.ok, true)
+  if (!second.ok) return
+  assert.equal(second.plan.deferrals.length, MAX_DEFERRALS)
+  assert.equal(
+    deferPlanItem(
+      second.plan,
+      'scenario:secondEntryRefusedScenario',
+      'and this too'
+    ).ok,
+    false
+  )
+  assert.match(renderPlanForBuild(second.plan), /DEFERRED/)
+})

--- a/packages/knowledge/src/plan.ts
+++ b/packages/knowledge/src/plan.ts
@@ -1,0 +1,1065 @@
+import { z } from 'zod'
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  MILESTONES_DIR,
+  listOf,
+  noteHash,
+  type MilestoneSurface,
+} from './notes.js'
+
+/**
+ * The technical plan for one milestone: what has to exist for the milestone to be
+ * built, written BEFORE the build and read by the gate afterwards.
+ *
+ * It exists because the build plan used to be the build agent's own `todo` list,
+ * which makes the agent both author and examiner — it can build
+ * a fraction, plan only that fraction, and certify itself complete. A plan written by
+ * a different seat, against the milestone, is a denominator the builder does not own.
+ *
+ * JSON rather than a knowledge note on purpose. Every other artefact under
+ * `knowledge/` is prose a human reads; this one is consumed field-by-field by the
+ * gate, and a markdown parser is one more place a misspelt heading silently passes.
+ * It also cannot live INSIDE the milestone note: that note is frozen once its status
+ * leaves `proposed`, so rewriting it would change what the builder was told.
+ *
+ * The plan holds INTENT. Reality lives in pikku's generated meta (`.pikku/**`), which
+ * already inventories functions, wires, scopes, roles, workflows, agents and features.
+ * Nothing here duplicates that — only what codegen cannot infer: why a thing exists,
+ * which pass it belongs to, and which knowledge note it discharges.
+ */
+export const PLAN_VERSION = 1
+
+export const FIRST_PASS = 1
+
+export const MAX_DEFERRALS = 2
+
+const Deferral = z.object({
+  item: z.string().min(1),
+  why: z.string().min(1),
+  at: z.string().min(1),
+})
+
+export type Deferral = z.infer<typeof Deferral>
+
+/**
+ * A slot is either filled or explicitly not needed, and both carry prose.
+ *
+ * An OPTIONAL field would collapse the two states that matter most: a slot nobody
+ * thought about and a slot deliberately left empty read identically as `undefined`.
+ * Forcing `n/a` to carry its reason is what turns an omission into a decision, and it
+ * is the omission — four unwired functions and no screen — that every failed build so
+ * far has been.
+ */
+const slot = <T extends z.ZodTypeAny>(item: T) =>
+  z.discriminatedUnion('kind', [
+    z.object({
+      kind: z.literal('built'),
+      description: z.string().min(1),
+      items: z.array(item).min(1),
+    }),
+    z.object({ kind: z.literal('n/a'), description: z.string().min(1) }),
+  ])
+
+/**
+ * What a column holds, in privacy terms rather than storage terms.
+ *
+ * This is the field that lets a permission claim be checked against the data instead
+ * of only against itself: a function returning a `personal` column with no permission
+ * rule is a defect the gate can name, where prose alone would need a reader.
+ */
+export const CLASSIFICATIONS = [
+  'public',
+  'internal',
+  'personal',
+  'sensitive',
+] as const
+
+const ModelField = z.object({
+  name: z.string().min(1),
+  type: z.string().min(1),
+  classification: z.enum(CLASSIFICATIONS),
+})
+
+/**
+ * What happens to this row when the thing it belongs to is deleted.
+ *
+ * A foreign key states which rows are related; it does not state what the product wants
+ * when the parent goes, and that is a product decision with three genuinely different
+ * answers. Naming it in the plan is what lets a build be wrong about it: `cascade` and
+ * `orphan` produce identical schemas until someone deletes something.
+ */
+const ModelRelationship = z.object({
+  /** The column on THIS table pointing at the parent, e.g. `user_id`. */
+  column: z.string().min(1),
+  /** The parent table it points at. */
+  references: z.string().min(1),
+  onDelete: z.enum(['cascade', 'restrict', 'orphan']),
+  /**
+   * The `pikkuScenario` that deletes the parent and asserts what became of this row.
+   *
+   * Required for `cascade`, on the same reasoning as a permission rule needing a refusal
+   * scenario: a cascade nobody ever triggers is a `REFERENCES` clause, not a behaviour.
+   * Both builds measured on the journal fixture wrote a cascade and no delete path at all,
+   * so nothing they shipped could have told you whether it worked.
+   */
+  provedBy: z.string().min(1).optional(),
+})
+
+const ModelItem = z.object({
+  table: z.string().min(1),
+  description: z.string().min(1),
+  fields: z.array(ModelField).min(1),
+  /** Optional so plans written before relationships existed still parse. */
+  relationships: z.array(ModelRelationship).default([]),
+})
+
+/**
+ * A wire and a permission rule live ON the function rather than in parallel lists,
+ * because that is where pikku enforces them: the rule IS the function's `permissions`
+ * field, and a wire without its function means nothing. Two lists to keep in step is
+ * two lists that drift.
+ *
+ * `permission` is a sentence, not a role name — the roles are an implementation
+ * detail the engineer picks, while the rule ("only the person who wrote it can edit
+ * it") is the part that has to survive the translation. `null` means open to anyone
+ * signed in, stated rather than left to omission.
+ */
+/**
+ * Every way a function can be reached other than its own RPC.
+ *
+ * Exported because `plan-meta.ts` derives its per-transport meta paths from this, so a
+ * transport added here fails to compile until it has somewhere to be checked back from —
+ * rather than being planned, built, and silently certified against nothing.
+ */
+export const WireTransport = z.enum([
+  'http',
+  'queue',
+  'channel',
+  'scheduler',
+  'workflow',
+])
+
+const FunctionItem = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+  pass: z.number().int().min(1),
+  wire: z
+    .object({
+      transport: WireTransport,
+      route: z
+        .string()
+        .optional()
+        .describe(
+          'The path, for `http` only — the URL the outside system posts to.'
+        ),
+    })
+    .nullable()
+    .optional()
+    .describe(
+      "OMIT THIS for a normal function, which is nearly all of them: pikku already serves every function as an RPC at /rpc/<name> and the client calls it by name, so there is no wire to decide. State one when the function is reached some OTHER way — its own HTTP path via wireHTTP (a webhook, a payment callback, a public URL someone else posts to), a queue job, or a channel. State one ALSO when the work itself is not a request: `workflow` for a process that pauses on a person and then carries on (an approval, a sign-off, an escalation), `scheduler` for something that happens on the app's own clock with nobody present (an overdue sweep, a nightly digest, a reminder). Those two are not alternate URLs, they are what the milestone IS — its note says so on `requires:`, and a plan that omits them ships a `status` column nothing advances or a job nobody runs."
+    ),
+  scopes: z.array(z.string()).default([]),
+  permission: z.string().nullable(),
+})
+
+const UiItem = z.object({
+  route: z.string().min(1),
+  description: z.string().min(1),
+  pass: z.number().int().min(1),
+  app: z
+    .string()
+    .optional()
+    .describe(
+      'The app slug this screen belongs to, matching the `app` on the roles who use it. OMIT it for a single-app project. A screen serves ONE app — the same list shown to staff and to customers is two screens with different nav and different permitted actions, not one screen. A screen anyone can open without an account is not a separate app: it is a PUBLIC ROUTE on the app that owns it, so route it outside `/app` (`/`, `/shop`, `/shop/$id`, `/checkout`) and leave `/app/*` for the screens that require a session. Every project needs `/` to be a real page that a signed-out visitor can use — a plan whose only entry point is a login screen has no front door.'
+    ),
+  scenarios: z.array(z.string()).default([]),
+})
+
+const NamedItem = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+})
+
+/**
+ * A role and the app they sign into.
+ *
+ * `app` is what makes a second frontend a PLANNED fact rather than a build-time guess, and
+ * it is the only field `plannedApps` reads — so its guidance lives in `.describe()`, which
+ * survives into the JSON Schema the architect is handed, not in this comment, which does not.
+ */
+const RoleItem = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+  app: z
+    .string()
+    .min(1)
+    .describe(
+      'REQUIRED on every role: the slug of the app this person USES — lowercase, one word, named for what they do there (`workshop`, `storefront`, `portal`). The distinct values across all roles ARE the apps this project needs, and the build agent runs `fabric new-app` for each one after the first, so this field alone decides how many frontends exist. When everyone is on the same side, give every role the SAME slug — one app is a real answer and often the right one. The test is the counter, not the org chart: the mechanic, the person on the counter and the bookkeeper are colleagues and share ONE app, differing only by nav and permitted actions; a customer WITH AN ACCOUNT is across the counter and gets their own, as do the tenant, the patient and the practitioner. Never invent a person the milestone notes do not name in order to reach two. A ROLE WHO NEVER SIGNS IN NEVER GETS A SLUG OF THEIR OWN: an app is built around the people who log into it, so a shopper who checks out as a guest, a diner reading a menu or anyone opening a link takes the SAME slug as the signed-in role they transact with, and their screens live on that app\u2019s public routes outside `/app`. A shop where a guest buys and one seller packs is ONE app and ONE slug: `/`, `/shop` and `/checkout` public, `/app/orders` behind the login. Give that shopper their own slug and the storefront is built on a second hostname while the product\u2019s own domain answers the people it is for with a login screen \u2014 the exact failure this field exists to prevent.'
+    ),
+})
+
+const ScenarioItem = z.object({
+  feature: z.string().min(1),
+  scenario: z.string().min(1),
+  fn: z.string().optional(),
+  /**
+   * The `pikkuScenario` export this becomes, e.g. `saveEntryScenario` — the only field here
+   * a completion gate can check. `feature` and `scenario` are prose written for a reader,
+   * and prose cannot be matched against codegen without guessing; a plan whose scenarios are
+   * only prose is an intention, not an obligation. Optional so plans written before this
+   * existed still parse, but `checkFirstPass` requires it of new ones.
+   */
+  name: z.string().min(1).optional(),
+  /**
+   * Which pass writes it, defaulting by level — see `scenarioPass`. Permission scenarios
+   * default to pass 2 because they harden a journey that has to exist before they can
+   * cover it, and a milestone whose skeleton works ships without waiting on the whole
+   * role x resource cross product.
+   */
+  pass: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe(
+      'Which pass writes this scenario. Backend and browser scenarios default to pass 1 — they prove the journey works. Permission scenarios default to pass 2: they harden a journey that has to exist first, and only pass 1 has to be built for the milestone to ship, so a role x resource cross product here costs the milestone nothing.'
+    ),
+})
+
+/**
+ * Scenarios are keyed by level rather than tagged with one, so a plan carrying four
+ * backend scenarios and no browser scenario fails on its shape. A flat list lets that
+ * through, and it is exactly the milestone that builds an API and ships no screen.
+ */
+const Scenarios = z.object({
+  backend: slot(ScenarioItem),
+  browser: slot(ScenarioItem),
+  permission: slot(ScenarioItem),
+})
+
+/**
+ * `complete: false` is the honest default for a note whose claims span milestones.
+ * Without it the ledger lies in the flattering direction — one milestone touching a
+ * decision note would mark the whole note discharged and the rest of it would never
+ * be built.
+ *
+ * `hash` is what makes the claim about CONTENT rather than about a filename. A note is
+ * edited after the milestone that discharged it ships — the interview keeps going, and
+ * a new sentence in an old note is the commonest way a requirement arrives. Keyed on
+ * path alone that note stays `covered` forever and the new sentence is never built by
+ * anybody. Recording what was actually claimed means an edit downgrades the note to
+ * `changed`, which is the backlog signal.
+ */
+const Covers = z.object({
+  note: z.string().min(1),
+  hash: z.string().min(6),
+  complete: z.boolean(),
+})
+
+export const PlanSchema = z.object({
+  version: z.literal(PLAN_VERSION),
+  milestone: z.string().min(1),
+  description: z.string().min(1),
+  covers: z.array(Covers).min(1),
+  model: slot(ModelItem),
+  functions: slot(FunctionItem),
+  roles: slot(RoleItem),
+  scopes: slot(NamedItem),
+  ui: slot(UiItem),
+  scenarios: Scenarios,
+  deferrals: z
+    .array(Deferral)
+    .default([])
+    .describe(
+      'NOT YOURS TO WRITE — leave it out. The build agent appends to this through `fabric plan-defer` when a pass-1 item turns out to be impossible, and the reason it gives is the record of where this plan was wrong.'
+    ),
+})
+
+/**
+ * The pass a planned scenario belongs to.
+ *
+ * Backend and browser scenarios prove the journey works, so they are the walking
+ * skeleton and default to pass 1. Permission scenarios prove nobody else can reach it —
+ * necessary, but hardening of a journey that must already exist, and combinatorial in
+ * roles x resources: run hmt3fz3c0's first milestone planned ten of them against four
+ * other items, and the build never shipped a working deployed app because completion
+ * demanded the cross product before the skeleton could be signed off.
+ */
+export const scenarioPass = (
+  level: 'backend' | 'browser' | 'permission',
+  item: { pass?: number }
+): number => item.pass ?? (level === 'permission' ? 2 : 1)
+
+export type Plan = z.infer<typeof PlanSchema>
+export type PlanSlot<T> =
+  | { kind: 'built'; description: string; items: T[] }
+  | { kind: 'n/a'; description: string }
+
+export const itemsOf = <T>(s: { kind: string; items?: T[] }): T[] =>
+  s.kind === 'built' ? (s.items ?? []) : []
+
+/**
+ * The apps this plan calls for, in declaration order — the first is the primary.
+ *
+ * Read off the roles rather than stored separately, so there is one answer to "how many
+ * apps" and it cannot drift from who signs into them. A plan with no roles at all wants
+ * one app, which is why that case returns `[]` rather than inventing a slug.
+ */
+export function plannedApps(plan: Plan): string[] {
+  const seen: string[] = []
+  for (const role of itemsOf(plan.roles)) {
+    if (role.app && !seen.includes(role.app)) seen.push(role.app)
+  }
+  return seen
+}
+
+/** Where a milestone's plan lives: beside the note, same stem. */
+export function planPathFor(milestonePath: string): string {
+  return milestonePath.replace(/\.(md|markdown|txt)$/i, '.plan.json')
+}
+
+/** A plan's id, which is the note's stem and the console's URL segment. */
+export function planIdFor(milestonePath: string): string {
+  return milestonePath
+    .replace(/\.(md|markdown|txt)$/i, '')
+    .split('/')
+    .pop()!
+}
+
+/**
+ * The milestone note a plan id names, resolved by scanning the milestones directory
+ * rather than by joining the id onto a path.
+ *
+ * The id arrives from a URL, so building a path out of it hands the caller the file
+ * system — `../../.env` is a plan id as far as string concatenation is concerned.
+ * Matching against ids we generated ourselves means an unknown id finds nothing.
+ */
+export function milestonePathForPlanId(
+  cwd: string,
+  planId: string
+): string | null {
+  let entries: string[]
+  try {
+    entries = readdirSync(join(cwd, MILESTONES_DIR))
+  } catch {
+    return null
+  }
+  const note = entries.find(
+    (entry) =>
+      /\.(md|markdown|txt)$/i.test(entry) && planIdFor(entry) === planId
+  )
+  return note ? `${MILESTONES_DIR}/${note}` : null
+}
+
+export type PlanRead =
+  | { ok: true; plan: Plan; path: string }
+  | {
+      ok: false
+      path: string
+      reason: string
+      /**
+       * There is no file, as opposed to a file that will not read.
+       *
+       * Callers that only ask `.ok` treat the two alike, which is how an architect came to
+       * be told a milestone "has no plan — write it" with an unparseable one sitting at
+       * that exact path.
+       */
+      missing?: true
+    }
+
+/**
+ * Read and validate a milestone's plan.
+ *
+ * Validation errors are reported with their field path because the reader is an
+ * agent: "invalid plan" costs a turn of guessing, while `functions.items[2].permission
+ * — expected string, received undefined` is one edit.
+ */
+export function readPlan(cwd: string, milestonePath: string): PlanRead {
+  const path = planPathFor(milestonePath)
+  const full = join(cwd, path)
+  if (!existsSync(full)) {
+    return {
+      ok: false,
+      path,
+      missing: true,
+      reason: `No plan at ${path}. Write it before dispatching the build.`,
+    }
+  }
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(full, 'utf8'))
+  } catch (err) {
+    return {
+      ok: false,
+      path,
+      reason: `${path} is not valid JSON: ${String(err)}`,
+    }
+  }
+  const version = (raw as { version?: unknown } | null)?.version
+  if (version !== PLAN_VERSION) {
+    return {
+      ok: false,
+      path,
+      reason: `${path} is plan version ${JSON.stringify(version)}; this reader only understands ${PLAN_VERSION}.`,
+    }
+  }
+  const parsed = PlanSchema.safeParse(raw)
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .slice(0, 8)
+      .map((i) => `${i.path.join('.') || '(root)'} — ${i.message}`)
+      .join('; ')
+    return {
+      ok: false,
+      path,
+      reason: `${path} does not match the plan schema: ${issues}`,
+    }
+  }
+  return { ok: true, plan: parsed.data, path }
+}
+
+/**
+ * The plan as the build agent is given it.
+ *
+ * Rendered rather than handed over as JSON: the builder reads it once at the top of the
+ * turn and the shape has to be scannable, while the gate reads the file field by field.
+ * An `n/a` slot is printed WITH its reason — the whole point of the discriminated slot is
+ * that "no roles, because this app has one kind of user" and "nobody thought about roles"
+ * stop looking alike, and that distinction is only useful if the builder sees it.
+ */
+export function renderPlanForBuild(plan: Plan): string {
+  const lines: string[] = []
+  const slot = <T>(
+    name: string,
+    s: PlanSlot<T>,
+    render: (item: T) => string
+  ) => {
+    if (s.kind === 'n/a') {
+      lines.push(`${name}: none — ${s.description}`)
+      return
+    }
+    lines.push(`${name}: ${s.description}`)
+    for (const item of s.items) lines.push(`  - ${render(item)}`)
+  }
+
+  lines.push(
+    `PLAN — ${plan.milestone}`,
+    '',
+    plan.description,
+    '',
+    'PASS 1 COMPLETES THIS MILESTONE. Items marked pass 2 or higher are deferred — the gate does',
+    'not ask for them and the next milestone picks them up. Build pass 1, then run `fabric build-complete`.',
+    ''
+  )
+  slot(
+    'DATA',
+    plan.model,
+    (m) =>
+      `\`${m.table}\` — ${m.description}\n` +
+      m.fields
+        .map((f) => `      ${f.name}: ${f.type} [${f.classification}]`)
+        .join('\n') +
+      m.relationships
+        .map(
+          (r) =>
+            `\n      ${r.column} → ${r.references}, on delete ${r.onDelete}${r.provedBy ? ` (proved by \`${r.provedBy}\`)` : ''}`
+        )
+        .join('')
+  )
+  slot('FUNCTIONS', plan.functions, (f) => {
+    const wire = f.wire
+      ? `${f.wire.transport}${f.wire.route ? ` ${f.wire.route}` : ''}`
+      : 'rpc — /rpc/' + f.name
+    const scopes = f.scopes.length ? ` scopes: ${f.scopes.join(', ')};` : ''
+    const perm = f.permission
+      ? ` permission: ${f.permission}`
+      : ' permission: none — anyone signed in'
+    return `\`${f.name}\` (pass ${f.pass}) — ${f.description}\n      wire: ${wire};${scopes}${perm}`
+  })
+  const apps = plannedApps(plan)
+  if (apps.length > 1) {
+    lines.push(
+      `APPS: ${apps.length} — these people are on opposite sides of a counter and each side gets its own app.`
+    )
+    for (const app of apps) {
+      const who = itemsOf(plan.roles)
+        .filter((r) => r.app === app)
+        .map((r) => r.name)
+      lines.push(`  - \`${app}\` — ${who.join(', ')}`)
+    }
+    lines.push(
+      `Run \`fabric new-app --slug <slug> --serves <group> --personas <ids>\` for each one after the first, then \`fabric scaffold --app <slug>\` to write its screens.`
+    )
+  }
+  slot(
+    'ROLES',
+    plan.roles,
+    (r) => `\`${r.name}\` [${r.app}] — ${r.description}`
+  )
+  slot('SCOPES', plan.scopes, (s) => `\`${s.name}\` — ${s.description}`)
+  slot('UI', plan.ui, (u) => {
+    const covered = u.scenarios.length
+      ? `\n      proved by: ${u.scenarios.join(', ')}`
+      : ''
+    return `\`${u.route}\`${u.app ? ` [${u.app}]` : ''} (pass ${u.pass}) — ${u.description}${covered}`
+  })
+  lines.push(
+    '',
+    'The backticked id on each scenario below is the `pikkuScenario` export you write. Completion checks for it by that exact name, so a scenario you skip or rename reads as unbuilt.'
+  )
+  for (const [level, title, s] of [
+    ['backend', 'BACKEND SCENARIOS', plan.scenarios.backend],
+    ['browser', 'BROWSER SCENARIOS', plan.scenarios.browser],
+    ['permission', 'PERMISSION SCENARIOS', plan.scenarios.permission],
+  ] as const) {
+    slot(
+      title,
+      s,
+      (sc) =>
+        `\`${sc.name ?? '<unnamed>'}\` (pass ${scenarioPass(level, sc)}) — ${sc.feature}: ${sc.scenario}${sc.fn ? ` (drives \`${sc.fn}\`)` : ''}`
+    )
+  }
+  if (plan.deferrals.length > 0) {
+    lines.push(
+      '',
+      'DEFERRED — you moved these off pass 1 already. They do NOT block this milestone and you',
+      'must not build them now; the reason you gave is on the record and reaches the planner.',
+      ...plan.deferrals.map((d) => `  - \`${d.item}\` — ${d.why}`)
+    )
+  }
+  return lines.join('\n')
+}
+
+export const planSchemaJson = (): string =>
+  JSON.stringify(z.toJSONSchema(PlanSchema, { io: 'input' }))
+
+export function writePlan(
+  cwd: string,
+  milestonePath: string,
+  plan: Plan
+): string {
+  const path = planPathFor(milestonePath)
+  writeFileSync(join(cwd, path), `${JSON.stringify(plan, null, 2)}\n`)
+  return path
+}
+
+export type PlanDefer =
+  { ok: true; plan: Plan; label: string } | { ok: false; reason: string }
+
+const deferrableIds = (plan: Plan): string[] => [
+  ...itemsOf(plan.functions)
+    .filter((f) => f.pass === FIRST_PASS)
+    .map((f) => `function:${f.name}`),
+  ...(
+    [
+      ['backend', plan.scenarios.backend],
+      ['browser', plan.scenarios.browser],
+      ['permission', plan.scenarios.permission],
+    ] as const
+  ).flatMap(([level, slot]) =>
+    itemsOf(slot)
+      .filter((i) => i.name && scenarioPass(level, i) === FIRST_PASS)
+      .map((i) => `scenario:${i.name}`)
+  ),
+]
+
+/**
+ * Move ONE pass-1 item to pass 2. Returns a new plan so the caller can re-check the
+ * walking skeleton before anything reaches disk. Only functions and scenarios are
+ * deferrable — they are the only items `planShortfall` blocks on.
+ */
+export function deferPlanItem(
+  plan: Plan,
+  itemId: string,
+  why: string
+): PlanDefer {
+  if (plan.deferrals.length >= MAX_DEFERRALS) {
+    return {
+      ok: false,
+      reason:
+        `This milestone has already deferred ${plan.deferrals.length} item(s) — ${plan.deferrals
+          .map((d) => `\`${d.item}\``)
+          .join(
+            ', '
+          )} — which is the limit. Everything still on pass 1 has to be built. If the ` +
+        `milestone genuinely cannot land, say which items and why in your final message and stop; ` +
+        `deferring the rest would ship a milestone that is not the one that was planned.`,
+    }
+  }
+  if (plan.deferrals.some((d) => d.item === itemId)) {
+    return {
+      ok: false,
+      reason: `\`${itemId}\` is already deferred — it is not blocking you.`,
+    }
+  }
+
+  const options = deferrableIds(plan)
+  const refuseUnknown = (detail: string): PlanDefer => ({
+    ok: false,
+    reason:
+      `${detail}\n\nThe pass-1 items you can defer are:\n` +
+      (options.length
+        ? options.map((id) => `  • ${id}`).join('\n')
+        : '  (none — pass 1 is empty)'),
+  })
+
+  const [kind, ...rest] = itemId.split(':')
+  const name = rest.join(':')
+  if (!name) return refuseUnknown(`\`${itemId}\` is not an item id.`)
+
+  const next = structuredClone(plan)
+
+  if (kind === 'function') {
+    const fn = itemsOf(next.functions).find((f) => f.name === name)
+    if (!fn) return refuseUnknown(`No function \`${name}\` is planned.`)
+    if (fn.pass !== FIRST_PASS) {
+      return {
+        ok: false,
+        reason: `\`${name}\` is already pass ${fn.pass} — it is not blocking you.`,
+      }
+    }
+    fn.pass = FIRST_PASS + 1
+    next.deferrals.push({ item: itemId, why, at: new Date().toISOString() })
+    return { ok: true, plan: next, label: `function \`${name}\`` }
+  }
+
+  if (kind === 'scenario') {
+    for (const [level, slot] of [
+      ['backend', next.scenarios.backend],
+      ['browser', next.scenarios.browser],
+      ['permission', next.scenarios.permission],
+    ] as const) {
+      const found = itemsOf(slot).find((i) => i.name === name)
+      if (!found) continue
+      if (scenarioPass(level, found) !== FIRST_PASS) {
+        return {
+          ok: false,
+          reason: `\`${name}\` is not a pass-1 scenario — it is not blocking you.`,
+        }
+      }
+      found.pass = FIRST_PASS + 1
+      next.deferrals.push({ item: itemId, why, at: new Date().toISOString() })
+      return { ok: true, plan: next, label: `${level} scenario \`${name}\`` }
+    }
+    return refuseUnknown(`No scenario named \`${name}\` is planned.`)
+  }
+
+  if (kind === 'wire') {
+    return refuseUnknown(
+      `A wire is not deferred on its own — it belongs to the function that owns it, so defer that.`
+    )
+  }
+  if (kind === 'scope') {
+    return refuseUnknown(
+      `A scope carries no pass and cannot be deferred: it is one line in the app's scope list and every planned function that names it needs it to exist.`
+    )
+  }
+  return refuseUnknown(
+    `\`${kind}\` is not a deferrable kind — only \`function\` and \`scenario\` are.`
+  )
+}
+
+/**
+ * Move every still-unbuilt pass-1 item to pass 2 at once, for a milestone that was KILLED
+ * rather than finished.
+ *
+ * Deliberately outside `MAX_DEFERRALS`, which bounds what a build agent may talk itself out
+ * of — a guillotined milestone chose nothing. Without this a killed milestone records no
+ * deferrals at all, so its shortfall is invisible everywhere it is read from: the user is
+ * never told what is missing, and `knowledgeCoverage` reads its notes as fully discharged.
+ */
+export function deferOutstandingItems(
+  plan: Plan,
+  itemIds: string[],
+  why: string
+): { plan: Plan; deferred: string[] } {
+  const next = structuredClone(plan)
+  const at = new Date().toISOString()
+  const deferred: string[] = []
+  for (const itemId of itemIds) {
+    if (next.deferrals.some((d) => d.item === itemId)) continue
+    const [kind, ...rest] = itemId.split(':')
+    const name = rest.join(':')
+    if (!name) continue
+    if (kind === 'function') {
+      const fn = itemsOf(next.functions).find(
+        (f) => f.name === name && f.pass === FIRST_PASS
+      )
+      if (!fn) continue
+      fn.pass = FIRST_PASS + 1
+    } else if (kind === 'scenario') {
+      const found = (
+        [
+          ['backend', next.scenarios.backend],
+          ['browser', next.scenarios.browser],
+          ['permission', next.scenarios.permission],
+        ] as const
+      )
+        .flatMap(([level, slot]) =>
+          itemsOf(slot).map((item) => ({ level, item }))
+        )
+        .find(
+          ({ level, item }) =>
+            item.name === name && scenarioPass(level, item) === FIRST_PASS
+        )
+      if (!found) continue
+      found.item.pass = FIRST_PASS + 1
+    } else {
+      continue
+    }
+    next.deferrals.push({ item: itemId, why, at })
+    deferred.push(itemId)
+  }
+  return { plan: next, deferred }
+}
+
+/**
+ * The first pass has to put something on a screen — checked as a SHAPE, which is what
+ * replaced the old `MAX_ENTITIES_PER_MILESTONE` cap.
+ *
+ * The cap was a proxy for "small enough to finish" and a bad one: three entities with
+ * twenty functions sailed through while five cheap ones were refused, and a milestone
+ * could satisfy it while delivering four unwired functions and no page — which is
+ * precisely what the last build did. Size stopped being the risk once a plan made
+ * partial progress resumable, so what is enforced now is ORDER: pass one is a walking
+ * skeleton, and the rest of the milestone waits behind it.
+ */
+export function checkFirstPass(
+  plan: Plan,
+  surface: MilestoneSurface = 'app'
+): string[] {
+  const problems: string[] = []
+  const ui = itemsOf(plan.ui).filter((u) => u.pass === 1)
+  const fns = itemsOf(plan.functions).filter((f) => f.pass === 1)
+  if (surface === 'app' && ui.length === 0) {
+    problems.push(
+      'Pass 1 has no `ui` item. The first pass has to reach a screen — move one route into pass 1. If this milestone reaches its person some other way, that belongs on the note as `surface:`, not in the plan.'
+    )
+  }
+  if (fns.length === 0) {
+    problems.push(
+      surface === 'app'
+        ? 'Pass 1 has no `functions` item. A screen with nothing behind it is a mock — move the function that serves the pass-1 route into pass 1.'
+        : 'Pass 1 has no `functions` item. Pass one has to DO something a person can reach — move the function behind it into pass 1.'
+    )
+  }
+  if (surface !== 'app') {
+    const driven = new Set(
+      itemsOf(plan.scenarios.backend)
+        .map((s) => s.fn)
+        .filter(Boolean)
+    )
+    if (fns.length > 0 && !fns.some((f) => driven.has(f.name))) {
+      problems.push(
+        `This milestone is \`surface: ${surface}\` and no backend scenario drives a pass-1 function. An app is proved in the browser; this is proved at the backend level — add a \`scenarios.backend\` item carrying \`"fn": "${fns[0]!.name}"\`.`
+      )
+    }
+  }
+  // A scenario with no `name` is prose, and prose cannot be checked against codegen — the
+  // completion gate would certify the milestone without it. Caught at authoring time, where
+  // it costs one edit, rather than at the gate, where it costs a build turn.
+  for (const [level, slot] of [
+    ['backend', plan.scenarios.backend],
+    ['browser', plan.scenarios.browser],
+    ['permission', plan.scenarios.permission],
+  ] as const) {
+    if (slot.kind !== 'built') continue
+    for (const item of slot.items) {
+      if (!item.name) {
+        problems.push(
+          `The ${level} scenario "${item.scenario}" has no \`name\`. Give it the \`pikkuScenario\` export it becomes (e.g. \`saveEntryScenario\`), or nothing can verify it was written.`
+        )
+      }
+    }
+  }
+
+  const browser = itemsOf(plan.scenarios.browser)
+  for (const route of ui) {
+    const covered =
+      route.scenarios.length > 0 ||
+      browser.some((s) => s.feature.includes(route.route))
+    if (!covered) {
+      problems.push(
+        `Pass 1 route \`${route.route}\` has no browser scenario. Without one nothing proves the screen works. ` +
+          `Name the scenario in this route's \`scenarios\` (e.g. \`"scenarios": ["opensTonightsPracticeScenario"]\`), ` +
+          `or write a browser scenario whose \`feature\` contains \`${route.route}\`.`
+      )
+    }
+  }
+  return problems
+}
+
+/**
+ * What each transport promise is FOR, said in the refusal so the architect does not have
+ * to guess which function should carry it.
+ */
+const TRANSPORT_MEANS: Record<string, string> = {
+  workflow:
+    'the milestone promises a process that pauses on a person and then carries on, and a `status` column nothing advances renders identically and does nothing',
+  scheduler:
+    "the milestone promises work that happens on the app's own clock with nobody present, and a button someone remembers to press is a different product",
+  queue:
+    'the milestone promises work that outlives the request that asked for it',
+  channel:
+    'the milestone promises the browser pushing back up a socket mid-session',
+  http: 'the milestone promises a URL something outside this app posts to',
+}
+
+/**
+ * The `transport:<name>` tokens on a milestone's `requires:` that a plan can actually
+ * express. Anything the plan schema has no field for is skipped rather than demanded —
+ * the librarian is taught `transport:sse`, which `WireTransport` cannot carry, and a gate
+ * that refused it would be unsatisfiable.
+ */
+const requiredTransports = (requires: string | undefined): string[] =>
+  listOf(requires)
+    .map((token) => token.split(':').map((part) => part.trim()))
+    .filter(([kind, name]) => kind === 'transport' && !!name)
+    .map(([, name]) => name!)
+    .filter((name) =>
+      (WireTransport.options as readonly string[]).includes(name)
+    )
+
+/**
+ * Cross-checks between the plan and the milestone note it claims to implement.
+ *
+ * These do not prove the plan is complete — nothing can prove the architect thought of
+ * what it did not think of. They prove the two documents refer to the same thing,
+ * which catches the failure actually observed: a plan that quietly drifts off its own
+ * milestone.
+ */
+export function checkAgainstMilestone(
+  plan: Plan,
+  milestone: { entities?: string; path: string; requires?: string },
+  personas: string[],
+  surface: MilestoneSurface = 'app'
+): string[] {
+  const problems: string[] = []
+  const wired = new Set<string>(
+    itemsOf(plan.functions).flatMap((f) => (f.wire ? [f.wire.transport] : []))
+  )
+  for (const transport of requiredTransports(milestone.requires)) {
+    if (wired.has(transport)) continue
+    problems.push(
+      `${milestone.path} requires \`transport:${transport}\` and no function in the plan wires one — ${TRANSPORT_MEANS[transport]}. Give the function that does that work \`"wire": { "transport": "${transport}" }\`. If the milestone genuinely does not need it, that is a conversation with the user about the note, not a token to drop from \`requires:\`.`
+    )
+  }
+  const entities = listOf(milestone.entities)
+  const haystack = [
+    ...itemsOf(plan.functions).map((f) => `${f.name} ${f.description}`),
+    ...itemsOf(plan.model).map((m) => `${m.table} ${m.description}`),
+  ]
+    .join(' ')
+    .toLowerCase()
+  for (const entity of entities) {
+    if (!haystack.includes(entity.toLowerCase())) {
+      problems.push(
+        `${milestone.path} is about \`${entity}\` but no function or table in the plan mentions it.`
+      )
+    }
+  }
+  const driving =
+    surface === 'app'
+      ? itemsOf(plan.scenarios.browser)
+      : [...itemsOf(plan.scenarios.browser), ...itemsOf(plan.scenarios.backend)]
+  for (const persona of personas) {
+    const driven = driving.some((s) =>
+      s.scenario.toLowerCase().includes(persona.toLowerCase())
+    )
+    if (!driven) {
+      problems.push(
+        surface === 'app'
+          ? `'${persona}' is named in the milestone's scenario but no browser scenario drives them. A persona nobody puts through the UI is a milestone that built a backend. Name them in that scenario's \`scenario\` line.`
+          : `'${persona}' is named in the milestone's scenario but no scenario drives them. Name them in the \`scenario\` line of a \`scenarios.backend\` item — a person the plan never puts through the surface is a person nothing proves.`
+      )
+    }
+  }
+  return problems
+}
+
+/**
+ * Internal consistency: things the plan declares but never uses, and rules it states
+ * but never proves.
+ */
+export function checkPlanInternals(plan: Plan): string[] {
+  const problems: string[] = []
+  const apps = plannedApps(plan)
+  if (apps.length > 1) {
+    for (const screen of itemsOf(plan.ui)) {
+      if (!screen.app) {
+        problems.push(
+          `This plan has ${apps.length} apps (${apps.join(', ')}) but route \`${screen.route}\` does not say which one it belongs to. Every screen serves ONE app — give it \`"app"\`, matching the roles who use it.`
+        )
+      } else if (!apps.includes(screen.app)) {
+        problems.push(
+          `Route \`${screen.route}\` is on app \`${screen.app}\`, which no role signs into. The apps are the distinct \`app\` values across the roles: ${apps.join(', ')}.`
+        )
+      }
+    }
+  }
+  const fns = itemsOf(plan.functions)
+  const usedScopes = new Set(fns.flatMap((f) => f.scopes))
+  for (const scope of itemsOf(plan.scopes)) {
+    if (!usedScopes.has(scope.name)) {
+      problems.push(
+        `Scope \`${scope.name}\` is declared but gates no function. Either put it on the function it protects or drop it.`
+      )
+    }
+  }
+  const proven = new Set(
+    itemsOf(plan.scenarios.permission)
+      .map((s) => s.fn)
+      .filter(Boolean)
+  )
+  for (const fn of fns) {
+    if (fn.permission !== null && !proven.has(fn.name)) {
+      problems.push(
+        `\`${fn.name}\` has a permission rule with no scenario proving someone outside it is refused. Add an item to \`scenarios.permission\` carrying \`"fn": "${fn.name}"\` — that field is the link, not the prose — because a rule with no failing case is a claim, not a check.`
+      )
+    }
+  }
+  // A cascade is a rule stated in DDL and provable only by deleting something. Held to
+  // the same standard as a permission rule above: name the scenario that proves it, and
+  // let that scenario be one the plan actually promises, so completion can find it.
+  const plannedScenarios = new Set(
+    [
+      ...itemsOf(plan.scenarios.backend),
+      ...itemsOf(plan.scenarios.browser),
+      ...itemsOf(plan.scenarios.permission),
+    ]
+      .map((s) => s.name)
+      .filter((n): n is string => Boolean(n))
+  )
+  for (const table of itemsOf(plan.model)) {
+    const columns = new Set(table.fields.map((f) => f.name))
+    for (const rel of table.relationships) {
+      if (!columns.has(rel.column)) {
+        problems.push(
+          `\`${table.table}.${rel.column}\` is declared as a relationship to \`${rel.references}\` but is not one of the table's fields. Add the column or fix the name.`
+        )
+      }
+      if (rel.onDelete !== 'cascade') continue
+      if (!rel.provedBy) {
+        problems.push(
+          `\`${table.table}.${rel.column}\` cascades when a \`${rel.references}\` is deleted, with no scenario proving it. Add \`provedBy\` naming a scenario that deletes the ${rel.references} and asserts the ${table.table} rows are gone — a cascade nobody triggers is a claim, not a check.`
+        )
+      } else if (!plannedScenarios.has(rel.provedBy)) {
+        problems.push(
+          `\`${table.table}.${rel.column}\` says it is proved by \`${rel.provedBy}\`, but no scenario in this plan has that name. Add it to the scenarios, or point at one that is there.`
+        )
+      }
+    }
+  }
+  const personalTables = new Set(
+    itemsOf(plan.model)
+      .filter((m) =>
+        m.fields.some(
+          (f) =>
+            f.classification === 'personal' || f.classification === 'sensitive'
+        )
+      )
+      .map((m) => m.table.toLowerCase())
+  )
+  for (const fn of fns) {
+    if (fn.permission !== null || proven.has(fn.name)) continue
+    const touches = [...personalTables].find((t) =>
+      fn.description.toLowerCase().includes(t)
+    )
+    if (touches) {
+      problems.push(
+        `\`${fn.name}\` reads \`${touches}\`, which holds personal data, and its \`permission\` is null. Either write the rule as a sentence there — "only the person who wrote it may read it" — or leave it null because anyone signed in may genuinely call it. Either way add a \`scenarios.permission\` item carrying \`"fn": "${fn.name}"\`: that field is the link, not the prose, and the scenario is what makes the decision checkable.`
+      )
+    }
+  }
+  return problems
+}
+
+export type CoverageState =
+  'covered' | 'partial' | 'claimed' | 'changed' | 'uncovered'
+
+export type NoteCoverage = {
+  note: string
+  state: CoverageState
+  by: string[]
+  /** What the milestones that claimed this note deferred and never built. Empty unless `partial`. */
+  leftBehind: Deferral[]
+}
+
+/**
+ * Which knowledge notes are discharged, which are spoken for, which have moved on
+ * since they were planned, and which nobody has planned at all.
+ *
+ * This is the ledger that replaces re-reading the whole knowledge graph every turn:
+ *
+ *   covered   — a BUILT milestone claimed it complete, and it has not changed since
+ *   changed   — it was claimed, but the note has been edited since; the new content
+ *               was never planned by anyone, so it is backlog again
+ *   partial   — the milestone that claimed it landed, but with deferrals: part of what
+ *               it promised was never built, and no later milestone owns that yet
+ *   claimed   — a plan claims it and that milestone has not landed yet
+ *   uncovered — nobody has planned it
+ *
+ * `partial` is what stops a deferral falling out of the world. A deferred item leaves the
+ * pass it was planned in and nothing picks it up, so keyed on the milestone alone the note
+ * read `covered` and the librarian never wrote the milestone that would finish it. It
+ * settles on its own: a follow-up milestone claiming the note makes it `claimed` again.
+ *
+ * `changed` is the state that keeps the ledger honest over time. Coverage keyed on a
+ * path alone silently freezes: the interview keeps running, a sentence gets added to a
+ * note that shipped three milestones ago, and nothing ever surfaces it.
+ */
+export function knowledgeCoverage(
+  notes: Array<{ path: string; body?: string; reserved?: string }>,
+  plans: Array<{ plan: Plan; status?: string }>
+): NoteCoverage[] {
+  const claims = new Map<
+    string,
+    Array<{
+      milestone: string
+      hash: string
+      built: boolean
+      leftBehind: Deferral[]
+    }>
+  >()
+  for (const { plan, status } of plans) {
+    const landed = status === 'built'
+    for (const entry of plan.covers) {
+      claims.set(entry.note, [
+        ...(claims.get(entry.note) ?? []),
+        {
+          milestone: plan.milestone,
+          hash: entry.hash,
+          built: entry.complete && landed && plan.deferrals.length === 0,
+          leftBehind: entry.complete && landed ? plan.deferrals : [],
+        },
+      ])
+    }
+  }
+  return notes
+    .filter((n) => !n.reserved && !n.path.startsWith(`${MILESTONES_DIR}/`))
+    .map((n) => {
+      const claimed = claims.get(n.path)
+      if (!claimed)
+        return {
+          note: n.path,
+          state: 'uncovered' as const,
+          by: [],
+          leftBehind: [],
+        }
+      const by = claimed.map((c) => c.milestone)
+      const current = n.body === undefined ? null : noteHash(n.body)
+      const stale = current !== null && !claimed.some((c) => c.hash === current)
+      if (stale)
+        return { note: n.path, state: 'changed' as const, by, leftBehind: [] }
+      if (claimed.some((c) => c.built)) {
+        return { note: n.path, state: 'covered' as const, by, leftBehind: [] }
+      }
+      const leftBehind = claimed.flatMap((c) => c.leftBehind)
+      const pending = claimed.some((c) => c.leftBehind.length === 0)
+      if (!pending && leftBehind.length > 0) {
+        return { note: n.path, state: 'partial' as const, by, leftBehind }
+      }
+      return { note: n.path, state: 'claimed' as const, by, leftBehind: [] }
+    })
+}

--- a/packages/knowledge/src/plan.ts
+++ b/packages/knowledge/src/plan.ts
@@ -1,12 +1,8 @@
 import { z } from 'zod'
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import {
-  MILESTONES_DIR,
-  listOf,
-  noteHash,
-  type MilestoneSurface,
-} from './notes.js'
+import { listOf, noteHash } from './notes.js'
+import { MILESTONES_DIR, type MilestoneSurface } from './milestone.js'
 
 /**
  * The technical plan for one milestone: what has to exist for the milestone to be


### PR DESCRIPTION
A milestone note says what to build. A **plan** says what building it consists of — which functions, wires, roles, scopes, screens and scenarios a pass owes, and what was deferred to the next one.

The two halves were split across two repos. `@pikku/knowledge` owned the note format, `MILESTONE_TYPE` and `runKnowledgeValidate`; the plan lived downstream, so anything that wanted to write one had to reimplement the schema from an example. This lands the format here and puts a CLI on it.

## The format

- `PlanSchema` and `PLAN_VERSION` are the format; `readPlan`/`writePlan` are the only readers and writers.
- `checkFirstPass`, `checkAgainstMilestone` and `checkPlanInternals` are deterministic gates over a plan and its milestone. They judge whether a plan **holds**, never whether it is a **good** plan — that needs a model and a budget, and stays with whatever is driving the build.
- `planSchemaJson` emits the schema as JSON Schema, so an agent is handed the shape rather than made to infer it.
- `plan-meta` reads a generated `.pikku` meta directory and reports which planned items the code actually discharges: `planProgress`, `planShortfall`, `cascadeProblems`.
- `hollow-scenarios` classifies a scenario by what it proves, so a plan cannot be satisfied by scenarios that assert nothing.
- `milestone.ts` is new here: `readMilestones`, `surfaceOf`, `gherkinOf`, `personasIn`. `checkAgainstMilestone` needs a note, its surface and its personas, and none of those could be produced from the note vocabulary alone.
- `notes` gains `listOf` and `noteHash`, which the plan reads and which belong with the note vocabulary.

`readPlan` refuses a plan whose `version` this reader does not know, naming the version, rather than reporting the mismatch as a scatter of field errors. That is what lets the format change later without a stale reader spending its turn editing fields to satisfy a schema it cannot satisfy.

## The CLI

```
pikku knowledge plan schema
pikku knowledge plan show <milestone> [--for-build]
pikku knowledge plan set <milestone> <file>
pikku knowledge plan defer <milestone> <item> --reason "..."
```

`set` is the point of the exercise. It runs the schema, then `checkFirstPass`, `checkPlanInternals` and `checkAgainstMilestone` against the milestone note's own surface and personas, and **writes nothing unless all of them pass** — a plan validated at gate time instead has already cost the build it was measured against. A shape refusal carries the schema with it, so a writer told a field is invalid does not have to go looking for what the valid options are.

`defer` moves ONE first-pass item to the next pass with its reason recorded, which is the only sanctioned way for something planned to stop blocking the milestone.

The runners live in `@pikku/knowledge` as `runKnowledgePlanSchema`/`Show`/`Set`/`Defer`, so the CLI is wiring and rendering only and anything else driving a build gets the same order of checks. The command schemas go through `functions/knowledge/schemas.ts` for the reason that file already documents: the build bootstraps with the published CLI, so a schema identifier imported straight into a wired command resolves to a `.d.ts` and yields a module with no runtime exports.

## Verification

- 223 tests in `packages/knowledge` pass (12 of them new, covering the four runners).
- `packages/cli` typechecks with zero errors; oxlint clean.
- All four verbs exercised end-to-end against a scratch project with the built CLI: `show` refuses a missing plan and an unknown milestone by name; `set` wrote a valid plan and refused `{"version":1}` with nine field paths plus the schema; `defer` rewrote the plan with the deferral recorded, and refused an unknown item while listing the pass-1 items that *are* deferrable.

## Known, deliberately not fixed here

Four live strings in `plan.ts` — text a model reads and acts on — still name commands from the downstream build loop that have no counterpart here: `fabric plan-defer` (line 271), `fabric new-app` (194, 488), `fabric scaffold` (488) and `fabric build-complete` (448, which prints in `--for-build` output). Only the first has a portable equivalent now (`pikku knowledge plan defer`). The other three describe a build loop this package does not own, so the choice is to parameterise the command vocabulary or leave them to the caller — worth settling deliberately rather than guessing in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)