### PR TITLE
fix(deploy-standalone): open the database the runtime never provided, on either engine

### DIFF
--- a/.changeset/generated-entries-owe-the-app-its-lifecycle.md
+++ b/.changeset/generated-entries-owe-the-app-its-lifecycle.md
@@ -18,8 +18,9 @@ server entry — the one behind every `target: 'server'` unit — now import the
 app's lifecycle and call it: `beforeStart` after `init` and before the port
 opens, so work that must finish before the first request has, `afterStart` once
 the server is listening, and the stop hooks handed to the signal handler that
-already owns shutdown rather than a second listener racing it. A failing
-shutdown hook is logged and the process still stops.
+already owns shutdown rather than a second listener racing it. Each shutdown
+step is isolated from the ones after it, so a hook that throws is logged without
+taking the service teardown and the socket close down with it.
 
 Separately, `createAuthUser` and `setAuthUserPassword` wrote credential accounts
 with no `issuer`. From better-auth 1.7 a credential account is matched by its

--- a/.changeset/generated-entries-owe-the-app-its-lifecycle.md
+++ b/.changeset/generated-entries-owe-the-app-its-lifecycle.md
@@ -1,0 +1,30 @@
+---
+'@pikku/deploy-standalone': patch
+'@pikku/node-http-server': patch
+'@pikku/better-auth': patch
+'@pikku/bun-server': patch
+'@pikku/deploy': patch
+'@pikku/cli': patch
+---
+
+Run the app's server lifecycle in generated entries, and make an out-of-band
+account signable-in.
+
+`pikkuServerLifecycle` was only ever called by `pikku dev` and `pikku serve`, so
+an app that seeds its first admin account, probes a dependency, or warms a cache
+in `beforeStart` did all of that in development and silently skipped it
+everywhere it was actually deployed. The standalone entry and the shared node
+server entry — the one behind every `target: 'server'` unit — now import the
+app's lifecycle and call it: `beforeStart` after `init` and before the port
+opens, so work that must finish before the first request has, `afterStart` once
+the server is listening, and the stop hooks handed to the signal handler that
+already owns shutdown rather than a second listener racing it. A failing
+shutdown hook is logged and the process still stops.
+
+Separately, `createAuthUser` and `setAuthUserPassword` wrote credential accounts
+with no `issuer`. From better-auth 1.7 a credential account is matched by its
+issuer as well as its provider, so those accounts were invisible to sign-in,
+`updatePassword` and `findCredentialAccount` — a user who plainly existed in the
+table was reported as "user not found". The field is written only when the
+resolved schema has it, so older better-auth keeps working, and
+`setAuthUserPassword` repairs an account that predates the fix.

--- a/.changeset/standalone-opens-its-own-database.md
+++ b/.changeset/standalone-opens-its-own-database.md
@@ -15,21 +15,38 @@ first line of it. The artifact was only ever startable by projects that had no
 database at all, which is not the case the provider exists to serve.
 
 The generated entry now opens the database itself and passes `kysely` in.
-`EntryGenerationContext` carries a `db` descriptor, populated for projects with
-SQLite migrations and a generated coercion map, and the adapter emits the
-dialect its runtime can actually use — `@pikku/kysely-node-sqlite` for the node
-bundle, `@pikku/kysely-bun-sqlite` for a compiled bun binary, which has no
-`node:sqlite` to reach for. The project's generated coercion map is applied, so a
-deployed app and `pikku dev` agree about which columns are dates and which are
-booleans.
+`EntryGenerationContext` carries a `db` descriptor, and the engine is read from
+the migrations directory the project actually wrote — `db/sqlite` or
+`db/postgres`, the same two conventions the migrator emits to. Having both is
+refused rather than resolved: choosing on directory order would choose which
+database the deployed app talks to, and an app running happily against the
+wrong but entirely valid schema is invisible until someone reads the data.
 
-The file is located by `PIKKU_DATA_DIR` rather than derived from the bundle's
+For SQLite the adapter emits the dialect its runtime can actually use —
+`@pikku/kysely-node-sqlite` for the node bundle, `@pikku/kysely-bun-sqlite` for a
+compiled bun binary, which has no `node:sqlite` to reach for. For Postgres it
+emits `PikkuKysely` from `@pikku/kysely-postgres`, connected from `DATABASE_URL`,
+the same variable every other pikku host reads, so an artifact dropped onto a
+machine already running a pikku app needs no new one. An unset `DATABASE_URL`
+fails by name rather than as a driver error about an undefined connection
+string.
+
+The connection pool is closed on shutdown, in `afterStop` — after the app's own
+stop hook and the draining server have both finished with it, since a pool
+closed any earlier takes the queries they are still entitled to make down with
+it. SQLite needs no counterpart: the process exiting releases the file.
+
+The project's generated coercion map is applied to either engine, so a deployed
+app and `pikku dev` agree about which columns are dates and which are booleans.
+It is attached when the project generated one and skipped when it did not — the
+map is built from `db/annotations.ts` rather than from the dialect, so an app
+that annotates no columns is one with nothing to coerce rather than one that
+should be handed no database at all.
+
+A SQLite file is located by `PIKKU_DATA_DIR` rather than derived from the bundle's
 own path: a deploy that swaps the release directory would otherwise take the
 database with it. `PIKKU_DATABASE_FILE` overrides it outright, for when the path
 has to match one something else already chose — notably `pikku db migrate`,
 which has to open the same file or the app runs against an unmigrated schema.
 Neither being set fails with the variable's name rather than as a SQLite error
 about a path of `undefined`.
-
-Postgres is not wired: it self-hosts against a server the build cannot assume
-anything about, and needs a URL rather than a path.

--- a/.changeset/standalone-opens-its-own-database.md
+++ b/.changeset/standalone-opens-its-own-database.md
@@ -1,0 +1,35 @@
+---
+'@pikku/deploy-standalone': patch
+'@pikku/deploy': patch
+'@pikku/cli': patch
+---
+
+Give a standalone artifact the database connection every other provider's runtime hands it.
+
+`createSingletonServices` receives `kysely` from whatever is hosting the app —
+`pikku dev` builds one, a Cloudflare deploy binds one — so app code is written
+expecting it, and the generated templates throw outright when it is absent. The
+standalone provider is its own host and supplied nothing, so a bundle built from
+a project with a database started, called the services factory, and died on the
+first line of it. The artifact was only ever startable by projects that had no
+database at all, which is not the case the provider exists to serve.
+
+The generated entry now opens the database itself and passes `kysely` in.
+`EntryGenerationContext` carries a `db` descriptor, populated for projects with
+SQLite migrations and a generated coercion map, and the adapter emits the
+dialect its runtime can actually use — `@pikku/kysely-node-sqlite` for the node
+bundle, `@pikku/kysely-bun-sqlite` for a compiled bun binary, which has no
+`node:sqlite` to reach for. The project's generated coercion map is applied, so a
+deployed app and `pikku dev` agree about which columns are dates and which are
+booleans.
+
+The file is located by `PIKKU_DATA_DIR` rather than derived from the bundle's
+own path: a deploy that swaps the release directory would otherwise take the
+database with it. `PIKKU_DATABASE_FILE` overrides it outright, for when the path
+has to match one something else already chose — notably `pikku db migrate`,
+which has to open the same file or the app runs against an unmigrated schema.
+Neither being set fails with the variable's name rather than as a SQLite error
+about a path of `undefined`.
+
+Postgres is not wired: it self-hosts against a server the build cannot assume
+anything about, and needs a URL rather than a path.

--- a/packages/cli/src/deploy/build-pipeline.ts
+++ b/packages/cli/src/deploy/build-pipeline.ts
@@ -108,24 +108,41 @@ function findLockfile(projectDir: string): string | null {
  *
  * Engine comes from the migrations directory rather than the user config,
  * because that is the same signal `loadUserConfigForDb` falls back to and it
- * needs no module loading here. Only SQLite is wired today — Postgres self-hosts
- * against a server this cannot assume anything about, and needs a URL rather
- * than a path.
+ * needs no module loading here. `db/sqlite` and `db/postgres` are the two
+ * conventions the migrator already writes to, so a project declares its engine
+ * by having written migrations for it.
+ *
+ * Both at once is refused rather than resolved. Picking one would be picking
+ * which database the deployed app talks to on the strength of directory order,
+ * and the failure — an app running happily against the wrong, fully valid
+ * schema — is invisible until someone reads the data.
  */
 function resolveStandaloneDb(
   projectDir: string,
   pikkuDir: string,
   unitDir: string
-): { engine: 'sqlite'; coercionImportPath: string } | undefined {
-  if (!existsSync(join(projectDir, 'db', 'sqlite'))) return undefined
+): { engine: 'sqlite' | 'postgres'; coercionImportPath?: string } | undefined {
+  const hasSqlite = existsSync(join(projectDir, 'db', 'sqlite'))
+  const hasPostgres = existsSync(join(projectDir, 'db', 'postgres'))
 
+  if (hasSqlite && hasPostgres) {
+    throw new Error(
+      'This project has both db/sqlite and db/postgres migrations, so a standalone build cannot tell which database the app is meant to open. Keep the one this app deploys against.'
+    )
+  }
+
+  const engine = hasSqlite ? 'sqlite' : hasPostgres ? 'postgres' : undefined
+  if (!engine) return undefined
+
+  // Absent for an app that annotates no columns, which is a database with
+  // nothing to coerce rather than a reason to hand the app no database.
   const coercionFile = join(pikkuDir, 'db', 'coercion.gen.ts')
-  if (!existsSync(coercionFile)) return undefined
+  if (!existsSync(coercionFile)) return { engine }
 
   let rel = relative(unitDir, coercionFile).replace(/\\/g, '/')
   if (!rel.startsWith('.')) rel = `./${rel}`
 
-  return { engine: 'sqlite', coercionImportPath: rel.replace(/\.ts$/, '.js') }
+  return { engine, coercionImportPath: rel.replace(/\.ts$/, '.js') }
 }
 
 /**

--- a/packages/cli/src/deploy/build-pipeline.ts
+++ b/packages/cli/src/deploy/build-pipeline.ts
@@ -128,6 +128,29 @@ function resolveStandaloneDb(
   return { engine: 'sqlite', coercionImportPath: rel.replace(/\.ts$/, '.js') }
 }
 
+/**
+ * The app's server lifecycle, for entries that can call it.
+ *
+ * The hooks are resolved to an import rather than read at build time because
+ * they are the app's own code and have to run in the app's own process, with
+ * the services that process built.
+ */
+function resolveLifecycle(
+  unitDir: string,
+  state: InspectorState
+): { importPath: string; variable: string } | undefined {
+  const factory = state.filesAndMethods.serverLifecycleFactory
+  if (!factory) return undefined
+
+  let rel = relative(unitDir, factory.file).replace(/\\/g, '/')
+  if (!rel.startsWith('.')) rel = `./${rel}`
+
+  return {
+    importPath: rel.replace(/\.tsx?$/, '.js'),
+    variable: factory.variable,
+  }
+}
+
 export async function runBuildPipeline(options: {
   projectDir: string
   projectId: string
@@ -235,6 +258,7 @@ export async function runBuildPipeline(options: {
       ) as object),
       frontend: frontendMount,
       db: resolveStandaloneDb(projectDir, pikkuDir, unitDir),
+      lifecycle: resolveLifecycle(unitDir, inspectorState),
     }
     const source = provider.generateEntrySource(ctx as never)
 
@@ -377,7 +401,10 @@ export async function runBuildPipeline(options: {
       const entryPath = join(unitDir, 'entry.ts')
       await mkdir(unitDir, { recursive: true })
 
-      const ctx = getEntryContext(unitDir, pikkuDir, unit, inspectorState)
+      const ctx = {
+        ...(getEntryContext(unitDir, pikkuDir, unit, inspectorState) as object),
+        lifecycle: resolveLifecycle(unitDir, inspectorState),
+      }
       const source =
         unit.target === 'server'
           ? (provider.generateServerEntrySource?.(ctx as never) ??

--- a/packages/cli/src/deploy/build-pipeline.ts
+++ b/packages/cli/src/deploy/build-pipeline.ts
@@ -5,7 +5,7 @@
  * Outputs everything to .deploy/<provider>/ without deploying.
  */
 
-import { join } from 'node:path'
+import { join, relative } from 'node:path'
 import { existsSync } from 'node:fs'
 import { mkdir, writeFile, copyFile } from 'node:fs/promises'
 import type { InspectorState } from '@pikku/inspector'
@@ -94,6 +94,38 @@ function findLockfile(projectDir: string): string | null {
     if (existsSync(p)) return p
   }
   return null
+}
+
+/**
+ * The database a standalone bundle has to open for itself.
+ *
+ * Every other provider deploys onto a host that supplies `kysely` — `pikku dev`
+ * builds one, a Cloudflare deploy binds one — so `createSingletonServices` is
+ * written expecting it. A standalone artifact has no host, and shipped one that
+ * never got a connection at all: the app booted straight into whatever its
+ * services factory does when the database is missing, which for the generated
+ * templates is a throw.
+ *
+ * Engine comes from the migrations directory rather than the user config,
+ * because that is the same signal `loadUserConfigForDb` falls back to and it
+ * needs no module loading here. Only SQLite is wired today — Postgres self-hosts
+ * against a server this cannot assume anything about, and needs a URL rather
+ * than a path.
+ */
+function resolveStandaloneDb(
+  projectDir: string,
+  pikkuDir: string,
+  unitDir: string
+): { engine: 'sqlite'; coercionImportPath: string } | undefined {
+  if (!existsSync(join(projectDir, 'db', 'sqlite'))) return undefined
+
+  const coercionFile = join(pikkuDir, 'db', 'coercion.gen.ts')
+  if (!existsSync(coercionFile)) return undefined
+
+  let rel = relative(unitDir, coercionFile).replace(/\\/g, '/')
+  if (!rel.startsWith('.')) rel = `./${rel}`
+
+  return { engine: 'sqlite', coercionImportPath: rel.replace(/\.ts$/, '.js') }
 }
 
 export async function runBuildPipeline(options: {
@@ -202,6 +234,7 @@ export async function runBuildPipeline(options: {
         inspectorState
       ) as object),
       frontend: frontendMount,
+      db: resolveStandaloneDb(projectDir, pikkuDir, unitDir),
     }
     const source = provider.generateEntrySource(ctx as never)
 

--- a/packages/cli/src/deploy/server-entry.ts
+++ b/packages/cli/src/deploy/server-entry.ts
@@ -21,6 +21,11 @@ export function generateServerEntrySource(ctx: EntryGenerationContext): string {
     ctx.configImport,
     ctx.servicesImport,
     ctx.mcpImport,
+    ...(ctx.lifecycle
+      ? [
+          `import { ${ctx.lifecycle.variable} as __pikkuLifecycle } from '${ctx.lifecycle.importPath}'`,
+        ]
+      : []),
     `import '${ctx.bootstrapPath}'`,
     ``,
     `const PORT = Number(process.env.PORT ?? 8080)`,
@@ -36,9 +41,19 @@ export function generateServerEntrySource(ctx: EntryGenerationContext): string {
     `    singletonServices.logger,`,
     `    { ${ctx.mcpServerOption}}`,
     `  )`,
-    `  server.enableExitOnSignals()`,
+    `  server.enableExitOnSignals(${
+      ctx.lifecycle
+        ? `{ beforeStop: () => __pikkuLifecycle?.beforeStop?.(singletonServices), afterStop: () => __pikkuLifecycle?.afterStop?.(singletonServices) }`
+        : ''
+    })`,
     `  await server.init()`,
+    ...(ctx.lifecycle
+      ? [`  await __pikkuLifecycle?.beforeStart?.(singletonServices)`]
+      : []),
     `  await server.start()`,
+    ...(ctx.lifecycle
+      ? [`  await __pikkuLifecycle?.afterStart?.(singletonServices)`]
+      : []),
     `}`,
     ``,
     `main().catch((err) => {`,

--- a/packages/deploy/deploy-core/src/provider-adapter.ts
+++ b/packages/deploy/deploy-core/src/provider-adapter.ts
@@ -73,6 +73,22 @@ export interface EntryGenerationContext {
     /** Import specifier for the generated `coercionMap`, relative to unitDir. */
     coercionImportPath: string
   }
+
+  /**
+   * The app's `pikkuServerLifecycle` export, when it declares one.
+   *
+   * Only `pikku dev` and `pikku serve` have ever called these hooks, so an app
+   * that seeds its first admin account or opens a connection pool in
+   * `beforeStart` did that in development and silently skipped it everywhere it
+   * was actually deployed. A generated entry is the app's real host and owes it
+   * the same lifecycle the dev server gives it.
+   */
+  lifecycle?: {
+    /** Import specifier for the lifecycle module, relative to unitDir. */
+    importPath: string
+    /** The exported name to call the hooks on. */
+    variable: string
+  }
 }
 
 export interface ProviderAdapter {

--- a/packages/deploy/deploy-core/src/provider-adapter.ts
+++ b/packages/deploy/deploy-core/src/provider-adapter.ts
@@ -64,14 +64,21 @@ export interface EntryGenerationContext {
    * services factory had nothing to connect to.
    *
    * Only the engine and where to find the coercion map travel here. Which
-   * dialect package to import, and how to reach the file, is the provider's
+   * dialect package to import, and how to reach the database, is the provider's
    * business — a compiled bun binary and a node bundle do not open SQLite the
-   * same way.
+   * same way, and Postgres is reached by URL rather than by path at all.
    */
   db?: {
-    engine: 'sqlite'
-    /** Import specifier for the generated `coercionMap`, relative to unitDir. */
-    coercionImportPath: string
+    engine: 'sqlite' | 'postgres'
+    /**
+     * Import specifier for the generated `coercionMap`, relative to unitDir.
+     *
+     * Absent when the app generates no coercion map. It is not a SQLite
+     * concern: the map is built from `db/annotations.ts` rather than from the
+     * dialect, and a Postgres app that annotates a column needs it attached for
+     * the same reason.
+     */
+    coercionImportPath?: string
   }
 
   /**

--- a/packages/deploy/deploy-core/src/provider-adapter.ts
+++ b/packages/deploy/deploy-core/src/provider-adapter.ts
@@ -53,6 +53,26 @@ export interface EntryGenerationContext {
     urlPrefix: string
     spaFallback: boolean
   }
+  /**
+   * The database the generated entry has to open for itself, or undefined when
+   * the project has none.
+   *
+   * A hosted runtime hands `kysely` to `createSingletonServices` — `pikku dev`
+   * builds one, and a Cloudflare deploy binds one — so app code is written
+   * expecting it and typically throws without it. A standalone artifact has no
+   * such host: it IS the runtime, and until this existed it started an app whose
+   * services factory had nothing to connect to.
+   *
+   * Only the engine and where to find the coercion map travel here. Which
+   * dialect package to import, and how to reach the file, is the provider's
+   * business — a compiled bun binary and a node bundle do not open SQLite the
+   * same way.
+   */
+  db?: {
+    engine: 'sqlite'
+    /** Import specifier for the generated `coercionMap`, relative to unitDir. */
+    coercionImportPath: string
+  }
 }
 
 export interface ProviderAdapter {

--- a/packages/deploy/deploy-standalone/src/adapter.test.ts
+++ b/packages/deploy/deploy-standalone/src/adapter.test.ts
@@ -185,6 +185,27 @@ describe('StandaloneProviderAdapter deploy output', () => {
   })
 })
 
+/**
+ * Runs the database-file choice the generated entry makes, rather than reading
+ * the source it is written in. Asserting on the text cannot tell a working
+ * precedence from one that always takes the same branch.
+ */
+const chooseDatabaseFile = (source: string, env: NodeJS.ProcessEnv): string => {
+  const helper = source.match(/function __pikkuRequireDataDir\(\)[\s\S]*?\n\}/)
+  const selection = source.match(
+    /const __pikkuDbFile =([\s\S]*?)\n\s*__pikkuMkdirSync/
+  )
+  assert.ok(helper, 'the entry must define the data-dir helper it calls')
+  assert.ok(selection, 'the entry must choose a database file')
+
+  const choose = new Function(
+    'process',
+    '__pikkuDbJoin',
+    `${helper[0]}\nreturn (${selection[1]})`
+  ) as (proc: { env: NodeJS.ProcessEnv }, join: typeof join) => string
+  return choose({ env }, join)
+}
+
 const withDb = {
   ...(baseContext as object),
   db: {
@@ -265,7 +286,25 @@ describe('StandaloneProviderAdapter database wiring', () => {
 
     // `pikku db migrate` has to open the same file this does; without an
     // override the two can only agree by coincidence.
-    assert.match(source, /PIKKU_DATABASE_FILE/)
+    assert.equal(
+      chooseDatabaseFile(source, {
+        PIKKU_DATA_DIR: '/var/lib/pikku',
+        PIKKU_DATABASE_FILE: '/srv/shared/app.db',
+      }),
+      '/srv/shared/app.db',
+      'the override has to win over the data directory, not merely be mentioned'
+    )
+  })
+
+  test('the data directory is used when nothing overrides it', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'node',
+    }).generateEntrySource(withDb)
+
+    assert.equal(
+      chooseDatabaseFile(source, { PIKKU_DATA_DIR: '/var/lib/pikku' }),
+      join('/var/lib/pikku', 'pikku.db')
+    )
   })
 
   test('a missing data directory fails by name', () => {
@@ -273,9 +312,8 @@ describe('StandaloneProviderAdapter database wiring', () => {
       runtime: 'node',
     }).generateEntrySource(withDb)
 
-    assert.match(source, /__pikkuRequireDataDir/)
-    assert.match(
-      source,
+    assert.throws(
+      () => chooseDatabaseFile(source, {}),
       /Set PIKKU_DATA_DIR to a writable directory/,
       'the error has to name the variable, not surface as a path of undefined'
     )

--- a/packages/deploy/deploy-standalone/src/adapter.test.ts
+++ b/packages/deploy/deploy-standalone/src/adapter.test.ts
@@ -357,3 +357,104 @@ describe('StandaloneProviderAdapter database wiring (bun)', () => {
     assert.doesNotMatch(source, /PIKKU_DATA_DIR/)
   })
 })
+
+const withLifecycle = {
+  ...(baseContext as object),
+  lifecycle: { importPath: './lifecycle.js', variable: 'lifecycle' },
+} as never
+
+for (const runtime of ['node', 'bun'] as const) {
+  describe(`StandaloneProviderAdapter server lifecycle (${runtime})`, () => {
+    test('an app that declares no lifecycle gets no hook calls', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(baseContext)
+
+      assert.doesNotMatch(source, /__pikkuLifecycle/)
+      assert.match(source, /server\.enableExitOnSignals\(\)/)
+    })
+
+    test('the lifecycle is imported under a reserved name', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withLifecycle)
+
+      assert.match(
+        source,
+        /import \{ lifecycle as __pikkuLifecycle \} from '\.\/lifecycle\.js'/
+      )
+    })
+
+    test('beforeStart runs after init and before the port opens', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withLifecycle)
+
+      const init = source.indexOf('await server.init()')
+      const before = source.indexOf('__pikkuLifecycle?.beforeStart?.')
+      const start = source.indexOf('await server.start()')
+
+      assert.ok(init !== -1 && before !== -1 && start !== -1)
+      assert.ok(
+        init < before && before < start,
+        'work a hook must finish before the first request has to run before the port opens'
+      )
+    })
+
+    test('afterStart runs once the server is listening', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withLifecycle)
+
+      assert.ok(
+        source.indexOf('await server.start()') <
+          source.indexOf('__pikkuLifecycle?.afterStart?.')
+      )
+    })
+
+    test('the hooks are handed the services the app was built with', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withLifecycle)
+
+      for (const hook of [
+        'beforeStart',
+        'afterStart',
+        'beforeStop',
+        'afterStop',
+      ]) {
+        assert.match(
+          source,
+          new RegExp(
+            `__pikkuLifecycle\\?\\.${hook}\\?\\.\\(singletonServices\\)`
+          ),
+          `${hook} must receive singletonServices`
+        )
+      }
+    })
+
+    test('the stop hooks are given to the signal handler that owns shutdown', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withLifecycle)
+
+      assert.match(
+        source,
+        /server\.enableExitOnSignals\(\{ beforeStop:/,
+        'a separate signal listener would race the server teardown'
+      )
+    })
+
+    test('the lifecycle import is optional and never emitted twice', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withLifecycle)
+
+      assert.equal(
+        source.split('as __pikkuLifecycle').length - 1,
+        1,
+        'a duplicate binding would not compile'
+      )
+    })
+  })
+}

--- a/packages/deploy/deploy-standalone/src/adapter.test.ts
+++ b/packages/deploy/deploy-standalone/src/adapter.test.ts
@@ -214,6 +214,133 @@ const withDb = {
   },
 } as never
 
+const withPostgres = {
+  ...(baseContext as object),
+  db: {
+    engine: 'postgres' as const,
+    coercionImportPath: '../../.pikku/db/coercion.gen.js',
+  },
+} as never
+
+const withPostgresNoCoercion = {
+  ...(baseContext as object),
+  db: { engine: 'postgres' as const },
+} as never
+
+const withSqliteNoCoercion = {
+  ...(baseContext as object),
+  db: { engine: 'sqlite' as const },
+} as never
+
+for (const runtime of ['node', 'bun'] as const) {
+  describe(`StandaloneProviderAdapter postgres wiring (${runtime})`, () => {
+    test('the connection is opened from DATABASE_URL', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withPostgres)
+
+      assert.match(
+        source,
+        /import \{ PikkuKysely \} from '@pikku\/kysely-postgres'/
+      )
+      assert.match(source, /process\.env\.DATABASE_URL/)
+    })
+
+    test('a missing DATABASE_URL fails by name rather than by driver error', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withPostgres)
+
+      assert.match(source, /needs DATABASE_URL set/)
+    })
+
+    test('postgres brings none of the sqlite file handling with it', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withPostgres)
+
+      // PIKKU_DATA_DIR describes where a bundled database file lives. A
+      // postgres build has no file, and demanding the variable anyway would
+      // refuse to boot over a directory it never reads.
+      assert.doesNotMatch(source, /PIKKU_DATA_DIR/)
+      assert.doesNotMatch(source, /PIKKU_DATABASE_FILE/)
+      assert.doesNotMatch(source, /SqliteKysely/)
+    })
+
+    test('the connection is handed to the services factory, opened first', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withPostgres)
+
+      assert.match(
+        source,
+        /createSingletonServices\(config, \{[\s\S]*?\n    kysely,/
+      )
+      assert.ok(
+        source.indexOf('new PikkuKysely') <
+          source.indexOf('createSingletonServices(config')
+      )
+    })
+
+    test('the coercion map is applied to the postgres connection too', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withPostgres)
+
+      // The map comes from db/annotations.ts, not from the dialect: an
+      // annotated column needs coercing whichever database holds it.
+      assert.match(source, /withPlugin\(\s*createCoercionPlugin/)
+    })
+
+    test('an app with no coercion map still gets a database', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withPostgresNoCoercion)
+
+      // Nothing to coerce is a database with no annotated columns, not a
+      // reason to boot the app with no connection at all.
+      assert.match(source, /new PikkuKysely/)
+      assert.doesNotMatch(source, /createCoercionPlugin/)
+      assert.match(source, /\n    kysely,/)
+    })
+
+    test('sqlite with no coercion map still gets a database', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withSqliteNoCoercion)
+
+      assert.match(source, /SqliteKysely/)
+      assert.doesNotMatch(source, /createCoercionPlugin/)
+      assert.match(source, /\n    kysely,/)
+    })
+
+    test('the pool is closed on shutdown, after the server has stopped', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withPostgres)
+
+      // A pool closed in beforeStop would be gone while the app's own stop
+      // hook and the draining server are still entitled to query it.
+      assert.match(
+        source,
+        /afterStop: async \(\) => \{[^}]*__pikkuPg\.close\(\)/
+      )
+      assert.doesNotMatch(
+        source,
+        /beforeStop: async \(\) => \{[^}]*__pikkuPg\.close\(\)/
+      )
+    })
+
+    test('a sqlite build closes no pool', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(withDb)
+
+      assert.doesNotMatch(source, /__pikkuPg/)
+    })
+  })
+}
+
 describe('StandaloneProviderAdapter database wiring', () => {
   test('a node entry without a database opens none', () => {
     const source = new StandaloneProviderAdapter({

--- a/packages/deploy/deploy-standalone/src/adapter.test.ts
+++ b/packages/deploy/deploy-standalone/src/adapter.test.ts
@@ -184,3 +184,176 @@ describe('StandaloneProviderAdapter deploy output', () => {
     assert.equal(existsSync(join(outDir, 'frontend-assets.gen.js')), false)
   })
 })
+
+const withDb = {
+  ...(baseContext as object),
+  db: {
+    engine: 'sqlite' as const,
+    coercionImportPath: '../../.pikku/db/coercion.gen.js',
+  },
+} as never
+
+describe('StandaloneProviderAdapter database wiring', () => {
+  test('a node entry without a database opens none', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'node',
+    }).generateEntrySource(baseContext)
+
+    assert.doesNotMatch(source, /createNodeSqliteKysely/)
+    assert.doesNotMatch(source, /PIKKU_DATA_DIR/)
+  })
+
+  test('a node entry hands the connection to the services factory', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'node',
+    }).generateEntrySource(withDb)
+
+    assert.match(source, /createNodeSqliteKysely/)
+    // The whole point: app code receives `kysely` the way a hosted runtime
+    // would give it, rather than the factory finding nothing there.
+    assert.match(
+      source,
+      /createSingletonServices\(config, \{[\s\S]*?\n    kysely,/,
+      'kysely must be passed into the services factory, not merely constructed'
+    )
+  })
+
+  test('the connection is opened before the services that need it', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'node',
+    }).generateEntrySource(withDb)
+
+    assert.ok(
+      source.indexOf('createNodeSqliteKysely') <
+        source.indexOf('createSingletonServices(config'),
+      'a connection built after the factory ran would arrive too late to be used'
+    )
+  })
+
+  test('the generated coercion map is applied to the connection', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'node',
+    }).generateEntrySource(withDb)
+
+    assert.match(source, /from '\.\.\/\.\.\/\.pikku\/db\/coercion\.gen\.js'/)
+    // Without it a `date` column reads back as a string and a `bool` as 0/1,
+    // so the deployed app disagrees with `pikku dev` about its own row shapes.
+    assert.match(
+      source,
+      /createCoercionPlugin\(\{ map: __pikkuCoercionMap \}\)/
+    )
+  })
+
+  test('the database file lives outside the release directory', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'node',
+    }).generateEntrySource(withDb)
+
+    assert.match(source, /PIKKU_DATA_DIR/)
+    // A path derived from the bundle's own location would be swapped out —
+    // and deleted — by the next release.
+    assert.doesNotMatch(
+      source,
+      /filename: __pikkuJoin\(__pikkuDirname\(__pikkuFileURLToPath/
+    )
+  })
+
+  test('an explicit database file overrides the data directory', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'node',
+    }).generateEntrySource(withDb)
+
+    // `pikku db migrate` has to open the same file this does; without an
+    // override the two can only agree by coincidence.
+    assert.match(source, /PIKKU_DATABASE_FILE/)
+  })
+
+  test('a missing data directory fails by name', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'node',
+    }).generateEntrySource(withDb)
+
+    assert.match(source, /__pikkuRequireDataDir/)
+    assert.match(
+      source,
+      /Set PIKKU_DATA_DIR to a writable directory/,
+      'the error has to name the variable, not surface as a path of undefined'
+    )
+  })
+
+  test('the directory is created rather than required to exist', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'node',
+    }).generateEntrySource(withDb)
+
+    assert.match(
+      source,
+      /__pikkuMkdirSync\(__pikkuDbDirname\(__pikkuDbFile\), \{ recursive: true \}\)/
+    )
+  })
+
+  test('a database and a frontend do not fight over their path aliases', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'node',
+    }).generateEntrySource({
+      ...(baseContext as object),
+      frontend: { urlPrefix: '/', spaFallback: true },
+      db: {
+        engine: 'sqlite' as const,
+        coercionImportPath: './coercion.gen.js',
+      },
+    } as never)
+
+    // Two imports of node:path are legal; two bindings of one name are not.
+    const bound = source.match(/(?:dirname|join) as (\w+)/g) ?? []
+    assert.equal(
+      new Set(bound).size,
+      bound.length,
+      `each path helper must bind a distinct name, got ${bound.join(', ')}`
+    )
+    assert.match(source, /__pikkuJoin\(__pikkuDirname\(__pikkuFileURLToPath/)
+    assert.match(source, /__pikkuDbJoin\(__pikkuRequireDataDir\(\)/)
+  })
+})
+
+describe('StandaloneProviderAdapter database wiring (bun)', () => {
+  test('a bun entry opens SQLite through the bun driver', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'bun',
+    }).generateEntrySource(withDb)
+
+    // node:sqlite is not available inside a compiled bun binary, so reaching
+    // for the node factory here produces an artifact that cannot start.
+    assert.match(source, /createBunSqliteKysely/)
+    assert.doesNotMatch(source, /kysely-node-sqlite/)
+  })
+
+  test('a bun entry hands the connection to the services factory', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'bun',
+    }).generateEntrySource(withDb)
+
+    assert.match(
+      source,
+      /createSingletonServices\(config, \{[\s\S]*?\n    kysely,/
+    )
+  })
+
+  test('a bun entry defines the data-dir helper it calls', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'bun',
+    }).generateEntrySource(withDb)
+
+    // Calling it without defining it is a ReferenceError at first boot.
+    assert.match(source, /function __pikkuRequireDataDir\(\)/)
+  })
+
+  test('a bun entry without a database opens none', () => {
+    const source = new StandaloneProviderAdapter({
+      runtime: 'bun',
+    }).generateEntrySource(baseContext)
+
+    assert.doesNotMatch(source, /createBunSqliteKysely/)
+    assert.doesNotMatch(source, /PIKKU_DATA_DIR/)
+  })
+})

--- a/packages/deploy/deploy-standalone/src/adapter.ts
+++ b/packages/deploy/deploy-standalone/src/adapter.ts
@@ -52,6 +52,88 @@ const sidecarHandshakeLines = (): string[] => [
 const SIDECAR_RUNTIME_IMPORT = `import { watchParentProcess } from '@pikku/deploy-standalone/runtime'`
 
 /**
+ * Environment variable naming the directory the SQLite file lives in.
+ *
+ * The database has to outlive a release. A deploy that swaps the artifact
+ * directory would take the database with it if the file sat beside the bundle,
+ * so the path comes from the environment and points somewhere the operator
+ * keeps stable across releases, rather than being derived from the bundle's own
+ * location the way the frontend directory is.
+ */
+const DATA_DIR_VAR = 'PIKKU_DATA_DIR'
+
+/**
+ * Full override for the database file, for when it must match a path something
+ * else already decided — notably `pikku db migrate`, which has to open the same
+ * file this opens or the app runs against an unmigrated database.
+ */
+const DATABASE_FILE_VAR = 'PIKKU_DATABASE_FILE'
+
+const DEFAULT_DATABASE_FILENAME = 'pikku.db'
+
+/**
+ * The dialect factory each runtime opens SQLite with. bun cannot use the node
+ * one — `bun:sqlite` is a different driver, and the node build reaches for
+ * `node:sqlite`, which a compiled bun binary does not carry.
+ */
+const SQLITE_FACTORY = {
+  node: {
+    specifier: '@pikku/kysely-node-sqlite',
+    fn: 'createNodeSqliteKysely',
+  },
+  bun: { specifier: '@pikku/kysely-bun-sqlite', fn: 'createBunSqliteKysely' },
+} as const
+
+/** Imports a SQLite-backed entry needs on top of the common set. */
+const sqliteImportLines = (
+  runtime: 'node' | 'bun',
+  coercionImportPath: string
+): string[] => [
+  `import { ${SQLITE_FACTORY[runtime].fn} } from '${SQLITE_FACTORY[runtime].specifier}'`,
+  `import { createCoercionPlugin } from '@pikku/kysely'`,
+  `import { coercionMap as __pikkuCoercionMap } from '${coercionImportPath}'`,
+  `import { mkdirSync as __pikkuMkdirSync } from 'node:fs'`,
+  `import { dirname as __pikkuDbDirname, join as __pikkuDbJoin } from 'node:path'`,
+]
+
+/**
+ * Opens the database before services are built, so `createSingletonServices`
+ * receives `kysely` exactly as a hosted runtime would hand it over.
+ *
+ * Creating the directory rather than requiring it is deliberate: the artifact
+ * is expected to start on a machine where nothing has run yet, and a missing
+ * parent directory is the difference between a first boot that works and one
+ * that needs a documented mkdir nobody reads.
+ */
+const sqliteSetupLines = (runtime: 'node' | 'bun'): string[] => [
+  `  const __pikkuDbFile = process.env.${DATABASE_FILE_VAR}`,
+  `    ? process.env.${DATABASE_FILE_VAR}`,
+  `    : __pikkuDbJoin(__pikkuRequireDataDir(), '${DEFAULT_DATABASE_FILENAME}')`,
+  `  __pikkuMkdirSync(__pikkuDbDirname(__pikkuDbFile), { recursive: true })`,
+  `  const kysely = ${SQLITE_FACTORY[runtime].fn}({`,
+  `    filename: __pikkuDbFile,`,
+  `    plugins: [createCoercionPlugin({ map: __pikkuCoercionMap })],`,
+  `  })`,
+]
+
+/**
+ * Fails with the variable's name rather than whatever SQLite says about a path
+ * of `undefined/pikku.db`, which is the error an operator would otherwise have
+ * to work backwards from.
+ */
+const dataDirHelperLines = (): string[] => [
+  `function __pikkuRequireDataDir() {`,
+  `  const dir = process.env.${DATA_DIR_VAR}`,
+  `  if (!dir) {`,
+  `    throw new Error(`,
+  `      'This build bundles a SQLite database, so it needs somewhere to keep it. Set ${DATA_DIR_VAR} to a writable directory that survives a release swap, or set ${DATABASE_FILE_VAR} to the database file itself.'`,
+  `    )`,
+  `  }`,
+  `  return dir`,
+  `}`,
+]
+
+/**
  * `rustc -vV`, or nothing when no toolchain is installed. The triple then falls
  * back to the Node platform pair, which is right for every ordinary host — the
  * cases rustc knows better about (musl, Rosetta) are the ones where a Rust
@@ -129,6 +211,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
             `import { fileURLToPath as __pikkuFileURLToPath } from 'node:url'`,
           ]
         : []),
+      ...(ctx.db ? sqliteImportLines('node', ctx.db.coercionImportPath) : []),
       ``,
       ctx.configImport,
       ctx.servicesImport,
@@ -149,8 +232,10 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `  const eventHub = new LocalEventHubService()`,
       `  workflowService.wireQueueWorkers()`,
       `  wireAgentScorerQueueWorkers()`,
+      ...(ctx.db ? sqliteSetupLines('node') : []),
       `  const singletonServices = await ${ctx.servicesVar}(config, {`,
       `    logger,`,
+      ...(ctx.db ? [`    kysely,`] : []),
       `    schedulerService,`,
       `    queueService,`,
       `    workflowService,`,
@@ -195,6 +280,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `  process.exit(1)`,
       `})`,
       ``,
+      ...(ctx.db ? [...dataDirHelperLines(), ``] : []),
     ].join('\n')
   }
 
@@ -210,6 +296,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       ...(ctx.frontend
         ? [`import { frontendAssets } from '${STANDALONE_FRONTEND_MANIFEST}'`]
         : []),
+      ...(ctx.db ? sqliteImportLines('bun', ctx.db.coercionImportPath) : []),
       ``,
       ctx.configImport,
       ctx.servicesImport,
@@ -230,8 +317,10 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `  const eventHub = new BunEventHubService()`,
       `  workflowService.wireQueueWorkers()`,
       `  wireAgentScorerQueueWorkers()`,
+      ...(ctx.db ? sqliteSetupLines('bun') : []),
       `  const singletonServices = await ${ctx.servicesVar}(config, {`,
       `    logger,`,
+      ...(ctx.db ? [`    kysely,`] : []),
       `    schedulerService,`,
       `    queueService,`,
       `    workflowService,`,
@@ -268,6 +357,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `  process.exit(1)`,
       `})`,
       ``,
+      ...(ctx.db ? [...dataDirHelperLines(), ``] : []),
     ].join('\n')
   }
 

--- a/packages/deploy/deploy-standalone/src/adapter.ts
+++ b/packages/deploy/deploy-standalone/src/adapter.ts
@@ -116,6 +116,34 @@ const sqliteSetupLines = (runtime: 'node' | 'bun'): string[] => [
   `  })`,
 ]
 
+/** Imports the app's own lifecycle module, when it declares one. */
+const lifecycleImportLines = (
+  lifecycle: NonNullable<EntryGenerationContext['lifecycle']>
+): string[] => [
+  `import { ${lifecycle.variable} as __pikkuLifecycle } from '${lifecycle.importPath}'`,
+]
+
+/**
+ * Runs the app's start hooks around the port opening, the same order and the
+ * same services `pikku dev` gives them.
+ *
+ * `beforeStart` runs after `init` so a hook can rely on everything the server
+ * resolved, and before `start` so work that must finish before the first
+ * request — a seeded admin account, a schema probe — is finished when one
+ * arrives.
+ */
+const lifecycleStartLines = (): string[] => [
+  `  await __pikkuLifecycle?.beforeStart?.(singletonServices)`,
+]
+
+const lifecycleAfterStartLines = (): string[] => [
+  `  await __pikkuLifecycle?.afterStart?.(singletonServices)`,
+]
+
+/** Hands the stop hooks to the signal handler that owns the shutdown. */
+const lifecycleShutdownArg = (): string =>
+  `{ beforeStop: () => __pikkuLifecycle?.beforeStop?.(singletonServices), afterStop: () => __pikkuLifecycle?.afterStop?.(singletonServices) }`
+
 /**
  * Fails with the variable's name rather than whatever SQLite says about a path
  * of `undefined/pikku.db`, which is the error an operator would otherwise have
@@ -212,6 +240,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
           ]
         : []),
       ...(ctx.db ? sqliteImportLines('node', ctx.db.coercionImportPath) : []),
+      ...(ctx.lifecycle ? lifecycleImportLines(ctx.lifecycle) : []),
       ``,
       ctx.configImport,
       ctx.servicesImport,
@@ -270,8 +299,10 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `  await server.init()`,
       `  await schedulerService.start()`,
       `  await triggerService.start()`,
-      `  server.enableExitOnSignals()`,
+      ...(ctx.lifecycle ? lifecycleStartLines() : []),
+      `  server.enableExitOnSignals(${ctx.lifecycle ? lifecycleShutdownArg() : ''})`,
       `  await server.start()`,
+      ...(ctx.lifecycle ? lifecycleAfterStartLines() : []),
       ...sidecarHandshakeLines(),
       `}`,
       ``,
@@ -297,6 +328,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
         ? [`import { frontendAssets } from '${STANDALONE_FRONTEND_MANIFEST}'`]
         : []),
       ...(ctx.db ? sqliteImportLines('bun', ctx.db.coercionImportPath) : []),
+      ...(ctx.lifecycle ? lifecycleImportLines(ctx.lifecycle) : []),
       ``,
       ctx.configImport,
       ctx.servicesImport,
@@ -347,8 +379,10 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `  await server.init()`,
       `  await schedulerService.start()`,
       `  await triggerService.start()`,
-      `  server.enableExitOnSignals()`,
+      ...(ctx.lifecycle ? lifecycleStartLines() : []),
+      `  server.enableExitOnSignals(${ctx.lifecycle ? lifecycleShutdownArg() : ''})`,
       `  await server.start()`,
+      ...(ctx.lifecycle ? lifecycleAfterStartLines() : []),
       ...sidecarHandshakeLines(),
       `}`,
       ``,

--- a/packages/deploy/deploy-standalone/src/adapter.ts
+++ b/packages/deploy/deploy-standalone/src/adapter.ts
@@ -84,16 +84,33 @@ const SQLITE_FACTORY = {
   bun: { specifier: '@pikku/kysely-bun-sqlite', fn: 'createBunSqliteKysely' },
 } as const
 
-/** Imports a SQLite-backed entry needs on top of the common set. */
-const sqliteImportLines = (
-  runtime: 'node' | 'bun',
-  coercionImportPath: string
-): string[] => [
-  `import { ${SQLITE_FACTORY[runtime].fn} } from '${SQLITE_FACTORY[runtime].specifier}'`,
+/**
+ * The environment variable a Postgres build reads its connection string from.
+ *
+ * The same name every other pikku host uses, so an artifact dropped onto a
+ * machine that already runs a pikku app needs no new variable.
+ */
+const DATABASE_URL_VAR = 'DATABASE_URL'
+
+/** Imports the coercion plugin, for an app that generated a map. */
+const coercionImportLines = (coercionImportPath: string): string[] => [
   `import { createCoercionPlugin } from '@pikku/kysely'`,
   `import { coercionMap as __pikkuCoercionMap } from '${coercionImportPath}'`,
-  `import { mkdirSync as __pikkuMkdirSync } from 'node:fs'`,
-  `import { dirname as __pikkuDbDirname, join as __pikkuDbJoin } from 'node:path'`,
+]
+
+/** Imports a database-backed entry needs on top of the common set. */
+const dbImportLines = (
+  runtime: 'node' | 'bun',
+  db: NonNullable<EntryGenerationContext['db']>
+): string[] => [
+  ...(db.engine === 'sqlite'
+    ? [
+        `import { ${SQLITE_FACTORY[runtime].fn} } from '${SQLITE_FACTORY[runtime].specifier}'`,
+        `import { mkdirSync as __pikkuMkdirSync } from 'node:fs'`,
+        `import { dirname as __pikkuDbDirname, join as __pikkuDbJoin } from 'node:path'`,
+      ]
+    : [`import { PikkuKysely } from '@pikku/kysely-postgres'`]),
+  ...(db.coercionImportPath ? coercionImportLines(db.coercionImportPath) : []),
 ]
 
 /**
@@ -105,16 +122,45 @@ const sqliteImportLines = (
  * parent directory is the difference between a first boot that works and one
  * that needs a documented mkdir nobody reads.
  */
-const sqliteSetupLines = (runtime: 'node' | 'bun'): string[] => [
-  `  const __pikkuDbFile = process.env.${DATABASE_FILE_VAR}`,
-  `    ? process.env.${DATABASE_FILE_VAR}`,
-  `    : __pikkuDbJoin(__pikkuRequireDataDir(), '${DEFAULT_DATABASE_FILENAME}')`,
-  `  __pikkuMkdirSync(__pikkuDbDirname(__pikkuDbFile), { recursive: true })`,
-  `  const kysely = ${SQLITE_FACTORY[runtime].fn}({`,
-  `    filename: __pikkuDbFile,`,
-  `    plugins: [createCoercionPlugin({ map: __pikkuCoercionMap })],`,
-  `  })`,
-]
+const dbSetupLines = (
+  runtime: 'node' | 'bun',
+  db: NonNullable<EntryGenerationContext['db']>
+): string[] => {
+  const plugins = db.coercionImportPath
+    ? `[createCoercionPlugin({ map: __pikkuCoercionMap })]`
+    : `[]`
+
+  if (db.engine === 'sqlite') {
+    return [
+      `  const __pikkuDbFile = process.env.${DATABASE_FILE_VAR}`,
+      `    ? process.env.${DATABASE_FILE_VAR}`,
+      `    : __pikkuDbJoin(__pikkuRequireDataDir(), '${DEFAULT_DATABASE_FILENAME}')`,
+      `  __pikkuMkdirSync(__pikkuDbDirname(__pikkuDbFile), { recursive: true })`,
+      `  const kysely = ${SQLITE_FACTORY[runtime].fn}({`,
+      `    filename: __pikkuDbFile,`,
+      `    plugins: ${plugins},`,
+      `  })`,
+    ]
+  }
+
+  return [
+    `  const __pikkuDbUrl = process.env.${DATABASE_URL_VAR}`,
+    `  if (!__pikkuDbUrl) {`,
+    `    throw new Error(`,
+    `      'This build connects to Postgres, so it needs ${DATABASE_URL_VAR} set to the database it should open.'`,
+    `    )`,
+    `  }`,
+    `  const __pikkuPg = new PikkuKysely(logger, __pikkuDbUrl)`,
+    `  await __pikkuPg.init()`,
+    ...(db.coercionImportPath
+      ? [
+          `  const kysely = __pikkuPg.kysely.withPlugin(`,
+          `    createCoercionPlugin({ map: __pikkuCoercionMap })`,
+          `  )`,
+        ]
+      : [`  const kysely = __pikkuPg.kysely`]),
+  ]
+}
 
 /** Imports the app's own lifecycle module, when it declares one. */
 const lifecycleImportLines = (
@@ -140,9 +186,37 @@ const lifecycleAfterStartLines = (): string[] => [
   `  await __pikkuLifecycle?.afterStart?.(singletonServices)`,
 ]
 
-/** Hands the stop hooks to the signal handler that owns the shutdown. */
-const lifecycleShutdownArg = (): string =>
-  `{ beforeStop: () => __pikkuLifecycle?.beforeStop?.(singletonServices), afterStop: () => __pikkuLifecycle?.afterStop?.(singletonServices) }`
+/**
+ * Hands the stop hooks to the signal handler that owns the shutdown.
+ *
+ * The connection pool is closed in `afterStop`, once the app's own hook and the
+ * server have both finished with it — a pool closed any earlier takes the
+ * queries they are still allowed to make down with it. SQLite needs no
+ * counterpart: the process exiting releases the file.
+ */
+const shutdownHooksArg = (ctx: EntryGenerationContext): string => {
+  const before: string[] = []
+  const after: string[] = []
+
+  if (ctx.lifecycle) {
+    before.push(`await __pikkuLifecycle?.beforeStop?.(singletonServices)`)
+    after.push(`await __pikkuLifecycle?.afterStop?.(singletonServices)`)
+  }
+  if (ctx.db?.engine === 'postgres') {
+    after.push(`await __pikkuPg.close()`)
+  }
+
+  if (before.length === 0 && after.length === 0) return ''
+
+  const hooks: string[] = []
+  if (before.length > 0) {
+    hooks.push(`beforeStop: async () => { ${before.join('; ')} }`)
+  }
+  if (after.length > 0) {
+    hooks.push(`afterStop: async () => { ${after.join('; ')} }`)
+  }
+  return `{ ${hooks.join(', ')} }`
+}
 
 /**
  * Fails with the variable's name rather than whatever SQLite says about a path
@@ -239,7 +313,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
             `import { fileURLToPath as __pikkuFileURLToPath } from 'node:url'`,
           ]
         : []),
-      ...(ctx.db ? sqliteImportLines('node', ctx.db.coercionImportPath) : []),
+      ...(ctx.db ? dbImportLines('node', ctx.db) : []),
       ...(ctx.lifecycle ? lifecycleImportLines(ctx.lifecycle) : []),
       ``,
       ctx.configImport,
@@ -261,7 +335,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `  const eventHub = new LocalEventHubService()`,
       `  workflowService.wireQueueWorkers()`,
       `  wireAgentScorerQueueWorkers()`,
-      ...(ctx.db ? sqliteSetupLines('node') : []),
+      ...(ctx.db ? dbSetupLines('node', ctx.db) : []),
       `  const singletonServices = await ${ctx.servicesVar}(config, {`,
       `    logger,`,
       ...(ctx.db ? [`    kysely,`] : []),
@@ -300,7 +374,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `  await schedulerService.start()`,
       `  await triggerService.start()`,
       ...(ctx.lifecycle ? lifecycleStartLines() : []),
-      `  server.enableExitOnSignals(${ctx.lifecycle ? lifecycleShutdownArg() : ''})`,
+      `  server.enableExitOnSignals(${shutdownHooksArg(ctx)})`,
       `  await server.start()`,
       ...(ctx.lifecycle ? lifecycleAfterStartLines() : []),
       ...sidecarHandshakeLines(),
@@ -311,7 +385,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `  process.exit(1)`,
       `})`,
       ``,
-      ...(ctx.db ? [...dataDirHelperLines(), ``] : []),
+      ...(ctx.db?.engine === 'sqlite' ? [...dataDirHelperLines(), ``] : []),
     ].join('\n')
   }
 
@@ -327,7 +401,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       ...(ctx.frontend
         ? [`import { frontendAssets } from '${STANDALONE_FRONTEND_MANIFEST}'`]
         : []),
-      ...(ctx.db ? sqliteImportLines('bun', ctx.db.coercionImportPath) : []),
+      ...(ctx.db ? dbImportLines('bun', ctx.db) : []),
       ...(ctx.lifecycle ? lifecycleImportLines(ctx.lifecycle) : []),
       ``,
       ctx.configImport,
@@ -349,7 +423,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `  const eventHub = new BunEventHubService()`,
       `  workflowService.wireQueueWorkers()`,
       `  wireAgentScorerQueueWorkers()`,
-      ...(ctx.db ? sqliteSetupLines('bun') : []),
+      ...(ctx.db ? dbSetupLines('bun', ctx.db) : []),
       `  const singletonServices = await ${ctx.servicesVar}(config, {`,
       `    logger,`,
       ...(ctx.db ? [`    kysely,`] : []),
@@ -380,7 +454,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `  await schedulerService.start()`,
       `  await triggerService.start()`,
       ...(ctx.lifecycle ? lifecycleStartLines() : []),
-      `  server.enableExitOnSignals(${ctx.lifecycle ? lifecycleShutdownArg() : ''})`,
+      `  server.enableExitOnSignals(${shutdownHooksArg(ctx)})`,
       `  await server.start()`,
       ...(ctx.lifecycle ? lifecycleAfterStartLines() : []),
       ...sidecarHandshakeLines(),
@@ -391,7 +465,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `  process.exit(1)`,
       `})`,
       ``,
-      ...(ctx.db ? [...dataDirHelperLines(), ``] : []),
+      ...(ctx.db?.engine === 'sqlite' ? [...dataDirHelperLines(), ``] : []),
     ].join('\n')
   }
 

--- a/packages/runtimes/bun-server/src/pikku-bun-server.ts
+++ b/packages/runtimes/bun-server/src/pikku-bun-server.ts
@@ -111,6 +111,16 @@ const isSerializable = (data: unknown): boolean =>
  * Handles HTTP via the fetch handler and WebSocket via Bun.serve's native
  * websocket handler (which is backed by uWebSockets internally).
  */
+/**
+ * Work the process owes its app on the way down, run around the service
+ * teardown `enableExitOnSignals` already does. A failing hook is logged and
+ * shutdown continues: a process that has been told to stop has to stop.
+ */
+export type ShutdownHooks = {
+  beforeStop?: () => void | Promise<void>
+  afterStop?: () => void | Promise<void>
+}
+
 export class PikkuBunServer {
   private server: BunServer<WsData> | null = null
   private readonly eventHub: BunEventHubService
@@ -438,12 +448,16 @@ export class PikkuBunServer {
     this.server = null
   }
 
-  public enableExitOnSignals(): void {
+  public enableExitOnSignals(hooks?: ShutdownHooks): void {
     const shutdown = async (signal: string) => {
       this.logger.info(`pikku-bun-server: ${signal} received, stopping`)
       try {
+        await hooks?.beforeStop?.()
         await stopSingletonServices()
         await this.stop()
+        await hooks?.afterStop?.()
+      } catch (error) {
+        this.logger.error(`pikku-bun-server: shutdown hook failed`, error)
       } finally {
         process.exit(0)
       }

--- a/packages/runtimes/bun-server/src/pikku-bun-server.ts
+++ b/packages/runtimes/bun-server/src/pikku-bun-server.ts
@@ -449,15 +449,31 @@ export class PikkuBunServer {
   }
 
   public enableExitOnSignals(hooks?: ShutdownHooks): void {
+    /**
+     * Every step of the shutdown is isolated from the ones after it. Sharing
+     * one catch means a hook that throws takes the service teardown and the
+     * socket close down with it, leaving the process to exit with connections
+     * still open and services still holding their handles.
+     */
+    const phase = async (name: string, run: () => void | Promise<void>) => {
+      try {
+        await run()
+      } catch (error) {
+        this.logger.error(
+          `pikku-bun-server: ${name} failed during shutdown`,
+          error
+        )
+      }
+    }
     const shutdown = async (signal: string) => {
       this.logger.info(`pikku-bun-server: ${signal} received, stopping`)
       try {
-        await hooks?.beforeStop?.()
-        await stopSingletonServices()
-        await this.stop()
-        await hooks?.afterStop?.()
-      } catch (error) {
-        this.logger.error(`pikku-bun-server: shutdown hook failed`, error)
+        await phase('beforeStop', () => hooks?.beforeStop?.())
+        await phase('stopping singleton services', () =>
+          stopSingletonServices()
+        )
+        await phase('stopping the server', () => this.stop())
+        await phase('afterStop', () => hooks?.afterStop?.())
       } finally {
         process.exit(0)
       }

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.test.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.test.ts
@@ -869,3 +869,82 @@ describe('PikkuNodeHTTPServer dispatch routes', { concurrency: false }, () => {
     assert.notEqual(response.status, 204)
   })
 })
+
+describe('PikkuNodeHTTPServer shutdown', { concurrency: false }, () => {
+  const runShutdown = async (hooks: {
+    beforeStop?: () => void | Promise<void>
+    afterStop?: () => void | Promise<void>
+  }) => {
+    const errors: string[] = []
+    const logger = {
+      ...createMockLogger(),
+      error: (msg: string | Error) => errors.push(String(msg)),
+    }
+    const server = new PikkuNodeHTTPServer(
+      { port: 0, hostname: '127.0.0.1' },
+      logger as any
+    )
+    await server.init()
+    await server.start()
+
+    const realExit = process.exit
+    const exited = new Promise<void>((resolve) => {
+      // The shutdown ends in process.exit, which would take the test runner
+      // with it; swapping it out is the only way to observe what ran first.
+      process.exit = (() => {
+        resolve()
+      }) as never
+    })
+    try {
+      server.enableExitOnSignals(hooks)
+      process.emit('SIGTERM' as never)
+      await exited
+    } finally {
+      process.exit = realExit
+      process.removeAllListeners('SIGTERM')
+      await server.stop()
+    }
+    return { errors, listening: server.server.listening }
+  }
+
+  test('a rejected beforeStop does not skip the server stop', async () => {
+    const { errors, listening } = await runShutdown({
+      beforeStop: async () => {
+        throw new Error('beforeStop exploded')
+      },
+    })
+
+    assert.equal(
+      listening,
+      false,
+      'a hook that throws must not leave the socket open'
+    )
+    assert.ok(errors.some((e) => /beforeStop failed during shutdown/.test(e)))
+  })
+
+  test('a rejected beforeStop does not skip afterStop', async () => {
+    let afterStopRan = false
+    const { errors } = await runShutdown({
+      beforeStop: async () => {
+        throw new Error('beforeStop exploded')
+      },
+      afterStop: async () => {
+        afterStopRan = true
+      },
+    })
+
+    assert.ok(afterStopRan, 'afterStop owes the app its teardown either way')
+    assert.ok(errors.some((e) => /beforeStop failed during shutdown/.test(e)))
+  })
+
+  test('a rejected afterStop is logged rather than thrown', async () => {
+    const { errors, listening } = await runShutdown({
+      afterStop: async () => {
+        throw new Error('afterStop exploded')
+      },
+    })
+
+    assert.equal(listening, false)
+    assert.ok(errors.some((e) => /afterStop failed during shutdown/.test(e)))
+  })
+})

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
@@ -177,6 +177,16 @@ const HARDENING_DEFAULTS = {
  * else (Cloudflare Workers, a load balancer, `pikku dev` proxy) sits in
  * front, this is the right default.
  */
+/**
+ * Work the process owes its app on the way down, run around the service
+ * teardown `enableExitOnSignals` already does. A failing hook is logged and
+ * shutdown continues: a process that has been told to stop has to stop.
+ */
+export type ShutdownHooks = {
+  beforeStop?: () => void | Promise<void>
+  afterStop?: () => void | Promise<void>
+}
+
 export class PikkuNodeHTTPServer {
   public server: Server
   private listening = false
@@ -957,12 +967,16 @@ export class PikkuNodeHTTPServer {
     }
   }
 
-  public enableExitOnSignals(): void {
+  public enableExitOnSignals(hooks?: ShutdownHooks): void {
     const shutdown = async (signal: string) => {
       this.logger.info(`pikku-node-http-server: ${signal} received, stopping`)
       try {
+        await hooks?.beforeStop?.()
         await stopSingletonServices()
         await this.stop()
+        await hooks?.afterStop?.()
+      } catch (error) {
+        this.logger.error(`pikku-node-http-server: shutdown hook failed`, error)
       } finally {
         process.exit(0)
       }

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
@@ -968,15 +968,31 @@ export class PikkuNodeHTTPServer {
   }
 
   public enableExitOnSignals(hooks?: ShutdownHooks): void {
+    /**
+     * Every step of the shutdown is isolated from the ones after it. Sharing
+     * one catch means a hook that throws takes the service teardown and the
+     * socket close down with it, leaving the process to exit with connections
+     * still open and services still holding their handles.
+     */
+    const phase = async (name: string, run: () => void | Promise<void>) => {
+      try {
+        await run()
+      } catch (error) {
+        this.logger.error(
+          `pikku-node-http-server: ${name} failed during shutdown`,
+          error
+        )
+      }
+    }
     const shutdown = async (signal: string) => {
       this.logger.info(`pikku-node-http-server: ${signal} received, stopping`)
       try {
-        await hooks?.beforeStop?.()
-        await stopSingletonServices()
-        await this.stop()
-        await hooks?.afterStop?.()
-      } catch (error) {
-        this.logger.error(`pikku-node-http-server: shutdown hook failed`, error)
+        await phase('beforeStop', () => hooks?.beforeStop?.())
+        await phase('stopping singleton services', () =>
+          stopSingletonServices()
+        )
+        await phase('stopping the server', () => this.stop())
+        await phase('afterStop', () => hooks?.afterStop?.())
       } finally {
         process.exit(0)
       }

--- a/packages/services/better-auth/src/admin-users.test.ts
+++ b/packages/services/better-auth/src/admin-users.test.ts
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
-import { createAuthUser } from './admin-users.js'
+import { createAuthUser, setAuthUserPassword } from './admin-users.js'
 
-const authWith = (internalAdapter: Record<string, any>) => {
+const authWith = (
+  internalAdapter: Record<string, any>,
+  context: Record<string, any> = {}
+) => {
   const calls: string[] = []
   const traced = Object.fromEntries(
     Object.entries(internalAdapter).map(([name, fn]) => [
@@ -21,6 +24,7 @@ const authWith = (internalAdapter: Record<string, any>) => {
           hash: async (password: string) => `hashed:${password}`,
         },
         internalAdapter: traced,
+        ...context,
       },
     }) as any
   return { auth, calls }
@@ -92,5 +96,198 @@ describe('createAuthUser', () => {
       createAuthUser(auth, { email: 'a@b.com', password: 'longenough' }),
       /user user-1 could not be removed/
     )
+  })
+})
+
+describe('credential accounts across better-auth schema versions', () => {
+  test('a legacy schema is linked without an issuer it has no column for', async () => {
+    let linked: any
+    const { auth } = authWith(
+      {
+        findUserByEmail: async () => null,
+        createUser: async () => ({ id: 'user-1' }),
+        linkAccount: async (account: any) => {
+          linked = account
+        },
+        deleteUser: async () => undefined,
+      },
+      { tables: { account: { fields: {} } } }
+    )
+
+    await createAuthUser(auth, { email: 'a@b.com', password: 'longenough' })
+
+    // Before 1.7 the column does not exist and writing it fails the insert.
+    assert.equal('issuer' in linked, false)
+    assert.equal(linked.accountId, 'user-1')
+  })
+
+  test('an issuer-aware schema is linked with the credential issuer', async () => {
+    let linked: any
+    const { auth } = authWith(
+      {
+        findUserByEmail: async () => null,
+        createUser: async () => ({ id: 'user-1' }),
+        linkAccount: async (account: any) => {
+          linked = account
+        },
+        deleteUser: async () => undefined,
+      },
+      { tables: { account: { fields: { issuer: {} } } } }
+    )
+
+    await createAuthUser(auth, { email: 'a@b.com', password: 'longenough' })
+
+    // From 1.7 sign-in filters on the issuer, so an account written without
+    // one is invisible to every path that would use it.
+    assert.equal(linked.issuer, 'local:credential')
+    assert.equal(linked.accountId, 'user-1')
+  })
+})
+
+describe('setAuthUserPassword', () => {
+  const passwordContext = (
+    accounts: any[],
+    fields: Record<string, unknown>
+  ) => {
+    const updatedAccounts: Array<[string, any]> = []
+    const passwords: Array<[string, string]> = []
+    let created: any
+    const { auth, calls } = authWith(
+      {
+        findUserById: async () => ({ id: 'user-1' }),
+        findAccounts: async () => accounts,
+        updateAccount: async (id: string, values: any) =>
+          updatedAccounts.push([id, values]),
+        updatePassword: async (userId: string, hashed: string) =>
+          passwords.push([userId, hashed]),
+        createAccount: async (account: any) => {
+          created = account
+        },
+      },
+      { tables: { account: { fields } } }
+    )
+    return {
+      auth,
+      calls,
+      updatedAccounts,
+      passwords,
+      created: () => created,
+    }
+  }
+
+  test('a missing user is refused before anything is written', async () => {
+    const { auth, calls } = authWith({
+      findUserById: async () => null,
+      findAccounts: async () => [],
+      createAccount: async () => undefined,
+    })
+
+    await assert.rejects(
+      setAuthUserPassword(auth, {
+        userId: 'user-1',
+        newPassword: 'longenough',
+      }),
+      /User not found/
+    )
+    assert.deepEqual(calls, ['findUserById'])
+  })
+
+  test('a short password is refused before the user is even looked up', async () => {
+    const { auth, calls } = authWith({
+      findUserById: async () => ({ id: 'user-1' }),
+      findAccounts: async () => [],
+      createAccount: async () => undefined,
+    })
+
+    await assert.rejects(
+      setAuthUserPassword(auth, { userId: 'user-1', newPassword: 'short' }),
+      /at least 8 characters/
+    )
+    assert.deepEqual(calls, [])
+  })
+
+  test('a user with no credential account gets one created', async () => {
+    const ctx = passwordContext([{ id: 'acc-1', providerId: 'google' }], {})
+
+    await setAuthUserPassword(ctx.auth, {
+      userId: 'user-1',
+      newPassword: 'longenough',
+    })
+
+    assert.equal(ctx.created().accountId, 'user-1')
+    assert.equal(ctx.created().providerId, 'credential')
+    assert.equal(ctx.created().password, 'hashed:longenough')
+    assert.equal('issuer' in ctx.created(), false)
+  })
+
+  test('a created credential account carries the issuer when the schema has one', async () => {
+    const ctx = passwordContext([], { issuer: {} })
+
+    await setAuthUserPassword(ctx.auth, {
+      userId: 'user-1',
+      newPassword: 'longenough',
+    })
+
+    assert.equal(ctx.created().issuer, 'local:credential')
+    assert.equal(ctx.created().accountId, 'user-1')
+  })
+
+  test('an existing credential account has its password updated in place', async () => {
+    const ctx = passwordContext(
+      [{ id: 'acc-1', providerId: 'credential', issuer: 'local:credential' }],
+      { issuer: {} }
+    )
+
+    await setAuthUserPassword(ctx.auth, {
+      userId: 'user-1',
+      newPassword: 'longenough',
+    })
+
+    assert.deepEqual(ctx.passwords, [['user-1', 'hashed:longenough']])
+    assert.equal(ctx.created(), undefined)
+  })
+
+  test('a credential account written without an issuer is repaired', async () => {
+    const ctx = passwordContext([{ id: 'acc-1', providerId: 'credential' }], {
+      issuer: {},
+    })
+
+    await setAuthUserPassword(ctx.auth, {
+      userId: 'user-1',
+      newPassword: 'longenough',
+    })
+
+    // An account stamped by an older pikku is invisible to 1.7 sign-in until
+    // its issuer matches what sign-in filters on.
+    assert.deepEqual(ctx.updatedAccounts, [
+      ['acc-1', { issuer: 'local:credential' }],
+    ])
+    assert.deepEqual(ctx.passwords, [['user-1', 'hashed:longenough']])
+  })
+
+  test('a matching issuer is left alone', async () => {
+    const ctx = passwordContext(
+      [{ id: 'acc-1', providerId: 'credential', issuer: 'local:credential' }],
+      { issuer: {} }
+    )
+
+    await setAuthUserPassword(ctx.auth, {
+      userId: 'user-1',
+      newPassword: 'longenough',
+    })
+
+    assert.deepEqual(ctx.updatedAccounts, [])
+  })
+
+  test('a legacy schema never writes the column it does not have', async () => {
+    const ctx = passwordContext([{ id: 'acc-1', providerId: 'credential' }], {})
+
+    await setAuthUserPassword(ctx.auth, {
+      userId: 'user-1',
+      newPassword: 'longenough',
+    })
+
+    assert.deepEqual(ctx.updatedAccounts, [])
+    assert.deepEqual(ctx.passwords, [['user-1', 'hashed:longenough']])
   })
 })

--- a/packages/services/better-auth/src/admin-users.ts
+++ b/packages/services/better-auth/src/admin-users.ts
@@ -21,6 +21,25 @@ export type AuthGetter = (() => Promise<BetterAuthInstance>) | undefined
  * Ban state is written here but enforced by the {@link ban} plugin, which must
  * be wired for the columns to exist.
  */
+/**
+ * The issuer better-auth stamps on accounts from providers that have none of
+ * their own, for the versions that have the column.
+ *
+ * From 1.7 a credential account is looked up by its issuer as well as its
+ * provider — sign-in, `updatePassword` and `findCredentialAccount` all filter on
+ * it — so an account written without one is invisible to every path that would
+ * use it, and a user who plainly exists is reported as not found. Before 1.7 the
+ * column does not exist and writing it fails the insert, so the field is
+ * included only when the resolved schema has it.
+ *
+ * The value is better-auth's own encoding rather than its exported helper: the
+ * helper does not exist in the versions this package still supports.
+ */
+const CREDENTIAL_ISSUER = 'local:credential'
+
+const credentialIssuerFields = (ctx: any): { issuer?: string } =>
+  ctx.tables?.account?.fields?.issuer ? { issuer: CREDENTIAL_ISSUER } : {}
+
 const context = async (auth: AuthGetter) => {
   if (!auth) {
     throw new Error(
@@ -81,6 +100,7 @@ export const createAuthUser = async (
         userId: user.id,
         accountId: user.id,
         providerId: 'credential',
+        ...credentialIssuerFields(ctx),
         password: await ctx.password.hash(password),
       })
     } catch (error) {
@@ -115,13 +135,21 @@ export const setAuthUserPassword = async (
 
   const hashed = await ctx.password.hash(newPassword)
   const accounts = await ctx.internalAdapter.findAccounts(userId)
-  if (accounts.some((account: any) => account.providerId === 'credential')) {
+  const credential = accounts.find(
+    (account: any) => account.providerId === 'credential'
+  )
+  if (credential) {
+    const issuerFields = credentialIssuerFields(ctx)
+    if (issuerFields.issuer && credential.issuer !== issuerFields.issuer) {
+      await ctx.internalAdapter.updateAccount(credential.id, issuerFields)
+    }
     await ctx.internalAdapter.updatePassword(userId, hashed)
   } else {
     await ctx.internalAdapter.createAccount({
       userId,
       accountId: userId,
       providerId: 'credential',
+      ...credentialIssuerFields(ctx),
       password: hashed,
     })
   }


### PR DESCRIPTION
What a generated entry owes the app it starts: the database it was never handed — on either engine — the lifecycle it never ran, and the shutdown it gave up on halfway.

## The database the runtime never provided

`createSingletonServices` receives `kysely` from whatever hosts the app — `pikku dev` builds one, a Cloudflare deploy binds one — so app code (and the generated templates) is written expecting it and throws outright without it.

The standalone provider is its own host and supplied nothing. A bundle built from a project with a database started, called the services factory, and died inside it. In practice the standalone artifact was only startable by projects with no database at all.

`EntryGenerationContext` gains a `db` descriptor, populated by the build pipeline from whichever migrations directory the project actually wrote — `db/sqlite/` or `db/postgres/`, the two conventions the migrator already emits to. The generated entry then opens the connection itself and passes it into `createSingletonServices`.

Having both directories is refused rather than resolved. Choosing between them would choose which database the deployed app talks to on the strength of directory order, and the failure — an app running happily against the wrong but entirely valid schema — stays invisible until someone reads the data.

Each runtime gets the dialect it can actually use:

- node → `createNodeSqliteKysely` (`@pikku/kysely-node-sqlite`)
- bun → `createBunSqliteKysely` (`@pikku/kysely-bun-sqlite`), since a compiled bun binary has no `node:sqlite` to reach for

Postgres connects through `PikkuKysely` (`@pikku/kysely-postgres`) from `DATABASE_URL` — the variable every other pikku host already reads, so an artifact dropped onto a machine already running a pikku app needs no new one. An unset `DATABASE_URL` fails by name rather than as a driver error about an undefined connection string, and the pool is closed in `afterStop`: after the app's own stop hook and the draining server have both finished with it, since a pool closed any earlier takes the queries they are still entitled to make down with it. SQLite needs no counterpart — the process exiting releases the file.

The project's coercion map is applied to either engine, so a deployed app and `pikku dev` agree about which columns are dates and which are booleans. It is attached when the project generated one and skipped when it did not: the map is built from `db/annotations.ts` rather than from the dialect, so an app that annotates no columns has nothing to coerce rather than being one that should boot with no database at all. That gate is a fix in its own right — a missing coercion map previously returned no `db` descriptor, so such an app started with no connection.

### Where the SQLite file lives

Located via `PIKKU_DATA_DIR` rather than derived from the bundle's own path — a release swap would otherwise delete the database along with the directory it sat in. `PIKKU_DATABASE_FILE` overrides it for when the path has to match one something else already chose, notably `pikku db migrate`, which must open the same file or the app serves an unmigrated schema. With neither set, boot fails naming the variable instead of surfacing as a SQLite error about `undefined/pikku.db`.

## The lifecycle the entry never ran

`pikkuServerLifecycle` was only ever called by `pikku dev` and `pikku serve`. An app that seeds its first admin account, probes a dependency, or warms a cache in `beforeStart` did all of that in development and silently skipped it everywhere it was actually deployed.

The standalone entry and the shared node server entry — the one behind every `target: 'server'` unit — now import the app's lifecycle and call it: `beforeStart` after `init` and before the port opens, so work that must finish before the first request has; `afterStart` once the server is listening; and the stop hooks handed to the signal handler that already owns shutdown, rather than a second listener racing it.

Separately, `createAuthUser` and `setAuthUserPassword` wrote credential accounts with no `issuer`. From better-auth 1.7 a credential account is matched by its issuer as well as its provider, so those accounts were invisible to sign-in, `updatePassword` and `findCredentialAccount` — a user who plainly existed in the table was reported as "user not found". The field is written only when the resolved schema has it, so older better-auth keeps working, and `setAuthUserPassword` repairs an account that predates the fix.

## The shutdown that gave up halfway

`enableExitOnSignals` wrapped every shutdown phase in one try/catch, so a rejected `beforeStop` took the service teardown, the socket close *and* `afterStop` down with it before force-exiting — the opposite of what the `ShutdownHooks` doc directly above it promised. Each phase now catches and names its own failure, in both the node and bun runtimes:

```ts
await phase('beforeStop', () => hooks?.beforeStop?.())
await phase('stopping singleton services', () => stopSingletonServices())
await phase('stopping the server', () => this.stop())
await phase('afterStop', () => hooks?.afterStop?.())
```

This covers `stopSingletonServices()` and `this.stop()` too, not just the hooks — a service whose `stop()` threw was previously enough to leave the socket open.

## Tests

`adapter.test.ts` covers the database wiring across node and bun. The database-file precedence is executed rather than grepped: the test pulls the generated `__pikkuRequireDataDir` helper and the `__pikkuDbFile` expression out of the entry source and evaluates them against a supplied env, so a regression that always took the data-directory branch fails instead of passing on a string match.

`pikku-node-http-server.test.ts` gains three shutdown failure-path cases that start a real server on port 0, stub `process.exit`, emit `SIGTERM` and assert on what ran. All three fail against the pre-fix code.

`admin-users.test.ts` gains ten cases for the issuer branches — the legacy schema that has no such column, the issuer-aware write, the mismatched-issuer repair, the matching-issuer no-op, and every `setAuthUserPassword` path. The three issuer-behaviour cases fail against `main`.

Green: deploy-standalone 49/49, better-auth 216/216, node-http-server 40/40, bun-server 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standalone deployments now initialize their own SQLite database connections.
  * Added configurable database locations through `PIKKU_DATA_DIR` and `PIKKU_DATABASE_FILE`.
  * Server lifecycle hooks now run consistently during startup and shutdown across deployment modes.
  * Credential accounts now support improved sign-in compatibility with better-auth.

* **Bug Fixes**
  * Improved shutdown handling so individual hook failures do not interrupt service teardown.
  * Prevented competing signal listeners during shutdown.
  * Added clearer errors when required database location settings are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

