### PR TITLE
docs(skills): state that the webhook primitive owns no subscription model

### DIFF
--- a/.changeset/webhook-skill-subscription-boundary.md
+++ b/.changeset/webhook-skill-subscription-boundary.md
@@ -1,0 +1,5 @@
+---
+'@pikku/skills': patch
+---
+
+pikku-webhook: state that the primitive owns no subscription model, and that the endpoint table is the app's to build

--- a/packages/skills/skills/pikku-webhook/SKILL.md
+++ b/packages/skills/skills/pikku-webhook/SKILL.md
@@ -121,6 +121,31 @@ With neither secret set, deliveries go **unsigned**. A missing named secret is
 logged as an error and still sends unsigned; treat that log line as a
 misconfiguration, not noise.
 
+## What this does not give you
+
+There is no subscription model. `webhookSchema` owns exactly two tables —
+`webhookDelivery` and `webhookDeliveryAttempt` — and both are delivery-side
+history. Nothing stores _which_ URL belongs to which customer, which events
+they asked for, or whether their endpoint is still enabled.
+
+That is the app's table, and every app that exposes webhooks to its users
+needs one:
+
+| Column    | Why                                                                                                           |
+| --------- | ------------------------------------------------------------------------------------------------------------- |
+| `url`     | where to POST                                                                                                 |
+| `secret`  | the raw HMAC key, passed as `SendWebhookInput.secret`                                                         |
+| `events`  | which event names this endpoint subscribed to                                                                 |
+| `enabled` | so a failing endpoint can be paused without deleting it                                                       |
+| scope     | the org/tenant column you filter on — mirror it into `organizationId` so the delivery log scopes the same way |
+
+So one emitted event becomes a `SELECT` over your endpoint table and one
+`send()` per row. Everything after that call — signing, queueing, retrying,
+recording — is the primitive's.
+
+The single-integration case needs none of this: one fixed URL on the row it
+belongs to, and `send()` straight at it.
+
 ## Verifying on the receiving side
 
 `sign()` produces `sha256=<hex>` (GitHub style, body only, no timestamp) into


### PR DESCRIPTION
The `pikku-webhook` skill's frontmatter lists *"build a webhook endpoint settings screen"* as a trigger, but nothing in the body said that endpoint table is the app's to build.

`webhookSchema` owns exactly two tables — `webhookDelivery` and `webhookDeliveryAttempt` — both delivery-side history. Nothing stores which URL belongs to which customer, which events they subscribed to, or whether the endpoint is still enabled. The only hint was a passing clause in the secrets table ("held in your own table").

Adds a **What this does not give you** section: the boundary, the columns an app's endpoint table needs, the `SELECT`-then-`send()`-per-row shape, and a note that the single-integration case needs none of it.

Found while building an event fan-out on the primitive in a downstream app and reaching for the skill to answer exactly this question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that webhook functionality provides delivery and attempt history, not endpoint subscription management.
  * Documented that applications must maintain endpoint details, select matching endpoints, and send webhooks accordingly.
  * Added guidance for applications using a single fixed integration endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->