### PR TITLE
fix(kysely): report the delivery id from send(), not just the broker's job id

### DIFF
--- a/.changeset/tidy-pans-repeat.md
+++ b/.changeset/tidy-pans-repeat.md
@@ -1,0 +1,10 @@
+---
+'@pikku/kysely': patch
+'@pikku/core': patch
+---
+
+`send()` now reports the delivery id it wrote, not only the broker's job id.
+
+`KyselyWebhookService.send()` returned `{ jobId }` straight from `queueService.add()`, and callers handed that to `getDelivery()`. That only worked because every queue in the test suite echoed the requested `jobId` back. A broker is free to assign its own identity — the JetStream queue returns a stream sequence — so on those the read-back looked up an id that was never written and 404'd.
+
+`SendWebhookResult` gains an optional `deliveryId`, which store-backed implementations always populate.

--- a/packages/core/src/services/webhook-service.ts
+++ b/packages/core/src/services/webhook-service.ts
@@ -20,6 +20,14 @@ export interface SendWebhookInput {
 
 export interface SendWebhookResult {
   jobId: string
+  /**
+   * The delivery row's id, which is what `getDelivery` reads back. Present only
+   * on store-backed implementations. It is not interchangeable with `jobId`: a
+   * broker is free to assign its own identity — the JetStream queue returns a
+   * stream sequence — so a caller that hands `jobId` to `getDelivery` looks up
+   * an id that was never written.
+   */
+  deliveryId?: string
 }
 
 export interface WebhookServiceConfig {

--- a/packages/services/kysely/src/kysely-webhook-service.test.ts
+++ b/packages/services/kysely/src/kysely-webhook-service.test.ts
@@ -75,6 +75,35 @@ describe('KyselyWebhookService', () => {
     assert.equal(delivery!.attempts.length, 0)
   })
 
+  test('send() reports the delivery id even when the broker assigns its own', async () => {
+    const db = createDb()
+    const added: { data: any; options: any }[] = []
+    const queue = {
+      supportsResults: false,
+      add: async (_name: string, data: any, options: any) => {
+        added.push({ data, options })
+        return '42'
+      },
+      getJob: async () => null,
+    }
+    await applyPikkuSchemas(db, [webhookSchema])
+    const service = new KyselyWebhookService(queue as any, db)
+    await service.init()
+
+    const { jobId, deliveryId } = await service.send({
+      url: 'https://example.com/hook',
+      event: 'user.created',
+      data: { id: 'u1' },
+      organizationId: 'org-1',
+    })
+
+    assert.equal(jobId, '42')
+    assert.notEqual(deliveryId, jobId)
+    assert.equal(deliveryId, added[0]!.options.jobId)
+    assert.ok(await service.getDelivery(deliveryId!))
+    assert.equal(await service.getDelivery(jobId), null)
+  })
+
   test('recordAttempt() appends attempts and rolls status forward', async () => {
     const db = createDb()
     const { queue } = createQueue()

--- a/packages/services/kysely/src/kysely-webhook-service.ts
+++ b/packages/services/kysely/src/kysely-webhook-service.ts
@@ -36,7 +36,9 @@ export class KyselyWebhookService extends QueueWebhookService {
     this.initialized = true
   }
 
-  public async send(input: SendWebhookInput): Promise<SendWebhookResult> {
+  public async send(
+    input: SendWebhookInput
+  ): Promise<Required<SendWebhookResult>> {
     const deliveryId = globalThis.crypto.randomUUID()
     const { jobData, options } = await this.prepareDelivery(input)
 
@@ -57,7 +59,7 @@ export class KyselyWebhookService extends QueueWebhookService {
       { ...jobData, deliveryId },
       { ...options, jobId: deliveryId }
     )
-    return { jobId }
+    return { jobId, deliveryId }
   }
 
   public async recordAttempt(


### PR DESCRIPTION
## The bug

`KyselyWebhookService.send()` returned `{ jobId }` straight from `queueService.add()`, and every caller handed that id to `getDelivery()`.

That only worked because the id and the delivery row's id happened to coincide — `send()` asks for `{ jobId: deliveryId }`, and a queue that honours the requested id gives it back. **A broker is not obliged to.** `@pikkufabric/queue-nats` returns the JetStream stream sequence and says so in its own comment:

```ts
// The stream sequence is the only broker-assigned identity a message has.
// ... note it is NOT the `jobId` the caller may have passed.
return String(ack.seq)
```

So on a JetStream-backed deployment `send()` reports something like `"42"`, and the read-back looks up an id that was never written. The delivery row and all its attempts are sitting correctly in the database; they are simply unreachable.

Found by fabric's webhook-delivery user flow, which passes register → subscribe → test-send and then 404s on the last step.

## Why the tests didn't catch it

Every fake queue in the suite echoes the requested id:

```ts
return options?.jobId ?? 'job-1'
```

which is precisely the case that works. The new test uses a queue that returns its own id — the case the old fake could not express.

## The fix

`SendWebhookResult` gains an optional `deliveryId`, populated by store-backed implementations. `KyselyWebhookService.send()` narrows its return to `Required<SendWebhookResult>` so those callers get it without a null check. `jobId` keeps its meaning — the broker's identity, for correlating logs and telemetry.

Both fields are needed and they are not interchangeable, which is the thing the old single-field result quietly asserted.

## Verification

`@pikku/kysely` tests: 313 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)