### PR TITLE
deploy: lift PlatformServiceContributor into @pikku/deploy

### DIFF
--- a/.changeset/deploy-contributor-lift.md
+++ b/.changeset/deploy-contributor-lift.md
@@ -1,0 +1,21 @@
+---
+'@pikku/deploy': patch
+'@pikku/deploy-cloudflare': patch
+'@pikku/deploy-standalone': patch
+---
+
+Lift `PlatformServiceContributor` into `@pikku/deploy` so any provider adapter
+can accept the same service contributors.
+
+A contributor now declares the binding sources its emitted code reads from
+(`requires`, defaulting to `env`). An adapter that cannot provide one of them
+refuses the contributor by name at construction instead of silently emitting
+code that reads bindings the runtime never has.
+
+`@pikku/deploy-cloudflare` keeps its entry output unchanged and re-exports the
+type from the core package. The container entry it generates now runs only the
+contributors that live on `env`. `@pikku/deploy-standalone` gains a
+`contributors` option: both the node and bun entries build the contributed
+services from `process.env` and spread them last into
+`createSingletonServices`, so a contributed service overrides the in-process
+default.

--- a/packages/deploy/deploy-cloudflare/full-deploy-dry-run.ts
+++ b/packages/deploy/deploy-cloudflare/full-deploy-dry-run.ts
@@ -2,7 +2,7 @@
  * Full dry-run deploy test: analyze → codegen per worker → bundle → plan
  *
  * Generates all files locally without hitting Cloudflare.
- * Usage: npx tsx packages/deploy/deploy-cloudflare/test-full-deploy.ts
+ * Usage: npx tsx packages/deploy/deploy-cloudflare/full-deploy-dry-run.ts
  */
 
 import { resolve, join } from 'node:path'

--- a/packages/deploy/deploy-cloudflare/package.json
+++ b/packages/deploy/deploy-cloudflare/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc -b",
-    "tsc": "tsc --noEmit"
+    "tsc": "tsc --noEmit",
+    "test": "node --test --import tsx src/*.test.ts"
   },
   "devDependencies": {
     "typescript": "^6.0.3"

--- a/packages/deploy/deploy-cloudflare/src/adapter.test.ts
+++ b/packages/deploy/deploy-cloudflare/src/adapter.test.ts
@@ -1,0 +1,79 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import type { PlatformServiceContributor } from '@pikku/deploy'
+
+import { CloudflareProviderAdapter } from './adapter.js'
+
+const unit = {
+  name: 'api',
+  role: 'function',
+  target: 'server',
+  services: [
+    { capability: 'queue', sourceServiceName: 'queueService' },
+    { capability: 'kv', sourceServiceName: 'browser' },
+  ],
+  handlers: ['http', 'queue'],
+  dependsOn: [],
+} as never
+
+const ctx = {
+  unit,
+  unitDir: '/build/api',
+  bootstrapPath: './.pikku/pikku-bootstrap.gen.js',
+  configImport: `import { createConfig } from './config.js'`,
+  configVar: 'createConfig',
+  servicesImport: `import { createSingletonServices } from './services.js'`,
+  servicesVar: 'createSingletonServices',
+  singletonServicesImport: '',
+  servicesType: 'Record<string, unknown>',
+  mcpImport: '',
+  mcpServerOption: '',
+} as never
+
+const kysely: PlatformServiceContributor = {
+  name: 'kysely',
+  imports: [`import { Kysely } from 'kysely'`],
+  emit: () => [`  if (env.DATABASE_URL) services.kysely = new Kysely({})`],
+}
+
+const queueBinding: PlatformServiceContributor = {
+  name: 'queue-binding',
+  requires: ['cloudflare'],
+  imports: [`import { bindQueue } from './queue.js'`],
+  emit: () => [`  services.queue = bindQueue(env.QUEUE)`],
+}
+
+describe('CloudflareProviderAdapter contributors', () => {
+  test('a worker entry runs env and cloudflare contributors', () => {
+    const source = new CloudflareProviderAdapter({
+      contributors: [kysely, queueBinding],
+    }).generateEntrySource(ctx)
+
+    assert.match(source, /import { Kysely } from 'kysely'/)
+    assert.match(source, /services\.kysely = new Kysely/)
+    assert.match(source, /import { bindQueue } from '\.\/queue\.js'/)
+    assert.match(source, /services\.queue = bindQueue\(env\.QUEUE\)/)
+  })
+
+  test('the container entry runs only contributors that live on env', () => {
+    const source = new CloudflareProviderAdapter({
+      contributors: [kysely, queueBinding],
+    }).generateServerEntrySource(ctx)
+
+    assert.match(source, /services\.kysely = new Kysely/)
+    assert.doesNotMatch(source, /bindQueue/)
+    assert.match(source, /\.\.\.platformServices,\n  }\)/)
+  })
+
+  test('a later contributor with the same name replaces the earlier one', () => {
+    const source = new CloudflareProviderAdapter({
+      contributors: [
+        kysely,
+        { ...kysely, emit: () => [`  services.kysely = replaced()`] },
+      ],
+    }).generateServerEntrySource(ctx)
+
+    assert.match(source, /services\.kysely = replaced\(\)/)
+    assert.doesNotMatch(source, /new Kysely/)
+  })
+})

--- a/packages/deploy/deploy-cloudflare/src/adapter.ts
+++ b/packages/deploy/deploy-cloudflare/src/adapter.ts
@@ -14,56 +14,32 @@ import {
   serverProxyConstants,
 } from './server-proxy-entry.js'
 import type {
+  BindingSource,
+  ContributorPlatform,
   DeploymentManifest,
   DeploymentUnit,
   EntryGenerationContext,
+  PlatformServiceContributor,
   ProviderAdapter,
 } from '@pikku/deploy'
+import {
+  assertContributorsSupported,
+  collectContributorImports,
+  collectContributorLines,
+  dedupeContributors,
+  partitionContributors,
+} from '@pikku/deploy'
 
-export type PlatformImports = {
+export type { PlatformServiceContributor } from '@pikku/deploy'
+
+export const CLOUDFLARE_BINDING_SOURCES: readonly BindingSource[] = [
+  'env',
+  'cloudflare',
+]
+
+export type PlatformImports = ContributorPlatform & {
   cfImports: string[]
   needsD1: boolean
-  needsQueue: boolean
-  needsWorkflow: boolean
-  needsAgent: boolean
-  /**
-   * Wired service names required by this unit (from each unit-service's
-   * `sourceServiceName`). Lets a contributor gate its imports on a custom,
-   * platform-specific service being present without the OSS adapter needing to
-   * know that service by name (e.g. a fabric contributor gating on 'browser').
-   */
-  serviceNames: string[]
-}
-
-/**
- * Hook for callers (custom deployers, orchestrators) to inject extra services
- * into the generated `createPlatformServices` block. Each contributor is
- * called once per entry; lines are emitted before `return services`. Imports
- * are spliced into the entry's import header.
- *
- * Contributors should gate their service wiring on env bindings being present
- * (`if (env.MY_BINDING) { ... }`) so the same generated entry runs both for
- * users who declare the bindings and for those who don't.
- */
-export interface PlatformServiceContributor {
-  /** Identifier — used for diagnostics and dedup if a contributor is passed twice. */
-  name: string
-  /**
-   * Module-level import lines this contributor's emitted code depends on.
-   * May be a static array or a function gated on platform capabilities —
-   * useful to avoid bundling heavy packages into workers that don't need them.
-   */
-  imports?: string[] | ((platform: PlatformImports) => string[])
-  /**
-   * Lines emitted inside `createPlatformServices`, before `return services`.
-   * `services` is in scope (typed as `ctx.servicesType`); so is `env` and
-   * `logger`. Return `[]` to opt out for the given context.
-   */
-  emit(args: {
-    ctx: EntryGenerationContext
-    platform: PlatformImports
-    isGateway: boolean
-  }): string[]
 }
 
 export interface CloudflareProviderAdapterOptions {
@@ -119,49 +95,42 @@ export class CloudflareProviderAdapter implements ProviderAdapter {
   constructor(options: CloudflareProviderAdapterOptions = {}) {
     this.workflowQueues = options.workflowQueues ?? false
     this.httpQueueJobs = options.httpQueueJobs ?? false
-    // De-dupe contributors by name (last wins).
-    const byName = new Map<string, PlatformServiceContributor>()
-    for (const c of options.contributors ?? []) {
-      byName.set(c.name, c)
-    }
-    this.contributors = [...byName.values()]
+    this.contributors = dedupeContributors(options.contributors)
+    assertContributorsSupported(
+      this.contributors,
+      CLOUDFLARE_BINDING_SOURCES,
+      this.name
+    )
   }
 
   getPlatform(): 'browser' {
     return 'browser'
   }
 
-  /** Collect all contributor imports as a flat, de-duplicated array. */
-  private contributorImports(platform: PlatformImports): string[] {
-    const seen = new Set<string>()
-    const out: string[] = []
-    for (const c of this.contributors) {
-      const lines =
-        typeof c.imports === 'function'
-          ? c.imports(platform)
-          : (c.imports ?? [])
-      for (const line of lines) {
-        if (!seen.has(line)) {
-          seen.add(line)
-          out.push(line)
-        }
-      }
-    }
-    return out
+  private contributorImports(
+    platform: PlatformImports,
+    sources: readonly BindingSource[] = CLOUDFLARE_BINDING_SOURCES
+  ): string[] {
+    return collectContributorImports(this.contributorsFor(sources), platform)
   }
 
-  /** Run every contributor's emit() and concatenate the resulting lines. */
   private contributorLines(
     ctx: EntryGenerationContext,
     platform: PlatformImports,
-    isGateway: boolean
+    isGateway: boolean,
+    sources: readonly BindingSource[] = CLOUDFLARE_BINDING_SOURCES
   ): string[] {
-    const out: string[] = []
-    for (const c of this.contributors) {
-      const lines = c.emit({ ctx, platform, isGateway })
-      if (lines.length > 0) out.push(...lines)
-    }
-    return out
+    return collectContributorLines(this.contributorsFor(sources), {
+      ctx,
+      platform,
+      isGateway,
+    })
+  }
+
+  private contributorsFor(
+    sources: readonly BindingSource[]
+  ): PlatformServiceContributor[] {
+    return partitionContributors(this.contributors, sources).supported
   }
 
   /**
@@ -246,7 +215,7 @@ export class CloudflareProviderAdapter implements ProviderAdapter {
       `import { pikkuState } from '@pikku/core/state'`,
       `import { JsonConsoleLogger, LocalVariablesService, LocalSecretService } from '@pikku/core/services'`,
       `import { CFWorkerSchemaService } from '@pikku/schema-cfworker'`,
-      ...this.contributorImports(platform),
+      ...this.contributorImports(platform, ['env']),
       ctx.configImport,
       ctx.servicesImport,
       ctx.singletonServicesImport,
@@ -308,7 +277,7 @@ export class CloudflareProviderAdapter implements ProviderAdapter {
       `  const logger = new JsonConsoleLogger()`,
       `  services.logger = logger`,
       `  services.schema = new CFWorkerSchemaService(logger)`,
-      ...this.contributorLines(ctx, platform, false),
+      ...this.contributorLines(ctx, platform, false, ['env']),
       `  return services`,
       `}`,
     ]

--- a/packages/deploy/deploy-core/src/index.ts
+++ b/packages/deploy/deploy-core/src/index.ts
@@ -25,6 +25,22 @@ export type {
   ProviderAdapter,
 } from './provider-adapter.js'
 
+export type {
+  BindingSource,
+  ContributorPlatform,
+  PlatformServiceContributor,
+} from './platform-service-contributor.js'
+
+export {
+  DEFAULT_BINDING_SOURCES,
+  assertContributorsSupported,
+  collectContributorImports,
+  collectContributorLines,
+  contributorBindingSources,
+  dedupeContributors,
+  partitionContributors,
+} from './platform-service-contributor.js'
+
 export { nodeBuiltinExternals } from './node-builtins.js'
 
 export { SERVER_READY_MARKER, serverReadyLine } from './server-ready.js'

--- a/packages/deploy/deploy-core/src/platform-service-contributor.test.ts
+++ b/packages/deploy/deploy-core/src/platform-service-contributor.test.ts
@@ -1,0 +1,113 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  assertContributorsSupported,
+  collectContributorImports,
+  collectContributorLines,
+  dedupeContributors,
+  partitionContributors,
+  type ContributorPlatform,
+  type PlatformServiceContributor,
+} from './platform-service-contributor.js'
+
+const platform: ContributorPlatform = {
+  serviceNames: ['browser'],
+  needsQueue: false,
+  needsWorkflow: false,
+  needsAgent: true,
+}
+
+const ctx = { unit: { name: 'app', role: 'function' } } as never
+
+const kysely: PlatformServiceContributor = {
+  name: 'kysely',
+  imports: (p) => [
+    `import { Kysely } from 'kysely'`,
+    ...(p.needsAgent ? [`import { agentTables } from './agent.js'`] : []),
+  ],
+  emit: () => [`  services.kysely = new Kysely({})`],
+}
+
+const browser: PlatformServiceContributor = {
+  name: 'browser',
+  imports: [
+    `import { Kysely } from 'kysely'`,
+    `import { Browser } from './browser.js'`,
+  ],
+  emit: ({ isGateway }) =>
+    isGateway ? [] : [`  services.browser = new Browser()`],
+}
+
+const queue: PlatformServiceContributor = {
+  name: 'queue',
+  requires: ['cloudflare'],
+  emit: () => [`  services.queue = env.QUEUE`],
+}
+
+describe('platform service contributors', () => {
+  test('dedupe keeps the last contributor registered under a name', () => {
+    const replacement: PlatformServiceContributor = {
+      ...browser,
+      emit: () => ['  replaced'],
+    }
+    const result = dedupeContributors([kysely, browser, replacement])
+
+    assert.deepEqual(
+      result.map((c) => c.name),
+      ['kysely', 'browser']
+    )
+    assert.deepEqual(result[1]!.emit({ ctx, platform, isGateway: false }), [
+      '  replaced',
+    ])
+  })
+
+  test('imports are resolved against the platform and de-duplicated', () => {
+    assert.deepEqual(collectContributorImports([kysely, browser], platform), [
+      `import { Kysely } from 'kysely'`,
+      `import { agentTables } from './agent.js'`,
+      `import { Browser } from './browser.js'`,
+    ])
+  })
+
+  test('lines are emitted in registration order and empty emits vanish', () => {
+    assert.deepEqual(
+      collectContributorLines([kysely, browser], {
+        ctx,
+        platform,
+        isGateway: true,
+      }),
+      [`  services.kysely = new Kysely({})`]
+    )
+  })
+
+  test('a contributor without requires needs only env bindings', () => {
+    const { supported, unsupported } = partitionContributors(
+      [kysely, queue],
+      ['env']
+    )
+
+    assert.deepEqual(
+      supported.map((c) => c.name),
+      ['kysely']
+    )
+    assert.deepEqual(
+      unsupported.map((c) => c.name),
+      ['queue']
+    )
+  })
+
+  test('an adapter that cannot satisfy a contributor names it', () => {
+    assert.throws(
+      () => assertContributorsSupported([kysely, queue], ['env'], 'standalone'),
+      /standalone adapter only provides env bindings; unsupported contributors: queue \(requires cloudflare\)/
+    )
+    assert.doesNotThrow(() =>
+      assertContributorsSupported(
+        [kysely, queue],
+        ['env', 'cloudflare'],
+        'cloudflare'
+      )
+    )
+  })
+})

--- a/packages/deploy/deploy-core/src/platform-service-contributor.ts
+++ b/packages/deploy/deploy-core/src/platform-service-contributor.ts
@@ -1,0 +1,111 @@
+import type { EntryGenerationContext } from './provider-adapter.js'
+
+export type BindingSource = 'env' | 'cloudflare'
+
+export interface ContributorPlatform {
+  serviceNames: string[]
+  needsQueue: boolean
+  needsWorkflow: boolean
+  needsAgent: boolean
+}
+
+export interface PlatformServiceContributor<
+  TPlatform extends ContributorPlatform = ContributorPlatform,
+> {
+  name: string
+  requires?: BindingSource[]
+  imports?: string[] | ((platform: TPlatform) => string[])
+  emit(args: {
+    ctx: EntryGenerationContext
+    platform: TPlatform
+    isGateway: boolean
+  }): string[]
+}
+
+export const DEFAULT_BINDING_SOURCES: readonly BindingSource[] = ['env']
+
+export const contributorBindingSources = (
+  contributor: PlatformServiceContributor<any>
+): readonly BindingSource[] => contributor.requires ?? DEFAULT_BINDING_SOURCES
+
+export const dedupeContributors = <T extends PlatformServiceContributor<any>>(
+  contributors: readonly T[] | undefined
+): T[] => {
+  const byName = new Map<string, T>()
+  for (const contributor of contributors ?? []) {
+    byName.set(contributor.name, contributor)
+  }
+  return [...byName.values()]
+}
+
+export const partitionContributors = <
+  T extends PlatformServiceContributor<any>,
+>(
+  contributors: readonly T[],
+  supported: readonly BindingSource[]
+): { supported: T[]; unsupported: T[] } => {
+  const ok: T[] = []
+  const rejected: T[] = []
+  for (const contributor of contributors) {
+    const sources = contributorBindingSources(contributor)
+    if (sources.every((source) => supported.includes(source))) {
+      ok.push(contributor)
+    } else {
+      rejected.push(contributor)
+    }
+  }
+  return { supported: ok, unsupported: rejected }
+}
+
+export const assertContributorsSupported = (
+  contributors: readonly PlatformServiceContributor<any>[],
+  supported: readonly BindingSource[],
+  adapterName: string
+): void => {
+  const { unsupported } = partitionContributors(contributors, supported)
+  if (unsupported.length === 0) return
+  const detail = unsupported
+    .map(
+      (contributor) =>
+        `${contributor.name} (requires ${contributorBindingSources(contributor).join(', ')})`
+    )
+    .join('; ')
+  throw new Error(
+    `${adapterName} adapter only provides ${supported.join(', ')} bindings; unsupported contributors: ${detail}`
+  )
+}
+
+export const collectContributorImports = <
+  TPlatform extends ContributorPlatform,
+>(
+  contributors: readonly PlatformServiceContributor<TPlatform>[],
+  platform: TPlatform
+): string[] => {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const contributor of contributors) {
+    const lines =
+      typeof contributor.imports === 'function'
+        ? contributor.imports(platform)
+        : (contributor.imports ?? [])
+    for (const line of lines) {
+      if (!seen.has(line)) {
+        seen.add(line)
+        out.push(line)
+      }
+    }
+  }
+  return out
+}
+
+export const collectContributorLines = <TPlatform extends ContributorPlatform>(
+  contributors: readonly PlatformServiceContributor<TPlatform>[],
+  args: { ctx: EntryGenerationContext; platform: TPlatform; isGateway: boolean }
+): string[] => {
+  const out: string[] = []
+  for (const contributor of contributors) {
+    const lines = contributor.emit(args)
+    if (lines.length > 0) out.push(...lines)
+  }
+  return out
+}

--- a/packages/deploy/deploy-core/src/shared-contract.test.ts
+++ b/packages/deploy/deploy-core/src/shared-contract.test.ts
@@ -14,7 +14,9 @@ const repoRoot = join(packageDir, '..', '..', '..')
  */
 const OWNED_NAMES = [
   'AgentDefinition',
+  'BindingSource',
   'ChannelDefinition',
+  'ContributorPlatform',
   'DeploymentHandler',
   'DeploymentManifest',
   'DeploymentUnit',
@@ -23,6 +25,7 @@ const OWNED_NAMES = [
   'GrantedAddon',
   'HttpRouteInfo',
   'MCPEndpointDefinition',
+  'PlatformServiceContributor',
   'ProviderAdapter',
   'QueueDefinition',
   'ScheduledTaskDefinition',

--- a/packages/deploy/deploy-standalone/src/adapter.ts
+++ b/packages/deploy/deploy-standalone/src/adapter.ts
@@ -16,8 +16,23 @@
  *   compiles the bundle into a single self-contained executable via
  *   `bun build --compile`. No runtime needed on the target host.
  */
-import type { EntryGenerationContext, ProviderAdapter } from '@pikku/deploy'
-import { nodeBuiltinExternals, SERVER_READY_MARKER } from '@pikku/deploy'
+import type {
+  BindingSource,
+  ContributorPlatform,
+  EntryGenerationContext,
+  PlatformServiceContributor,
+  ProviderAdapter,
+} from '@pikku/deploy'
+import {
+  assertContributorsSupported,
+  collectContributorImports,
+  collectContributorLines,
+  dedupeContributors,
+  nodeBuiltinExternals,
+  SERVER_READY_MARKER,
+} from '@pikku/deploy'
+
+export const STANDALONE_BINDING_SOURCES: readonly BindingSource[] = ['env']
 
 export type StandaloneRuntime = 'node' | 'bun'
 
@@ -340,6 +355,21 @@ export interface StandaloneProviderAdapterOptions {
    * The window is a webview onto that origin and nothing else is shipped.
    */
   desktopUrl?: string
+  contributors?: PlatformServiceContributor[]
+}
+
+const contributorPlatform = (
+  ctx: EntryGenerationContext
+): ContributorPlatform => {
+  const services = ctx.unit.services ?? []
+  return {
+    serviceNames: services.map((s) => s.sourceServiceName),
+    needsQueue: services.some((s) => s.capability === 'queue'),
+    needsWorkflow: services.some((s) => s.capability === 'workflow-state'),
+    needsAgent: services.some(
+      (s) => s.capability === 'ai-storage' || s.capability === 'ai-model'
+    ),
+  }
 }
 
 export class StandaloneProviderAdapter implements ProviderAdapter {
@@ -351,6 +381,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
   readonly projectDir?: string
   readonly desktopIdentifier?: string
   readonly desktopUrl?: string
+  readonly contributors: PlatformServiceContributor[]
 
   constructor(options: StandaloneProviderAdapterOptions = {}) {
     this.runtime = options.runtime ?? 'node'
@@ -358,6 +389,48 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
     this.projectDir = options.projectDir
     this.desktopIdentifier = options.desktopIdentifier
     this.desktopUrl = options.desktopUrl
+    this.contributors = dedupeContributors(options.contributors)
+    assertContributorsSupported(
+      this.contributors,
+      STANDALONE_BINDING_SOURCES,
+      this.name
+    )
+  }
+
+  private contributorImportLines(ctx: EntryGenerationContext): string[] {
+    if (this.contributors.length === 0) return []
+    return collectContributorImports(
+      this.contributors,
+      contributorPlatform(ctx)
+    )
+  }
+
+  private platformServicesBlock(ctx: EntryGenerationContext): string[] {
+    if (this.contributors.length === 0) return []
+    return [
+      `const createPlatformServices = async (env: Record<string, string | undefined>): Promise<${ctx.servicesType}> => {`,
+      `  const services: ${ctx.servicesType} = {}`,
+      ...collectContributorLines(this.contributors, {
+        ctx,
+        platform: contributorPlatform(ctx),
+        isGateway: false,
+      }),
+      `  return services`,
+      `}`,
+      ``,
+    ]
+  }
+
+  private platformServicesCallLines(): string[] {
+    if (this.contributors.length === 0) return []
+    return [
+      `  const platformServices = await createPlatformServices(process.env as Record<string, string | undefined>)`,
+    ]
+  }
+
+  private platformServicesSpreadLines(): string[] {
+    if (this.contributors.length === 0) return []
+    return [`    ...platformServices,`]
   }
 
   generateEntrySource(ctx: EntryGenerationContext): string {
@@ -387,6 +460,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
         : []),
       ...(ctx.db ? dbImportLines('node', ctx.db) : []),
       ...(ctx.lifecycle ? lifecycleImportLines(ctx.lifecycle) : []),
+      ...this.contributorImportLines(ctx),
       ``,
       ctx.configImport,
       ctx.servicesImport,
@@ -400,8 +474,10 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       ``,
       ...commandParseLines(ctx),
       ``,
+      ...this.platformServicesBlock(ctx),
       `async function main() {`,
       `  const config = await ${ctx.configVar}()`,
+      ...this.platformServicesCallLines(),
       `  const schedulerService = new InMemorySchedulerService()`,
       `  const queueService = new InMemoryQueueService()`,
       `  const workflowService = new InMemoryWorkflowService()`,
@@ -420,6 +496,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `    workflowRunService: workflowService,`,
       `    triggerService,`,
       `    eventHub,`,
+      ...this.platformServicesSpreadLines(),
       `  })`,
       `  pikkuState(null, 'package', 'singletonServices', singletonServices)`,
       ``,
@@ -483,6 +560,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
         : []),
       ...(ctx.db ? dbImportLines('bun', ctx.db) : []),
       ...(ctx.lifecycle ? lifecycleImportLines(ctx.lifecycle) : []),
+      ...this.contributorImportLines(ctx),
       ``,
       ctx.configImport,
       ctx.servicesImport,
@@ -496,8 +574,10 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       ``,
       ...commandParseLines(ctx),
       ``,
+      ...this.platformServicesBlock(ctx),
       `async function main() {`,
       `  const config = await ${ctx.configVar}()`,
+      ...this.platformServicesCallLines(),
       `  const schedulerService = new InMemorySchedulerService()`,
       `  const queueService = new InMemoryQueueService()`,
       `  const workflowService = new InMemoryWorkflowService()`,
@@ -516,6 +596,7 @@ export class StandaloneProviderAdapter implements ProviderAdapter {
       `    workflowRunService: workflowService,`,
       `    triggerService,`,
       `    eventHub,`,
+      ...this.platformServicesSpreadLines(),
       `  })`,
       `  pikkuState(null, 'package', 'singletonServices', singletonServices)`,
       ``,

--- a/packages/deploy/deploy-standalone/src/contributors.test.ts
+++ b/packages/deploy/deploy-standalone/src/contributors.test.ts
@@ -1,0 +1,96 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import type { PlatformServiceContributor } from '@pikku/deploy'
+
+import { StandaloneProviderAdapter } from './adapter.js'
+
+const ctx = {
+  unit: {
+    name: 'app',
+    role: 'function',
+    services: [{ capability: 'kv', sourceServiceName: 'browser' }],
+  },
+  unitDir: '/build/app',
+  bootstrapPath: './.pikku/pikku-bootstrap.gen.js',
+  configImport: `import { createConfig } from './config.js'`,
+  configVar: 'createConfig',
+  servicesImport: `import { createSingletonServices } from './services.js'`,
+  servicesVar: 'createSingletonServices',
+  singletonServicesImport: '',
+  servicesType: 'Record<string, unknown>',
+  mcpImport: '',
+  mcpServerOption: '',
+} as never
+
+const kysely: PlatformServiceContributor = {
+  name: 'kysely',
+  imports: [`import { Kysely } from 'kysely'`],
+  emit: () => [`  if (env.DATABASE_URL) services.kysely = new Kysely({})`],
+}
+
+const browser: PlatformServiceContributor = {
+  name: 'browser',
+  imports: (platform) =>
+    platform.serviceNames.includes('browser')
+      ? [`import { Browser } from './browser.js'`]
+      : [],
+  emit: () => [`  services.browser = new Browser(env, logger)`],
+}
+
+const queueBinding: PlatformServiceContributor = {
+  name: 'queue-binding',
+  requires: ['cloudflare'],
+  emit: () => [`  services.queue = env.QUEUE`],
+}
+
+for (const runtime of ['node', 'bun'] as const) {
+  describe(`StandaloneProviderAdapter contributors (${runtime})`, () => {
+    test('without contributors the entry has no platform services block', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+      }).generateEntrySource(ctx)
+
+      assert.doesNotMatch(source, /createPlatformServices/)
+      assert.doesNotMatch(source, /platformServices/)
+    })
+
+    test('contributor imports, lines and the spread are all emitted', () => {
+      const source = new StandaloneProviderAdapter({
+        runtime,
+        contributors: [kysely, browser],
+      }).generateEntrySource(ctx)
+
+      assert.match(source, /import { Kysely } from 'kysely'/)
+      assert.match(source, /import { Browser } from '\.\/browser\.js'/)
+      assert.match(
+        source,
+        /const createPlatformServices = async \(env: Record<string, string \| undefined>\): Promise<Record<string, unknown>> => \{/
+      )
+      assert.match(
+        source,
+        /if \(env\.DATABASE_URL\) services\.kysely = new Kysely\(\{\}\)/
+      )
+      assert.match(source, /services\.browser = new Browser\(env, logger\)/)
+      assert.match(
+        source,
+        /const platformServices = await createPlatformServices\(process\.env as Record<string, string \| undefined>\)/
+      )
+      assert.match(
+        source,
+        /eventHub,\n    \.\.\.platformServices,\n  \}\)/,
+        'contributed services must be spread last so they override the defaults'
+      )
+    })
+
+    test('a contributor that needs cloudflare bindings is refused up front', () => {
+      assert.throws(
+        () =>
+          new StandaloneProviderAdapter({
+            runtime,
+            contributors: [kysely, queueBinding],
+          }),
+        /standalone adapter only provides env bindings; unsupported contributors: queue-binding \(requires cloudflare\)/
+      )
+    })
+  })
+}

--- a/packages/deploy/deploy-standalone/src/index.ts
+++ b/packages/deploy/deploy-standalone/src/index.ts
@@ -17,6 +17,7 @@ import {
 
 export { StandaloneProviderAdapter }
 export type { StandaloneProviderAdapterOptions } from './adapter.js'
+export type { PlatformServiceContributor } from '@pikku/deploy'
 
 export const createAdapter = (options?: StandaloneProviderAdapterOptions) =>
   new StandaloneProviderAdapter(options)


### PR DESCRIPTION
## Summary
- `@pikku/deploy` now owns `PlatformServiceContributor`, `ContributorPlatform`, `BindingSource` and the dedupe/collect/partition helpers. A contributor declares the binding sources its emitted code reads from (`requires`, default `env`); an adapter that cannot provide one refuses it by name at construction instead of silently emitting code that reads bindings the runtime never has.
- `@pikku/deploy-cloudflare` uses the core helpers and re-exports the type. Worker entry output is byte-identical (checked against nine golden cases and against fabric's twelve real contributors). Its container entry now runs only `env` contributors.
- `@pikku/deploy-standalone` gains a `contributors` option. Node and bun entries build the contributed services from `process.env` and spread them last into `createSingletonServices`. Entries without contributors are unchanged.
- The shared-contract test now guards the three new names against re-declaration.

## Test plan
- [x] `deploy-core`: 13 tests pass, including 5 new ones for the helpers
- [x] `deploy-cloudflare`: new `adapter.test.ts`, 3 tests pass; package gains a `test` script
- [x] `deploy-standalone`: 160 tests pass, 6 new
- [x] golden diff of `generateServerEntrySource` / `generateEntrySource` before and after: identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)