### PR TITLE
fix(cli): report one stubbed-import finding per import, not per service

### DIFF
--- a/.changeset/olive-parrots-agree.md
+++ b/.changeset/olive-parrots-agree.md
@@ -1,0 +1,7 @@
+---
+'@pikku/cli': patch
+---
+
+Report one `services-static-stubbed-import` finding per import, not one per service that stubs it.
+
+`SERVICE_MODULE_MAP` deliberately shares a single pattern array between `agentRunner` and `ai`, so a validate run reported the same import twice with only the service name differing. The remedy is identical either way, so the first matching service names the finding.

--- a/packages/cli/src/functions/validate/shared-checks.ts
+++ b/packages/cli/src/functions/validate/shared-checks.ts
@@ -187,10 +187,14 @@ export const staticStubbedImports = (
     ) {
       continue
     }
-    for (const [service, patterns] of Object.entries(SERVICE_MODULE_MAP)) {
-      if (patterns.some((pattern) => pattern.test(specifier))) {
-        found.push({ module: specifier, service })
-      }
+    // Services share pattern arrays — the AI SDKs gate on both `agentRunner`
+    // and `ai` — so a per-service push reports one import as many findings.
+    // The remedy is the same whichever service names it: one entry per import.
+    const service = Object.entries(SERVICE_MODULE_MAP).find(([, patterns]) =>
+      patterns.some((pattern) => pattern.test(specifier))
+    )?.[0]
+    if (service) {
+      found.push({ module: specifier, service })
     }
   }
   return found


### PR DESCRIPTION
## Why

The Release run on `main` ([33799092903](https://github.com/pikkujs/pikku/actions/runs/33799092903)) failed on **Unit Tests**, and the release job `needs: [… unit-tests …]` — so nothing was published. `main` currently carries `@pikku/console@0.12.74`, `@pikku/addon-console@0.12.50` and `@pikku/cli@0.12.135` while npm is still one patch behind on all three.

## Cause

`SERVICE_MODULE_MAP` deliberately shares one pattern array between `agentRunner` and `ai` so the patterns stay identity-equal for `getDeadGenFilePatterns`. `staticStubbedImports` looped over every service and pushed a result per match, so a single `import { VercelAgentRunner } from '@pikku/ai-vercel'` produced two entries — and `validate` emitted two findings differing only in the service name.

```
actual:   [ '@pikku/ai-vercel', '@pikku/ai-vercel', '@ai-sdk/openai', '@ai-sdk/openai' ]
expected: [ '@pikku/ai-vercel', '@ai-sdk/openai' ]
```

## Fix

One entry per import specifier, named by the first service that gates it. The remedy the finding recommends — load the package through a dynamic import — is identical whichever service names it.

## Verification

Reproduced the failure on a clean `origin/main` worktree, then confirmed green after the fix:

- `shared-checks.test.ts`: 11 pass / 0 fail
- full `@pikku/cli` suite: 1449 pass / 2 fail, both failures being `.pikku/` codegen missing in a bare worktree (unrelated to this change; CI generates it during build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)