### PR TITLE
fix(inspector): keep wired addons for units with the /rpc/:rpcName catch-all

### DIFF
--- a/packages/inspector/src/utils/filter-inspector-state.test.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.test.ts
@@ -2141,4 +2141,67 @@ describe('invokedAgentsByFile', () => {
       ['/test/project/src/api/users.ts']
     )
   })
+
+  describe('Wired addon retention', () => {
+    // A unit that owns the generic `/rpc/:rpcName` catch-all (the rpcCaller
+    // unit, and agent units) dispatches arbitrary RPCs at runtime via
+    // `rpc.exposed(name)`, including namespaced addon RPCs like
+    // `admin:createUser`. No app-local function statically references those
+    // ids, so the catch-all must be enough to keep every wired addon's
+    // declaration — otherwise the per-unit bootstrap omits the addon package
+    // bootstrap and `rpc.exposed('admin:createUser')` throws RPCNotFoundError
+    // on a deployed stage.
+    const withAddons = () => {
+      const state = createMockInspectorState()
+      state.rpc.wireAddonDeclarations = new Map([
+        ['admin', { package: '@pikku/addon-admin' } as any],
+        ['console', { package: '@pikku/addon-console' } as any],
+      ])
+      state.rpc.usedAddons = new Set(['admin', 'console'])
+      return state
+    }
+
+    test('keeps all wired addons for a unit with the /rpc/:rpcName catch-all', () => {
+      const result = filterInspectorState(
+        withAddons(),
+        { names: ['/rpc/:rpcName', 'http:post:/rpc/:rpcName', 'rpcCaller'] },
+        mockLogger
+      )
+      assert.deepStrictEqual(
+        [...result.rpc.wireAddonDeclarations.keys()].sort(),
+        ['admin', 'console']
+      )
+      assert.deepStrictEqual([...result.rpc.usedAddons].sort(), [
+        'admin',
+        'console',
+      ])
+    })
+
+    test('drops wired addons for a unit without the catch-all that references no namespace', () => {
+      const result = filterInspectorState(
+        withAddons(),
+        { names: ['getUsers'] },
+        mockLogger
+      )
+      assert.deepStrictEqual([...result.rpc.wireAddonDeclarations.keys()], [])
+      assert.deepStrictEqual([...result.rpc.usedAddons], [])
+    })
+
+    test('still keeps an addon a surviving function statically references, without the catch-all', () => {
+      const state = withAddons()
+      state.serviceAggregation.usedFunctions.add('getUsers')
+      state.rpc.invokedFunctionsByFile = new Map([
+        ['/test/project/src/api/users.ts', new Set(['admin:createUser'])],
+      ])
+      const result = filterInspectorState(
+        state,
+        { names: ['getUsers'] },
+        mockLogger
+      )
+      assert.deepStrictEqual(
+        [...result.rpc.wireAddonDeclarations.keys()],
+        ['admin']
+      )
+    })
+  })
 })

--- a/packages/inspector/src/utils/filter-inspector-state.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.ts
@@ -1258,8 +1258,21 @@ export function filterInspectorState(
     ) as Array<{ tools?: string[] }>) {
       for (const tool of agentMeta.tools ?? []) referencedIds.add(tool)
     }
+    // A unit carrying the generic `/rpc/:rpcName` catch-all (the rpcCaller
+    // unit, and agent units) dispatches arbitrary RPCs at runtime via
+    // `rpc.exposed(name)`, including namespaced addon RPCs (e.g.
+    // `admin:createUser`). Those never appear in referencedIds because no
+    // app-local function statically references them, so keep every wired
+    // addon's declaration for such units — otherwise the per-unit bootstrap
+    // omits the addon package bootstrap and `rpc.exposed('admin:createUser')`
+    // throws RPCNotFoundError on the deployed stage.
+    const hasRpcCatchAll = (filters.names ?? []).includes('/rpc/:rpcName')
     const keptNamespaces = new Set<string>()
     for (const namespace of filteredState.rpc.wireAddonDeclarations.keys()) {
+      if (hasRpcCatchAll) {
+        keptNamespaces.add(namespace)
+        continue
+      }
       const prefix = `${namespace}:`
       for (const id of referencedIds) {
         if (id.startsWith(prefix)) {


### PR DESCRIPTION
## Problem

Per-unit deploy codegen filters the inspector state down to a single unit's functions. `filterInspectorState` kept a `wireAddon` declaration only when a surviving referenced function id was namespaced under that addon (e.g. `admin:...`).

The `rpcCaller` unit — and agent units — own the generic `/rpc/:rpcName` catch-all and dispatch arbitrary RPCs at runtime via `rpc.exposed(name)`, including namespaced addon RPCs (`admin:createUser`, `console:getMyAccess`, …). But they reference none of those ids statically, so **every wired addon was pruned from that unit**.

The unit's generated `pikku-bootstrap.gen.ts` then imported the wireAddon file (which registers the namespace) **without** the addon package bootstrap (which loads the function meta). At runtime `resolveNamespace('admin:createUser')` resolved the namespace but found empty meta → `RPCNotFoundError`. Net effect: **every wired-addon RPC 404s on a Fabric-deployed stage**, even though it works in-process (e2e) where the addon bootstrap is always loaded.

## Fix

Keep all wired addon declarations for any unit whose filter names include the `/rpc/:rpcName` catch-all — it can dispatch to any of them. Units without the catch-all still keep only the addons a surviving function statically references (unchanged behavior).

```js
const hasRpcCatchAll = (filters.names ?? []).includes('/rpc/:rpcName')
// ...for each wired addon namespace: if (hasRpcCatchAll) keep; else keep-if-referenced
```

## Verification

- Reproduced against a real app's inspector state: the catch-all unit's generated bootstrap now imports `@pikku/addon-admin/.pikku/pikku-bootstrap.gen.js` (+ `@pikku/addon-console`); a non-catch-all unit still omits them.
- 3 new regression tests (catch-all keep / no-catch-all drop / preserved static-reference path). Full `filter-inspector-state.test.ts` suite: 92/92 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)