### PR TITLE
fix(cli): release the old inspector state's types before re-inspecting

### DIFF
--- a/.changeset/quiet-inspector-release.md
+++ b/.changeset/quiet-inspector-release.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Release the previous inspector state's `typesLookup` before re-inspecting. The live `ts.Type`s in that map kept the old `ts.Program` and its exercised type checker reachable across every re-inspection in `pikku all`, so two full programs were alive at once and large projects ran out of heap in CI. The codegen benchmark now measures live heap at the start of each inspector pass and peak heap, and fails when a pass starts a program's worth above the first.

--- a/benchmarks/bench-codegen-perf.ts
+++ b/benchmarks/bench-codegen-perf.ts
@@ -7,7 +7,14 @@
  *   # or via the CI job (see .github/workflows/develop.yml)
  */
 import { spawnSync } from 'child_process'
-import { mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync } from 'fs'
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  symlinkSync,
+  readFileSync,
+} from 'fs'
 import { resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import os from 'os'
@@ -17,6 +24,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..')
 const PIKKU_BIN = resolve(REPO_ROOT, 'node_modules/.bin/pikku')
 const PIKKU_NODE_MODULES = resolve(REPO_ROOT, 'node_modules')
+const HEAP_PROBE = resolve(__dirname, 'codegen-heap-probe.cjs')
 
 const PROJECT_DIR = resolve(os.tmpdir(), 'pikku-codegen-perf')
 const FUNCTION_COUNT = 500
@@ -36,6 +44,25 @@ const REINSPECT_MAX_MS = 4500
 // Sample the timed inspection a few times and judge the best (lowest) re-inspect,
 // so a one-off GC/IO stall on a CI runner can't flake the gate.
 const REINSPECT_SAMPLES = 3
+// Memory gates, measured by codegen-heap-probe.cjs on a separate cold run.
+//
+// `pikku all` builds several ts.Programs in one process (a setup-only inspector
+// pass, the full pass, ts-json-schema-generator's own, plus a re-inspection per
+// codegen stage that touched the source tree). Only the current pass's program
+// should be alive; if the previous pass's state pins its program — its
+// `typesLookup` holds ts.Types, and a type reaches the checker and the whole
+// program — every pass starts a full program + exercised checker higher than
+// the one before, and a large project OOMs on a 2GB CI heap. On this fixture
+// that pin makes the second inspector pass start ~120MB above the first, where
+// a healthy run starts within a few MB of it.
+const INSPECTOR_LIVE_GROWTH_MAX_MB = 64
+// Everything alive at once, at the worst moment of the run — the number that
+// actually hits the heap limit. ~490MB healthy on this fixture; two live
+// programs push it to ~640MB.
+const PEAK_HEAP_MAX_MB = 560
+// Programs built on a run: the setup-only pass and the full pass.
+// Building more means a stage re-inspects (or re-parses) that didn't before.
+const PROGRAM_COUNT_MAX = 2
 
 // ── project scaffold ──────────────────────────────────────────────────────────
 
@@ -253,16 +280,39 @@ function clearSchemaCache(): void {
   })
 }
 
-function runAll(timing = false): { ms: number; stdout: string } {
+type HeapProgram = {
+  index: number
+  kind: 'inspector' | 'schema' | 'other'
+  caller: string
+  atMs: number
+  liveMb: number
+}
+type HeapReport = { programs: HeapProgram[]; peakMb: number }
+
+function runAll(opts: { timing?: boolean; probe?: boolean } = {}): {
+  ms: number
+  stdout: string
+  heap?: HeapReport
+} {
   clearSchemaCache()
+  const probeOut = resolve(PROJECT_DIR, 'heap-probe.json')
+  rmSync(probeOut, { force: true })
   const start = performance.now()
+  // No `--max-old-space-size` override: the child gets Node's default heap,
+  // like the CI jobs that run `pikku all`, so a memory regression fails here
+  // before it fails there.
   const result = spawnSync(PIKKU_BIN, ['all'], {
     cwd: PROJECT_DIR,
     timeout: 120_000,
     env: {
       ...process.env,
-      NODE_OPTIONS: '--max-old-space-size=4096',
-      ...(timing ? { PIKKU_TIMING: '1' } : {}),
+      ...(opts.probe
+        ? {
+            NODE_OPTIONS: `--expose-gc --require ${HEAP_PROBE}`,
+            PIKKU_HEAP_PROBE_OUT: probeOut,
+          }
+        : { NODE_OPTIONS: '' }),
+      ...(opts.timing ? { PIKKU_TIMING: '1' } : {}),
     },
   })
   if (result.status !== 0) {
@@ -273,6 +323,9 @@ function runAll(timing = false): { ms: number; stdout: string } {
   return {
     ms: performance.now() - start,
     stdout: result.stdout?.toString() ?? '',
+    ...(opts.probe
+      ? { heap: JSON.parse(readFileSync(probeOut, 'utf8')) as HeapReport }
+      : {}),
   }
 }
 
@@ -353,7 +406,7 @@ async function main() {
   // absolute ms ceiling so a regression to full re-walks fails (see
   // REINSPECT_MAX_MS for why an absolute budget, not a ratio, is runner-stable).
   const samples = Array.from({ length: REINSPECT_SAMPLES }, () => {
-    const steps = parseStepTimings(runAll(true).stdout)
+    const steps = parseStepTimings(runAll({ timing: true }).stdout)
     const initial = steps.get('Generate function types') ?? 0
     const reinspects = [...steps.entries()].filter(([name]) =>
       name.startsWith('Re-inspect')
@@ -404,6 +457,67 @@ async function main() {
   } else {
     console.warn(
       `\nWARN: could not find inspector pass timings — skipping structural gate`
+    )
+  }
+
+  // ── memory gate ──────────────────────────────────────────────────────────
+  // Its own cold run: the probe's forced GCs would inflate the timed one.
+  process.stdout.write(`\nMeasuring heap across inspector passes ... `)
+  const { heap } = runAll({ probe: true })
+  if (!heap) throw new Error('heap probe produced no report')
+  console.log(`${heap.programs.length} programs, peak ${heap.peakMb}MB`)
+  for (const p of heap.programs) {
+    console.log(
+      `  #${p.index}  t=${String(p.atMs).padStart(5)}ms  ` +
+        `live=${String(p.liveMb).padStart(4)}MB  ${p.kind}  ` +
+        `(${p.caller.replace(/\(.*\//, '(')})`
+    )
+  }
+
+  const inspectorPasses = heap.programs.filter((p) => p.kind === 'inspector')
+  const [first, ...later] = inspectorPasses
+  if (!first || later.length === 0) {
+    console.error(
+      `\nFAIL: expected at least two inspector passes, saw ${inspectorPasses.length}`
+    )
+    failed = true
+  } else {
+    const worst = later.reduce((a, b) => (b.liveMb > a.liveMb ? b : a))
+    const growth = worst.liveMb - first.liveMb
+    if (growth > INSPECTOR_LIVE_GROWTH_MAX_MB) {
+      console.error(
+        `\nFAIL: inspector pass #${worst.index} starts with ${worst.liveMb}MB live, ` +
+          `${growth}MB above pass #${first.index} (> ${INSPECTOR_LIVE_GROWTH_MAX_MB}MB). ` +
+          `The previous pass's state is keeping its ts.Program (and checker) alive ` +
+          `across the re-inspection — see the typesLookup release in services.ts.`
+      )
+      failed = true
+    } else {
+      console.log(
+        `\nPASS: inspector passes start within ${growth}MB of the first ` +
+          `(<= ${INSPECTOR_LIVE_GROWTH_MAX_MB}MB)`
+      )
+    }
+  }
+
+  if (heap.peakMb > PEAK_HEAP_MAX_MB) {
+    console.error(
+      `FAIL: peak heap ${heap.peakMb}MB exceeds ${PEAK_HEAP_MAX_MB}MB`
+    )
+    failed = true
+  } else {
+    console.log(`PASS: peak heap ${heap.peakMb}MB <= ${PEAK_HEAP_MAX_MB}MB`)
+  }
+
+  if (heap.programs.length > PROGRAM_COUNT_MAX) {
+    console.error(
+      `FAIL: ${heap.programs.length} ts.Programs built ` +
+        `(> ${PROGRAM_COUNT_MAX}) — a stage is re-inspecting that didn't before`
+    )
+    failed = true
+  } else {
+    console.log(
+      `PASS: ${heap.programs.length} ts.Programs built (<= ${PROGRAM_COUNT_MAX})`
     )
   }
 

--- a/benchmarks/codegen-heap-probe.cjs
+++ b/benchmarks/codegen-heap-probe.cjs
@@ -1,0 +1,75 @@
+/**
+ * Heap probe preloaded into the `pikku all` child by bench-codegen-perf.ts
+ * (via `NODE_OPTIONS=--expose-gc --require`). Writes, on exit, a JSON report
+ * to $PIKKU_HEAP_PROBE_OUT:
+ *
+ *   {
+ *     programs: [{ index, kind, caller, atMs, liveMb }], // one per ts.Program
+ *     peakMb,                                      // highest used heap seen
+ *   }
+ *
+ * A program is detected by the read of TypeScript's default lib: neither the
+ * inspector nor ts-json-schema-generator shares a compiler host, so every
+ * `ts.createProgram` reads lib.es5.d.ts exactly once. `liveMb` is the used
+ * heap after a forced full GC at that moment — only what is still reachable.
+ * That is the number that grows when a finished inspector pass keeps its
+ * program alive (its `typesLookup` holds ts.Types, which reach the checker,
+ * which reaches the program): the next pass then starts one whole program +
+ * checker higher than the first one did. `kind` tells the inspector's own
+ * programs apart from the small one ts-json-schema-generator builds.
+ */
+const fs = require('node:fs')
+const v8 = require('node:v8')
+
+const usedMb = () => Math.round(v8.getHeapStatistics().used_heap_size / 1048576)
+
+const programs = []
+let peakMb = 0
+const sample = () => {
+  peakMb = Math.max(peakMb, usedMb())
+}
+// Coarse: the event loop is blocked while a program parses, so most of the
+// peak comes from the samples taken at each program start and on exit.
+setInterval(sample, 25).unref()
+
+// The first frame above TypeScript itself: who asked for this program.
+const callerOf = () => {
+  const limit = Error.stackTraceLimit
+  Error.stackTraceLimit = 400
+  const frames = (new Error().stack ?? '').split('\n').slice(1)
+  Error.stackTraceLimit = limit
+  const frame = frames.find(
+    (f) => !f.includes('/typescript/') && !f.includes(__filename)
+  )
+  return frame ? frame.trim().replace(/^at\s+/, '') : '?'
+}
+
+const kindOf = (caller) =>
+  caller.includes('ts-json-schema-generator')
+    ? 'schema'
+    : caller.includes('/inspector/')
+      ? 'inspector'
+      : 'other'
+
+const readFileSync = fs.readFileSync
+fs.readFileSync = function (path, ...rest) {
+  if (typeof path === 'string' && path.endsWith('lib.es5.d.ts')) {
+    sample()
+    if (typeof globalThis.gc === 'function') globalThis.gc()
+    const caller = callerOf()
+    programs.push({
+      index: programs.length + 1,
+      kind: kindOf(caller),
+      caller,
+      atMs: Math.round(performance.now()),
+      liveMb: usedMb(),
+    })
+  }
+  return readFileSync.call(this, path, ...rest)
+}
+
+process.on('exit', () => {
+  sample()
+  const out = process.env.PIKKU_HEAP_PROBE_OUT
+  if (out) fs.writeFileSync(out, JSON.stringify({ programs, peakMb }))
+})

--- a/packages/cli/src/services.ts
+++ b/packages/cli/src/services.ts
@@ -360,6 +360,16 @@ export const createSingletonServices: CreateSingletonServices<
         ? ((await loadManifest(join(config.rootDir, 'versions.pikku.json'))) ??
           undefined)
         : undefined
+      // The outgoing state's `typesLookup` holds live `ts.Type`s. A type reaches
+      // its checker and the checker reaches the whole program, so that one map
+      // pins a parsed program and an exercised checker for as long as the state
+      // exists — `releaseProgram` alone frees nothing. Every reader of the old
+      // state is done once a re-inspection is asked for, so drop the types here
+      // and the old program is collectable while the new one is built, instead
+      // of both being live at once.
+      if (unfilteredState && 'typesLookup' in unfilteredState) {
+        unfilteredState.typesLookup.clear()
+      }
       const oldProgram = unfilteredState?.program ?? undefined
       const inspectStart = Date.now()
       unfilteredStateIsSetupOnly = setupOnly


### PR DESCRIPTION
## Problem

Fabric's CI OOMs during `pikku all` on api-functions (791 files). Root cause: `InspectorState.typesLookup: Map<string, ts.Type[]>` holds live `ts.Type`s. A type reaches its checker and the checker reaches the whole `ts.Program`, so the outgoing state pinned a parsed program *and* an exercised checker for as long as it existed — `releaseProgram` (#1405) nulled `state.program` but freed nothing.

Each of the three re-inspections in `all.workflow.ts` (after agents / workflows / CLI channel) therefore had two full programs live at once. Forced-GC live heap per program on Fabric: 165 → 689 → 1297 → 872 → 888 → 1407 → 1491 MB, peak RSS 2.26 GB against a ~2 GB default heap.

## Fix

Clear the old state's `typesLookup` in `services.ts` right before a re-inspection builds its program. Nothing reads the old state after that point (the only `typesLookup` consumer is `pikku-command-workflow.ts`, on the current state).

Fabric, same run: 178 → 319 → 331 MB, peak RSS 1.32 GB (−41%), `.pikku` output byte-identical, less GC/sys time.

## Benchmark

`bench-codegen-perf.ts` now preloads `codegen-heap-probe.cjs` into a separate cold `pikku all` run (`--expose-gc --require`). The probe records forced-GC live heap at the start of every `ts.Program` (detected by the `lib.es5.d.ts` read, attributed to the inspector or the schema generator by caller) plus peak used heap, and the bench gates on:

- live heap at the start of each inspector pass within 64 MB of the first (unfixed: +150 MB, fixed: +3 MB on the 500-fn fixture)
- peak heap ≤ 560 MB (unfixed 637 MB, fixed 492 MB)
- ≤ 2 programs built

Validated both ways locally: fails on the unfixed dist, passes with the fix. The `--max-old-space-size=4096` override on the child is removed so the bench runs with the same default heap as the CI jobs it stands in for.

## Note on the existing timing gate

Correction to an earlier version of this note: step durations are recorded fine. The structural gate was passing vacuously for two other reasons — it looks for a step named `Generate function types`, which no longer exists (the passes are `Function types split` and `CLI types`), and the 500-function fixture has nothing that triggers a re-inspection, so `Re-inspect after agents` is a 0 ms no-op. A follow-up PR replaces that gate with per-pass work counters and adds an agent to the fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
