### PR TITLE
Let the actor sign-in gate take the opt-in from the caller

### DIFF
--- a/.changeset/cold-lions-count.md
+++ b/.changeset/cold-lions-count.md
@@ -1,0 +1,28 @@
+---
+'@pikku/better-auth': patch
+---
+
+Let the actor gate take the opt-in from the caller, not only `process.env`.
+
+`resolveActorSignIn()` read `PIKKU_ALLOW_ACTOR_SIGN_IN` off the environment and
+nowhere else, which quietly excluded the runtime most stages deploy to. A
+Cloudflare Worker has no populated `process.env`: bindings reach user code
+through the variables service, and workerd mirrors them into `process.env` only
+under `nodejs_compat_populate_process_env`, default for compatibility dates from
+2025-04-01. A deployment that pushed the opt-in as a binding — the only shape a
+Worker takes — therefore configured a stage whose gate could never see it, and
+`/sign-in/actor` answered `Actor sign-in is disabled outside \`pikku dev\`` with
+the value sitting right there on the script.
+
+`pikkuActor` now accepts `allowSignIn`, and `resolveActorSignIn(optIn?)` prefers
+it over the environment. Such a stage passes
+`await variables.get(ACTOR_SIGN_IN_OPT_IN_ENV)`, beside the secret it already
+reads there. Everything the gate decided before, it decides identically: only
+`passwordless-actor-sign-in` opens it, any other value is a logged near miss
+whose text still never reproduces what it was given, and provisioning stays a
+separate power held by `pikku dev` alone.
+
+The value is passed, never a boolean, and never baked in: what opens the gate
+remains something the deployment set and an operator can read back out of it.
+When a caller passes one, the environment is not consulted — a stage is opened by
+its own configuration or not at all.

--- a/examples/online-shop/src/auth.ts
+++ b/examples/online-shop/src/auth.ts
@@ -1,5 +1,10 @@
 import { betterAuth } from 'better-auth'
-import { pikkuActor, pikkuBan, pikkuFabric } from '@pikku/better-auth'
+import {
+  ACTOR_SIGN_IN_OPT_IN_ENV,
+  pikkuActor,
+  pikkuBan,
+  pikkuFabric,
+} from '@pikku/better-auth'
 import { pikkuBetterAuth } from '#pikku/auth'
 import {
   personaConfigs,
@@ -56,6 +61,10 @@ export const auth = pikkuBetterAuth(
     // every stage; locally it's simply absent, which disables /sign-in/fabric.
     // Asymmetric — the app verifies, it can never forge an operator login.
     const FABRIC_AUTH_PUBLIC_KEY = await variables.get('FABRIC_AUTH_PUBLIC_KEY')
+    // The opt-in that lets a deployed stage run scenarios. Read through
+    // `variables` rather than left to `process.env`, because a Worker receives
+    // it as a binding and has no populated environment to find it in.
+    const ALLOW_ACTOR_SIGN_IN = await variables.get(ACTOR_SIGN_IN_OPT_IN_ENV)
 
     return betterAuth({
       secret: BETTER_AUTH_SECRET,
@@ -106,7 +115,10 @@ export const auth = pikkuBetterAuth(
       // afterStart: that hook only ever runs under `pikku dev` and `pikku serve`,
       // so a deployed stage would provision nobody.
       plugins: [
-        pikkuActor({ secret: SCENARIO_ACTOR_SECRET }),
+        pikkuActor({
+          secret: SCENARIO_ACTOR_SECRET,
+          allowSignIn: ALLOW_ACTOR_SIGN_IN,
+        }),
         pikkuBan(),
         pikkuFabric({
           publicKey: FABRIC_AUTH_PUBLIC_KEY,

--- a/packages/services/better-auth/src/actor-plugin.test.ts
+++ b/packages/services/better-auth/src/actor-plugin.test.ts
@@ -35,7 +35,7 @@ const recordingLogger = () => {
 const makeAuth = (
   db: Record<string, any[]>,
   secret?: string,
-  options: { logger?: any } = {}
+  options: { logger?: any; allowSignIn?: string } = {}
 ) =>
   betterAuth({
     baseURL: 'http://localhost:3000',
@@ -43,7 +43,11 @@ const makeAuth = (
     database: memoryAdapter(db),
     emailAndPassword: { enabled: true },
     plugins: [
-      pikkuActor({ secret, logger: options.logger ?? recordingLogger() }),
+      pikkuActor({
+        secret,
+        allowSignIn: options.allowSignIn,
+        logger: options.logger ?? recordingLogger(),
+      }),
     ],
   })
 
@@ -304,6 +308,57 @@ describe('actor sign-in gate', () => {
       logger.lines.info.join('\n'),
       new RegExp(DEV_ACTOR_SIGN_IN_ENV)
     )
+  })
+
+  test('a caller that holds the opt-in itself opens the gate', async () => {
+    const db: Record<string, any[]> = { user: [], session: [], account: [] }
+    db.user!.push({
+      id: 'provisioned-1',
+      email: 'customer@actors.local',
+      name: 'customer',
+      actor: true,
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    assert.equal(
+      process.env[ACTOR_SIGN_IN_OPT_IN_ENV],
+      undefined,
+      'the environment is empty — this is the Worker case, where the opt-in arrives as a binding'
+    )
+    const res = await signInActor(
+      makeAuth(db, ROOT, { allowSignIn: ACTOR_SIGN_IN_OPT_IN_VALUE }),
+      {
+        email: 'customer@actors.local',
+        secret: await credentialFor('customer@actors.local'),
+      }
+    )
+    assert.equal(res.status, 200)
+  })
+
+  test('a passed opt-in is spelt exactly, and is not rescued by the environment', async () => {
+    const db: Record<string, any[]> = { user: [], session: [], account: [] }
+    process.env[ACTOR_SIGN_IN_OPT_IN_ENV] = ACTOR_SIGN_IN_OPT_IN_VALUE
+
+    const nearMiss = recordingLogger()
+    const refused = await signInActor(
+      makeAuth(db, ROOT, { allowSignIn: 'true', logger: nearMiss }),
+      {
+        email: 'customer@actors.local',
+        secret: await credentialFor('customer@actors.local'),
+      }
+    )
+    assert.equal(
+      refused.status,
+      401,
+      'the caller said where to read the opt-in from, so the environment is not consulted'
+    )
+    assert.match(
+      nearMiss.lines.warn.join('\n'),
+      new RegExp(ACTOR_SIGN_IN_OPT_IN_VALUE)
+    )
+    assert.doesNotMatch(nearMiss.lines.warn.join('\n'), /'true'/)
   })
 
   test('still declares the actor column while disabled', () => {

--- a/packages/services/better-auth/src/actor-plugin.ts
+++ b/packages/services/better-auth/src/actor-plugin.ts
@@ -31,6 +31,18 @@ export interface ActorPluginOptions {
     | string
     | undefined
     | (() => string | undefined | Promise<string | undefined>)
+  /**
+   * The opt-in that enables sign-in outside `pikku dev`, when the caller has
+   * already read it. Falls back to `process.env[ACTOR_SIGN_IN_OPT_IN_ENV]`.
+   *
+   * A Worker gets it as a binding rather than an environment variable, so a
+   * stage deployed there passes `await variables.get(ACTOR_SIGN_IN_OPT_IN_ENV)`
+   * here — the same call it already makes for its other deployment-supplied
+   * configuration. Only `ACTOR_SIGN_IN_OPT_IN_VALUE` opens the gate; any other
+   * value is refused and logged as a near miss, exactly as the environment
+   * variable is.
+   */
+  allowSignIn?: string
   /** Defaults to `console`: `actor()` is wired inside `betterAuth({...})`, where the app's logger is often not in scope. */
   logger?: Pick<Logger, 'info' | 'warn'>
 }
@@ -46,7 +58,7 @@ export interface ActorPluginOptions {
  */
 export const pikkuActor = (options: ActorPluginOptions): BetterAuthPlugin => {
   const logger = options.logger ?? console
-  const gate = resolveActorSignIn()
+  const gate = resolveActorSignIn(options.allowSignIn)
 
   if (gate.nearMissOptIn) {
     logger.warn(actorSignInNearMissMessage())

--- a/packages/services/better-auth/src/actor-sign-in-gate.ts
+++ b/packages/services/better-auth/src/actor-sign-in-gate.ts
@@ -32,14 +32,25 @@ export interface ActorSignInGate {
   nearMissOptIn: boolean
 }
 
-export const resolveActorSignIn = (): ActorSignInGate => {
+/**
+ * Resolves the gate, optionally from a value the caller already has.
+ *
+ * `optIn` exists because `process.env` is not where every runtime keeps its
+ * configuration. A Cloudflare Worker receives the opt-in as a binding, which
+ * reaches user code through the variables service and never appears on
+ * `process.env` unless the deployment opts into `nodejs_compat_populate_process_env`
+ * — so a gate that reads only the environment is shut on precisely the stages
+ * that deploy there. Passing the resolved value in keeps the decision in one
+ * place while letting the caller say where it read it from.
+ */
+export const resolveActorSignIn = (optIn?: string): ActorSignInGate => {
   const env = typeof process === 'undefined' ? undefined : process.env
-  const optIn = env?.[ACTOR_SIGN_IN_OPT_IN_ENV]
+  const resolvedOptIn = optIn ?? env?.[ACTOR_SIGN_IN_OPT_IN_ENV]
   const nearMissOptIn =
-    optIn !== undefined && optIn !== ACTOR_SIGN_IN_OPT_IN_VALUE
+    resolvedOptIn !== undefined && resolvedOptIn !== ACTOR_SIGN_IN_OPT_IN_VALUE
   const isDev = env?.[DEV_ACTOR_SIGN_IN_ENV] === 'true'
 
-  if (optIn === ACTOR_SIGN_IN_OPT_IN_VALUE) {
+  if (resolvedOptIn === ACTOR_SIGN_IN_OPT_IN_VALUE) {
     return {
       enabled: true,
       reason: 'allow-outside-dev-env',

--- a/packages/skills/skills/pikku-auth/references/better-auth.md
+++ b/packages/skills/skills/pikku-auth/references/better-auth.md
@@ -15,7 +15,6 @@ The only acceptable auth implementation in a Pikku app is the one described in t
 
 ---
 
-
 ## Installation
 
 ```bash
@@ -448,9 +447,14 @@ someone" means **a particular kind of user** rather than one fixed admin.
 Register it explicitly — it is not automatic:
 
 ```typescript
-import { pikkuActor } from '@pikku/better-auth'
+import { ACTOR_SIGN_IN_OPT_IN_ENV, pikkuActor } from '@pikku/better-auth'
 
-plugins: [pikkuActor({ secret: SCENARIO_ACTOR_SECRET })]
+plugins: [
+  pikkuActor({
+    secret: SCENARIO_ACTOR_SECRET,
+    allowSignIn: await variables.get(ACTOR_SIGN_IN_OPT_IN_ENV),
+  }),
+]
 ```
 
 `POST ${basePath}/sign-in/actor` `{ email, secret, name? }` → 200 + the normal
@@ -481,9 +485,19 @@ itself instead.
 A stage that genuinely must run scenarios opts in on purpose, with
 `PIKKU_ALLOW_ACTOR_SIGN_IN=passwordless-actor-sign-in`. Any other value is
 ignored and warned about, so the hatch cannot be opened by copying a `true` from
-the line above, and it is the only hatch — there is no build-time option, because
-an option compiled into the bundle cannot be audited from the environment it
-runs in.
+the line above.
+
+**Pass it in on any runtime without a populated `process.env`.** The gate reads
+the environment by default, which is enough for Node but not for a Worker: there
+the opt-in arrives as a binding and reaches user code through the variables
+service, so a gate left to `process.env` stays shut on exactly the stages a
+deployment targets. `allowSignIn` takes the value the caller already read —
+`await variables.get(ACTOR_SIGN_IN_OPT_IN_ENV)` — and is checked against the same
+literal, near-miss warning included. It is deliberately a value and not a flag:
+what opens the gate is still something the deployment set and an operator can
+read back out of it, never something compiled into the bundle. A value passed
+here is the one consulted, so the environment cannot quietly override what the
+stage was configured with.
 
 **Signing in and provisioning are separate powers.** An unknown address becomes
 an `actor: true` row only under `pikku dev`. With the opt-in set, a stage signs


### PR DESCRIPTION
`resolveActorSignIn()` reads `PIKKU_ALLOW_ACTOR_SIGN_IN` off `process.env` and nowhere else, which quietly excludes the runtime most stages deploy to.

A Cloudflare Worker has no populated `process.env`. Its bindings reach user code through the variables service — `@pikku/cloudflare` constructs `new LocalVariablesService(env)` and nothing in the tree ever writes to `process.env` — and workerd mirrors bindings into `process.env` only under `nodejs_compat_populate_process_env`, [default for compatibility dates from 2025-04-01](https://developers.cloudflare.com/workers/runtime-apis/nodejs/process/). A deployment that pushes the opt-in as a binding, which is the only shape a Worker takes, therefore configures a stage whose gate can never see it: `/sign-in/actor` answers `Actor sign-in is disabled outside \`pikku dev\`` with the value sitting right there on the script.

That is how it surfaced — a deployer pushing the opt-in to every non-production stage, correct on container stages and inert on Worker ones.

## The change

`pikkuActor` takes an optional `allowSignIn`, and `resolveActorSignIn(optIn?)` prefers it over the environment. Such a stage passes `await variables.get(ACTOR_SIGN_IN_OPT_IN_ENV)`, beside the secret it already reads there.

Everything the gate decided before, it decides identically:

- only `passwordless-actor-sign-in` opens it;
- any other value is a logged near miss whose text still never reproduces what it was given;
- provisioning stays a separate power held by `pikku dev` alone.

Two decisions worth naming, since the reference doc previously said there was no option at all:

- **It is a value, not a flag.** What opens the gate remains something the deployment set and an operator can read back out of it, never something compiled into the bundle — which was the reason the doc gave for having no option, and it still holds.
- **A passed value wins outright.** The environment is not consulted when the caller supplies one, so a stage is opened by its own configuration or not at all, rather than by whichever source happens to say yes.

## Testing

`packages/services/better-auth`: 218/218 pass, including two new cases — a caller-held opt-in opening the gate with the environment empty (the Worker case), and a near-miss passed value being refused, not rescued by a correct environment variable, and not echoed into the warning. `tsc --noEmit` clean.

Docs and `examples/online-shop` updated to read it through `variables`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Actor sign-in can now be enabled using deployment-provided configuration, including environments where `process.env` is unavailable.
  * Explicit configuration takes precedence when determining whether actor sign-in is allowed.
  * Only the approved opt-in value enables actor sign-in; invalid values remain blocked.

* **Documentation**
  * Updated authentication guidance and examples to show configuration through deployment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->