### PR TITLE
fix(ci): publish over OIDC trusted publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -476,6 +476,15 @@ jobs:
     # What stays: validate-deps (workspace-protocol deps and peer ranges are
     # precisely what must not reach npm), lint, build, unit-tests, e2e.
     needs: [validate-deps, build, lint, unit-tests, e2e]
+    # Publishing is npm trusted publishing (OIDC), so the job needs to mint an
+    # id-token. Naming any permission drops the repo-wide `write` default for
+    # every one not listed, so the two this job already relied on are spelled
+    # out: `contents` pushes the git tags and creates the GitHub releases the
+    # binary upload then attaches to, and `pull-requests` opens Version Packages.
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
@@ -494,10 +503,14 @@ jobs:
           version: node .github/changeset-version.cjs
           publish: yarn release
           createGithubReleases: true
+        # No NPM_TOKEN, deliberately. npm now demands a 2FA OTP that a classic
+        # token cannot answer, which is what had every release since 2026-09-02
+        # failing on `child "otp" fails`. Trusted publishing is exempt — but in
+        # yarn the OIDC branch sits *after* the token check, so a token left in
+        # this env would short-circuit OIDC and put the failure straight back.
+        # changesets/action is likewise guarded on NPM_TOKEN being absent.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: '0'
       - name: Upload CLI native binaries to GitHub Release
         if: steps.changesets.outputs.published == 'true'

--- a/scripts/npm-trust-publishers.mjs
+++ b/scripts/npm-trust-publishers.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+// Points every publishable package's npm trusted publisher at this repo's
+// Release workflow, so `yarn npm publish` authenticates over OIDC instead of a
+// token.
+//
+// Why a script: a trusted publisher is configured per package, and there are
+// ~70 of them. The npm UI would be that many identical forms; `npm trust` is
+// the same operation from the CLI, and doing them in one loop means one 2FA
+// prompt rather than one per package (npm opens a ~5 minute window after the
+// first).
+//
+// This cannot run in CI. `npm trust` refuses granular access tokens that bypass
+// 2FA, so it needs a human-authenticated `npm login` with 2FA on the account.
+//
+//   node scripts/npm-trust-publishers.mjs --dry-run   # print the commands
+//   node scripts/npm-trust-publishers.mjs             # apply them
+//   node scripts/npm-trust-publishers.mjs --list      # show current state
+import { execFileSync } from 'node:child_process'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+const REPO = 'pikkujs/pikku'
+// The filename, not the workflow's `name:`. npm matches the path under
+// `.github/`, so the "Release" workflow is `main.yml` here.
+const WORKFLOW = 'main.yml'
+
+// Every directory a publishable package can live in. `templates/`, `verifiers/`
+// and `e2e/` are private by definition, so they are not walked at all.
+const PACKAGE_ROOTS = ['packages']
+
+const args = new Set(process.argv.slice(2))
+const dryRun = args.has('--dry-run')
+const list = args.has('--list')
+
+function findPackageJsons(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist' || entry === '.deploy')
+      continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) findPackageJsons(full, out)
+    else if (entry === 'package.json') out.push(full)
+  }
+  return out
+}
+
+const names = []
+for (const root of PACKAGE_ROOTS) {
+  for (const file of findPackageJsons(join(ROOT, root))) {
+    let pkg
+    try {
+      pkg = JSON.parse(readFileSync(file, 'utf8'))
+    } catch {
+      continue
+    }
+    if (pkg.private === true || !pkg.name) continue
+    names.push(pkg.name)
+  }
+}
+names.sort()
+
+if (names.length === 0) {
+  console.error('No publishable packages found — refusing to continue.')
+  process.exit(1)
+}
+
+console.log(`${names.length} publishable packages`)
+console.log(`  repo:     ${REPO}`)
+console.log(`  workflow: ${WORKFLOW}\n`)
+
+const run = (argv) => execFileSync('npm', argv, { stdio: 'inherit', cwd: ROOT })
+
+const failures = []
+for (const name of names) {
+  const argv = list
+    ? ['trust', 'list', name]
+    : [
+        'trust',
+        'github',
+        name,
+        '--file',
+        WORKFLOW,
+        '--repo',
+        REPO,
+        '--allow-publish',
+        '--yes',
+      ]
+
+  if (dryRun) {
+    console.log(`npm ${argv.join(' ')}`)
+    continue
+  }
+
+  try {
+    run(argv)
+  } catch {
+    // Keep going: npm allows one trusted publisher per package, so a package
+    // that already has one errors rather than updating. Collecting them and
+    // reporting at the end beats stopping the loop and re-prompting for 2FA.
+    failures.push(name)
+  }
+}
+
+if (failures.length) {
+  console.error(`\n${failures.length} package(s) did not apply:`)
+  for (const name of failures) console.error(`  ${name}`)
+  console.error(
+    '\nA package that already has a trusted publisher must be revoked first:\n' +
+      '  npm trust list <pkg>\n' +
+      '  npm trust revoke <pkg> --id <trust-id>'
+  )
+  process.exit(1)
+}
+
+if (!dryRun && !list) {
+  console.log('\nAll packages configured.')
+}


### PR DESCRIPTION
Closes #1561.

Releases have been failing at the publish step since 2026-09-02 — npm now requires a 2FA OTP that a classic token cannot answer, so `yarn npm publish` fails with `child "otp" fails because ["otp" with value "not-otp" ...]`. Trusted publishing (OIDC) is exempt.

## The change

- `permissions:` on the `release` job with `id-token: write`. `contents: write` and `pull-requests: write` are spelled out because naming any permission drops the repo-wide `write` default, and the job pushes tags, creates GitHub releases and opens Version Packages.
- **`NPM_TOKEN` / `YARN_NPM_AUTH_TOKEN` removed.** Not kept as a fallback: in yarn the OIDC branch sits *after* the token check, so a token left in the env short-circuits OIDC and puts the failure straight back. `changesets/action@v1` is guarded on `if (process.env.NPM_TOKEN)` and falls through to "No NPM_TOKEN found, but OIDC is available - using npm trusted publishing".
- `scripts/npm-trust-publishers.mjs` — configures one trusted publisher per publishable package (68), bound to `pikkujs/pikku` + `main.yml`.

No toolchain change was needed: yarn **4.10.3**, the version pinned here, is the release that shipped the scoped-package OIDC fix (yarnpkg/berry#6911), and every package is `@pikku/*`.

## Before merging

The npm side must be configured first, or the first publish after merge fails for every package. It needs a 2FA login, so it can't run in CI:

```bash
npm whoami                                       # must be an account with 2FA
node scripts/npm-trust-publishers.mjs --dry-run  # review
node scripts/npm-trust-publishers.mjs            # apply (one 2FA prompt, ~5 min window)
node scripts/npm-trust-publishers.mjs --list     # verify
```

`npm trust` needs npm ≥ 11.15.0. The trusted publisher binds to the workflow *filename* (`main.yml`), not its `name:` ("Release").

## Verification

No test covers a real npm publish, so this is verified by reading the paths it goes through:

- yarn's `getOidcToken` returns null unless `GITHUB_ACTIONS` plus `ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN` are set — the last two exist only with `id-token: write`.
- changesets 3.0.0 selects `yarn npm publish` for a yarn-berry repo (`getPublishPlan.mjs:553-565`) and performs no auth check of its own.
- The workflow parses and the job's env is now `GITHUB_TOKEN` + `HUSKY` only.

The real proof is the first release run after merge.