### PR TITLE
Move five skills out of Fabric, and fix --json

### DIFF
--- a/.changeset/better-auth-hardening-and-2fa.md
+++ b/.changeset/better-auth-hardening-and-2fa.md
@@ -1,0 +1,5 @@
+---
+'@pikku/skills': patch
+---
+
+pikku-auth's Better Auth reference gains two-factor, security hardening and post-signup hooks

--- a/.changeset/date-fields-arrive-as-date-objects.md
+++ b/.changeset/date-fields-arrive-as-date-objects.md
@@ -1,0 +1,5 @@
+---
+'@pikku/skills': patch
+---
+
+pikku-react's client reference now says what `transformDate: true` costs you: a date field arrives as a `Date`, so a string method on it throws and a raw one in JSX crashes the route.

--- a/.changeset/date-fields-arrive-as-date-objects.md
+++ b/.changeset/date-fields-arrive-as-date-objects.md
@@ -2,4 +2,4 @@
 '@pikku/skills': patch
 ---
 
-pikku-react's client reference now says what `transformDate: true` costs you: a date field arrives as a `Date`, so a string method on it throws and a raw one in JSX crashes the route.
+pikku-react's client reference now says what `transformDate: true` costs you: a fully-zoned ISO instant arrives as a `Date` while a bare or zoneless date stays a string, so one field's runtime type follows the value — a string method on a revived one throws, and a raw one in JSX crashes the route.

--- a/.changeset/five-skills-leave-fabric.md
+++ b/.changeset/five-skills-leave-fabric.md
@@ -1,0 +1,11 @@
+---
+'@pikku/skills': patch
+---
+
+Add `pikku-a11y`, `pikku-seo`, `pikku-permissions`, `pikku-list-query` and
+`pikku-realtime`, which lived in Fabric's sandbox image and are not about Fabric.
+
+None of them needs a sandbox, a console or the `fabric` CLI, so a local project
+gets the same guidance the hosted build agent has been getting. `pikku-realtime`
+carries the SSE and channel patterns inline rather than pointing at a scaffold
+command that only exists inside Fabric.

--- a/.changeset/json-output-for-every-command.md
+++ b/.changeset/json-output-for-every-command.md
@@ -1,0 +1,7 @@
+---
+'@pikku/core': patch
+---
+
+`--json` now serialises the result of any command, not only the eleven that ship a renderer of their own.
+
+The flag swapped in the JSON renderer only when a command-specific renderer existed, so on the other 94 commands it fell through to the program's default renderer — which prints forwarded log lines and drops anything else. `pikku info functions --json` therefore exited 0 and printed no JSON at all, which reads as "this command has no output" rather than as an unsupported flag.

--- a/.changeset/multi-app-decision-doctrine.md
+++ b/.changeset/multi-app-decision-doctrine.md
@@ -1,0 +1,5 @@
+---
+'@pikku/skills': patch
+---
+
+pikku-build's multi-app reference now says how to decide it is two apps, not just how to clone one

--- a/.changeset/no-fabric-commands-in-oss-corpus.md
+++ b/.changeset/no-fabric-commands-in-oss-corpus.md
@@ -1,0 +1,5 @@
+---
+'@pikku/skills': patch
+---
+
+The corpus now fails on a bare `fabric` command, which the OSS reader has no binary for

--- a/.changeset/review-fixes-list-realtime-workflow.md
+++ b/.changeset/review-fixes-list-realtime-workflow.md
@@ -1,0 +1,5 @@
+---
+'@pikku/skills': patch
+---
+
+Three review fixes across the wiring skills: pikku-list-query now caps `limit` and reads `filter` as the recursive AND/OR tree it is (a `'status' in filter` check silently returns unfiltered rows for a group or an operator leaf); pikku-realtime warns that `/events/:topic` is unauthenticated so a topic must carry a projection rather than `returningAll()`, and invalidates the `[name, input]` query key instead of hand-patching a `ListOutput`; pikku-workflow replaces "each step is its own transaction" — pikku opens none — with where atomicity actually comes from, plus provider idempotency keys for retried external side effects.

--- a/.changeset/ungrouped-skills-never-installed.md
+++ b/.changeset/ungrouped-skills-never-installed.md
@@ -1,0 +1,13 @@
+---
+'@pikku/skills': patch
+---
+
+Give `pikku-architect`, `pikku-build`, `pikku-knowledge` and
+`pikku-software-archaeology` an `installGroups`. A skill with none is skipped
+whenever any group is requested, so `pikku skills install --core` never
+installed these four — including the archaeology skill other tooling documents
+as installed by that command.
+
+Also qualify pikku-i18n's "do not wrap `m`" rule: wrapping the namespace is a
+real tradeoff (it forgoes per-message tree-shaking) rather than a mistake, and
+is worth it when it buys something the gate cannot, such as debug masking.

--- a/.changeset/workflow-decision-doctrine.md
+++ b/.changeset/workflow-decision-doctrine.md
@@ -1,0 +1,9 @@
+---
+'@pikku/skills': patch
+---
+
+Give `pikku-workflow` the "should this even BE a workflow?" section: the
+external-boundary test, the checkout-with/without-payment split, "one durable
+step is a queue worker, not a workflow", and "atomicity is a TRANSACTION, not a
+workflow". It answers the question that comes before choosing a factory, and it
+was only written down in Fabric's copy of the skill.

--- a/packages/core/src/wirings/cli/cli-runner.test.ts
+++ b/packages/core/src/wirings/cli/cli-runner.test.ts
@@ -829,4 +829,141 @@ describe('CLI Runner', () => {
       assert.ok(printed.includes('at '))
     })
   })
+  describe('--json output', () => {
+    const wireGreet = (renderers: Record<string, any>, defaultRenderer: any) => {
+      pikkuState(null, 'cli', 'meta', {
+        programs: {
+          'test-cli': {
+            program: 'test-cli',
+            commands: {
+              greet: {
+                command: 'greet',
+                pikkuFuncId: 'greetFunc',
+                positionals: [],
+                options: {},
+              },
+            },
+            options: {},
+          },
+        },
+        renderers: {},
+      })
+
+      pikkuState(null, 'cli', 'programs', {
+        'test-cli': { defaultRenderer, middleware: [], renderers },
+      })
+
+      pikkuState(null, 'function', 'meta', {
+        greetFunc: {
+          pikkuFuncId: 'greetFunc',
+          inputSchemaName: null,
+          outputSchemaName: null,
+          sessionless: true,
+        },
+      })
+
+      addFunction('greetFunc', {
+        func: async () => ({ name: 'Alice' }),
+        auth: false,
+      })
+    }
+
+    const captureStdout = async (fn: () => Promise<unknown>) => {
+      const lines: string[] = []
+      const original = console.log
+      console.log = (...args: unknown[]) => {
+        lines.push(args.map(String).join(' '))
+      }
+      try {
+        await fn()
+      } finally {
+        console.log = original
+      }
+      return lines
+    }
+
+    test('serialises the result for a command with no renderer of its own', async () => {
+      const textOnly = () => {}
+      wireGreet({}, textOnly)
+
+      const lines = await captureStdout(() =>
+        runCLICommand({
+          program: 'test-cli',
+          commandPath: ['greet'],
+          data: { json: true },
+          singletonServices,
+          createWireServices,
+        })
+      )
+
+      assert.deepEqual(lines, ['{"name":"Alice"}'])
+    })
+
+    test('--output json is equivalent to --json', async () => {
+      const textOnly = () => {}
+      wireGreet({}, textOnly)
+
+      const lines = await captureStdout(() =>
+        runCLICommand({
+          program: 'test-cli',
+          commandPath: ['greet'],
+          data: { output: 'json' },
+          singletonServices,
+          createWireServices,
+        })
+      )
+
+      assert.deepEqual(lines, ['{"name":"Alice"}'])
+    })
+
+    test('json overrides a command renderer', async () => {
+      let renderedWith: unknown
+      wireGreet(
+        {
+          greet: (_s: any, data: any) => {
+            renderedWith = data
+          },
+        },
+        () => {}
+      )
+
+      const lines = await captureStdout(() =>
+        runCLICommand({
+          program: 'test-cli',
+          commandPath: ['greet'],
+          data: { json: true },
+          singletonServices,
+          createWireServices,
+        })
+      )
+
+      assert.equal(renderedWith, undefined)
+      assert.deepEqual(lines, ['{"name":"Alice"}'])
+    })
+
+    test('without json the command renderer still wins', async () => {
+      let renderedWith: unknown
+      wireGreet(
+        {
+          greet: (_s: any, data: any) => {
+            renderedWith = data
+          },
+        },
+        () => {}
+      )
+
+      const lines = await captureStdout(() =>
+        runCLICommand({
+          program: 'test-cli',
+          commandPath: ['greet'],
+          data: {},
+          singletonServices,
+          createWireServices,
+        })
+      )
+
+      assert.deepEqual(renderedWith, { name: 'Alice' })
+      assert.deepEqual(lines, [])
+    })
+  })
 })

--- a/packages/core/src/wirings/cli/cli-runner.ts
+++ b/packages/core/src/wirings/cli/cli-runner.ts
@@ -391,10 +391,9 @@ export async function runCLICommand({
       const jsonMode =
         (data as { json?: unknown; output?: unknown }).json === true ||
         (data as { json?: unknown; output?: unknown }).output === 'json'
-      const finalRenderer: CorePikkuCLIRender<any> | undefined =
-        jsonMode && commandRenderer !== undefined
-          ? defaultJSONRenderer
-          : (commandRenderer ?? programData?.defaultRenderer)
+      const finalRenderer: CorePikkuCLIRender<any> | undefined = jsonMode
+        ? defaultJSONRenderer
+        : (commandRenderer ?? programData?.defaultRenderer)
       if (finalRenderer !== undefined) {
         await Promise.resolve(
           finalRenderer(

--- a/packages/skills/skills/pikku-a11y/SKILL.md
+++ b/packages/skills/skills/pikku-a11y/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: pikku-a11y
+description: >-
+  Accessibility rules (WCAG 2.2) for the app UI: labeled inputs, real buttons/links, keyboard and focus, contrast and not-color-alone, modals, reduced motion.
+  TRIGGER when: building forms or any interactive UI, icon-only buttons, modals/drawers, tables/lists with actions, keyboard/focus work, or the user mentions accessibility / screen readers / WCAG.
+  DO NOT TRIGGER when: working on backend functions, database, or deployment with no UI.
+installGroups: [client]
+---
+
+# Accessibility Rules
+
+Mantine components are accessible ONLY when used properly — the rules below are the
+"properly". They apply to every page; heading order, landmarks, and image alt text are
+covered in the `pikku-seo` skill and apply app-wide, not just on public pages.
+
+## Every input has a label
+
+- Use the `label` prop on every Mantine input — a placeholder is NOT a label (it
+  disappears on input and is never announced as one). Placeholder = example value only.
+- Use the `error` and `description` props for validation/help text — Mantine associates
+  them with the input for screen readers; a loose `<Text c="red">` next to the field
+  does not.
+- Icon-only controls (`ActionIcon`, icon `Button`) MUST have `aria-label={m.key()}`
+  naming the action ("Delete item", not "Trash icon").
+
+## Interactive = a real button or link
+
+- Never `onClick` on a `div`/`Box`/`Card` — it is invisible to keyboard and screen
+  readers. Use `Button`, `ActionIcon`, `UnstyledButton`, or `<Link>`; navigation is a
+  link (href), actions are buttons.
+- Everything reachable by Tab, activatable by Enter/Space. Never remove focus outlines
+  (the theme owns the focus ring), never set `tabIndex` greater than 0, never trap focus
+  yourself.
+- Whole-row/whole-card click: put the button/link INSIDE with the row as its label —
+  don't make the container clickable and unfocusable.
+
+## Don't say it with color alone
+
+- Status must carry text or an icon, not only a color: a Badge says "Overdue", a form
+  error has a message — a red tint by itself is invisible to colorblind users.
+- Contrast comes from the theme; don't undermine it by stacking `c="dimmed"` on small
+  text over tinted backgrounds. Body copy stays at least AA-readable.
+- Touch targets: WCAG 2.2 minimum 24px — don't shrink `ActionIcon`/`Checkbox` below
+  size `sm`, and keep adjacent row actions spaced.
+
+## Overlays and motion
+
+- Modals/drawers: use Mantine `Modal`/`Drawer` and ALWAYS pass `title` — that is what
+  gets announced; focus trap and Escape come built in. (This project uses drawers, not
+  dialogs.)
+- Landing-page animation (the only custom-CSS surface) respects
+  `prefers-reduced-motion: reduce` — gate transforms/parallax behind the media query.
+
+## Self-check before declaring UI done
+
+Tab through the page once: every control reachable and visibly focused, every input
+labeled, every icon button named, every status readable without color. A browser
+scenario proves the flow works, not that it is reachable without a mouse — this
+manual pass is the only check that does.

--- a/packages/skills/skills/pikku-architect/SKILL.md
+++ b/packages/skills/skills/pikku-architect/SKILL.md
@@ -11,6 +11,7 @@ description: >-
   NOT TRIGGER when: the milestone notes themselves are still being written (use pikku-knowledge),
   the plan already exists and the job is to build it (use pikku-build), or the ask is a one-off
   edit to a working app.
+installGroups: [core]
 ---
 
 # Plan one milestone

--- a/packages/skills/skills/pikku-auth/references/better-auth.md
+++ b/packages/skills/skills/pikku-auth/references/better-auth.md
@@ -638,3 +638,82 @@ export const auth = pikkuBetterAuth(async ({ secrets, variables, kysely }) => be
 - Export exactly ONE `pikkuBetterAuth` per project; the CLI generates a single catch-all worker for all auth routes.
 - `betterAuthSession({ auth })` (generated) bridges the better-auth session into the Pikku session on every request — you never add it by hand.
 - MFA, organizations, passkeys, etc. are better-auth plugins: add them to `betterAuth({ plugins: [...] })`. The catch-all route already forwards their endpoints.
+
+---
+
+## Post-signup side effects
+
+Anything that must happen after a user signs up — a welcome email, seeding a first
+row, creating a personal organization — goes in `databaseHooks.user.create.after`
+inside the `betterAuth({...})` config. Never a custom signup RPC that writes the
+user itself: better-auth owns the `user` table, and a second write path desyncs it
+from the session bridge.
+
+## Two-factor (2FA / MFA)
+
+TOTP authenticator apps, email/SMS OTP, backup codes and trusted devices are all
+better-auth's `twoFactor()` plugin. Never hand-roll TOTP or OTP.
+
+1. **Enable + migrate** — add `twoFactor({ issuer: '<AppName>' })` to the `plugins`
+   array in the `pikkuBetterAuth` factory, then generate its schema
+   (`npx @better-auth/cli generate`) and apply it as a migration like any other
+   table change. `twoFactorSecret` lands on `user`.
+2. **Client** — add `twoFactorClient({ onTwoFactorRedirect() { /* go to /2fa */ } })`
+   to `createAuthClient({ plugins: [...] })`, and expose thin wrappers
+   (`enable2FA`, `verifyTotp`, `disable2FA`, …) rather than leaking the raw
+   `authClient`, same as every other auth call.
+3. **OTP delivery** — `otpOptions.sendOTP` goes through the injected email service
+   and a rendered template, not a raw `sendEmail`. Set `storeOTP: 'encrypted'`.
+4. **Sign-in flow** — after `signIn.email(...)`, check `context.data.twoFactorRedirect`
+   in `onSuccess`; if true, route to a `/2fa` page to verify via
+   `verifyTotp`/`verifyOtp`/`verifyBackupCode` (`trustDevice: true` for a 30-day
+   trusted device). The session cookie is only created after verification.
+5. **UI** — a QR rendered from `data.totpURI` plus the `data.backupCodes` list.
+   Enabling, disabling and regenerating backup codes all require the user's
+   password.
+
+TOTP secrets and backup codes are encrypted at rest with the auth secret, and 2FA
+endpoints are rate-limited (3/10s) out of the box. 2FA only applies to
+email/password accounts.
+
+## Security hardening
+
+The `pikkuBetterAuth` factory — where `betterAuth({...})` is built — is the one
+place to harden. Everything below is a `betterAuth` option, not a pikku one.
+
+- **Secret** — `BETTER_AUTH_SECRET` comes from the injected secrets service
+  (`await secrets.getSecret('BETTER_AUTH_SECRET')`), never `process.env`, a
+  literal, or a fallback default. 32+ chars, high entropy
+  (`openssl rand -base64 32`). Better Auth rejects placeholder secrets in
+  production.
+- **Trusted origins** — the `baseURL` origin is auto-trusted, so a single-domain
+  app serving its API same-origin needs nothing. Add `trustedOrigins` (or a
+  comma-separated `BETTER_AUTH_TRUSTED_ORIGINS` variable; wildcards like
+  `*.example.com` allowed) ONLY when the browser origin differs from the API
+  origin — embedded, preview, or custom-domain deployments. An untrusted
+  `callbackURL`/`redirectTo`/`origin` is a 403.
+- **CSRF** — keep it on (`advanced.disableCSRFCheck: false`, the default). A
+  proxy in front of the app must preserve the `/api/auth/*` prefix so origin
+  checks still work; do not disable the check to "fix" a redirect.
+- **Rate limiting** — on by default in production (100/10s global, 3/10s on
+  sign-in/up/change-password). `storage: 'memory'` resets on restart, so a
+  deployed app wants `storage: 'database'`. Tighten sensitive routes with
+  `customRules`, e.g. `'/api/auth/sign-in/email': { window: 60, max: 5 }`.
+- **Cookies & sessions** — the defaults are already secure (`httpOnly`, `secure`,
+  `sameSite: 'lax'`, `__Secure-` prefix), with `session.expiresIn` 7d and
+  `updateAge` 1d. Add `freshAge` for sensitive actions, and
+  `cookieCache: { strategy: 'jwe' }` if the session carries sensitive data — see
+  the cookieCache section above, which you want enabled regardless. Only enable
+  `crossSubDomainCookies` if auth is genuinely shared across subdomains.
+- **OAuth tokens** — set `account.encryptOAuthTokens: true` (AES-256-GCM) if you
+  store provider tokens to call their APIs later.
+- **Audit** — drive auth events from `databaseHooks` (`session.create.after`,
+  `user.update.after` for email changes, `account.create.after` for links) into
+  whatever audit service the app injects, never a bespoke audit table wired into
+  a function body. Returning `false` from a `before` hook blocks the operation.
+- **Background tasks** — on a serverless target, hand fire-and-forget work
+  (emails, logging) to `advanced.backgroundTasks.handler` → `ctx.waitUntil(promise)`
+  so it does not delay the response.
+- **Enumeration** — handled already (generic "Invalid credentials", dummy work on
+  unknown users). Keep your own error copy generic too; never leak "user not
+  found".

--- a/packages/skills/skills/pikku-auth/references/better-auth.md
+++ b/packages/skills/skills/pikku-auth/references/better-auth.md
@@ -655,26 +655,39 @@ TOTP authenticator apps, email/SMS OTP, backup codes and trusted devices are all
 better-auth's `twoFactor()` plugin. Never hand-roll TOTP or OTP.
 
 1. **Enable + migrate** — add `twoFactor({ issuer: '<AppName>' })` to the `plugins`
-   array in the `pikkuBetterAuth` factory, then generate its schema
-   (`npx @better-auth/cli generate`) and apply it as a migration like any other
-   table change. `twoFactorSecret` lands on `user`.
+   array in the `pikkuBetterAuth` factory, then generate its schema and apply it as a
+   migration like any other table change. Run the CLI at the version of better-auth the
+   project actually has installed (`npx @better-auth/cli@<that version> generate`) — a
+   bare `npx @better-auth/cli` resolves the latest release, which can emit a schema for
+   a library you are not running. `twoFactorSecret` lands on `user`.
 2. **Client** — add `twoFactorClient({ onTwoFactorRedirect() { /* go to /2fa */ } })`
    to `createAuthClient({ plugins: [...] })`, and expose thin wrappers
    (`enable2FA`, `verifyTotp`, `disable2FA`, …) rather than leaking the raw
    `authClient`, same as every other auth call.
 3. **OTP delivery** — `otpOptions.sendOTP` goes through the injected email service
    and a rendered template, not a raw `sendEmail`. Set `storeOTP: 'encrypted'`.
-4. **Sign-in flow** — after `signIn.email(...)`, check `context.data.twoFactorRedirect`
-   in `onSuccess`; if true, route to a `/2fa` page to verify via
-   `verifyTotp`/`verifyOtp`/`verifyBackupCode` (`trustDevice: true` for a 30-day
-   trusted device). The session cookie is only created after verification.
+4. **Sign-in flow** — the challenge is raised on the three CREDENTIAL endpoints:
+   `signIn.email`, `signIn.username` and `signIn.phoneNumber`. Check
+   `context.data.twoFactorRedirect` in `onSuccess`; if true, route to a `/2fa` page
+   and verify via `verifyTotp`/`verifyOtp`/`verifyBackupCode` (`trustDevice: true`
+   for a 30-day trusted device). The response also carries `twoFactorMethods`
+   (`'totp'` only once that user has a verified secret, `'otp'` whenever
+   `otpOptions.sendOTP` is configured) — render the choice from it rather than
+   assuming TOTP. The session cookie is only created after verification: the
+   credential handler's session is deleted while the challenge is in flight, so a
+   hook reading `ctx.context.newSession` after sign-in must null-check it.
 5. **UI** — a QR rendered from `data.totpURI` plus the `data.backupCodes` list.
    Enabling, disabling and regenerating backup codes all require the user's
    password.
 
-TOTP secrets and backup codes are encrypted at rest with the auth secret, and 2FA
-endpoints are rate-limited (3/10s) out of the box. 2FA only applies to
-email/password accounts.
+TOTP secrets and backup codes are encrypted at rest with the auth secret, and
+`/two-factor/*` is rate-limited (3/10s) out of the box.
+
+**2FA gates credential sign-in only.** Magic link, email OTP and OAuth are not
+matched by the plugin's hook, so a user with 2FA enabled who signs in through one
+of them is NOT challenged. If every route into the app must be gated, either do not
+offer the passwordless ones to 2FA users or add your own check — enabling the
+plugin does not do it.
 
 ## Security hardening
 
@@ -698,9 +711,17 @@ place to harden. Everything below is a `betterAuth` option, not a pikku one.
 - **Rate limiting** — on by default in production (100/10s global, 3/10s on
   sign-in/up/change-password). `storage: 'memory'` resets on restart, so a
   deployed app wants `storage: 'database'`. Tighten sensitive routes with
-  `customRules`, e.g. `'/api/auth/sign-in/email': { window: 60, max: 5 }`.
-- **Cookies & sessions** — the defaults are already secure (`httpOnly`, `secure`,
-  `sameSite: 'lax'`, `__Secure-` prefix), with `session.expiresIn` 7d and
+  `customRules`, e.g. `'/sign-in/email': { window: 60, max: 5 }` — the key is matched
+  against the path with the base path ALREADY STRIPPED, so a rule written as
+  `'/api/auth/sign-in/email'` matches nothing and silently leaves the route on the
+  default.
+- **Cookies & sessions** — `httpOnly`, `sameSite: 'lax'` and `path: '/'` are
+  unconditional, but `secure` and the `__Secure-` name prefix are NOT: they follow a
+  `baseURL` on `https://` (or production, or an explicit
+  `advanced.useSecureCookies: true`). A deployment whose TLS terminates at a proxy
+  and passes an `http://` baseURL through therefore ships session cookies with no
+  `secure` flag — set `useSecureCookies` there rather than assuming. Defaults are
+  `session.expiresIn` 7d and
   `updateAge` 1d. Add `freshAge` for sensitive actions, and
   `cookieCache: { strategy: 'jwe' }` if the session carries sensitive data — see
   the cookieCache section above, which you want enabled regardless. Only enable
@@ -711,9 +732,13 @@ place to harden. Everything below is a `betterAuth` option, not a pikku one.
   `user.update.after` for email changes, `account.create.after` for links) into
   whatever audit service the app injects, never a bespoke audit table wired into
   a function body. Returning `false` from a `before` hook blocks the operation.
-- **Background tasks** — on a serverless target, hand fire-and-forget work
-  (emails, logging) to `advanced.backgroundTasks.handler` → `ctx.waitUntil(promise)`
-  so it does not delay the response.
+- **Background tasks** — on a serverless target, hand genuinely disposable work
+  (analytics, logging) to `advanced.backgroundTasks.handler` → `ctx.waitUntil(promise)`
+  so it does not delay the response. Not mail: the default handler is
+  `p.catch(() => {})`, so anything that must actually arrive — an invitation, a
+  password reset — is lost without a trace if the platform reaps the request first.
+  Better Auth sends its own through `runInBackgroundOrAwait`, which awaits when no
+  handler is configured; do the same for yours.
 - **Enumeration** — handled already (generic "Invalid credentials", dummy work on
   unknown users). Keep your own error copy generic too; never leak "user not
   found".

--- a/packages/skills/skills/pikku-build/SKILL.md
+++ b/packages/skills/skills/pikku-build/SKILL.md
@@ -12,6 +12,7 @@ description: >-
   or wants one specific surface explained rather than built (use that surface's skill).
 allowed-tools: Bash(yarn pikku meta *), Bash(yarn pikku all *), Bash(yarn tsc), Bash(git status *), Bash(git diff *), Bash(git switch *), Bash(git checkout *), Bash(git checkout -b *), Bash(git add *), Bash(git commit *), Bash(git rm *), Bash(git mv *), Bash(git log *), Bash(git branch *), Bash(yarn pikku fabric report *), Bash(npx --no pikku fabric report *)
 argument-hint: '[feature description]'
+installGroups: [core]
 ---
 
 # Build on Pikku

--- a/packages/skills/skills/pikku-build/references/app.md
+++ b/packages/skills/skills/pikku-build/references/app.md
@@ -265,7 +265,7 @@ the database still holds that code no longer declares — both need §0's bootst
 to have run, and both are worth a look once it has.
 
 **One warning about the scaffold's own notes:** `knowledge/index.md` may claim
-the people live in `pikku.config.json`, put there by a `fabric persona` command.
+the people live in `pikku.config.json`, put there by a persona command.
 That is stale. In this template they live in `personas.ts` as above, and
 `pikku.config.json` carries no personas key at all — only `scenarios.emailDomain`.
 Trust the file you can read over the note describing it.

--- a/packages/skills/skills/pikku-build/references/multi-app.md
+++ b/packages/skills/skills/pikku-build/references/multi-app.md
@@ -8,6 +8,61 @@ leaves `pikkufabric.config.json` pointing at an app nobody has designed yet.
 If the split is "one app with paths", you never need this file — add route
 segments under `/app` and give each audience its own entries in `useNavItems()`.
 
+## Deciding it is two apps, not one
+
+The split you are acting on should already be recorded, but this is the reasoning
+behind it — and the place people get it wrong is the third case at the bottom.
+
+**A group that comes in through its own front door gets its own app.** A role
+*inside* an app is not that: it changes which nav items and which buttons a person
+sees, and lives in `useNavItems()` and the `permissions` on the function, not in a
+route subtree.
+
+**The test is which side of the counter they are on.** Colleagues share one app and
+differ by nav — the mechanic, the person on the counter, the bookkeeper. Someone
+across the counter with an account of their own gets their own — the customer, the
+tenant, the patient. One app is a real answer and often the right one.
+
+**The asymmetry that forces a split is sign-up.** Where staff accounts are created
+*for* people and customers create their own, the two need different sign-up, different
+onboarding and different session shape, and bending one app around both costs more
+than the second app does. Do not collapse two audiences into one app to save a build.
+
+Never invent a person the notes do not name in order to reach two.
+
+### The group that never signs in
+
+Some people use the product with no account at all — ordering from a menu, booking a
+table, opening an invitation. They are not a third case, and **they do not get their
+own frontend**: an app is built around the personas who sign into it. What they get is
+the public route space every app already has.
+
+- **`/app/*` is the signed-in application.** One `beforeLoad` on `/app` bounces a
+  signed-out visitor to the login. There is no per-route exception.
+- **Every other route is public** — `/`, `/menu`, `/book`, `/r/$code`. No gate, no
+  session.
+- **`/` is a landing page and you must write it.** A starter that forwards `/` to
+  `/app` does so only because it ships no homepage. Leave the forward in and the
+  product's front door is a sign-in form: the anonymous visitor arrives at a login it
+  has no account for and never reaches the thing it came for — **while every check
+  still passes**, because everything that looks at the app signs in first. This is the
+  failure this section exists for.
+
+So a screen whose users have no account goes at `/menu`, never `/app/menu`.
+
+### The frontend guard is UX and proves nothing
+
+The bundle is on the origin and the nav is a client-side decision; anyone can read
+both. The security boundary is the `permissions` field on the function — see
+pikku-permissions. Hiding a nav item keeps people out of screens that would confuse
+them; it never protects data. Never let a hidden UI be the only thing between a user
+and someone else's record: if the invoices nav item is hidden but `listAllInvoices`
+has no `permissions`, the app is wide open and the nav is decoration.
+
+Worth a scenario each, because they are two different claims: that a mechanic cannot
+*see* the invoices nav item, and that their call to an invoices RPC is *refused*. The
+second is the one that catches a `permissions` field nobody wired.
+
 ## The clone
 
 ```bash

--- a/packages/skills/skills/pikku-build/references/ship.md
+++ b/packages/skills/skills/pikku-build/references/ship.md
@@ -74,8 +74,8 @@ Everything above is open source. This is the contract that keeps
 - **`pikkufabric.config.json` describes reality.** Every app has an entry with
   the right `cwd`, `port`, `kind` and `dev.command`; exactly one is `primary`;
   `serves` and `personas` name real personas from the personas section. Leave `projectId` as
-  `__PROJECT_ID__` — that placeholder means "unlinked", and `fabric init` writes
-  the real one. Do not invent a value to make it look configured.
+  `__PROJECT_ID__` — that placeholder means "unlinked", and linking the project
+  writes the real one. Do not invent a value to make it look configured.
 - **One `definePersonas` call**, every persona reachable through exactly one
   frontend. Fabric materialises these as its virtual users; a persona nobody
   serves imports as a person with no way in.

--- a/packages/skills/skills/pikku-i18n/SKILL.md
+++ b/packages/skills/skills/pikku-i18n/SKILL.md
@@ -63,9 +63,11 @@ is what makes an RTL language just another locale file.
 - **Do not `asI18n()` a hardcoded English string.** `asI18n` exists to pass
   opaque server data (a name, a slug, an id) through the i18n gate. An enum value
   goes through its generated label map.
-- **Do not wrap `m`.** No re-export module, no branding layer. `m.some__key()`
-  already satisfies the `I18nNode` gate; a wrapper adds nothing and costs
-  per-message tree-shaking.
+- **Do not wrap `m` without a reason you can name.** `m.some__key()` already
+  satisfies the `I18nNode` gate, so a plain re-export module adds nothing and
+  costs per-message tree-shaking. Wrapping the namespace is only worth it when it
+  buys a feature the gate cannot — debug masking of translated copy, say — and
+  then the catalogue has to be small enough to ship whole.
 - **Do not translate message keys.** `auth__login__title` stays English in
   `de.json`; only the value changes.
 - **Do not edit or commit `src/paraglide/`, `i18n-enum.gen.ts` or `enums.gen.ts`.**

--- a/packages/skills/skills/pikku-knowledge/SKILL.md
+++ b/packages/skills/skills/pikku-knowledge/SKILL.md
@@ -13,6 +13,7 @@ description: >-
   brief to record. DO NOT TRIGGER when: user asks what
   functions, routes, tables or permissions exist (that is `pikku meta` / `pikku info`, never a
   note), or to write a scenario test (use pikku-scenario).
+installGroups: [core]
 ---
 
 # Pikku Knowledge

--- a/packages/skills/skills/pikku-list-query/SKILL.md
+++ b/packages/skills/skills/pikku-list-query/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: pikku-list-query
+description: >-
+  Use when building a paginated/infinite-scroll list — any RPC that returns rows a user scrolls through (tables, card grids, search results). Covers pikkuListFunc, the ListInput/ListOutput cursor contract, and the generated usePikkuInfiniteQuery hook.
+  TRIGGER when: user asks for infinite scroll, "load more", a paginated table/list/grid, or a list that could grow beyond a single page.
+  DO NOT TRIGGER when: the list is small and fixed (e.g. a settings page with 5 items) — a plain pikkuFunc + usePikkuQuery returning a full array is simpler and correct there.
+installGroups: [core, client]
+---
+
+# Pikku List Queries
+
+## Agent Operating Procedure
+
+1. Capture baseline. Run `pikku all` BEFORE writing code; only NEW errors are yours to fix.
+2. Write the backend function with `pikkuListFunc` (below) — never a bespoke `{items: [...]}` shape once the list can page.
+3. Run `pikku all` to regenerate `usePikkuInfiniteQuery` for the new function.
+4. Wire the frontend with `usePikkuInfiniteQuery`, not a hand-rolled `useState` page counter and not a raw `useInfiniteQuery` — the generated hook already resolves cursor plumbing from your function's types.
+5. Validate with `pikku all`.
+
+## The `pikkuListFunc` contract
+
+A list function is a normal `pikkuFunc`/`pikkuSessionlessFunc` whose input/output conform to two shared shapes from `@pikku/core`:
+
+```typescript
+interface ListInput<F extends Record<string, unknown> = {}, S extends string = never> {
+  cursor?: string // opaque — echo back whatever you returned as nextCursor
+  limit?: number // page size; server may cap it
+  sort?: Array<{ column: S; direction: 'asc' | 'desc' }>
+  filter?: Filter<F> // structured AND/OR tree, Prisma-style leaf operators
+  search?: string // free-text search across server-chosen fields
+}
+
+interface ListOutput<Row> {
+  rows: Row[]
+  nextCursor: string | null // null = no more pages
+  totalCount?: number // optional — skip when expensive to compute
+}
+```
+
+Adopting this shape is what makes the function eligible for the generated `usePikkuInfiniteQuery` hook — the react-query codegen structurally detects any RPC whose output includes `nextCursor` and generates an infinite-query hook for it automatically. No manual wiring, no opt-in flag.
+
+```typescript
+import { pikkuListFunc } from '#pikku/function'
+
+interface Item {
+  id: string
+  label: string
+}
+
+export const listItems = pikkuListFunc<{ status?: string }, Item>({
+  expose: true,
+  auth: true,
+  readonly: true,
+  description: 'List items for the signed-in user, paginated.',
+  // `input` is inferred as ListInput<{ status?: string }> from the generics above —
+  // never re-annotate it inline.
+  func: async ({ kysely }, input, { session }) => {
+    const limit = input.limit ?? 20
+    const offset = input.cursor ? Number(input.cursor) : 0
+
+    let query = kysely.selectFrom('item').where('userId', '=', session!.userId)
+    if (input.filter && 'status' in input.filter) {
+      query = query.where('status', '=', (input.filter as any).status)
+    }
+
+    const rows = await query.orderBy('createdAt', 'desc').offset(offset).limit(limit).execute()
+    const nextOffset = offset + rows.length
+    const totalCount = await query
+      .select((eb) => eb.fn.countAll<number>().as('count'))
+      .executeTakeFirstOrThrow()
+
+    return {
+      rows: rows.map((r) => ({ id: r.id, label: r.label })),
+      nextCursor: nextOffset < totalCount.count ? String(nextOffset) : null,
+      totalCount: totalCount.count,
+    }
+  },
+})
+```
+
+Cursor doesn't have to be a numeric offset — any opaque string works (a keyset value, an encoded timestamp, etc.), as long as you can turn it back into a query position on the next call.
+
+## Frontend: `usePikkuInfiniteQuery`
+
+Generated automatically alongside `usePikkuQuery`/`usePikkuMutation` once `reactQueryFile` is configured (see the react-query wiring docs) — no separate setup for list functions specifically.
+
+```tsx
+import { usePikkuInfiniteQuery } from '.pikku/pikku-react-query.gen'
+
+function ItemList() {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = usePikkuInfiniteQuery(
+    'listItems',
+    { limit: 20 }, // never pass cursor here — the hook manages it
+  )
+
+  const rows = data?.pages.flatMap((page) => page.rows) ?? []
+
+  return (
+    <>
+      {rows.map((row) => (
+        <div key={row.id}>{row.label}</div>
+      ))}
+      {hasNextPage && (
+        <button disabled={isFetchingNextPage} onClick={() => fetchNextPage()}>
+          Load more
+        </button>
+      )}
+    </>
+  )
+}
+```
+
+For scroll-triggered loading (rather than a button), pair it with an `IntersectionObserver` sentinel at the end of the list that calls `fetchNextPage()` when it enters the viewport and `hasNextPage` is true — don't poll on a scroll event handler.
+
+## Common mistakes
+
+- **Bespoke output shape** (`{items, total}` with no `nextCursor`) — compiles, but disqualifies the function from `usePikkuInfiniteQuery`; you're left hand-rolling pagination state. Use `ListOutput<Row>`'s field names (`rows`, `nextCursor`) even if you don't need `filter`/`sort`/`search` yet — they're optional.
+- **Fixed large `limit` instead of real pagination** (e.g. `{ limit: 500 }` fetched once) — works until the collection outgrows the cap, then silently truncates. If a list can grow unbounded, page it from the start.
+- **Passing `cursor` manually into `usePikkuInfiniteQuery`'s input argument** — the hook injects it into each page request itself; the input you pass is the _base_ filter/limit shared by every page.

--- a/packages/skills/skills/pikku-list-query/SKILL.md
+++ b/packages/skills/skills/pikku-list-query/SKILL.md
@@ -55,12 +55,16 @@ export const listItems = pikkuListFunc<{ status?: string }, Item>({
   // `input` is inferred as ListInput<{ status?: string }> from the generics above —
   // never re-annotate it inline.
   func: async ({ kysely }, input, { session }) => {
-    const limit = input.limit ?? 20
-    const offset = input.cursor ? Number(input.cursor) : 0
+    // `limit` is caller-supplied on an exposed RPC, so it is CAPPED, not trusted —
+    // `ListInput` says "server may cap" and this is where that happens.
+    const limit = Math.min(Math.max(Math.trunc(input.limit ?? 20) || 20, 1), 100)
+    const parsed = input.cursor ? Number(input.cursor) : 0
+    const offset = Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0
 
     let query = kysely.selectFrom('item').where('userId', '=', session!.userId)
-    if (input.filter && 'status' in input.filter) {
-      query = query.where('status', '=', (input.filter as any).status)
+    const status = leafEquals(input.filter, 'status')
+    if (status !== undefined) {
+      query = query.where('status', '=', status)
     }
 
     const rows = await query.orderBy('createdAt', 'desc').offset(offset).limit(limit).execute()
@@ -117,3 +121,43 @@ For scroll-triggered loading (rather than a button), pair it with an `Intersecti
 - **Bespoke output shape** (`{items, total}` with no `nextCursor`) — compiles, but disqualifies the function from `usePikkuInfiniteQuery`; you're left hand-rolling pagination state. Use `ListOutput<Row>`'s field names (`rows`, `nextCursor`) even if you don't need `filter`/`sort`/`search` yet — they're optional.
 - **Fixed large `limit` instead of real pagination** (e.g. `{ limit: 500 }` fetched once) — works until the collection outgrows the cap, then silently truncates. If a list can grow unbounded, page it from the start.
 - **Passing `cursor` manually into `usePikkuInfiniteQuery`'s input argument** — the hook injects it into each page request itself; the input you pass is the _base_ filter/limit shared by every page.
+
+## `filter` is a TREE, not a bag of fields
+
+`Filter<F>` is recursive: an **array** is an AND of its children, a **multi-key object** is
+an OR keyed by labels that mean nothing at evaluation time, and only a **single-key object**
+is a leaf. A leaf's value is either the value itself or an operator object
+(`{ contains, in, gt, gte, lt, lte, not, startsWith, … }`).
+
+So `'status' in input.filter` answers `false` for `[{ status: 'open' }, { userId: 'u1' }]`
+and for `{ status: { in: ['open', 'held'] } }` — the first because the filter is an array,
+the second because the value is an operator object rather than the string the code then
+compares. Both cases **silently return unfiltered rows**, which on a list endpoint means
+handing back records the caller asked to exclude. Pikku ships no filter-to-SQL helper: the
+backend decides what it accepts, and it has to say so.
+
+Read exactly the shape you support, and refuse the rest rather than ignoring it:
+
+```typescript
+import type { Filter } from '@pikku/core/function'
+
+/** The one shape this endpoint accepts: a single-key leaf with a plain value. */
+function leafEquals<F extends Record<string, unknown>, K extends keyof F & string>(
+  filter: Filter<F> | undefined,
+  field: K,
+): F[K] | undefined {
+  if (!filter || Array.isArray(filter)) return undefined
+  const keys = Object.keys(filter)
+  if (keys.length !== 1 || keys[0] !== field) return undefined
+  const value = (filter as Record<string, unknown>)[field]
+  if (value !== null && typeof value === 'object') {
+    throw new Error(`filter.${field} takes a value, not an operator object`)
+  }
+  return value as F[K]
+}
+```
+
+Supporting AND/OR or operators means walking the tree properly — recurse into the array and
+the multi-key object, and map each leaf operator to its Kysely equivalent. Do that when the
+UI needs it; until then, throwing on the shapes you do not handle is what stops a filter
+from being quietly dropped.

--- a/packages/skills/skills/pikku-permissions/SKILL.md
+++ b/packages/skills/skills/pikku-permissions/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: pikku-permissions
+description: >-
+  Use when deciding WHO may call a function — resource ownership, role gates, admin-only actions, or any "only their own rows" rule. Covers the `permissions` field, `pikkuPermission`, `pikkuAuth`, scopes, and where ownership belongs versus where it does not.
+  TRIGGER when: writing or reviewing any function that touches a row a user owns, gating an action on a role, building the permissions half of a contract in build PHASE 2, or about to write an `if` in a function body that decides whether the caller is allowed.
+  DO NOT TRIGGER when: the question is how to sign someone in or seed a persona (that is pikku-auth), or how to shape a paginated list (that is pikku-list-query).
+installGroups: [core]
+---
+
+# Pikku Permissions
+
+## The rule
+
+**Authorization goes in the `permissions` field. Never in the `func` body.**
+
+`permissions` runs before `func`, and it is DECLARED — `pikku meta` and the auditor can
+see it. An `if` in the body is the same check, invisible: nothing can tell you which
+functions are gated or how, and the next person to add a caller gets no warning.
+
+```typescript
+// RIGHT
+export const deleteBook = pikkuFunc({
+  permissions: { owner: isBookOwner },
+  func: async ({ kysely }, { bookId }) => {
+    await kysely.deleteFrom('book').where('bookId', '=', bookId).execute()
+  },
+})
+
+// WRONG — the gate is buried in the body
+export const deleteBook = pikkuFunc({
+  func: async ({ kysely }, { bookId }, { session }) => {
+    const book = await kysely.selectFrom('book')...executeTakeFirst()
+    if (book?.ownerId !== session.userId) throw new UnauthorizedError()
+    await kysely.deleteFrom('book').where('bookId', '=', bookId).execute()
+  },
+})
+```
+
+## `auth: true` IS NOT OWNERSHIP — this is the one people get wrong
+
+`auth: true` means "somebody is signed in". It does NOT mean "this row is theirs". A CRUD
+function set to `auth: true` and nothing else lets ANY signed-in user delete ANY other
+user's row by passing its id. Every function that takes a row id needs BOTH: `auth: true`
+for the session, and a `permissions` entry for the ownership.
+
+Equally: do NOT write an `isSignedIn` permission that returns `!!session`. That re-checks
+authentication, which `auth: true` already did. A permission answers *may this user do
+this* — role, ownership, tier — never *is there a session*.
+
+## Single row vs list — where ownership actually goes
+
+This is the distinction to get right, and both halves are correct code:
+
+- **A function taking a row id** (`get`, `update`, `delete`) — ownership is a
+  PERMISSION. Load the row, compare the owner to the session. It is a yes/no question
+  about one row, which is exactly what a permission is.
+- **A function returning many rows** (`list`, `search`, any stats query) — ownership is
+  a `WHERE` clause in the query, because "only their rows" is a filter, not a yes/no.
+  There is no permission to write here; scoping the query IS the enforcement.
+
+A list that fetches everything and then filters in JS is a bug, not a permission.
+
+## Writing the checkers
+
+Put them in `src/permissions/`, one file per entity, and reuse one checker across every function on that
+entity rather than writing a near-copy per function.
+
+```typescript
+// src/permissions/book.ts
+import { pikkuPermission, pikkuAuth } from '#pikku/auth'
+
+// Data-aware: gets the input, so it can load the row the caller named.
+export const isBookOwner = pikkuPermission(
+  async ({ kysely }, { bookId }, { session }) => {
+    const book = await kysely
+      .selectFrom('book')
+      .select('ownerId')
+      .where('bookId', '=', bookId)
+      .executeTakeFirst()
+    return book?.ownerId === session?.userId
+  },
+)
+
+// Session-only: no input needed. Use for role and flag gates.
+export const isAdmin = pikkuAuth(async (_services, session) => session?.role === 'admin')
+```
+
+## OR and AND
+
+```typescript
+permissions: {
+  owner: isBookOwner,            // OR — an owner may
+  admin: isAdmin,                // OR — an admin may
+  editor: [isAdmin, isBookOwner] // AND — both, inside one group
+}
+```
+
+Groups are OR'd; entries inside a group array are AND'd.
+
+## Roles
+
+If the app has roles, the role lives on the session (see pikku-auth / `mapSession`) and
+every mutating or admin-only function names it in `permissions`. Gate the FUNCTION — hiding
+an admin button in the UI is UX, never enforcement, and a member who guesses the RPC name
+gets straight through if the function itself is open.
+
+## Scopes
+
+`scopes: ['admin:invoices:void']` is an AND gate checked BEFORE permissions and before
+input validation. Declare the tree once with `defineScope`; a function naming an
+undeclared scope fails codegen rather than gating on nothing. A grant satisfies a scope if
+it is that scope, an ancestor, or a wildcard — a session holding `admin` satisfies
+`admin:invoices:void`. Most apps need roles, not scopes; reach for these only when the
+plan asked for granular grants.
+
+## The one sanctioned exception
+
+`permissionsInBody: true` — for a check that genuinely cannot be a permission because the
+identity arrives in the payload and there is no session: a webhook signature, a signed
+token, an invite code. It is purely declarative and enforces nothing; its job is to tell
+the auditor the openness is deliberate. Anything expressible as a permission must be one.
+
+## After changes
+
+`pikku all` — regenerates and typechecks the checkers. A permission whose signature is
+wrong fails here, not at runtime.

--- a/packages/skills/skills/pikku-react/references/client.md
+++ b/packages/skills/skills/pikku-react/references/client.md
@@ -195,6 +195,19 @@ const pikku = createPikku(PikkuFetch, PikkuRPC, {
 })
 ```
 
+`transformDate: true` means every date field arrives as a real `Date`, not the ISO string
+the schema declared. Two consequences that both typecheck:
+
+- **A string method on one throws at runtime.** `row.createdAt.split('T')[0]` — there is no
+  string to slice.
+- **A raw `Date` in JSX crashes the route.** `<span>{row.createdAt}</span>` throws
+  `Objects are not valid as a React child (found: [object Date])` and the page falls into its
+  error boundary — a white screen, with nothing catching it first.
+
+Format before rendering, with whatever date library the project already uses. Coercing
+instead (`` `${d}` ``, `String(d)`) does not crash but prints
+`Mon Jun 15 2026 02:00:00 GMT+0200`, which is a different bug.
+
 There is no request-interceptor hook. For a token that changes after startup,
 call the setter on the shared instance — RPC and realtime pick it up because
 they hold the same fetch:

--- a/packages/skills/skills/pikku-react/references/client.md
+++ b/packages/skills/skills/pikku-react/references/client.md
@@ -195,17 +195,24 @@ const pikku = createPikku(PikkuFetch, PikkuRPC, {
 })
 ```
 
-`transformDate: true` means every date field arrives as a real `Date`, not the ISO string
-the schema declared. Two consequences that both typecheck:
+`transformDate: true` revives **fully-zoned ISO-8601 instants** — `2026-03-14T08:12:00Z`,
+`2026-03-14T08:12:00.000+01:00` — into `Date` objects. Nothing else is touched: a bare
+`2026-03-14`, a zoneless `2026-03-14T08:12:00`, and a shaped-but-impossible
+`2026-02-31T00:00:00Z` all stay the strings the server sent, because each names a reading
+rather than a moment and `new Date` would guess a different instant per machine.
 
-- **A string method on one throws at runtime.** `row.createdAt.split('T')[0]` — there is no
-  string to slice.
+So the field's runtime type follows the VALUE, not the schema — one `z.string()` column can
+arrive as a `Date` from one row and a string from the next. Two consequences, both of which
+typecheck:
+
+- **A string method on a revived field throws at runtime.** `row.createdAt.split('T')[0]` —
+  there is no string to slice.
 - **A raw `Date` in JSX crashes the route.** `<span>{row.createdAt}</span>` throws
   `Objects are not valid as a React child (found: [object Date])` and the page falls into its
   error boundary — a white screen, with nothing catching it first.
 
-Format before rendering, with whatever date library the project already uses. Coercing
-instead (`` `${d}` ``, `String(d)`) does not crash but prints
+Format before rendering, with whatever date library the project already uses, and let it take
+either type. Coercing instead (`` `${d}` ``, `String(d)`) does not crash but prints
 `Mon Jun 15 2026 02:00:00 GMT+0200`, which is a different bug.
 
 There is no request-interceptor hook. For a token that changes after startup,

--- a/packages/skills/skills/pikku-realtime/SKILL.md
+++ b/packages/skills/skills/pikku-realtime/SKILL.md
@@ -41,11 +41,21 @@ const lot = await kysely
   .updateTable('lot')
   .set({ status: 'sold' })
   .where('id', '=', input.lotId)
-  .returningAll()
+  .returning(['id', 'status', 'currentBid', 'updatedAt'])
   .executeTakeFirstOrThrow()
 await eventHub.publish('lot-updated', null, { topic: 'lot-updated', data: lot })
 return lot
 ```
+
+**A topic is PUBLIC — publish a projection, never `returningAll()`.** The generated
+`/events/:topic` route is wired `auth: false` with a sessionless handler, so anyone who can
+reach the origin can subscribe to any topic name and read every frame on it. `returningAll()`
+then ships the whole row — `reservePrice`, `sellerId`, internal notes, whatever the table
+grows next — to unauthenticated subscribers, and it does it silently because the RPC's own
+`output` schema never sees the event payload. List the columns the topic is FOR, the way the
+example does. If a change genuinely has per-viewer content, it does not belong on a topic:
+publish an id-only "something changed" frame and let each client refetch through an
+authenticated RPC that applies its own permissions.
 
 The **2nd arg is the channel to EXCLUDE** from the broadcast: pass `null` from a
 normal HTTP/RPC write (there is no one to skip); pass `channel.channelId` ONLY
@@ -66,16 +76,25 @@ export function useLiveLots() {
   const queryClient = useQueryClient()
 
   useEffect(() => {
-    const subscription = realtime.subscribeToTopic('lot-updated', (event) => {
-      const lot = event.data
-      queryClient.setQueryData(['listLots'], (rows: Lot[] = []) =>
-        rows.map((row) => (row.id === lot.id ? lot : row))
-      )
+    const subscription = realtime.subscribeToTopic('lot-updated', () => {
+      queryClient.invalidateQueries({ queryKey: ['listLots'] })
     })
     return () => subscription.close()
   }, [queryClient])
 }
 ```
+
+**Invalidate; do not hand-patch the cache.** The generated hooks key a query as
+`[name, input]` — `['listLots', { status: 'open', cursor: undefined }]`, one entry per set of
+arguments — so `setQueryData(['listLots'], …)` writes to a key nothing reads and the screen
+never changes. `invalidateQueries({ queryKey: ['listLots'] })` prefix-matches, so it refreshes
+every variant of that list whatever input each one was fetched with.
+
+Patching also has to know the payload's shape, and a list RPC returns
+`ListOutput<Lot>` — `{ rows, nextCursor, totalCount? }`, not `Lot[]` — so a `rows.map(...)`
+updater is reading `.map` off an object. Refetching sidesteps both, and it re-applies the server's own filtering,
+which a locally patched row does not: a lot that just moved to `sold` may no longer belong in
+an "open lots" list at all.
 
 `subscribeToTopic` returns `{ close }` — ALWAYS close on unmount or you leak the
 stream. Never hand-roll an `EventSource`.

--- a/packages/skills/skills/pikku-realtime/SKILL.md
+++ b/packages/skills/skills/pikku-realtime/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: pikku-realtime
+description: >-
+  Use when making ANY view live/realtime in a Pikku app — a board, shared list, dashboard, ticker, bidding room, live count — or when adding two-way chat/presence. Covers the DEFAULT event-hub SSE path and the two-way WebSocket channel.
+  TRIGGER when: the user wants live updates, realtime, "update without refresh", a live board/feed/ticker/room, presence, or chat; or when data that MORE THAN ONE signed-in user can change should reflect others
+  DO NOT TRIGGER when: a plain one-shot query/refetch is fine (data only one user changes, or a manual refresh is acceptable), or for background jobs (that is pikku-schedule/pikku-workflow).
+installGroups: [core, client]
+---
+
+# Pikku Realtime (SSE + WebSocket channels)
+
+There is NOTHING to hand-roll and NOTHING to "find". The event-hub SSE transport
+is already wired into every app, and the two patterns below ARE the realtime
+templates. Start from them and rename — never grep the project for existing
+`sse`/`eventHub` code to copy, never write a custom `EventSource`, and never
+write a bespoke `sse: true` route for a plain live feed.
+
+## Pick the transport (almost always SSE)
+
+- **Server → client live updates → SSE via the event-hub.** This is the DEFAULT
+  for making any view live: a board, list, dashboard, ticker, feed, or a "room"
+  (a bidding room, sale room, live auction). The client only RECEIVES — the
+  change itself happens through a NORMAL HTTP RPC (`placeBid`, `updateLot`, …)
+  that publishes the new row.
+- **Client → server push mid-session → a WebSocket channel.** ONLY when the
+  BROWSER must send up the socket without a page action: live chat messages,
+  typing indicators, cursors/presence.
+
+A screen being called a "room", or being multi-user, or being live is NOT a
+reason to use a channel. If the browser isn't pushing frames up, it's SSE.
+
+## Level 1 — live updates (event-hub SSE, the default)
+
+Two halves; both are required or nothing arrives.
+
+**Backend — publish after every write.** In each create/update/status function,
+AFTER the DB write, publish the changed row on a topic:
+
+```ts
+const lot = await kysely
+  .updateTable('lot')
+  .set({ status: 'sold' })
+  .where('id', '=', input.lotId)
+  .returningAll()
+  .executeTakeFirstOrThrow()
+await eventHub.publish('lot-updated', null, { topic: 'lot-updated', data: lot })
+return lot
+```
+
+The **2nd arg is the channel to EXCLUDE** from the broadcast: pass `null` from a
+normal HTTP/RPC write (there is no one to skip); pass `channel.channelId` ONLY
+when you publish from INSIDE a channel handler, or the sender gets an echo of its
+own update. `eventHub` is already injected — do not wire it.
+
+**Frontend — subscribe over SSE.** The generated
+`PikkuRealtime.subscribeToTopic(topic, handler)` opens an SSE stream to the
+built-in `/events/:topic` route. Seed state from a normal query, then patch it as
+events arrive; the event is the `{ topic, data }` envelope, so read `.data`.
+
+```tsx
+import { useEffect } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { realtime } from '../lib/pikku'
+
+export function useLiveLots() {
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    const subscription = realtime.subscribeToTopic('lot-updated', (event) => {
+      const lot = event.data
+      queryClient.setQueryData(['listLots'], (rows: Lot[] = []) =>
+        rows.map((row) => (row.id === lot.id ? lot : row))
+      )
+    })
+    return () => subscription.close()
+  }, [queryClient])
+}
+```
+
+`subscribeToTopic` returns `{ close }` — ALWAYS close on unmount or you leak the
+stream. Never hand-roll an `EventSource`.
+
+## Level 2 — two-way channel
+
+Only when the client pushes up the socket. The backend channel lives in its own
+`*.channel.ts` with `onConnect`/`onMessage` handlers:
+
+```ts
+import { pikkuChannelFunc, wireChannel } from '#pikku/channel'
+
+export const onMessage = pikkuChannelFunc<{ text: string }>({
+  func: async ({ eventHub }, input, { channel, session }) => {
+    const message = { id: crypto.randomUUID(), text: input.text, userId: session!.userId }
+    await eventHub.publish('room', channel.channelId, { topic: 'room', data: message })
+    return message
+  },
+})
+
+wireChannel({ name: 'room', route: '/room', auth: true, onMessage })
+```
+
+The frontend opens it with `PikkuRealtime.connectToChannel(path)`, which returns
+a socket you both `.send(...)` on and read via `onmessage`:
+
+```tsx
+useEffect(() => {
+  const socket = realtime.connectToChannel('/room')
+  socket.onmessage = (event) => appendMessage(JSON.parse(event.data))
+  return () => socket.close()
+}, [])
+```
+
+Publish server→client fan-out from a channel handler with
+`eventHub.publish(topic, channel.channelId, envelope)` — the 2nd arg excludes the
+sender, so the browser that sent the message does not receive its own echo.
+
+## Do NOT
+
+- Do **not** grep the project for existing SSE/eventHub infra to reverse-engineer
+  or copy — the patterns above ARE the template (same rule as never reading
+  `.gen.ts` to learn an API).
+- Do **not** write a custom `sse: true` HTTP route or a bespoke `EventSource` for
+  an ordinary live feed — the event-hub covers it. (A dedicated `sse: true` route
+  is only for a long-job PROGRESS stream, and is not needed for an initial build.)
+- Do **not** use a WebSocket channel for a live board/ticker/room — that is SSE.
+  A channel is for client→server push (chat/presence) ONLY.
+- Do **not** forget the backend `eventHub.publish(...)` — a subscribed frontend
+  with no publisher is a silent, empty stream.

--- a/packages/skills/skills/pikku-seo/SKILL.md
+++ b/packages/skills/skills/pikku-seo/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: pikku-seo
+description: >-
+  On-page SEO rules for the app's PUBLIC pages: per-route head() titles and meta descriptions, Open Graph tags, one-h1 heading hierarchy, semantic/crawlable markup, JSON-LD on the landing page, and noindex for the logged-in area.
+  TRIGGER when: building or reworking any public page (landing, pricing, about, blog/content pages), writing page titles or meta tags, or the user asks about SEO / Google / discoverability / social sharing previews.
+  DO NOT TRIGGER when: working on logged-in /app screens (they are noindexed — only the one robots rule below applies), backend functions, database, or deployment.
+installGroups: [client]
+---
+
+# SEO Rules
+
+Apps render SSR from the edge, so crawlers see full HTML — the ranking work is
+getting the on-page signals right while you build. These rules apply to PUBLIC
+routes only (the landing page and any marketing/content pages). The logged-in
+`/app` area is private: it gets `noindex` and nothing else from this skill.
+
+## Per-route head() — every public route, no exceptions
+
+Titles and descriptions live in TanStack Start's `head()` on the route, merged
+root → leaf (the leaf's title/meta win). The root route already carries the
+site-wide defaults and OG tags; every public page you add MUST override both:
+
+```tsx
+export const Route = createFileRoute('/pricing')({
+  head: () => ({
+    meta: [
+      { title: 'Pricing — Acme Scheduling' },
+      {
+        name: 'description',
+        content:
+          'Simple per-seat pricing for Acme Scheduling. Start free, upgrade when your team grows — no setup fees, cancel anytime.',
+      },
+      { property: 'og:title', content: 'Pricing — Acme Scheduling' },
+      { property: 'og:description', content: 'Simple per-seat pricing. Start free.' },
+    ],
+  }),
+  component: PricingPage,
+})
+```
+
+`head()` strings are plain strings (they do not go through the Mantine i18n
+gate) — write real copy for THIS app, in the app's voice.
+
+- **Title**: unique per page, 50–60 characters, the page's primary topic first,
+  brand at the end (`Topic — AppName`). The template's `__APP_TITLE__` default
+  must never survive the rebrand, on any page.
+- **Description**: unique per page, 150–160 characters, states the concrete
+  value of the page in plain language — a reason to click, not a keyword list.
+- **Dynamic public pages** (e.g. a public detail page) build both from loader
+  data: `head: ({ loaderData }) => ({ meta: [{ title: `${loaderData.name} — AppName` }, ...] })`.
+- **Never invent URLs**: the deployed domain is unknown at build time, so do
+  NOT emit `canonical`, `og:url`, or `og:image` pointing at a made-up domain —
+  omit them (same principle as the `/api` serverUrl rule). `og:image` only if a
+  real asset exists in the app.
+
+## Logged-in area = noindex
+
+The `/app` route (the authenticated layout route) gets exactly one meta entry:
+
+```tsx
+head: () => ({ meta: [{ name: 'robots', content: 'noindex' }] })
+```
+
+Never noindex a public page, and never put per-page SEO effort into `/app`
+screens — they are invisible to crawlers by design.
+
+## Headings — exactly one h1 per page
+
+- Every page has EXACTLY ONE h1 (`<Title order={1}>` in Mantine, `<h1>` in
+  Tailwind) and it names the page's primary topic — aligned with the title tag,
+  not identical boilerplate.
+- Logical hierarchy below it: h1 → h2 → h3, no skipped levels, headings
+  describe the content under them. Never pick a heading level for its font
+  size — set the size on the correct level (`<Title order={2} fz="xs">`).
+
+## Crawlable, semantic markup
+
+- Landmarks on public pages: `<nav>`, `<main>`, `<footer>` (Mantine: `component="nav"` etc.).
+- Navigation between public pages uses real links (`<Link>`/`<a href>`) with
+  descriptive anchor text — crawlers follow hrefs; a `div onClick` navigation
+  is invisible to them. No public page may be orphaned: every public page is
+  reachable by link from the landing page (directly or via nav/footer).
+- Every meaningful `<img>` has alt text describing the image; decorative images
+  get `alt=""`. Prefer descriptive file names for real assets.
+- Readable URLs: public routes are lowercase, hyphen-separated, and named for
+  their content (`/pricing`, `/how-it-works`) — never `/page2` or query-param
+  navigation.
+
+## JSON-LD on the landing page
+
+The landing page carries one structured-data script describing the product.
+Only mark up what is visibly true on the page — never invent ratings, reviews,
+or offers (fake schema is a Google penalty, not a boost):
+
+```tsx
+head: () => ({
+  meta: [
+    /* title + description as above */
+  ],
+  scripts: [
+    {
+      type: 'application/ld+json',
+      children: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@graph': [
+          { '@type': 'Organization', name: 'Acme Scheduling', description: '…' },
+          { '@type': 'WebSite', name: 'Acme Scheduling' },
+        ],
+      }),
+    },
+  ],
+})
+```
+
+Add further types only when the page genuinely IS that thing and shows the
+required fields: `FAQPage` for a real FAQ section, `Article` for a blog post
+(headline, datePublished, author), `Product`/`Offer` for a real price list.
+Omit `url`/`logo` fields — deployed domain unknown (see "never invent URLs").
+
+## Verify
+
+Open each PUBLIC page and read its `<head>`: a title, a meta description, and
+exactly one `h1`. A public page is not done while any of the three is missing.
+Signed-in pages under `/app` are exempt once `noindex` is set — they are not
+indexed, so their head tags do not matter.
+
+## Don'ts
+
+- No keyword stuffing — write for the reader; one clear topic per page.
+- Don't duplicate the same title/description across pages (worse than absent).
+- Don't render SEO-critical copy only after client-side effects — it must be
+  in the SSR HTML (loader data is fine; `useEffect`-fetched content is not).
+- Don't add robots.txt/sitemap plumbing — the platform owns that layer.

--- a/packages/skills/skills/pikku-software-archaeology/SKILL.md
+++ b/packages/skills/skills/pikku-software-archaeology/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pikku-software-archaeology
 description: 'Use when reverse-engineering an existing repository into a Product Blueprint — recovering what product an undocumented or organically-grown codebase implements so it can be rebuilt cleanly (e.g. as a Pikku app) — and when turning that blueprint into a plain-language second opinion for the non-technical owner who holds the app. TRIGGER when: user says "extract a blueprint", "reverse engineer this app", "what does this codebase actually do as a product", "prepare this repo for a rewrite/migration", points at a legacy repo (any language — JS, TS, Ruby, Python, PHP, Go) and asks for its domains, workflows, business rules or a rebuild plan, or asks "explain how my app works" / "what would you do differently" / "is this built well?" for a founder, PM or operator audience. DO NOT TRIGGER for: documenting code structure, generating API docs from an already-clean codebase, or an engineer-facing code review.'
+installGroups: [core]
 ---
 
 # Software Archaeology

--- a/packages/skills/skills/pikku-workflow/SKILL.md
+++ b/packages/skills/skills/pikku-workflow/SKILL.md
@@ -27,6 +27,24 @@ See `pikku-concepts` for the core mental model.
 
 Build durable, multi-step workflows with automatic retry, sleep, suspend/resume, and parallel execution. Steps are cached for replay safety.
 
+## Decide FIRST: should this even BE a workflow?
+
+The deciding question is: **does any part of this cross an external boundary that can fail and MUST NOT be lost or double-run** — a payment authorised/captured through a provider, a third-party API call, an email/webhook, a wait for approval? If yes → workflow (durability, retries, restart-survival, and a visible run). If it's **a single algorithm done in one shot, purely local, and not reused elsewhere** → a plain `pikkuFunc` is correct; do NOT wrap it in a workflow.
+
+- **Checkout WITH payment → workflow.** Get cart → compute total → **(atomic: create order + order items, deduct stock, clear cart)** → **charge payment through the provider** → send confirmation email. It's a workflow because the payment leg (and the email) are external and must be **retried, not lost, and not charged twice** across a restart — and the user benefits from seeing where the run is.
+- **Checkout with NO external payment** — e.g. it just records the order and decrements stock in one transaction, nothing leaves the process — is a **single-shot algorithm**: a plain `pikkuFunc` wrapping one `kysely.transaction`. Not a workflow. A workflow here would add durability machinery for a thing that already commits atomically in one shot.
+- **One durable step is NOT a workflow — it's a queue worker.** A lone side-effect that must be retried / not lost (send one email, fire one webhook, one external charge) → a **queue worker** (`pikku-queue`), enqueued fire-and-forget. A workflow adds a step graph for a thing that has no steps to orchestrate. (A single non-durable step is just a direct RPC call.)
+- Also workflows: onboarding sequences, settlements/payouts, digests and batch sends, anything that waits (`sleep`/`suspend`) or fans out with retries — the common thread is **multiple** steps or a durable wait, never a single step.
+
+**HARD RULE — never a single-RPC (one-step) workflow.** A workflow whose body is one `workflow.do('x', 'someRpc', …)` is a mislabeled durable function, not orchestration. Route by durability, NOT into a workflow:
+
+- **Not durable** — the caller wants the result now / it can just run in-request → **call the RPC directly** (this is also the synchronous path). No workflow, no queue.
+- **Durable** — must be **retried / not lost / survive a restart** (one email, one webhook, one external charge) → a **queue worker** (`wireQueueWorker` + `queueService.add(...)`). Fire-and-forget, retried by the queue.
+
+There is no "one-step workflow is justified for the durability" exception — durability for a single step is a QUEUE. A workflow earns its name only with genuine multi-step orchestration (a `sleep`/`suspend` wait, fan-out, or a saga).
+
+**Atomicity is a TRANSACTION, not a workflow.** All-or-nothing multi-write units (create order + items + deduct stock + clear cart) belong inside ONE `kysely.transaction(async (trx) => { … })` — a single step or a single plain `pikkuFunc` — **never split across workflow steps.** Each `workflow.do` step is its own transaction, so spreading one logical transaction over several steps leaves partial state if it crashes between them (reach for compensating/saga steps only when you truly need cross-service rollback). So a payment checkout is a workflow whose _atomic DB writes are ONE transactional step_, with the payment charge and email as the other durable steps around it.
+
 ## Choosing the right factory
 
 | Factory                    | When to use                                                                                                                                                                                                | Step-graph view?              |

--- a/packages/skills/skills/pikku-workflow/SKILL.md
+++ b/packages/skills/skills/pikku-workflow/SKILL.md
@@ -43,7 +43,26 @@ The deciding question is: **does any part of this cross an external boundary tha
 
 There is no "one-step workflow is justified for the durability" exception — durability for a single step is a QUEUE. A workflow earns its name only with genuine multi-step orchestration (a `sleep`/`suspend` wait, fan-out, or a saga).
 
-**Atomicity is a TRANSACTION, not a workflow.** All-or-nothing multi-write units (create order + items + deduct stock + clear cart) belong inside ONE `kysely.transaction(async (trx) => { … })` — a single step or a single plain `pikkuFunc` — **never split across workflow steps.** Each `workflow.do` step is its own transaction, so spreading one logical transaction over several steps leaves partial state if it crashes between them (reach for compensating/saga steps only when you truly need cross-service rollback). So a payment checkout is a workflow whose _atomic DB writes are ONE transactional step_, with the payment charge and email as the other durable steps around it.
+**Atomicity is a TRANSACTION, not a workflow.** All-or-nothing multi-write units (create order + items + deduct stock + clear cart) belong inside ONE `kysely.transaction(async (trx) => { … })` — a single step or a single plain `pikkuFunc` — **never split across workflow steps.** A step is a unit of RETRY and REPLAY, not a unit of atomicity: pikku opens no transaction around `workflow.do`, so a step that does three writes and throws on the third leaves the first two committed, and the retry runs them again. Spreading one logical transaction over several steps is the same failure one level up. Your writes are atomic only where YOU opened a transaction, so open one inside the step (reach for compensating/saga steps only when you truly need cross-service rollback). So a payment checkout is a workflow whose _atomic DB writes are ONE step that opens ONE transaction_, with the payment charge and email as the other durable steps around it.
+
+**A retried step re-runs its side effects.** Replay caching only covers steps that already
+returned; a step that failed — or that timed out after the provider accepted it — runs again
+from the top, so a charge, an email or a webhook can fire twice. Durability is at-least-once,
+not exactly-once. Pass a stable idempotency key the provider deduplicates on, derived from the
+workflow's own data rather than generated inside the step:
+
+```typescript
+await workflow.do('Charge', 'chargePayment', {
+  orderId: data.orderId,
+  amount: data.amount,
+  idempotencyKey: `order-${data.orderId}-charge`,
+})
+```
+
+`randomUUID()` or `Date.now()` inside the step is a different key on every attempt, which is
+the double-charge. Where the provider has no such header, make the step itself idempotent —
+check for the effect before performing it, or record a unique row that the second attempt
+collides with.
 
 ## Choosing the right factory
 

--- a/packages/skills/src/corpus.test.ts
+++ b/packages/skills/src/corpus.test.ts
@@ -234,6 +234,48 @@ describe('bundled skills corpus', () => {
     )
   })
 
+  test('no skill outside pikku-fabric teaches a bare `fabric` command', async () => {
+    // The corpus is the OSS one: a reader running these skills has the `pikku`
+    // CLI and no `fabric` binary, so `fabric verify` is a command that does not
+    // exist on their machine. Fabric's own overlay skills keep those; what must
+    // not happen is one migrating back in as a skill moves out of Fabric.
+    //
+    // `pikku fabric <verb>` is the real OSS command and stays, as does
+    // `pikkufabric.config.json`, the `fabric-theme` tool named as Fabric's, and
+    // prose about the platform — only a bare `fabric ` + verb is a hit.
+    const offenders: string[] = []
+    for (const skill of await readSkills()) {
+      if (FABRIC_SKILLS.includes(skill.name)) continue
+      const docs: Array<[string, string]> = [['SKILL.md', skill.body]]
+      const refs = join(skill.dir, 'references')
+      if (existsSync(refs))
+        for (const file of await readdir(refs))
+          docs.push([`references/${file}`, await readFile(join(refs, file), 'utf-8')])
+
+      for (const [where, doc] of docs) {
+        let inFence = false
+        for (const [i, line] of doc.split('\n').entries()) {
+          if (line.startsWith('```')) {
+            inFence = !inFence
+            continue
+          }
+          // A command an agent would copy: inside a fence, or backticked in
+          // prose. A lowercase noun phrase ("the fabric plugin", "a fabric
+          // dispatcher") is describing Fabric, not telling anyone to run it.
+          const commands = inFence
+            ? [...line.matchAll(/(?<!pikku )(?<![\w/@-])fabric ([a-z][a-z-]+)/g)]
+            : [...line.matchAll(/`(?<!pikku )fabric ([a-z][a-z-]+)[^`]*`/g)]
+          for (const m of commands) offenders.push(`${skill.name}/${where}:${i + 1}: ${m[0]}`)
+        }
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `the OSS corpus has no fabric binary — use the pikku equivalent:\n  ${offenders.join('\n  ')}`
+    )
+  })
+
   test('relative paths referenced in a skill resolve on disk', async () => {
     for (const skill of await readSkills()) {
       const docs = [skill.body]


### PR DESCRIPTION
Fabric was carrying five skills that describe nothing Fabric-specific. They move here, so the OSS reader gets them and Fabric stops maintaining a second copy.

## Skills

- **a11y, seo, permissions, list-query, realtime** arrive from Fabric. `pikku-a11y` and `pikku-seo` are `installGroups: [client]`; the other three are `[core]`.
- **Four skills had no `installGroups` at all**, so `--core` never installed them.
- **`pikku-workflow` gains a "Decide FIRST" section** — the external-boundary test, and why one durable step is a queue worker.
- **`pikku-auth`'s Better Auth reference gains** 2FA, security hardening, and post-signup `databaseHooks`.
- **`pikku-build` gains `references/multi-app.md`** — it said how to clone a second app but never whether to.
- **`pikku-react`'s client reference now says what `transformDate: true` costs you**: the field arrives as a `Date`, so a string method on it throws and a raw one in JSX crashes the route.

## Corpus test

A new case fails the corpus on any `fabric <cmd>` an OSS reader cannot run. Three skills were quietly telling readers to run Fabric commands.

## `--json`

`--json` emitted nothing on 94 of the 105 commands. `runCLICommand` only swapped in the JSON renderer when the command had a renderer of its own; every command falling back to the program default silently kept it, and `defaultCLIRenderer` drops any result that is not a log line. `--json` now always wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The CLI `--json` option now consistently returns JSON results for every command.

- **New Features**
  - Added accessibility, SEO, permissions, list-query, and realtime guidance.
  - Added recommendations for two-factor authentication, security hardening, post-signup actions, multi-app decisions, and workflow selection.
  - Core skills are now grouped for streamlined installation.

- **Documentation**
  - Clarified date transformation behavior, including formatting requirements before display.
  - Removed Fabric-specific instructions from open-source guidance and clarified localization wrapper recommendations.
  - Expanded guidance for list limits, realtime updates, workflow retries, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->