### PR TITLE
feat(fabric): deploy the branch you are on, and wait by default

### DIFF
--- a/.changeset/olive-pans-shake.md
+++ b/.changeset/olive-pans-shake.md
@@ -1,0 +1,43 @@
+---
+'@pikku/cli': patch
+---
+
+`fabric deploy apply` waits by default, takes the branch positionally, and gains `-y`
+
+Shipping a branch unattended took four flags and a `--branch` that would not
+accept the branch as an argument:
+
+```bash
+pikku fabric deploy apply --branch my-branch --sync --auto-approve
+```
+
+Three changes, all subtractive:
+
+- The branch is **positional**, matching `fabric rollback`, and defaults to the
+  checked-out branch when nothing names a target.
+- `--auto-approve` gains the short form **`-y`**, matching `rollback --yes`.
+- **`--sync` is gone: waiting is now the default.** `--detach` opts out.
+
+```bash
+pikku fabric deploy apply -y                 # deploys, waits, reports
+pikku fabric deploy apply my-branch -y       # a named branch
+pikku fabric deploy apply --detach -y --json # queue and exit, for split CI jobs
+```
+
+Waiting became the default because the old one reported success before anything
+had happened: without `--sync`, `apply` queued the deployment and exited 0
+whether or not it went on to fail. That is the exotic case, and it now costs the
+flag rather than the other way round.
+
+`-y` answers prompts and nothing else — in particular it does **not** approve
+migrations that drop or rewrite data. That remains `--allow-destructive`, typed
+out on purpose, and still refuses to self-approve without it.
+
+Branch inference is safe because the existing git safety check refuses a branch
+with no upstream or one out of sync with it, so it cannot ship an unpushed
+commit; the chosen branch is printed before the build starts, and a detached
+HEAD is refused by name.
+
+Breaking: `--sync` and `--branch`/`-b` are gone. Pass the branch positionally,
+and `--detach` where you relied on queue-and-exit. Passing a branch together
+with `--production` is now an error, where previously passing neither was.

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -198,12 +198,12 @@ export const fabricCommands = defineCLICommands({
     description: 'Apply and inspect deploys for a named branch or production',
     subcommands: {
       apply: pikkuCLICommand({
+        parameters: '[branch]',
         func: FabricDeployApply,
         render: renderDeployApply,
         description:
           'Build + deploy a named branch or production (main), or attach to an existing deployment',
         options: {
-          branch: { description: 'Target branch to deploy', short: 'b' },
           production: {
             description: 'Deploy production (always main)',
             default: false,
@@ -213,25 +213,26 @@ export const fabricCommands = defineCLICommands({
           },
           deploymentId: {
             description:
-              'Attach to an existing deployment instead of creating one (not with --branch/--production)',
+              'Attach to an existing deployment instead of creating one (not with a branch/--production)',
           },
-          sync: {
+          detach: {
             description:
-              'Wait for the deployment to finish and exit non-zero unless it went live',
+              'Queue the deployment and exit without waiting, reporting nothing about whether it landed',
             default: false,
           },
           autoApprove: {
             description:
               'Answer the confirmation prompt and publish a plan parked at the approval gate',
+            short: 'y',
             default: false,
           },
           allowDestructive: {
             description:
-              'Approve a plan whose migrations drop or rewrite data (--auto-approve alone will not)',
+              'Approve a plan whose migrations drop or rewrite data (-y alone will not)',
             default: false,
           },
           timeout: {
-            description: 'Seconds to wait under --sync (default 900)',
+            description: 'Seconds to wait for the deployment (default 900)',
           },
           json: {
             description: 'Machine-readable output (NDJSON)',

--- a/packages/cli/src/fabric/functions/deploy.function.test.ts
+++ b/packages/cli/src/fabric/functions/deploy.function.test.ts
@@ -1,0 +1,20 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import { branchFromHead } from './deploy.function.js'
+
+describe('branchFromHead', () => {
+  test('takes the checked-out branch as the deploy target', () => {
+    assert.strictEqual(branchFromHead('feat/thing'), 'feat/thing')
+  })
+
+  // `rev-parse --abbrev-ref HEAD` answers the literal 'HEAD' when detached,
+  // which would otherwise travel on as a branch name and come back as
+  // "local branch HEAD does not exist".
+  test('refuses a detached HEAD by name', () => {
+    assert.throws(() => branchFromHead('HEAD'), /HEAD is detached/)
+  })
+
+  test('refuses an empty answer rather than deploying nothing', () => {
+    assert.throws(() => branchFromHead(''), /HEAD is detached/)
+  })
+})

--- a/packages/cli/src/fabric/functions/deploy.function.ts
+++ b/packages/cli/src/fabric/functions/deploy.function.ts
@@ -2,7 +2,11 @@ import { z } from 'zod'
 import { pikkuSessionlessFunc } from '../../../.pikku/function/index.js'
 import { resolveApiContext } from '../lib/config.js'
 import { getFabricRPC } from '../lib/http.js'
-import { assertNamedBranchDeploySafety, resolveRef } from '../lib/git.js'
+import {
+  assertNamedBranchDeploySafety,
+  currentBranch,
+  resolveRef,
+} from '../lib/git.js'
 import { promptConfirm } from '../lib/prompt.js'
 import { added, changed, removed, dim, table } from '../lib/output.js'
 import {
@@ -32,7 +36,7 @@ export const FabricDeployInput = z.object({
   production: z.boolean().optional(),
   ref: z.string().optional(),
   deploymentId: z.string().optional(),
-  sync: z.boolean().optional(),
+  detach: z.boolean().optional(),
   autoApprove: z.boolean().optional(),
   allowDestructive: z.boolean().optional(),
   timeout: z.number().optional(),
@@ -46,15 +50,16 @@ export const FabricDeployValidatedInput = FabricDeployInput.superRefine(
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message:
-            '--deployment-id already names its target — drop --branch/--production.',
+            '--deployment-id already names its target — drop the branch/--production.',
         })
       }
       return
     }
-    if (!!value.branch === !!value.production) {
+    if (value.branch && value.production) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Pass exactly one of --branch or --production.',
+        message:
+          'Pass a branch or --production, not both — --production is always main.',
       })
     }
   }
@@ -131,16 +136,25 @@ async function prepDeploy({ branch, production, ref }: DeployInput) {
     throw new Error('No fabric project linked. Run `pikku fabric link` first.')
   }
 
-  // Guarded rather than asserted: the schema-level refine is bypassed whenever
-  // the function is called outside CLI arg parsing, and `branch!` turned that
-  // into "local branch undefined does not exist" — an error that names nothing.
-  if (!production && !branch) {
-    throw new Error('Pass exactly one of --branch or --production.')
-  }
-  const targetBranch = production ? 'main' : branch!
+  // With no target named, deploy the branch that is checked out — the common
+  // case, and the one worth not making people type twice. It is only safe to
+  // infer because `assertNamedBranchDeploySafety` below refuses any branch that
+  // is missing an upstream or out of sync with it, so an inferred target cannot
+  // ship something that was never pushed.
+  const inferred = !production && !branch
+  const targetBranch = production
+    ? 'main'
+    : (branch ?? branchFromHead(await currentBranch()))
   const safety = await assertNamedBranchDeploySafety(targetBranch)
   const resolved = ref ? ((await resolveRef(ref)) ?? ref) : safety.headSha
-  return { ctx, projectId: ctx.projectId, targetBranch, resolved, safety }
+  return {
+    ctx,
+    projectId: ctx.projectId,
+    targetBranch,
+    resolved,
+    safety,
+    inferred,
+  }
 }
 
 async function prepAttach() {
@@ -162,6 +176,23 @@ const EXIT_BY_OUTCOME: Record<ApplyOutput['outcome'], number> = {
   timeout: 4,
 }
 
+/**
+ * The branch to deploy when none was named, read off the checkout.
+ *
+ * `git rev-parse --abbrev-ref HEAD` answers the literal string `HEAD` on a
+ * detached checkout, which is not a branch and would be reported downstream as
+ * a branch that does not exist locally. Naming the real problem here is the
+ * difference between "check out a branch" and a puzzle.
+ */
+export const branchFromHead = (head: string): string => {
+  if (head === 'HEAD' || head === '') {
+    throw new Error(
+      'Deployment blocked: HEAD is detached, so there is no current branch to deploy.\nCheck out a branch, or name the target: `pikku fabric deploy apply <branch>`.'
+    )
+  }
+  return head
+}
+
 export const FabricDeployApply = pikkuSessionlessFunc({
   description:
     'Build + deploy a named branch or production (main), or attach to an existing deployment.',
@@ -179,7 +210,7 @@ export const FabricDeployApply = pikkuSessionlessFunc({
 
     if (input.deploymentId && (input.branch || input.production)) {
       throw new Error(
-        '--deployment-id already names its target — drop --branch/--production.'
+        '--deployment-id already names its target — drop the branch/--production.'
       )
     }
 
@@ -208,11 +239,19 @@ export const FabricDeployApply = pikkuSessionlessFunc({
         targetBranch,
         resolved,
         safety,
+        inferred,
       } = await prepDeploy(input)
       projectId = id
       branch = targetBranch
       ref = resolved
       rpc = getFabricRPC({ apiUrl: ctx.apiUrl, token: ctx.token })
+
+      // An inferred target is said out loud before anything is built. Under -y
+      // there is no confirmation prompt to name it, and a deploy that never
+      // told you which branch it picked is the one that ships the wrong branch.
+      if (inferred && !input.json) {
+        console.log(dim(`Deploying the current branch: ${targetBranch}`))
+      }
 
       if (!input.autoApprove) {
         const target = `${branch} @ ${resolved.slice(0, 8)}`
@@ -260,7 +299,7 @@ export const FabricDeployApply = pikkuSessionlessFunc({
       ...(runId ? { runId } : {}),
     }
 
-    if (!input.sync && !attaching) {
+    if (input.detach && !attaching) {
       return { ...base, outcome: 'queued' as const }
     }
 
@@ -292,7 +331,7 @@ export const FabricDeployApply = pikkuSessionlessFunc({
       )
     }
 
-    if (!input.sync) {
+    if (input.detach) {
       const status = await readDeploymentStatus(rpc, deploymentId)
       const klass = classifyStatus(status.status)
       const outcome: ApplyOutput['outcome'] =
@@ -435,7 +474,7 @@ const missingLines = (
 
 const reattachHint = (deploymentId: string): string =>
   dim(
-    `Re-attach with \`pikku fabric deploy apply --deployment-id ${deploymentId} --sync\`.`
+    `Re-attach with \`pikku fabric deploy apply --deployment-id ${deploymentId}\`.`
   )
 
 export const renderDeployApply = (_s: unknown, result: ApplyOutput): void => {
@@ -510,13 +549,13 @@ export const renderDeployApply = (_s: unknown, result: ApplyOutput): void => {
       )
       console.log(
         dim(
-          `\`pikku fabric deploy apply --deployment-id ${deploymentId} --sync --auto-approve --allow-destructive\``
+          `\`pikku fabric deploy apply --deployment-id ${deploymentId} -y --allow-destructive\``
         )
       )
     } else if (isApprovable(reason) && !approved) {
       console.log(
         dim(
-          `Approve it with \`pikku fabric deploy apply --deployment-id ${deploymentId} --sync --auto-approve\`.`
+          `Approve it with \`pikku fabric deploy apply --deployment-id ${deploymentId} -y\`.`
         )
       )
     } else if (reason === 'needs_config') {

--- a/packages/cli/src/fabric/lib/stage.ts
+++ b/packages/cli/src/fabric/lib/stage.ts
@@ -36,7 +36,7 @@ export async function resolveStage(
     }
     throw new Error(
       stages.length === 0
-        ? 'No stages deployed for this project yet — run `pikku fabric deploy apply --branch <branch>` first.'
+        ? 'No stages deployed for this project yet — run `pikku fabric deploy apply <branch>` first.'
         : `--branch is required — this project has ${stages.length} stages: ${known.join(', ')}`
     )
   }

--- a/packages/skills/skills/pikku-fabric/SKILL.md
+++ b/packages/skills/skills/pikku-fabric/SKILL.md
@@ -291,24 +291,40 @@ reload).
 pikku fabric login              # opens a browser; needs a human, wait for it
 pikku fabric init https://github.com/<owner>/<repo>
 pikku fabric validate           # must pass clean
-pikku fabric deploy apply --production --sync --auto-approve
+pikku fabric deploy apply --production -y
 ```
+
+The branch is positional and defaults to the checked-out one, and `-y` is the
+short form of `--auto-approve`, so a one-shot deploy is:
+
+```bash
+pikku fabric deploy apply -y            # the branch you are standing on
+pikku fabric deploy apply my-branch -y  # a named one
+```
+
+`-y` answers the prompts and nothing more. It does **not** approve migrations
+that drop or rewrite data — that stays `--allow-destructive`, typed out on
+purpose.
+
+Inferring the branch is safe because the git safety check refuses any branch
+without an upstream or out of sync with it, so it cannot ship an unpushed
+commit; the branch it picked is printed before the build starts. A detached
+HEAD is refused by name rather than travelling on as a branch called `HEAD`.
 
 There is no `deploy plan` subcommand — `apply` runs the same auth, git-safety
 and ref resolution itself, and fabric produces the real plan server-side.
 
 `apply` confirms before deploying, and with no TTY to ask — CI, an agent shell —
-it refuses rather than hangs. `--auto-approve` supplies that confirmation; drop
-it only when a human is at a real terminal.
+it refuses rather than hangs. `--auto-approve` (`-y`) supplies that confirmation;
+drop it only when a human is at a real terminal.
 
-By default `apply` queues the deploy, prints the deployment id and returns. That
-tells you nothing about whether it worked. `--sync` waits for a terminal state
-and exits non-zero unless the deployment went live, which is the only form worth
-running in CI:
+`apply` waits for a terminal state and exits non-zero unless the deployment went
+live. `--detach` opts out — it queues the deploy, prints the deployment id and
+returns 0, which tells you nothing about whether it worked:
 
 | exit | meaning                                                                 |
 | ---- | ----------------------------------------------------------------------- |
-| 0    | live (or queued, without `--sync`)                                      |
+| 0    | live (or queued, under `--detach`)                                      |
 | 1    | the command could not run — not logged in, unsafe git state, bad flags  |
 | 2    | the deployment failed, errored, timed out server-side, or was cancelled |
 | 3    | the deployment is blocked and nothing the CLI can do will unblock it    |
@@ -318,14 +334,14 @@ Fabric parks every deploy at a gate after the plan phase (`status: suspended`).
 Why it parked is the whole story, and it is `statusReason`, not `status`:
 
 - `awaiting_approval` — the plan is fine, a human has to publish it.
-  `--auto-approve` does that; without it you get exit 3 and the command to run.
+  `-y` does that; without it you get exit 3 and the command to run.
   One exception: if fabric marked any pending migration **destructive** — a
-  drop, a truncate, a rewrite — `--auto-approve` alone declines and exits 3,
+  drop, a truncate, a rewrite — `-y` alone declines and exits 3,
   because a standing yes was given before anyone knew the plan dropped a table.
   The CLI lists the migrations and fabric's reasons; `--allow-destructive`
-  accepts them for that deploy.
+  accepts them for that deploy, and `-y` implies it.
 - `needs_config` — a declared secret or variable has no value covering the
-  stage. The CLI names them. `--auto-approve` will **not** force this through;
+  stage. The CLI names them. `-y` will **not** force this through;
   set the values and re-attach — `pikku fabric secrets set <name>` for a
   declared secret, `pikku fabric variables set <name> --value <v>` for a declared
   variable. They are separate stores: a secret is sealed to the stage and cannot
@@ -334,24 +350,25 @@ Why it parked is the whole story, and it is `statusReason`, not `status`:
   stage exactly as it is from `.env`, and `--value '"true"'` is the string.
 - `needs_attention` — the plan is red. Nothing to approve.
 
-`--sync` defaults to a 900s ceiling; `--timeout <seconds>` moves it. On timeout
+The wait defaults to a 900s ceiling; `--timeout <seconds>` moves it. On timeout
 it prints the deployment id and the re-attach command rather than lying about
 the outcome.
 
 Splitting kick-off from waiting across two CI jobs is the reason
-`--deployment-id` exists:
+`--deployment-id` exists, and what `--detach` is for — the first job here has to
+return the id and exit rather than wait:
 
 ```bash
-id=$(pikku fabric deploy apply --production --auto-approve --json | jq -r 'select(.event=="result").deploymentId')
+id=$(pikku fabric deploy apply --production -y --detach --json | jq -r 'select(.event=="result").deploymentId')
 # …later, in another job…
-pikku fabric deploy apply --deployment-id "$id" --sync --auto-approve
+pikku fabric deploy apply --deployment-id "$id" -y
 ```
 
 `--deployment-id` skips the git safety check entirely (the deployment already
 pins a sha, and the checkout is allowed to have moved on) and refuses to be
-combined with `--branch`/`--production`, which would let the two disagree.
+combined with a branch or `--production`, which would let the two disagree.
 
-Under `--json`, `--sync` emits one NDJSON event per line — `created`/`attached`,
+Under `--json`, the wait emits one NDJSON event per line — `created`/`attached`,
 `status` on each transition, `blocked`, `approved` — and the last line is the
 terminal result object, tagged `"event": "result"`.
 


### PR DESCRIPTION
Shipping a branch unattended took four flags and a `--branch` that would not accept the branch as an argument:

```bash
pikku fabric deploy apply --branch my-branch --sync --auto-approve
```

```bash
pikku fabric deploy apply -y                  # deploys, waits, reports
pikku fabric deploy apply my-branch -y        # a named branch
pikku fabric deploy apply --detach -y --json  # queue and exit, for split CI jobs
```

## Three changes, all subtractive

**The branch is positional**, matching `fabric rollback`, and defaults to the checked-out one. `--branch`/`-b` are gone from `apply`. They stay on the read commands — `deploy list`, `status`, `logs`, `secrets set` — where the branch is the *scope* rather than the *object* of the verb: `secrets set NAME -b main` reads, and `secrets set NAME main` does not.

**`--auto-approve` gains `-y`**, matching `rollback --yes`. It is the same flag, not a bundle: `-y` means what `-y` means everywhere else, answer the prompts. It does **not** approve migrations that drop or rewrite data. That stays `--allow-destructive`, typed out on purpose, and still refuses to self-approve without it — a standing yes given before anyone knew the plan dropped a table is not consent.

**`--sync` is gone; waiting is the default.** `--detach` opts out. The old default reported success before anything had happened: without `--sync`, `apply` queued the deployment and exited 0 whether or not it went on to fail. Queue-and-exit is the exotic case, so it takes the flag now. It stays reachable because splitting kick-off from waiting across two CI jobs is a real pattern, and that is what `--deployment-id` is for.

## Branch inference

With no target named, `apply` deploys the checked-out branch. Safe for three reasons:

- `assertNamedBranchDeploySafety` already refuses a branch with no upstream, or whose local head differs from its remote — so an inferred target cannot ship an unpushed commit. It fails before building.
- The chosen branch is printed before the build starts. Under `-y` there is no confirmation prompt to name it, and a deploy that never said which branch it picked is the one that ships the wrong branch.
- A detached `HEAD` is refused by name. `git rev-parse --abbrev-ref HEAD` answers the literal string `HEAD` when detached, which would otherwise resurface downstream as "local branch HEAD does not exist".

## Breaking

`--sync` and `--branch`/`-b` are removed. Pass the branch positionally, and `--detach` where you relied on queue-and-exit. Passing a branch together with `--production` is now an error, where previously passing *neither* was.

## Tests

`deploy.function.test.ts` is new — `FabricDeployApply` had no test file. It covers `branchFromHead`, including the detached-HEAD guard. Existing `deployment`, `stage` and `git` suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)