### PR TITLE
feat(inspector): keep parsed source files across passes, without the checker

### DIFF
--- a/.changeset/quick-files-remember.md
+++ b/.changeset/quick-files-remember.md
@@ -1,0 +1,5 @@
+---
+'@pikku/inspector': patch
+---
+
+Keep parsed source files across inspector passes. A re-inspection in `pikku all` used to re-parse and re-bind every file, because the previous `ts.Program` — the thing TypeScript reuses parses from — had to be dropped to free its type checker. The inspector now builds each program through a compiler host with a content-hashed `SourceFile` cache, so a re-inspection parses only what codegen just wrote while holding no checker: on the 500-function benchmark the re-inspection reuses all 908 files, its CPU time falls by a third, and peak heap drops.

--- a/benchmarks/bench-codegen-perf.ts
+++ b/benchmarks/bench-codegen-perf.ts
@@ -51,6 +51,12 @@ const REINSPECT_WORK_MAX_RATIO = 1.1
 // few; a re-inspect that starts walking node_modules or a second project
 // accounts for hundreds.
 const REINSPECT_EXTRA_FILES_MAX = 16
+// ...and must not re-parse what it already had. The inspector keeps parsed
+// source files across programs (see packages/inspector/src/source-file-cache.ts),
+// so a re-inspection parses only the files codegen just wrote. Reuse dropping
+// to zero means every pass pays the full parse + bind again — the CPU half of
+// the memory/CPU trade the gates above watch the other half of.
+const REINSPECT_REUSE_MIN_RATIO = 0.9
 
 // ── memory gates ──────────────────────────────────────────────────────────────
 // Live heap (after a forced GC) at the moment each inspector pass starts,
@@ -61,14 +67,17 @@ const REINSPECT_EXTRA_FILES_MAX = 16
 // before, and a large project OOMs on a 2GB CI heap.
 //
 // The second pass is the sharp check: nothing but the setup pass has run, so
-// it starts within a few MB of the first (~150MB) unless that pass's program
-// is pinned (~+150MB).
-const PASS2_LIVE_GROWTH_MAX_MB = 64
-// By the re-inspection the full pass's state is legitimately alive — its meta,
-// 500 schemas, the schema generator's cached program — so it starts ~140MB
-// above the first pass. A pinned full-pass program and checker adds several
-// hundred MB on top.
-const REINSPECT_LIVE_GROWTH_MAX_MB = 256
+// the only thing legitimately carried over is the inspector's source-file
+// cache — the parsed ASTs of all ~900 files, ~75MB here — and the pass starts
+// that far above the first. A pinned program adds its checker on top, ~+165MB
+// even for the barely-exercised setup pass.
+const PASS2_LIVE_GROWTH_MAX_MB = 128
+// By the re-inspection the full pass's state is legitimately alive too — its
+// meta, 500 schemas, the schema generator's cached program — so it starts
+// ~210MB above the first pass. A pinned full-pass program and its exercised
+// checker add several hundred MB on top (~+450MB total when #1581's release
+// is reverted).
+const REINSPECT_LIVE_GROWTH_MAX_MB = 320
 // Everything alive at once, at the worst moment of the run — the number that
 // actually hits the heap limit.
 const PEAK_HEAP_MAX_MB = 660
@@ -556,13 +565,19 @@ async function main() {
           `(<= ${REINSPECT_EXTRA_FILES_MAX})`
       )
     }
-    // Not gated yet: `releaseProgram` in services.ts drops the program the
-    // next pass would reuse, so every pass re-parses everything (reused=0).
-    // Reported so the fix is measurable when it lands; gate it then.
-    console.log(
-      `INFO: re-inspection reused ${reinspect.reused}/${reinspect.files} ` +
-        `source files from the previous program`
-    )
+    const reuseRatio = reinspect.reused / reinspect.files
+    if (reuseRatio < REINSPECT_REUSE_MIN_RATIO) {
+      fail(
+        `re-inspection reused only ${reinspect.reused}/${reinspect.files} ` +
+          `source files (< ${Math.round(REINSPECT_REUSE_MIN_RATIO * 100)}%) — ` +
+          `it is re-parsing files the previous pass already had`
+      )
+    } else {
+      pass(
+        `re-inspection reused ${reinspect.reused}/${reinspect.files} source ` +
+          `files (>= ${Math.round(REINSPECT_REUSE_MIN_RATIO * 100)}%)`
+      )
+    }
   }
 
   // ── memory gates ─────────────────────────────────────────────────────────

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -10,6 +10,7 @@ import type {
 } from './types.js'
 import { getFilesAndMethods } from './utils/get-files-and-methods.js'
 import { findCommonAncestor } from './utils/find-root-dir.js'
+import { createSourceFileCacheHost } from './source-file-cache.js'
 import { createNestedProjectFilter } from './utils/nested-project-filter.js'
 import {
   aggregateRequiredServices,
@@ -337,22 +338,18 @@ export const inspect = async (
   }
   const cpuStart = process.cpuUsage()
   const startProgram = performance.now()
+  const host = createSourceFileCacheHost(compilerOptions)
   const program = ts.createProgram(
     normalizedRouteFiles,
     compilerOptions,
-    undefined, // host
+    host,
     options.oldProgram
   )
+  host.prune(program)
+  const filesReused = host.reused()
   logger.debug(
-    `Created program in ${(performance.now() - startProgram).toFixed(0)}ms (${normalizedRouteFiles.length} files${options.oldProgram ? ', incremental' : ''})`
+    `Created program in ${(performance.now() - startProgram).toFixed(0)}ms (${normalizedRouteFiles.length} files, ${filesReused} source files reused)`
   )
-
-  // TS hands back the same SourceFile object for a file `oldProgram` already
-  // had and that hasn't changed, so identity is the reuse count.
-  const oldSourceFiles = new Set(options.oldProgram?.getSourceFiles() ?? [])
-  const filesReused = program
-    .getSourceFiles()
-    .filter((sf) => oldSourceFiles.has(sf)).length
 
   const startChecker = performance.now()
   const checker = program.getTypeChecker()

--- a/packages/inspector/src/source-file-cache.ts
+++ b/packages/inspector/src/source-file-cache.ts
@@ -1,0 +1,73 @@
+import * as ts from 'typescript'
+import { createHash } from 'crypto'
+
+/**
+ * Parsed source files, kept across programs so a re-inspection only re-parses
+ * what changed. Keyed by path; an entry is valid while the file's content
+ * hash matches.
+ *
+ * This is the incremental reuse `oldProgram` used to give, without its cost.
+ * Passing the previous ts.Program keeps that program reachable, and a program
+ * memoises its type checker — so every re-inspection held a second, fully
+ * exercised checker for the sake of skipping a re-parse. A bare SourceFile
+ * carries its AST and binder symbols and nothing else; sharing it between
+ * programs is what the language service's document registry does.
+ *
+ * Module-level on purpose: `inspect()` is called several times per `pikku all`
+ * (and indefinitely in watch mode) from one process, and the cache is only
+ * worth having if it outlives the call.
+ */
+const cache = new Map<string, { hash: string; file: ts.SourceFile }>()
+
+export interface SourceFileCacheHost extends ts.CompilerHost {
+  /** Files served from the cache by the program just built. */
+  readonly reused: () => number
+  /**
+   * Drop entries the program did not use, so a file that left the project
+   * (or watch mode's churn) does not pin its AST forever.
+   */
+  readonly prune: (program: ts.Program) => void
+}
+
+export const createSourceFileCacheHost = (
+  options: ts.CompilerOptions
+): SourceFileCacheHost => {
+  const host = ts.createCompilerHost(options, true)
+  let reused = 0
+
+  host.getSourceFile = (fileName, languageVersionOrOptions, onError) => {
+    let text: string | undefined
+    try {
+      text = host.readFile(fileName)
+    } catch (e) {
+      onError?.(e instanceof Error ? e.message : String(e))
+      return undefined
+    }
+    if (text === undefined) return undefined
+
+    const hash = createHash('sha1').update(text).digest('hex')
+    const hit = cache.get(fileName)
+    if (hit && hit.hash === hash) {
+      reused++
+      return hit.file
+    }
+    const file = ts.createSourceFile(
+      fileName,
+      text,
+      languageVersionOrOptions,
+      true
+    )
+    cache.set(fileName, { hash, file })
+    return file
+  }
+
+  return Object.assign(host, {
+    reused: () => reused,
+    prune: (program: ts.Program) => {
+      const live = new Set(program.getSourceFiles().map((sf) => sf.fileName))
+      for (const fileName of cache.keys()) {
+        if (!live.has(fileName)) cache.delete(fileName)
+      }
+    },
+  })
+}

--- a/packages/inspector/src/types.ts
+++ b/packages/inspector/src/types.ts
@@ -296,9 +296,9 @@ export interface InspectorPassStats {
   /** Files under rootDir the inspector actually swept. */
   projectFiles: number
   /**
-   * Files taken over from `oldProgram` without re-parsing. Zero on a first
-   * pass; on a re-inspection it should be nearly all of `files` — the
-   * incremental reuse is what keeps a re-inspection cheaper than a cold one.
+   * Files served from the source-file cache without re-parsing. Zero on a
+   * first pass; on a re-inspection it should be nearly all of `files` — that
+   * reuse is what keeps a re-inspection cheaper than a cold one.
    */
   filesReused: number
   /** Checker work, as `tsc --extendedDiagnostics` counts it. */


### PR DESCRIPTION
Stacked on #1586 (needs its `[INSPECT]` counters and gates). The CPU half of the memory/CPU trade.

## Problem

TypeScript's incremental reuse goes through `oldProgram`, and a program memoises its checker — so reusing parses meant keeping a fully exercised checker alive. `releaseProgram` (#1405) chose memory, and since then every re-inspection in `pikku all` re-parses and re-binds all ~900 files (`reused=0` on every pass in #1586's table).

## Fix

`packages/inspector/src/source-file-cache.ts`: a compiler host whose `getSourceFile` serves from a module-level, content-hashed `SourceFile` cache. A bare SourceFile carries its AST and binder symbols and nothing else — sharing one across programs is what the language service's document registry does. Entries the program didn't use are pruned after each build. `inspect()` builds through this host; `stats.filesReused` now counts cache hits.

## Measured (500-fn fixture, same machine, back to back)

```
                    #1586 (no cache)              this PR
  pass   reused    cpu(ms)  live-at-start   reused    cpu(ms)  live-at-start
     1        0       2806      159MB            0       2683      159MB
     2        0       5305      162MB          908       3578      237MB
     3        0       4367      294MB          908       4314*     369MB
  peak heap            561MB                            499MB
```
\* 2778 ms on the previous run; this machine's load is 20–45, CPU-ms wobble ~30 %.

Reuse 0 → 908/908, full-pass CPU −33 %, peak heap −62 MB (less parse garbage). The cost: ~75 MB of retained ASTs carried into every later pass, visible as +78 MB at pass 2 — which **failed #1586's 64 MB gate**, exactly as it should. That gate exists to catch a pinned program+checker (+165 MB at pass 2, +370 MB at re-inspect with #1581 reverted); the limits are re-baselined to admit the cache and nothing more: pass 2 ≤ 128 MB, re-inspect ≤ 320 MB, peak ≤ 660 MB unchanged. `reused` is now gated at ≥ 90 %.

Inspector unit tests: 771/771 pass (many `inspect()` calls in one process, so the cache is exercised across differing fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)