### PR TITLE
fix(knowledge): let the caller own the plan's closing instruction

### DIFF
--- a/.changeset/knowledge-plan-seam.md
+++ b/.changeset/knowledge-plan-seam.md
@@ -1,0 +1,14 @@
+---
+'@pikku/knowledge': patch
+---
+
+Let the caller own the plan's closing instruction, and export `basePlan`.
+
+`renderPlanForBuild` ended every plan with "then run `fabric build-complete`" — one
+product's CLI command in the mouth of every reader of a plan. It now takes an optional
+`closing` the driving harness supplies, and says nothing of its own. The comments naming
+`fabric verify` and `fabric build-complete` describe the same contract generically: a
+mid-build check and a closing gate.
+
+`basePlan` — one plan that passes every check, for tests to vary from — was built and
+shipped but never exported, so no consumer could reach it.

--- a/packages/knowledge/src/hollow-scenarios.ts
+++ b/packages/knowledge/src/hollow-scenarios.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 
 // How much a scenario PROVES, read statically off pikku's generated step meta — one JSON
-// read per scenario, no browser, no dev server, no instrumentation. Cheap enough for
-// `fabric verify` rather than only the closing gate.
+// read per scenario, no browser, no dev server, no instrumentation. Cheap enough for a
+// mid-build check rather than only the closing gate.
 //
 // `scenario-rpc-coverage.ts` answers which mutations a journey drives. It is blind to a
 // browser journey twice over: the scenario drives no RPC, so it contributes nothing there

--- a/packages/knowledge/src/index.ts
+++ b/packages/knowledge/src/index.ts
@@ -139,3 +139,5 @@ export {
 } from './plan-command.js'
 
 export { type MilestoneNote, MILESTONE_SCALARS } from './milestone.js'
+
+export { basePlan } from './plan-fixture.js'

--- a/packages/knowledge/src/plan-meta.ts
+++ b/packages/knowledge/src/plan-meta.ts
@@ -48,9 +48,9 @@ function shallowScenarioProblem(
 /**
  * Every planned scenario that exists but proves less than its level claims.
  *
- * Exported so `fabric verify` can say it as a warning mid-build without re-deriving the
- * whole shortfall — the finding is worth hearing while scenarios are still being written,
- * and `fabric build-complete` refuses on the same list at the end.
+ * Exported so a mid-build check can say it as a warning without re-deriving the whole
+ * shortfall — the finding is worth hearing while scenarios are still being written, and
+ * the closing gate refuses on the same list at the end.
  */
 export function shallowScenarioProblems(plan: Plan, meta: PikkuMeta): string[] {
   const problems: string[] = []
@@ -338,7 +338,7 @@ export type PlanChecklistItem = {
   kind: 'function' | 'wire' | 'scope' | 'scenario'
   done: boolean
   /**
-   * Promised by a later pass, so `fabric build-complete` never asks for it.
+   * Promised by a later pass, so the closing gate never asks for it.
    *
    * Set by `planShortfall`, which is the only caller that can see every pass at once —
    * `planProgress` works one pass at a time and leaves it false.
@@ -521,7 +521,7 @@ const RENAME_STATEMENT =
  * That leaves the `on delete cascade` sitting in a `create table` for the TEMPORARY name,
  * which the plan never mentions — so a literal match reads the migration as absent and
  * the gate refuses a build that did exactly the right thing. Run hmt09oj7q died there,
- * rewriting the same migration on every `fabric build-complete` until it was killed.
+ * rewriting the same migration on every closing gate until it was killed.
  *
  * Chains are followed to the end so a rebuild done twice still lands on the real table.
  */
@@ -619,7 +619,7 @@ export type PlanShortfallResult = Omit<PlanProgress, 'pass'> & {
  *
  * What the union cost instead: a milestone ships only when every pass is done, so plan SIZE
  * became fatal. Run hmt3fz3c0 planned 14 items whose 10 permission scenarios were the role x
- * resource cross product, refused `fabric build-complete` thirteen times, and surrendered
+ * resource cross product, failed the closing gate thirteen times, and surrendered
  * with a deployed, rendering, signed-in app carrying 15 passing scenarios. Blocking on pass 1
  * alone makes an over-large plan slow rather than fatal, which is the only durable answer
  * when the budget cannot be expressed as a number of items.

--- a/packages/knowledge/src/plan.test.ts
+++ b/packages/knowledge/src/plan.test.ts
@@ -621,3 +621,18 @@ test('a build defers one impossible pass-1 item, and only within its budget', ()
   )
   assert.match(renderPlanForBuild(second.plan), /DEFERRED/)
 })
+
+// What to do once pass 1 is built belongs to whoever drives the build, not to the plan
+// format: naming one harness's command here would put it in front of every reader.
+test('the closing instruction is the caller’s, and absent by default', () => {
+  const plan = basePlan()
+  const bare = renderPlanForBuild(plan)
+  assert.match(bare, /Build pass 1\./)
+  assert.equal(/then run/.test(bare), false)
+
+  const driven = renderPlanForBuild(
+    plan,
+    'When pass 1 is done, run `acme finish`.'
+  )
+  assert.match(driven, /When pass 1 is done, run `acme finish`\./)
+})

--- a/packages/knowledge/src/plan.ts
+++ b/packages/knowledge/src/plan.ts
@@ -423,8 +423,12 @@ export function readPlan(cwd: string, milestonePath: string): PlanRead {
  * An `n/a` slot is printed WITH its reason — the whole point of the discriminated slot is
  * that "no roles, because this app has one kind of user" and "nobody thought about roles"
  * stop looking alike, and that distinction is only useful if the builder sees it.
+ *
+ * @param closing what the agent should do once pass 1 is built, appended verbatim. The
+ * harness driving the build owns that instruction — naming one here would put a specific
+ * product's command in the mouth of every reader of a plan.
  */
-export function renderPlanForBuild(plan: Plan): string {
+export function renderPlanForBuild(plan: Plan, closing?: string): string {
   const lines: string[] = []
   const slot = <T>(
     name: string,
@@ -445,7 +449,8 @@ export function renderPlanForBuild(plan: Plan): string {
     plan.description,
     '',
     'PASS 1 COMPLETES THIS MILESTONE. Items marked pass 2 or higher are deferred — the gate does',
-    'not ask for them and the next milestone picks them up. Build pass 1, then run `fabric build-complete`.',
+    'not ask for them and the next milestone picks them up. Build pass 1.',
+    ...(closing ? [closing] : []),
     ''
   )
   slot(


### PR DESCRIPTION
## What

`renderPlanForBuild` ended every rendered plan with:

> Build pass 1, then run \`fabric build-complete\`.

A package that has no idea what is driving the build was naming one specific downstream product's CLI command to every reader of a plan. It now takes an optional `closing` the driving harness supplies, and says nothing of its own. The OSS `knowledge plan show --for-build` command passes none.

Five comments named `fabric verify` / `fabric build-complete` for what are really two roles in the contract — a mid-build check and a closing gate. They now say that instead.

Also exports `basePlan`. It was written to be shared ("Shared rather than copied because two suites now need a plan the reader accepts"), compiled into `dist/plan-fixture.js`, and left out of `index.ts` — so no consumer could import it, and every suite outside this package kept its own copy to drift. Fabric has a 106-line one it can now delete.

## Why it matters

This is the seam between the plan *document* — schema, parse, validate, genuinely reusable — and the *instruction to the agent consuming it*, which belongs to whoever owns that agent. The file boundary and the concern boundary didn't match, and the port followed the file boundary.

## Verification

`npm run build` clean, 232 tests pass (231 before, plus one asserting the closing is absent by default and appended verbatim when given).

🤖 Generated with [Claude Code](https://claude.com/claude-code)