### PR TITLE
fix(cli): keep agent tool descriptions in the runtime meta

### DIFF
--- a/.changeset/agent-tool-descriptions.md
+++ b/.changeset/agent-tool-descriptions.md
@@ -1,0 +1,14 @@
+---
+'@pikku/cli': patch
+---
+
+Keep the description of a function an agent lists as a tool in the runtime meta
+
+`description` is classed as a verbose field and stripped from the meta a
+deployment ships, but `agent-prepare` needs it to tell the model what each tool
+does. Where the verbose file is unreadable — a deployed bundle, or any app
+shipping only the stripped copy — every tool was offered under its bare name.
+
+The functions an agent actually lists as tools now keep their description in the
+minimal meta, so the model sees them everywhere the agent runs. Descriptions for
+functions no agent calls stay stripped.

--- a/packages/cli/src/functions/wirings/functions/pikku-command-functions.ts
+++ b/packages/cli/src/functions/wirings/functions/pikku-command-functions.ts
@@ -6,6 +6,7 @@ import { getFileImportRelativePath } from '../../../utils/file-import-path.js'
 import {
   stripVerboseFields,
   reattachFunctionServices,
+  reattachAgentToolDescriptions,
 } from '../../../utils/strip-verbose-meta.js'
 import {
   writeMetaSidecar,
@@ -19,7 +20,7 @@ import { serializeScenarioFunctionMeta } from '../scenarios/serialize-scenario-m
 
 export const pikkuFunctions = pikkuSessionlessFunc<void, boolean | undefined>({
   func: async ({ logger, config, getInspectorState }) => {
-    const { functions, rpc } = await getInspectorState()
+    const { functions, rpc, agents } = await getInspectorState()
     const {
       functionsMetaFile,
       functionsMetaJsonFile,
@@ -38,6 +39,13 @@ export const pikkuFunctions = pikkuSessionlessFunc<void, boolean | undefined>({
     if (config.addonName) {
       minimalMeta = reattachFunctionServices(minimalMeta, appFunctionsMeta)
     }
+    minimalMeta = reattachAgentToolDescriptions(
+      minimalMeta,
+      appFunctionsMeta,
+      new Set(
+        Object.values(agents.agentsMeta).flatMap((agent) => agent.tools ?? [])
+      )
+    )
 
     const packageName = config.addonName ? `'${config.addonName}'` : 'null'
     const supportsImportAttributes = schema?.supportsImportAttributes ?? false

--- a/packages/cli/src/utils/strip-verbose-meta.test.ts
+++ b/packages/cli/src/utils/strip-verbose-meta.test.ts
@@ -4,6 +4,7 @@ import {
   stripVerboseFields,
   hasVerboseFields,
   reattachFunctionServices,
+  reattachAgentToolDescriptions,
 } from './strip-verbose-meta.js'
 
 describe('stripVerboseFields', () => {
@@ -187,5 +188,52 @@ describe('reattachFunctionServices', () => {
       { ghost: { services: { optimized: true, services: ['kysely'] } } } as any
     )
     assert.deepStrictEqual(result, {})
+  })
+})
+
+describe('reattachAgentToolDescriptions', () => {
+  const fullMeta = {
+    getDeploymentStatus: {
+      pikkuFuncId: 'getDeploymentStatus',
+      description: 'State of one deployment, and why it failed',
+    },
+    listInvoices: {
+      pikkuFuncId: 'listInvoices',
+      description: 'Every invoice on the organization',
+    },
+  } as any
+
+  test('restores the description of a function an agent lists as a tool', () => {
+    const minimal = stripVerboseFields(fullMeta) as any
+    assert.strictEqual(minimal.getDeploymentStatus.description, undefined)
+
+    const result = reattachAgentToolDescriptions(minimal, fullMeta, [
+      'getDeploymentStatus',
+    ]) as any
+
+    assert.strictEqual(
+      result.getDeploymentStatus.description,
+      'State of one deployment, and why it failed'
+    )
+  })
+
+  test('leaves a function no agent calls stripped', () => {
+    const result = reattachAgentToolDescriptions(
+      stripVerboseFields(fullMeta) as any,
+      fullMeta,
+      ['getDeploymentStatus']
+    ) as any
+
+    assert.strictEqual(result.listInvoices.description, undefined)
+  })
+
+  test('ignores a tool name with no matching function', () => {
+    const result = reattachAgentToolDescriptions(
+      stripVerboseFields(fullMeta) as any,
+      fullMeta,
+      ['someAgentDelegate']
+    ) as any
+
+    assert.strictEqual(result.someAgentDelegate, undefined)
   })
 })

--- a/packages/cli/src/utils/strip-verbose-meta.ts
+++ b/packages/cli/src/utils/strip-verbose-meta.ts
@@ -226,6 +226,24 @@ export function reattachFunctionServices<
 }
 
 /**
+ * `description` is stripped as visualization-only, but an agent's tools are
+ * offered to the model by name and description — without it the model chooses
+ * between bare RPC names. Re-attach it for the functions some agent actually
+ * lists as a tool, rather than shipping every description at runtime.
+ */
+export function reattachAgentToolDescriptions<
+  T extends Record<string, { description?: unknown }>,
+>(minimalMeta: T, fullMeta: T, toolNames: Iterable<string>): T {
+  for (const name of toolNames) {
+    const full = fullMeta[name]
+    if (full?.description && minimalMeta[name]) {
+      minimalMeta[name].description = full.description
+    }
+  }
+  return minimalMeta
+}
+
+/**
  * Check if an object has any verbose fields that would be stripped
  */
 export function hasVerboseFields(obj: unknown): boolean {


### PR DESCRIPTION
## Issue

`description` is on `VERBOSE_FIELDS`, so it is stripped from the meta a deployment ships. But `agent-prepare.ts` needs it at runtime — it is what the model is told each tool does, and the main thing it chooses between tools on:

```ts
description:
  describedFunctions?.[pikkuFuncId]?.description ||
  fnMeta?.description ||
  toolName,
```

That lookup reads the verbose file and falls back to the minimal one. Where the verbose file is unreadable — a deployed bundle, or any app shipping only the stripped copy — it resolves to `toolName`, and every tool is offered under its bare RPC name.

Checked against a real app with an agent: all nine of its tools key straight into the functions meta, and none of them carries a description in the minimal blob. So the model currently picks between `getDeploymentBuildLog` and `getDeploymentSecurityAudit` on the names alone.

## Change

`reattachAgentToolDescriptions` restores `description` for the function ids that appear in some agent's `tools` list, mirroring how an addon build already reattaches `services` via `reattachFunctionServices`.

Descriptions for functions no agent calls stay stripped, so the cost is one string per tool rather than shipping every description at runtime.

## Actions

1. `pikku-command-functions.ts` reads `agents` off the inspector state and passes the union of every agent's `tools` into the reattach.
2. `strip-verbose-meta.ts` gains the helper; `VERBOSE_FIELDS` is unchanged, so nothing else starts shipping.
3. Three cases added to `strip-verbose-meta.test.ts` — reattaches a listed tool, leaves an unlisted function stripped, ignores a tool name with no matching function. 14 tests pass in that file.

Not addressed here: sub-agent delegating tools take their description from `agentsMeta`, which already ships, so they were never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Agent tools now consistently display their descriptions in deployed applications, including environments where extended metadata is unavailable.
  - Agents can better distinguish between available tools based on their descriptions.
  - Descriptions remain limited to tools that agents are configured to use, keeping unrelated function metadata concise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->