### PR TITLE
feat(knowledge): add the milestone lifecycle and the gherkin lints

### DIFF
--- a/.changeset/olive-moons-clap.md
+++ b/.changeset/olive-moons-clap.md
@@ -1,0 +1,19 @@
+---
+'@pikku/knowledge': patch
+---
+
+Add the milestone lifecycle and the Gherkin lints.
+
+`setMilestoneStatus` is the one function that moves a milestone's state and the
+one that dates it (`statusAt:`) — the note's mtime is not the transition time.
+`holdMilestoneLifecycle` snapshots and restores that state across a turn that
+rewrites notes, because re-filing the body is wanted and reverting `status:` is
+how one milestone gets built twice. With them come `nominatedMilestone`,
+`dispatchedMilestone`, `markDispatchedMilestoneBuilt`, `withoutMilestonesDir`
+and `entitiesOf`.
+
+`firstPersonStep` and `quotedIn` are the two lints that decide whether a
+scenario can name an actor at all.
+
+`MILESTONE_STATUSES` moves from `validate.ts` to `milestone.ts`; it is still
+re-exported from both, so the public surface is unchanged.

--- a/packages/knowledge/src/index.ts
+++ b/packages/knowledge/src/index.ts
@@ -115,10 +115,19 @@ export {
   MILESTONE_SURFACES,
   type MilestoneSurface,
   inMilestonesDir,
+  withoutMilestonesDir,
   surfaceOf,
   readMilestones,
   gherkinOf,
   personasIn,
+  quotedIn,
+  entitiesOf,
+  firstPersonStep,
+  setMilestoneStatus,
+  nominatedMilestone,
+  dispatchedMilestone,
+  markDispatchedMilestoneBuilt,
+  holdMilestoneLifecycle,
 } from './milestone.js'
 
 export {

--- a/packages/knowledge/src/milestone-lifecycle.test.ts
+++ b/packages/knowledge/src/milestone-lifecycle.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, test } from 'node:test'
+import {
+  dispatchedMilestone,
+  firstPersonStep,
+  holdMilestoneLifecycle,
+  markDispatchedMilestoneBuilt,
+  nominatedMilestone,
+  quotedIn,
+  setMilestoneStatus,
+} from './milestone.js'
+
+let cwd: string
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'milestone-'))
+  mkdirSync(join(cwd, 'knowledge', 'milestones'), { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(cwd, { recursive: true, force: true })
+})
+
+const milestone = (name: string, frontmatter: string[], body = 'A piece of work.') => {
+  const path = `knowledge/milestones/${name}`
+  writeFileSync(
+    join(cwd, path),
+    `---\ntype: milestone\n${frontmatter.join('\n')}\n---\n\n${body}\n`
+  )
+  return path
+}
+
+describe('gherkin lints', () => {
+  test('a first-person step is found and quoted back', () => {
+    const step = firstPersonStep(
+      ["Given 'owner' has an account", 'When I open the page'].join('\n')
+    )
+    assert.equal(step, 'When I open the page')
+  })
+
+  test('a double-quoted domain value is not scenario voice', () => {
+    assert.equal(
+      firstPersonStep('Then the list shows "Took my meds"'),
+      null
+    )
+  })
+
+  test('a persona named mid-sentence is still collected', () => {
+    assert.deepEqual(
+      quotedIn("Given 'member' has borrowed a drill and 'member2' has a hammer"),
+      ['member', 'member2']
+    )
+  })
+
+  test("the product's own words are never read as a person", () => {
+    assert.deepEqual(quotedIn('Given the entry is called "Tonight"'), [])
+  })
+})
+
+describe('the milestone lifecycle', () => {
+  test('a status move stamps when it happened', async () => {
+    const path = milestone('01-tonight.md', ['status: proposed'])
+    setMilestoneStatus(cwd, path, 'dispatched')
+    const raw = readFileSync(join(cwd, path), 'utf8')
+    assert.match(raw, /status: dispatched/)
+    assert.match(raw, /statusAt: \d{4}-\d{2}-\d{2}T/)
+  })
+
+  test('a note that was never `proposed` cannot be moved', () => {
+    const path = milestone('01-tonight.md', ['title: Tonight'])
+    assert.throws(
+      () => setMilestoneStatus(cwd, path, 'dispatched'),
+      /no `status:` line/
+    )
+  })
+
+  test('exactly one dispatched milestone is marked built', async () => {
+    milestone('01-tonight.md', ['status: dispatched'])
+    const built = await markDispatchedMilestoneBuilt(cwd)
+    assert.equal(built?.path, 'knowledge/milestones/01-tonight.md')
+    assert.equal(await dispatchedMilestone(cwd), null)
+  })
+
+  test('two dispatched milestones mark nothing, so the queue repeats rather than loses one', async () => {
+    milestone('01-tonight.md', ['status: dispatched'])
+    milestone('02-this-week.md', ['status: dispatched'])
+    assert.equal(await markDispatchedMilestoneBuilt(cwd), null)
+    assert.equal(await dispatchedMilestone(cwd), null)
+  })
+
+  test('a status reverted by a turn that rewrites notes is restored', async () => {
+    const path = milestone('01-tonight.md', ['status: dispatched'])
+    const release = await holdMilestoneLifecycle(cwd)
+
+    writeFileSync(
+      join(cwd, path),
+      '---\ntype: milestone\nstatus: proposed\n---\n\nRe-filed from a later answer.\n'
+    )
+    await release()
+
+    const raw = readFileSync(join(cwd, path), 'utf8')
+    assert.match(raw, /status: dispatched/)
+    assert.match(raw, /Re-filed from a later answer/)
+  })
+})
+
+describe('nominatedMilestone', () => {
+  test('matches an unbuilt milestone by title or slug', async () => {
+    milestone('01-the-daily-entry.md', ['status: proposed', 'title: The daily entry'])
+    assert.equal(
+      (await nominatedMilestone(cwd, 'daily entry'))?.title,
+      'The daily entry'
+    )
+    assert.equal(
+      (await nominatedMilestone(cwd, 'The Daily Entry!'))?.title,
+      'The daily entry'
+    )
+  })
+
+  test('never nominates one that is already built, or a name matching nothing', async () => {
+    milestone('01-the-daily-entry.md', ['status: built', 'title: The daily entry'])
+    assert.equal(await nominatedMilestone(cwd, 'daily entry'), null)
+    assert.equal(await nominatedMilestone(cwd, ''), null)
+  })
+})

--- a/packages/knowledge/src/milestone.ts
+++ b/packages/knowledge/src/milestone.ts
@@ -1,4 +1,10 @@
-import { KNOWLEDGE_DIR, MILESTONE_TYPE, readKnowledgeNotes } from './notes.js'
+import { setNoteScalars } from './ledger.js'
+import {
+  KNOWLEDGE_DIR,
+  MILESTONE_TYPE,
+  listOf,
+  readKnowledgeNotes,
+} from './notes.js'
 import type { KnowledgeNote, ProfileNote } from './notes.js'
 
 export const MILESTONES_DIR = `${KNOWLEDGE_DIR}/milestones`
@@ -30,6 +36,24 @@ export type MilestoneNote = ProfileNote<(typeof MILESTONE_SCALARS)[number]>
 
 export const inMilestonesDir = (path: string): boolean =>
   path.startsWith(`${MILESTONES_DIR}/`)
+
+export const withoutMilestonesDir = (path: string): string =>
+  path.replace(`${MILESTONES_DIR}/`, '')
+
+/**
+ * `designing` sits before `proposed`: the milestone is written down but is NOT to
+ * be built yet, because whoever is being shown its looks has not picked one. Only
+ * `proposed` is dispatchable, so the two cannot be one status without a milestone
+ * being built out from under the person still choosing how it should look.
+ */
+export const MILESTONE_STATUSES = [
+  'designing',
+  'proposed',
+  'dispatched',
+  'built',
+] as const
+
+export type MilestoneStatus = (typeof MILESTONE_STATUSES)[number]
 
 const isSurface = (raw: string): raw is MilestoneSurface =>
   (MILESTONE_SURFACES as readonly string[]).includes(raw)
@@ -70,4 +94,222 @@ export function personasIn(gherkin: string): string[] {
     names.add(name!)
   }
   return [...names]
+}
+
+/** The entities a milestone's `entities:` names. */
+export const entitiesOf = (note: KnowledgeNote): string[] => listOf(note.entities)
+
+const PERSONA_QUOTE = /'([A-Za-z][A-Za-z0-9]*)'/g
+
+/**
+ * Every single-quoted name a Gherkin body mentions in a step, in ANY position —
+ * not just the subject.
+ *
+ * Only looking at the subject position missed a real planner output — `Given
+ * 'member' has borrowed a drill and 'member2' has borrowed a hammer` — where the
+ * undeclared second actor was mid-sentence, and the milestone dispatched with a
+ * scenario naming somebody who can never be resolved to an actor.
+ *
+ * Double quotes are deliberately NOT collected: they are the product's own words.
+ * A persona written in double quotes is not silently let through either —
+ * `personasIn` will not see it, so the scenario names nobody and is refused.
+ */
+export function quotedIn(gherkin: string): string[] {
+  const names = new Set<string>()
+  for (const line of gherkin.split('\n')) {
+    if (!/^\s*(given|when|then|and|but)\b/i.test(line)) continue
+    for (const [, name] of line.matchAll(PERSONA_QUOTE)) {
+      names.add(name!)
+    }
+  }
+  return [...names]
+}
+
+// A step written as the user rather than about them. Catching this at dispatch is
+// the cheap moment: once it has been turned into a scenario, the missing actor
+// shows up as a test that cannot run.
+const FIRST_PERSON =
+  /^\s*(given|when|then|and|but)\b[^\n]*\b(i|my|me|we|our)\b/i
+
+/**
+ * The first step written in the first person, or null.
+ *
+ * Double-quoted spans are blanked before the test, because a `"…"` is a DOMAIN
+ * VALUE rather than scenario voice — a checklist item is genuinely called "Took my
+ * meds". Testing the raw line flagged that step as first-person, and since the
+ * refusal did not say which line tripped it, a real run went looking, guessed wrong
+ * twice, and finally renamed the product's own content to get past the gate. A lint
+ * rule must never edit the product. (Single quotes still mean a persona, so they
+ * are left alone for `quotedIn`.)
+ *
+ * Returns the step so the refusal can quote it: "somewhere in this block" is not
+ * something an agent can act on in one step.
+ */
+export function firstPersonStep(gherkin: string): string | null {
+  for (const line of gherkin.split('\n')) {
+    if (FIRST_PERSON.test(line.replace(/"[^"]*"/g, '""'))) return line.trim()
+  }
+  return null
+}
+
+/**
+ * Move a milestone note to the next state, in place, and stamp WHEN.
+ *
+ * Rewrites only the `status:` line and the `statusAt:` beside it, so nothing an
+ * author wrote is touched. A milestone that stayed `proposed` after being dispatched
+ * would be dispatched again on the next call, which is how one milestone gets built
+ * twice.
+ *
+ * The stamp is what makes "how long has this been building?" answerable. The obvious
+ * alternative — the note's mtime — is not the transition time at all: the note is
+ * edited after dispatch for all sorts of reasons, and every edit would push the
+ * apparent dispatch time forward, so a build stuck for an hour would keep looking
+ * like it had just started.
+ */
+export function setMilestoneStatus(
+  cwd: string,
+  notePath: string,
+  status: MilestoneStatus
+): void {
+  setNoteScalars(
+    cwd,
+    notePath,
+    { status, statusAt: new Date().toISOString() },
+    ['status']
+  )
+}
+
+const normalise = (raw: string): string =>
+  raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+
+/**
+ * The unbuilt milestone a free-text nomination names, or null when it names none.
+ *
+ * A seat that runs out of written-down milestones can nominate a sub-feature — or
+ * anything at all — and an unchecked loop will build it and call it the next
+ * milestone. Matching against the notes is what keeps the count and what is on
+ * screen describing the same thing.
+ */
+export async function nominatedMilestone(
+  cwd: string,
+  nomination: string
+): Promise<MilestoneNote | null> {
+  const wanted = normalise(nomination)
+  if (!wanted) return null
+  const unbuilt = (await readMilestones(cwd)).filter(
+    (note) => note.status !== 'built'
+  )
+  return (
+    unbuilt.find((note) => {
+      const title = normalise(note.title ?? '')
+      const slug = normalise(
+        withoutMilestonesDir(note.path).replace(/^\d+[-_]?/, '')
+      )
+      return (
+        (title &&
+          (title === wanted ||
+            title.includes(wanted) ||
+            wanted.includes(title))) ||
+        (slug &&
+          (slug === wanted || slug.includes(wanted) || wanted.includes(slug)))
+      )
+    }) ?? null
+  )
+}
+
+/** The one milestone currently `dispatched`, or null when there is not exactly one. */
+export async function dispatchedMilestone(
+  cwd: string
+): Promise<MilestoneNote | null> {
+  try {
+    const dispatched = (await readMilestones(cwd)).filter(
+      (note) => note.status === 'dispatched'
+    )
+    return dispatched.length === 1 ? dispatched[0]! : null
+  } catch (err) {
+    console.warn(
+      `[milestone] could not read the dispatched milestone: ${String(err)}`
+    )
+    return null
+  }
+}
+
+/**
+ * Mark the dispatched milestone built, so the queue hands out the next one.
+ *
+ * Refuses when there is not exactly one: marking the wrong note built loses a
+ * milestone silently, whereas leaving them alone hands the same one out again —
+ * visible, and recoverable.
+ */
+export async function markDispatchedMilestoneBuilt(
+  cwd: string
+): Promise<MilestoneNote | null> {
+  try {
+    const dispatched = (await readMilestones(cwd)).filter(
+      (note) => note.status === 'dispatched'
+    )
+    if (dispatched.length !== 1) {
+      console.warn(
+        `[milestone] a build finished with ${dispatched.length} dispatched milestone(s) — nothing marked built, so the queue will hand the same milestone out again`
+      )
+      return null
+    }
+    setMilestoneStatus(cwd, dispatched[0]!.path, 'built')
+    return dispatched[0]!
+  } catch (err) {
+    console.warn(
+      `[milestone] could not mark the dispatched milestone built: ${String(err)}`
+    )
+    return null
+  }
+}
+
+/**
+ * Hold every milestone's lifecycle across a turn that rewrites its note.
+ *
+ * A milestone note is frozen once its status leaves `proposed` — whatever is
+ * building was dispatched against that exact body. Nothing otherwise enforces that
+ * against a seat which re-files notes WHILE a build is running and writes whole
+ * files: a run had a milestone dispatched at 10:21 and back to `proposed` with no
+ * `statusAt` at 10:28, seven minutes into its own build. A reader then shows a
+ * building milestone as next-up, and the gate hands the same milestone to a second
+ * builder.
+ *
+ * A snapshot-and-restore rather than a write ban, because re-filing the BODY is
+ * wanted — later answers genuinely belong in the note. Only the two scalars the
+ * state machine owns are put back.
+ */
+export async function holdMilestoneLifecycle(
+  cwd: string
+): Promise<() => Promise<void>> {
+  const held = new Map<string, { status: string; statusAt: string | null }>()
+  try {
+    for (const note of await readMilestones(cwd)) {
+      if (!note.status || note.status === 'proposed') continue
+      held.set(note.path, { status: note.status, statusAt: note.statusAt ?? null })
+    }
+  } catch (err) {
+    console.warn(`[milestone] could not snapshot the lifecycle: ${String(err)}`)
+  }
+  return async () => {
+    if (held.size === 0) return
+    try {
+      for (const note of await readMilestones(cwd)) {
+        const was = held.get(note.path)
+        if (!was || note.status === was.status) continue
+        console.warn(
+          `[milestone] ${note.path} came back \`${note.status ?? 'none'}\` from a turn that rewrites notes — restoring \`${was.status}\``
+        )
+        setNoteScalars(cwd, note.path, {
+          status: was.status,
+          statusAt: was.statusAt,
+        })
+      }
+    } catch (err) {
+      console.warn(`[milestone] could not restore the lifecycle: ${String(err)}`)
+    }
+  }
 }

--- a/packages/knowledge/src/validate.ts
+++ b/packages/knowledge/src/validate.ts
@@ -10,6 +10,10 @@ import {
 } from './plan-meta.js'
 import { checkPlanInternals, type PlanRead, readPlan } from './plan.js'
 import {
+  MILESTONE_STATUSES,
+  type MilestoneStatus,
+} from './milestone.js'
+import {
   KNOWLEDGE_DIR,
   type KnowledgeNote,
   MILESTONE_TYPE,
@@ -17,6 +21,8 @@ import {
   sectionOf,
   toPosix,
 } from './notes.js'
+
+export { MILESTONE_STATUSES, type MilestoneStatus }
 
 /**
  * Declared, not inferred from the schema below.
@@ -90,21 +96,6 @@ const FORBIDDEN_SECTIONS: Record<string, string> = {
   tables: '`pikku meta` — the generated db schema is the schema',
   routes: '`pikku meta` — the generated http meta is the routes',
 }
-
-/**
- * `designing` sits before `proposed`: the milestone is written down but is NOT to
- * be built yet, because whoever is being shown its looks has not picked one. Only
- * `proposed` is dispatchable, so the two cannot be one status without a milestone
- * being built out from under the person still choosing how it should look.
- */
-export const MILESTONE_STATUSES = [
-  'designing',
-  'proposed',
-  'dispatched',
-  'built',
-] as const
-
-export type MilestoneStatus = (typeof MILESTONE_STATUSES)[number]
 
 /** Max entities per milestone: more than three and it is not one buildable piece. */
 const MAX_MILESTONE_ENTITIES = 3


### PR DESCRIPTION
Follows #1595 (the attempt ledger), which is already on main. Second half of the same lift: moving the seat-driving loop out of Fabric into `@pikku/knowledge` so a harness other than Fabric can run it. Nothing consumes this yet — `nextAction` follows in a third PR, and this is the state machine it stands on.

## The milestone lifecycle

- **`setMilestoneStatus`** — the one function that moves the state, and the one that dates it. The obvious alternative, the note's mtime, is not the transition time at all: a note is edited after dispatch for all sorts of reasons, and every edit would push the apparent dispatch time forward, so a build stuck for an hour keeps looking like it just started.
- **`holdMilestoneLifecycle`** — snapshot and restore across a turn that rewrites notes. A milestone note is frozen once its status leaves `proposed`, because whatever is building was dispatched against that exact body. It is a snapshot-and-restore rather than a write ban, because re-filing the *body* is wanted — later answers genuinely belong in the note. Only the two scalars the state machine owns are put back. Without it, a run had a milestone dispatched at 10:21 and back to `proposed` with no `statusAt` at 10:28, seven minutes into its own build — after which the gate hands the same milestone to a second builder.
- `nominatedMilestone`, `dispatchedMilestone`, `markDispatchedMilestoneBuilt`, `withoutMilestonesDir`, `entitiesOf`

`markDispatchedMilestoneBuilt` refuses when there is not exactly one dispatched note: marking the wrong one built loses a milestone silently, whereas leaving them alone hands the same one out again — visible, and recoverable.

## The Gherkin lints

- **`firstPersonStep`** — blanks double-quoted spans before testing, because a `"…"` is a domain value rather than scenario voice. A checklist item is genuinely called "Took my meds"; testing the raw line flagged it, and since the refusal did not say which line tripped it, a real run guessed wrong twice and finally renamed the product's own content to get past the gate. A lint rule must never edit the product.
- **`quotedIn`** — collects single-quoted personas in any position, not just the subject. Subject-only missed `Given 'member' has borrowed a drill and 'member2' has a hammer`, and the milestone dispatched naming an actor that can never be resolved.

## Notes

`MILESTONE_STATUSES` moves from `validate.ts` to `milestone.ts`, where the vocabulary belongs, and is re-exported from `validate.ts` — the public surface is unchanged.

258 tests pass, 0 fail. `tsc` clean. Changeset is a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)