### PR TITLE
chore: regenerate api-report on commit, not in someone else's CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,10 @@
     "*.ts": [
       "oxlint",
       "prettier --write"
+    ],
+    "packages/core/src/**/*.ts": [
+      "yarn workspace @pikku/core run api-report",
+      "git add packages/core/api-report.md"
     ]
   }
 }


### PR DESCRIPTION
## Why

`packages/core/api-report.md` pins every member of every exported symbol, and `api-report.test.ts` fails when it and the code disagree. Nothing regenerated it, so the report goes stale on the commit that changed the surface and the failure surfaces later — on #1578 it surfaced *after* the PR had already merged, taking `main` red (fixed in #1579).

## What

`lint-staged` already auto-fixes and re-stages (`prettier --write`), so the report joins that lane:

```json
"packages/core/src/**/*.ts": [
  "yarn workspace @pikku/core run api-report",
  "git add packages/core/api-report.md"
]
```

Scoped to `packages/core/src`, so it costs nothing on every other commit. The generator builds its own `ts.Program` from `src` rather than reading `dist`, so it needs no prior build — which is what makes it safe in a hook.

The diff stays reviewable, which is the report's whole purpose. It just arrives in the PR that caused it instead of in the next person's run.

## Verified

Added a throwaway member to an exported interface and committed:

```
    packages/core/src/**/*.ts — 1 file
      ✔ yarn workspace @pikku/core run api-report
      ✔ git add packages/core/api-report.md

 package.json                                  | 4 ++++
 packages/core/api-report.md                   | 8 +++++---
 packages/core/src/services/webhook-service.ts | 1 +
```

with the report's counts and the new member in the same commit. Probe reverted; this PR is the four config lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)