### PR TITLE
feat(knowledge): the dispatch gate, the reconcile loop, and the refusal as a question

### DIFF
--- a/.changeset/brave-lions-tap.md
+++ b/.changeset/brave-lions-tap.md
@@ -1,0 +1,8 @@
+---
+'@pikku/skills': patch
+---
+
+Document `pikku knowledge next` in the `pikku-knowledge` skill: what the six actions mean,
+that `reason` is machine wording never to be repeated to a person, and that `ask-user`
+carries a separate `question` whose empty `options` list means offer free text rather than
+invent choices.

--- a/.changeset/brave-otters-write.md
+++ b/.changeset/brave-otters-write.md
@@ -1,0 +1,14 @@
+---
+'@pikku/skills': patch
+---
+
+Document the two frontmatter keys a driving loop writes, in `pikku-knowledge`.
+
+`statusAt:` and `attempts:` are bookkeeping rather than content, and an agent
+that rewrites a note has to know not to hand-edit them — clearing `attempts:`
+hands back a budget that exists to stop a note nothing can satisfy being
+rewritten forever.
+
+Also corrects the status vocabulary: it is `designing` → `proposed` →
+`dispatched` → `built`. The skill said `proposed` → `dispatched` → `built`,
+"nothing else", while `validate` has always accepted `designing`.

--- a/.changeset/eighty-pugs-shave.md
+++ b/.changeset/eighty-pugs-shave.md
@@ -1,0 +1,12 @@
+---
+'@pikku/cli': patch
+---
+
+Add `pikku knowledge next` — the one thing to do next with the knowledge base, derived
+from what is on disk rather than from what a previous step remembered to announce.
+
+It answers with exactly one action: repair a note, write a plan, ask the user, dispatch a
+build, hold, or nothing. On `ask-user` it prints the question a person should actually be
+asked, with its options numbered, and demotes the machine wording to a `why:` line — that
+reason names the note and the frontmatter key, and reads as gibberish to somebody who has
+never seen a note.

--- a/.changeset/violet-hoops-guess.md
+++ b/.changeset/violet-hoops-guess.md
@@ -19,3 +19,10 @@ it across a process boundary.
 Both take a profile's frontmatter keys, so a profile's gate is handed notes carrying its
 own keys and a repair to one of them refunds the attempt budget. `readMilestones` takes
 those keys too.
+
+A refusal a person has to settle also comes back as a `question`: a header, the question
+in the language of the app, and `options` when the answer comes from a vocabulary this
+package closes over — which `status:` a note is at, which `surface:` it has. Refusals
+about missing content carry no options, because inventing them would be inventing the
+answer. It is a value rather than a tool call, so a harness with a picker renders one and
+a harness without prints a list.

--- a/.changeset/violet-hoops-guess.md
+++ b/.changeset/violet-hoops-guess.md
@@ -1,0 +1,21 @@
+---
+'@pikku/knowledge': patch
+---
+
+Add the dispatch gate and the reconcile loop, with a seam for a profile's own gates.
+
+`readyMilestone` decides whether a milestone note is buildable: it carries `entities:`,
+a `gherkin` block that is not written in the first person, a scenario that names somebody
+who acts, a readable `surface:`, and `tools:` when that surface is an agent. It refuses
+with one sentence a seat can act on, and says who the refusal belongs to — the note's
+author, nobody yet, or a profile's own hold.
+
+`nextAction` derives the one thing to do next from what is on disk: repair a note, write a
+plan, ask the user, dispatch, or hold. Deriving it means calling it twice is free, nothing
+has to be armed by whoever noticed a transition, and the pipeline is testable in a temp
+directory. `runKnowledgeReconcile` flattens the same answer to paths, for a driver reading
+it across a process boundary.
+
+Both take a profile's frontmatter keys, so a profile's gate is handed notes carrying its
+own keys and a repair to one of them refunds the attempt budget. `readMilestones` takes
+those keys too.

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -42,6 +42,10 @@ import {
   renderKnowledgeIndex,
 } from './functions/commands/knowledge-index.js'
 import {
+  knowledgeReconcile,
+  renderKnowledgeReconcile,
+} from './functions/commands/knowledge-reconcile.js'
+import {
   knowledgePlanDefer,
   knowledgePlanProgress,
   knowledgePlanSchema,
@@ -646,6 +650,12 @@ wireCLI({
               default: false,
             },
           },
+        }),
+        next: pikkuCLICommand({
+          func: knowledgeReconcile,
+          render: renderKnowledgeReconcile,
+          description:
+            'Say the one thing to do next — repair a note, write a plan, ask the user, build, or nothing',
         }),
         plan: {
           description:

--- a/packages/cli/src/functions/commands/knowledge-reconcile.ts
+++ b/packages/cli/src/functions/commands/knowledge-reconcile.ts
@@ -1,0 +1,17 @@
+import { pikkuSessionlessFunc } from '#pikku/function'
+import { runKnowledgeReconcile } from '@pikku/knowledge'
+import { renderKnowledgeReconcile } from '../knowledge/render.js'
+import {
+  KnowledgeReconcileInputSchema,
+  KnowledgeReconcileOutputSchema,
+} from '../knowledge/schemas.js'
+
+export const knowledgeReconcile = pikkuSessionlessFunc({
+  description:
+    'Say the one thing to do next with the knowledge base — repair a note, write a plan, ask the user, dispatch a build, or nothing — derived from what is on disk rather than from what a previous step remembered to announce.',
+  input: KnowledgeReconcileInputSchema,
+  output: KnowledgeReconcileOutputSchema,
+  func: async ({ config }) => runKnowledgeReconcile(config.rootDir),
+})
+
+export { renderKnowledgeReconcile }

--- a/packages/cli/src/functions/knowledge/render.test.ts
+++ b/packages/cli/src/functions/knowledge/render.test.ts
@@ -1,7 +1,13 @@
 import assert from 'node:assert'
 import { afterEach, describe, test } from 'node:test'
-import type { KnowledgePlanProgressResult } from '@pikku/knowledge'
-import { renderKnowledgePlanProgress } from './render.js'
+import type {
+  KnowledgePlanProgressResult,
+  KnowledgeReconcileResult,
+} from '@pikku/knowledge'
+import {
+  renderKnowledgePlanProgress,
+  renderKnowledgeReconcile,
+} from './render.js'
 
 const result = (
   over: Partial<KnowledgePlanProgressResult> = {}
@@ -85,5 +91,98 @@ describe('renderKnowledgePlanProgress', () => {
     )
     assert.equal(process.exitCode, 1)
     assert.ok(out.includes('No milestone'))
+  })
+})
+
+describe('renderKnowledgeReconcile', () => {
+  afterEach(() => {
+    process.exitCode = 0
+  })
+
+  const action = (
+    over: Partial<KnowledgeReconcileResult> = {}
+  ): KnowledgeReconcileResult => ({
+    kind: 'idle',
+    reason: 'nothing is written down yet',
+    ...over,
+  })
+
+  test('idle says why and nothing else', () => {
+    const out = capture(() =>
+      renderKnowledgeReconcile(null, action({ kind: 'idle' }))
+    )
+    assert.match(out, /nothing is written down yet/)
+    assert.doesNotMatch(out, /IDLE/)
+  })
+
+  test('a question is numbered with its options, and the machine reason is demoted', () => {
+    const out = capture(() =>
+      renderKnowledgeReconcile(
+        null,
+        action({
+          kind: 'ask-user',
+          note: 'knowledge/milestones/01-the-daily-entry.md',
+          reason: 'Not dispatched: `status: ready` is not a status.',
+          question: {
+            header: 'Where it stands',
+            question: 'Where has "The daily entry" got to?',
+            options: [
+              {
+                label: 'proposed',
+                description: 'settled, and ready to be built',
+              },
+              { label: 'built', description: 'already built' },
+            ],
+          },
+        })
+      )
+    )
+    assert.match(out, /ASK/)
+    assert.match(out, /Where has "The daily entry" got to\?/)
+    assert.match(out, /1\. proposed/)
+    assert.match(out, /2\. built/)
+    // The refusal is still readable, but under `why:` rather than as the question.
+    assert.match(out, /why:/)
+    const question = out.indexOf('Where has')
+    assert.ok(
+      question < out.indexOf('why:'),
+      'the question comes before the reason'
+    )
+  })
+
+  test('a free-text question says so rather than printing an empty list', () => {
+    const out = capture(() =>
+      renderKnowledgeReconcile(
+        null,
+        action({
+          kind: 'ask-user',
+          note: 'knowledge/milestones/01-the-daily-entry.md',
+          reason: 'Not dispatched: no `entities:`.',
+          question: {
+            header: 'What it is about',
+            question: 'What is the main thing this is about?',
+            options: [],
+          },
+        })
+      )
+    )
+    assert.match(out, /\(free text\)/)
+  })
+
+  test('a hold names what it is held on and which notes', () => {
+    const out = capture(() =>
+      renderKnowledgeReconcile(
+        null,
+        action({
+          kind: 'hold',
+          reason: 'Not dispatched: nobody has agreed the screen yet.',
+          hold: 'screens',
+          notes: ['knowledge/screens/today.md'],
+        })
+      )
+    )
+    assert.match(out, /HELD/)
+    assert.match(out, /held on:\s+screens/)
+    assert.match(out, /knowledge\/screens\/today\.md/)
   })
 })

--- a/packages/cli/src/functions/knowledge/render.ts
+++ b/packages/cli/src/functions/knowledge/render.ts
@@ -5,6 +5,7 @@ import type {
   KnowledgePlanSchemaResult,
   KnowledgePlanSetResult,
   KnowledgePlanShowResult,
+  KnowledgeReconcileResult,
   KnowledgeValidateResult,
 } from '@pikku/knowledge'
 import { added, changed, dim, removed } from '../../fabric/lib/output.js'
@@ -200,4 +201,59 @@ export const renderKnowledgePlanDefer = (
 ): void => {
   console.log(`${ok ? added('✓') : removed('✗')}  ${message}`)
   if (!ok) process.exitCode = 1
+}
+
+/**
+ * What to do next, and — when only a person can settle it — the question to put to
+ * them.
+ *
+ * The action's `reason` is machine wording that names the note and the frontmatter
+ * key; on `ask-user` it is deliberately NOT what gets printed as the question, because
+ * the reader there has never seen a note. The options are numbered rather than
+ * rendered as a picker: this is the fallback every harness has, and one that can do
+ * better reads the same answer as JSON.
+ */
+export const renderKnowledgeReconcile = (
+  _services: unknown,
+  { kind, reason, note, hold, notes, question }: KnowledgeReconcileResult
+): void => {
+  if (kind === 'idle') {
+    console.log(`${dim('=')}  ${dim(reason)}`)
+    return
+  }
+
+  const label: Record<string, string> = {
+    'repair-note': 'REPAIR',
+    'write-plan': 'PLAN',
+    'ask-user': 'ASK',
+    dispatch: 'BUILD',
+    hold: 'HELD',
+  }
+  const paint = kind === 'dispatch' ? added : kind === 'hold' ? dim : changed
+  console.log(
+    `${paint(label[kind] ?? kind.toUpperCase())}  ${note ?? ''}`.trim()
+  )
+  console.log()
+
+  if (question) {
+    console.log(`${dim(question.header)}`)
+    console.log(question.question)
+    question.options.forEach((option, index) => {
+      const description = option.description
+        ? `  ${dim(option.description)}`
+        : ''
+      console.log(`  ${index + 1}. ${option.label}${description}`)
+    })
+    if (question.options.length === 0) console.log(dim('  (free text)'))
+    console.log()
+    console.log(`${dim('why:')}  ${dim(reason)}`)
+    return
+  }
+
+  console.log(reason)
+  if (hold) {
+    console.log()
+    console.log(`${dim('held on:')}  ${hold}`)
+    for (const path of notes ?? []) console.log(`  ${dim(path)}`)
+  }
 }

--- a/packages/cli/src/functions/knowledge/schemas.ts
+++ b/packages/cli/src/functions/knowledge/schemas.ts
@@ -11,6 +11,8 @@ import {
   KnowledgePlanSetOutput,
   KnowledgePlanShowInput,
   KnowledgePlanShowOutput,
+  KnowledgeReconcileInput,
+  KnowledgeReconcileOutput,
   KnowledgeValidateInput,
   KnowledgeValidateOutput,
 } from '@pikku/knowledge'
@@ -49,3 +51,6 @@ export const KnowledgePlanSetInputSchema = KnowledgePlanSetInput
 export const KnowledgePlanSetOutputSchema = KnowledgePlanSetOutput
 export const KnowledgePlanDeferInputSchema = KnowledgePlanDeferInput
 export const KnowledgePlanDeferOutputSchema = KnowledgePlanDeferOutput
+
+export const KnowledgeReconcileInputSchema = KnowledgeReconcileInput
+export const KnowledgeReconcileOutputSchema = KnowledgeReconcileOutput

--- a/packages/knowledge/src/index.ts
+++ b/packages/knowledge/src/index.ts
@@ -173,6 +173,17 @@ export {
 } from './milestone-gate.js'
 
 export {
+  KnowledgeQuestionOptionSchema,
+  KnowledgeQuestionSchema,
+  type KnowledgeQuestion,
+  type KnowledgeQuestionOption,
+  STATUS_DESCRIPTIONS,
+  SURFACE_DESCRIPTIONS,
+  askFreely,
+  chooseFrom,
+} from './question.js'
+
+export {
   MAX_ATTEMPTS,
   SEATS,
   type Seat,

--- a/packages/knowledge/src/index.ts
+++ b/packages/knowledge/src/index.ts
@@ -122,6 +122,8 @@ export {
   personasIn,
   quotedIn,
   entitiesOf,
+  toolsOf,
+  addonsOf,
   firstPersonStep,
   setMilestoneStatus,
   nominatedMilestone,
@@ -160,5 +162,27 @@ export {
 } from './plan-command.js'
 
 export { type MilestoneNote, MILESTONE_SCALARS } from './milestone.js'
+
+export {
+  type MilestoneHold,
+  type MilestoneReadiness,
+  type MilestoneRefusal,
+  type MilestoneGate,
+  type ReadyMilestoneOptions,
+  readyMilestone,
+} from './milestone-gate.js'
+
+export {
+  MAX_ATTEMPTS,
+  SEATS,
+  type Seat,
+  type ReconcileAction,
+  type ReconcileOptions,
+  nextAction,
+  KnowledgeReconcileInput,
+  KnowledgeReconcileOutput,
+  type KnowledgeReconcileResult,
+  runKnowledgeReconcile,
+} from './reconcile.js'
 
 export { basePlan } from './plan-fixture.js'

--- a/packages/knowledge/src/milestone-gate.test.ts
+++ b/packages/knowledge/src/milestone-gate.test.ts
@@ -1,0 +1,225 @@
+import assert from 'node:assert'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, test } from 'node:test'
+import { readyMilestone, type MilestoneRefusal } from './milestone-gate.js'
+import type { MilestoneNote } from './milestone.js'
+
+let cwd: string
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'gate-'))
+  mkdirSync(join(cwd, 'knowledge', 'milestones'), { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(cwd, { recursive: true, force: true })
+})
+
+const GHERKIN = [
+  '```gherkin',
+  "Given 'owner' has no entry for today",
+  "When 'owner' writes one",
+  "Then 'owner' reads it back",
+  '```',
+].join('\n')
+
+const milestone = (
+  name: string,
+  frontmatter: Record<string, string> = {},
+  body = GHERKIN
+) => {
+  const keys = {
+    type: 'milestone',
+    title: 'The daily entry',
+    status: 'proposed',
+    entities: 'entry',
+    ...frontmatter,
+  }
+  const fence = Object.entries(keys)
+    .filter(([, value]) => value !== '')
+    .map(([key, value]) => `${key}: ${value}`)
+    .join('\n')
+  writeFileSync(
+    join(cwd, 'knowledge/milestones', name),
+    `---\n${fence}\n---\n\n${body}\n`
+  )
+  return `knowledge/milestones/${name}`
+}
+
+const refusal = async (
+  ...args: Parameters<typeof readyMilestone>
+): Promise<MilestoneRefusal> => {
+  const readiness = await readyMilestone(...args)
+  assert.equal(readiness.ok, false, 'expected a refusal')
+  return readiness as MilestoneRefusal
+}
+
+describe('readyMilestone', () => {
+  test('passes a note that carries entities, gherkin and a person who acts', async () => {
+    const path = milestone('01-the-daily-entry.md')
+    const readiness = await readyMilestone(cwd)
+    assert.equal(readiness.ok, true)
+    assert.equal(readiness.ok && readiness.milestone.path, path)
+    assert.deepEqual(readiness.ok && readiness.personas, ['owner'])
+  })
+
+  test('says nothing is written down, distinctly from a note that failed a rule', async () => {
+    const empty = await refusal(cwd)
+    assert.equal(empty.awaitingNote, true)
+    assert.equal(empty.repairable, undefined)
+
+    milestone('01-the-daily-entry.md', { entities: '' })
+    const failed = await refusal(cwd)
+    assert.equal(failed.awaitingNote, undefined)
+    assert.match(failed.reason, /no `entities:`/)
+    assert.equal(
+      failed.repairable?.path,
+      'knowledge/milestones/01-the-daily-entry.md'
+    )
+  })
+
+  test('a milestone in flight is the refusal, ahead of anything queued behind it', async () => {
+    milestone('01-the-daily-entry.md', { status: 'dispatched' })
+    milestone('02-the-week.md', { entities: '' })
+    const held = await refusal(cwd)
+    assert.match(held.reason, /01-the-daily-entry\.md is already building/)
+    assert.equal(held.repairable, undefined)
+  })
+
+  test('an unreadable status is repairable rather than invisible', async () => {
+    milestone('01-the-daily-entry.md', { status: 'ready' })
+    const bad = await refusal(cwd)
+    assert.match(bad.reason, /`status: ready`, which is not a status/)
+    assert.equal(
+      bad.repairable?.path,
+      'knowledge/milestones/01-the-daily-entry.md'
+    )
+  })
+
+  test('a milestone being designed says the pick is missing, not the note', async () => {
+    milestone('01-the-daily-entry.md', { status: 'designing' })
+    const waiting = await refusal(cwd)
+    assert.match(waiting.reason, /`status: designing`/)
+    assert.equal(waiting.awaitingNote, undefined)
+  })
+
+  test('refuses a first-person step and quotes the line that tripped it', async () => {
+    milestone(
+      '01-the-daily-entry.md',
+      {},
+      ['```gherkin', 'Given I have no entry for today', '```'].join('\n')
+    )
+    const first = await refusal(cwd)
+    assert.match(first.reason, /Given I have no entry for today/)
+  })
+
+  test('a double-quoted domain value is not read as scenario voice', async () => {
+    milestone(
+      '01-the-daily-entry.md',
+      {},
+      [
+        '```gherkin',
+        'Given \'owner\' has a checklist item called "Took my meds"',
+        "Then 'owner' ticks it",
+        '```',
+      ].join('\n')
+    )
+    const readiness = await readyMilestone(cwd)
+    assert.equal(readiness.ok, true)
+  })
+
+  test('refuses a scenario that names nobody, and one that quotes somebody who never acts', async () => {
+    milestone(
+      '01-the-daily-entry.md',
+      {},
+      ['```gherkin', 'Given there is no entry for today', '```'].join('\n')
+    )
+    assert.match((await refusal(cwd)).reason, /names nobody/)
+
+    milestone(
+      '01-the-daily-entry.md',
+      {},
+      [
+        '```gherkin',
+        "Given 'owner' has borrowed a drill and 'member2' has borrowed a hammer",
+        '```',
+      ].join('\n')
+    )
+    assert.match(
+      (await refusal(cwd)).reason,
+      /quotes 'member2' without ever letting them act/
+    )
+  })
+
+  test('refuses an agent surface that names no tools, and an unknown surface', async () => {
+    milestone('01-the-daily-entry.md', { surface: 'agent' })
+    assert.match((await refusal(cwd)).reason, /names no `tools:`/)
+
+    milestone('01-the-daily-entry.md', {
+      surface: 'agent',
+      tools: 'writeEntry',
+    })
+    assert.equal((await readyMilestone(cwd)).ok, true)
+
+    milestone('01-the-daily-entry.md', { surface: 'telepathy' })
+    assert.match(
+      (await refusal(cwd)).reason,
+      /`surface: telepathy`, which is not one of/
+    )
+  })
+
+  test('a profile gate runs only on a note that already passed every shape check', async () => {
+    const seen: string[] = []
+    const gate = async (_cwd: string, note: MilestoneNote) => {
+      seen.push(note.path)
+      return null
+    }
+
+    milestone('01-the-daily-entry.md', { entities: '' })
+    await refusal(cwd, { gate })
+    assert.deepEqual(seen, [], 'a malformed note never reaches the profile')
+
+    milestone('01-the-daily-entry.md')
+    assert.equal((await readyMilestone(cwd, { gate })).ok, true)
+    assert.deepEqual(seen, ['knowledge/milestones/01-the-daily-entry.md'])
+  })
+
+  test("a profile's hold is carried through as its own refusal", async () => {
+    const path = milestone('01-the-daily-entry.md')
+    const held = await refusal(cwd, {
+      gate: async (_cwd, note) => ({
+        ok: false,
+        reason: 'Not dispatched: nobody has agreed the screen yet.',
+        awaiting: { hold: 'screens', notes: [note] },
+      }),
+    })
+    assert.equal(held.awaiting?.hold, 'screens')
+    assert.deepEqual(
+      held.awaiting?.notes.map((n) => n.path),
+      [path]
+    )
+    assert.equal(held.repairable, undefined)
+  })
+
+  test('walks past a note whose budget is gone and dispatches the one behind it', async () => {
+    const stuck = milestone('01-the-connection-check.md', { entities: '' })
+    const fine = milestone('02-browsing-backbone.md')
+
+    const wedged = await refusal(cwd)
+    assert.equal(wedged.repairable?.path, stuck)
+
+    const readiness = await readyMilestone(cwd, {
+      exhausted: (note) => note.path === stuck,
+    })
+    assert.equal(readiness.ok && readiness.milestone.path, fine)
+  })
+
+  test('keeps the first refusal when every queued note is exhausted', async () => {
+    const stuck = milestone('01-the-connection-check.md', { entities: '' })
+    milestone('02-browsing-backbone.md', { entities: '' })
+    const refused = await refusal(cwd, { exhausted: () => true })
+    assert.equal(refused.repairable?.path, stuck)
+  })
+})

--- a/packages/knowledge/src/milestone-gate.ts
+++ b/packages/knowledge/src/milestone-gate.ts
@@ -1,0 +1,278 @@
+import {
+  MILESTONES_DIR,
+  MILESTONE_STATUSES,
+  MILESTONE_SURFACES,
+  entitiesOf,
+  firstPersonStep,
+  gherkinOf,
+  personasIn,
+  quotedIn,
+  readMilestones,
+  surfaceOf,
+  toolsOf,
+  type MilestoneNote,
+} from './milestone.js'
+import type { KnowledgeNote } from './notes.js'
+
+/**
+ * Is there a milestone ready to hand to a builder, and which one?
+ *
+ * This is the dispatch gate: the last read before something spends a build on a note,
+ * and the only place that decides a note is buildable. It refuses with ONE sentence
+ * somebody can act on, never a list — the audience is an agent mid-turn, and a refusal
+ * it cannot act on in one step becomes a retry loop rather than a repair.
+ *
+ * Every check here is about the SHAPE of the note: what it must contain to be one
+ * buildable piece rather than an intention. What a profile layers on top — an
+ * agreement somebody has to give, a registry that has to resolve a name, a design
+ * round — comes in through `gate`, because none of it is knowable from the note alone.
+ */
+
+/**
+ * A refusal that belongs to somebody other than the note's author.
+ *
+ * The three refusal owners are the whole reason this is a union rather than a string:
+ * `repairable` is handed back to whoever writes the notes, `awaitingNote` says nothing
+ * is written down at all, and this one says the milestone is held on something no edit
+ * to the note resolves. `hold` names which of the profile's holds it is, so the caller
+ * can route it without this package learning what the hold means.
+ */
+export interface MilestoneHold {
+  hold: string
+  notes: KnowledgeNote[]
+}
+
+export type MilestoneReadiness =
+  | {
+      ok: true
+      milestone: MilestoneNote
+      gherkin: string
+      personas: string[]
+    }
+  | {
+      ok: false
+      reason: string
+      /**
+       * The note this refusal is ABOUT, when rewriting that note would fix it — a
+       * missing `entities:`, no gherkin, a first-person step, a scenario naming
+       * nobody. Absent for the refusals no edit resolves: a milestone already
+       * building, one waiting on a design pick, or no note written yet.
+       *
+       * It exists because one seat owns the note and nobody else may touch it, so a
+       * refusal is only actionable if it can be handed back there. Without it the
+       * only recovery is asking somebody a question and dispatching on the turn
+       * after — which silently requires a conversation to still be going.
+       */
+      repairable?: MilestoneNote
+      /**
+       * Nothing is written down at all, so the refusal is not about any note.
+       *
+       * Set because a caller has to tell two states apart that read alike: a
+       * milestone that failed a rule, and a conversation that has not settled one
+       * yet. Only the second is worth waiting on rather than acting on.
+       */
+      awaitingNote?: true
+      /** A profile's own hold — see {@link MilestoneHold}. */
+      awaiting?: MilestoneHold
+    }
+
+export type MilestoneRefusal = Extract<MilestoneReadiness, { ok: false }>
+
+/**
+ * A profile's own gate, run on a note that has already passed every shape check here.
+ *
+ * Returns null when the profile is content. It runs LAST for the same reason the
+ * screens check does in the profile that motivated this: a refusal from here typically
+ * sends somebody back to a conversation rather than back to the note, and spending
+ * that conversation on a note that is still malformed spends it on a milestone that
+ * cannot be dispatched anyway.
+ */
+export type MilestoneGate = (
+  cwd: string,
+  note: MilestoneNote
+) => Promise<MilestoneRefusal | null>
+
+export interface ReadyMilestoneOptions {
+  gate?: MilestoneGate
+  /**
+   * A profile's own frontmatter keys, so the notes handed to `gate` carry them.
+   *
+   * A gate that reads a key of its own gets an empty one otherwise, and refuses a note
+   * that says everything it asked for.
+   */
+  profileScalars?: readonly string[]
+  /**
+   * Says a note's repair budget is gone, so the queue walks past it.
+   *
+   * Reading only the front of the queue means one note nobody can fix wedges every
+   * milestone behind it: a first note written with no `entities:` that has spent both
+   * its repairs and its question sits idle with a flawless second note queued behind
+   * it that would have dispatched.
+   */
+  exhausted?: (note: MilestoneNote) => boolean
+}
+
+export async function readyMilestone(
+  cwd: string,
+  {
+    gate,
+    profileScalars = [],
+    exhausted = () => false,
+  }: ReadyMilestoneOptions = {}
+): Promise<MilestoneReadiness> {
+  const milestones: MilestoneNote[] = await readMilestones(cwd, profileScalars)
+
+  // Checked BEFORE anything about the queue, because a milestone in flight is the true
+  // reason for every refusal below it and the only one nobody can fix by editing.
+  // Ordering it after the queue rules tells a seat that had correctly written the next
+  // milestone to go delete a note, when the real answer is "the first one is building".
+  const inFlight = milestones.filter((note) => note.status === 'dispatched')
+  if (inFlight.length > 0) {
+    return {
+      ok: false,
+      reason: `Not dispatched: ${inFlight.map((n) => n.path).join(', ')} is already building. Write the next milestone note whenever the next piece settles, and dispatch it once this one lands — this note only records that it was dispatched, never how the build is doing.`,
+    }
+  }
+
+  // A status nothing recognises makes the note INVISIBLE: it is in no bucket, so the
+  // caller is told "nothing is written down yet" over a note that says everything, and
+  // the loop idles with a full knowledge base. Surfaced as repairable, because the fix
+  // is one line and belongs to whoever wrote it.
+  const unreadable = milestones.find(
+    (note) => !MILESTONE_STATUSES.includes(note.status as never)
+  )
+  if (unreadable) {
+    return {
+      ok: false,
+      reason: `Not dispatched: ${unreadable.path} has \`status: ${unreadable.status}\`, which is not a status. It is one of ${MILESTONE_STATUSES.join(', ')}, on its own line. Rewrite that line and leave the rest of the note alone.`,
+      repairable: unreadable,
+    }
+  }
+
+  // Path order IS build order — notes are `NN-name.md`, numbered as each piece settles
+  // — so several `proposed` notes are a QUEUE and this takes the front of it. Refusing
+  // the second one forbids writing ahead, which means a build finishing has nothing to
+  // pick up and the next milestone is only written once somebody notices.
+  const proposed = milestones
+    .filter((note) => note.status === 'proposed')
+    .sort((a, b) => a.path.localeCompare(b.path))
+
+  if (proposed.length === 0) {
+    // A milestone waiting on a look is the commonest reason there is nothing to
+    // dispatch, and it is NOT the same problem as a missing note: the note is written,
+    // and saying "write one" sends the caller to duplicate the note it already has.
+    const designing = milestones.filter((note) => note.status === 'designing')
+    if (designing.length > 0) {
+      return {
+        ok: false,
+        reason: `Not dispatched: ${designing.map((n) => n.path).join(', ')} is \`status: designing\` — somebody is being shown looks for it and has not picked one. When they pick, record the choice on that note and move it to \`status: proposed\`. If they have said to build it as it stands, move it to \`proposed\` as it is.`,
+      }
+    }
+    return {
+      ok: false,
+      awaitingNote: true,
+      reason: `Not dispatched: nothing is written down yet. A milestone is filed to ${MILESTONES_DIR}/ before it can be built, so there is nothing here to hand a builder. Settle one piece of what is being built and file it as a note.`,
+    }
+  }
+
+  let firstRefusal: MilestoneRefusal | null = null
+  for (const note of proposed) {
+    const readiness = await noteReadiness(cwd, note, gate)
+    if (readiness.ok) return readiness
+    firstRefusal ??= readiness
+    if (!readiness.repairable || !exhausted(readiness.repairable))
+      return readiness
+  }
+  return firstRefusal!
+}
+
+async function noteReadiness(
+  cwd: string,
+  milestone: MilestoneNote,
+  gate: MilestoneGate | undefined
+): Promise<MilestoneReadiness> {
+  if (entitiesOf(milestone).length === 0) {
+    return {
+      ok: false,
+      reason: `Not dispatched: ${milestone.path} has no \`entities:\` — name the thing this milestone is about, so it is one buildable piece rather than an intention.`,
+      repairable: milestone,
+    }
+  }
+
+  const gherkin = gherkinOf(milestone)
+  if (!gherkin) {
+    return {
+      ok: false,
+      reason: `Not dispatched: ${milestone.path} has no \`\`\`gherkin block. The scenario is what a builder turns into a real test — without it there is nothing that says the milestone is done.`,
+      repairable: milestone,
+    }
+  }
+
+  // Catching this at dispatch is the cheap moment: once a builder has turned the step
+  // into a scenario, the missing actor shows up as a test that cannot run.
+  const firstPerson = firstPersonStep(gherkin)
+  if (firstPerson) {
+    return {
+      ok: false,
+      reason: `Not dispatched: this step in ${milestone.path} is written in the first person — \`${firstPerson}\`. Write it about the persona — \`Given 'owner' has no entry for today\`, not \`Given I have no entry\` — because the scenario runs AS someone.`,
+      repairable: milestone,
+    }
+  }
+
+  // The gherkin IS where the people are named, and it is named BEFORE any of them is
+  // declared in code: a builder writes `definePersonas` from these names, so checking
+  // against declared personas here would refuse every first milestone — the one this
+  // gate most needs to let through.
+  //
+  // ONE person is enough, and this must never ask for a second. A single persona still
+  // proves a database, sign-in, an owned row and a query scoped to its owner, and
+  // owner-A-cannot-see-owner-B is a sharper test of the shape than a role invented to
+  // satisfy a counter. Asked for a second kind of person in order to dispatch at all, a
+  // planner will invent one — and then design them a surface nobody asked for.
+  const named = personasIn(gherkin)
+  if (named.length === 0) {
+    return {
+      ok: false,
+      reason: `Not dispatched: the scenario in ${milestone.path} names nobody. Quote the person in each step — \`Given 'owner' …\` — so the scenario knows who it runs as.`,
+      repairable: milestone,
+    }
+  }
+
+  // Every quoted token must DRIVE a step somewhere, not merely be mentioned in one. A
+  // person acts, so they appear in subject position, while a single-quoted domain value
+  // (`saved as 'today'`) and a second actor introduced mid-sentence never do. Refusing
+  // both is what makes quoting mean something.
+  const passive = quotedIn(gherkin).filter((name) => !named.includes(name))
+  if (passive.length > 0) {
+    return {
+      ok: false,
+      reason: `Not dispatched: the scenario in ${milestone.path} quotes ${passive.map((n) => `'${n}'`).join(', ')} without ever letting them act. A single quote means a person, so either give ${passive[0] ? `'${passive[0]}'` : 'them'} a step of their own — \`When '${passive[0]}' …\` — or drop the quotes if it was never a person (a domain value goes bare, or in double quotes).`,
+      repairable: milestone,
+    }
+  }
+
+  const surface = (milestone.surface ?? '').trim().toLowerCase()
+  if (
+    milestone.surface !== undefined &&
+    !(MILESTONE_SURFACES as readonly string[]).includes(surface)
+  ) {
+    return {
+      ok: false,
+      reason: `Not dispatched: ${milestone.path} has \`surface: ${milestone.surface}\`, which is not one of ${MILESTONE_SURFACES.join(', ')}. Use the one this milestone reaches its person through, or drop the line — absent means \`app\`.`,
+      repairable: milestone,
+    }
+  }
+
+  if (surfaceOf(milestone) === 'agent' && toolsOf(milestone).length === 0) {
+    return {
+      ok: false,
+      reason: `Not dispatched: ${milestone.path} is \`surface: agent\` and names no \`tools:\`. An agent is a model holding your app's own functions and deciding when to use them; given none, it ships a chat box that answers questions about the app confidently and cannot do one thing in it. List the functions it may call on a \`tools:\` line — \`tools: bookAppointment, listOpenSlots, cancelBooking\`. A tool that sends, charges, deletes or posts is built behind an approval, so name those too rather than avoiding them.`,
+      repairable: milestone,
+    }
+  }
+
+  const held = await gate?.(cwd, milestone)
+  if (held) return held
+
+  return { ok: true, milestone, gherkin, personas: named }
+}

--- a/packages/knowledge/src/milestone-gate.ts
+++ b/packages/knowledge/src/milestone-gate.ts
@@ -10,9 +10,17 @@ import {
   readMilestones,
   surfaceOf,
   toolsOf,
+  withoutMilestonesDir,
   type MilestoneNote,
 } from './milestone.js'
 import type { KnowledgeNote } from './notes.js'
+import {
+  STATUS_DESCRIPTIONS,
+  SURFACE_DESCRIPTIONS,
+  askFreely,
+  chooseFrom,
+  type KnowledgeQuestion,
+} from './question.js'
 
 /**
  * Is there a milestone ready to hand to a builder, and which one?
@@ -74,6 +82,18 @@ export type MilestoneReadiness =
       awaitingNote?: true
       /** A profile's own hold — see {@link MilestoneHold}. */
       awaiting?: MilestoneHold
+      /**
+       * The refusal put to a person, when it is worth putting to one.
+       *
+       * `reason` is machine wording for a machine audience: it names the note, the
+       * frontmatter key and what the gate wanted, none of which means anything to
+       * somebody who has never seen a note. This is the same refusal asked as a
+       * question about their app, and it carries options only where the answer comes
+       * from a vocabulary this package closes over — a status, a surface. Everything
+       * else refuses on missing CONTENT, where the honest offer is free text and
+       * inventing options would be inventing the answer.
+       */
+      question?: KnowledgeQuestion
     }
 
 export type MilestoneRefusal = Extract<MilestoneReadiness, { ok: false }>
@@ -146,6 +166,12 @@ export async function readyMilestone(
       ok: false,
       reason: `Not dispatched: ${unreadable.path} has \`status: ${unreadable.status}\`, which is not a status. It is one of ${MILESTONE_STATUSES.join(', ')}, on its own line. Rewrite that line and leave the rest of the note alone.`,
       repairable: unreadable,
+      question: chooseFrom(
+        'Where it stands',
+        `Where has "${unreadable.title ?? withoutMilestonesDir(unreadable.path)}" got to?`,
+        MILESTONE_STATUSES,
+        (status) => STATUS_DESCRIPTIONS[status]
+      ),
     }
   }
 
@@ -196,6 +222,10 @@ async function noteReadiness(
       ok: false,
       reason: `Not dispatched: ${milestone.path} has no \`entities:\` — name the thing this milestone is about, so it is one buildable piece rather than an intention.`,
       repairable: milestone,
+      question: askFreely(
+        'What it is about',
+        `What is the main thing "${milestone.title ?? withoutMilestonesDir(milestone.path)}" is about — the thing people would be creating, listing or changing?`
+      ),
     }
   }
 
@@ -260,6 +290,12 @@ async function noteReadiness(
       ok: false,
       reason: `Not dispatched: ${milestone.path} has \`surface: ${milestone.surface}\`, which is not one of ${MILESTONE_SURFACES.join(', ')}. Use the one this milestone reaches its person through, or drop the line — absent means \`app\`.`,
       repairable: milestone,
+      question: chooseFrom(
+        'Where it lives',
+        `How do people reach "${milestone.title ?? withoutMilestonesDir(milestone.path)}"?`,
+        MILESTONE_SURFACES,
+        (surface) => SURFACE_DESCRIPTIONS[surface]
+      ),
     }
   }
 

--- a/packages/knowledge/src/milestone.ts
+++ b/packages/knowledge/src/milestone.ts
@@ -30,8 +30,10 @@ export type MilestoneSurface = (typeof MILESTONE_SURFACES)[number]
  * `surface:` is what the milestone reaches its person THROUGH, and it lives on the note
  * rather than in the plan: a milestone that is a CLI is a fact about the milestone, not
  * about the document written from it. `requires:` is what it cannot be built without.
+ * `tools:` is the functions a `surface: agent` milestone lets its model call, which is
+ * the one surface whose capability is not implied by anything else on the note.
  */
-export const MILESTONE_SCALARS = ['surface', 'requires'] as const
+export const MILESTONE_SCALARS = ['surface', 'requires', 'tools'] as const
 export type MilestoneNote = ProfileNote<(typeof MILESTONE_SCALARS)[number]>
 
 export const inMilestonesDir = (path: string): boolean =>
@@ -63,8 +65,25 @@ export function surfaceOf(note: MilestoneNote): MilestoneSurface {
   return isSurface(raw) ? raw : 'app'
 }
 
-export async function readMilestones(cwd: string): Promise<MilestoneNote[]> {
-  return (await readKnowledgeNotes(cwd, MILESTONE_SCALARS)).filter(
+/**
+ * Every milestone note, index and log excluded.
+ *
+ * @param extraScalars a profile's own frontmatter keys, read alongside this one's. A
+ * profile that gates on a key of its own — or whose repair budget must notice that key
+ * changing — has to be handed the note WITH it: read without, the key is absent from
+ * the parsed note, so a gate reads it as empty and a fingerprint taken over it cannot
+ * tell that it moved.
+ */
+export async function readMilestones<Key extends string = never>(
+  cwd: string,
+  extraScalars: readonly Key[] = []
+): Promise<ProfileNote<(typeof MILESTONE_SCALARS)[number] | Key>[]> {
+  return (
+    await readKnowledgeNotes<(typeof MILESTONE_SCALARS)[number] | Key>(cwd, [
+      ...MILESTONE_SCALARS,
+      ...extraScalars,
+    ])
+  ).filter(
     (note) =>
       inMilestonesDir(note.path) &&
       !note.reserved &&
@@ -97,7 +116,33 @@ export function personasIn(gherkin: string): string[] {
 }
 
 /** The entities a milestone's `entities:` names. */
-export const entitiesOf = (note: KnowledgeNote): string[] => listOf(note.entities)
+export const entitiesOf = (note: KnowledgeNote): string[] =>
+  listOf(note.entities)
+
+/**
+ * The functions a `surface: agent` milestone lets its model call.
+ *
+ * An agent milestone is a model holding the app's own functions and deciding when to
+ * use them. Given none it ships a chat box that answers questions about the app
+ * confidently and cannot do one thing in it — and no dependency gate catches that,
+ * because a milestone that declared nothing has nothing unmet.
+ */
+export const toolsOf = (note: MilestoneNote): string[] =>
+  listOf(note.tools?.replace(/[[\]]/g, ''))
+
+/**
+ * The `addon:<name>` tokens on a milestone's `requires:` line, in declaration order.
+ *
+ * A `requires:` token names ONE published addon, never a category or a kind of
+ * service, and whether a given name resolves is not knowable here — the registry
+ * behind it belongs to whoever is driving the build. This is the parse; the
+ * resolution is a profile gate's.
+ */
+export const addonsOf = (note: MilestoneNote): string[] =>
+  listOf(note.requires)
+    .map((token) => token.split(':').map((part) => part.trim()))
+    .filter(([kind, name]) => kind === 'addon' && !!name)
+    .map(([, name]) => name!)
 
 const PERSONA_QUOTE = /'([A-Za-z][A-Za-z0-9]*)'/g
 
@@ -289,7 +334,10 @@ export async function holdMilestoneLifecycle(
   try {
     for (const note of await readMilestones(cwd)) {
       if (!note.status || note.status === 'proposed') continue
-      held.set(note.path, { status: note.status, statusAt: note.statusAt ?? null })
+      held.set(note.path, {
+        status: note.status,
+        statusAt: note.statusAt ?? null,
+      })
     }
   } catch (err) {
     console.warn(`[milestone] could not snapshot the lifecycle: ${String(err)}`)
@@ -309,7 +357,9 @@ export async function holdMilestoneLifecycle(
         })
       }
     } catch (err) {
-      console.warn(`[milestone] could not restore the lifecycle: ${String(err)}`)
+      console.warn(
+        `[milestone] could not restore the lifecycle: ${String(err)}`
+      )
     }
   }
 }

--- a/packages/knowledge/src/question.ts
+++ b/packages/knowledge/src/question.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod'
+
+/**
+ * A question to put to a person, as a value rather than as a call.
+ *
+ * The shape is deliberately the one every picker already wants — a short label, the
+ * question itself, and zero or more options — because the alternative is a tool call,
+ * and a tool call belongs to one harness. A loop that RETURNS a question can be
+ * rendered as a picker by a harness that has one, printed as a numbered list by a
+ * harness that does not, and read across a process boundary by something that is
+ * neither. Nothing here knows which of those is on the other side.
+ *
+ * `options` is empty for a question nothing can enumerate — "what is this milestone
+ * about?" has no candidate answers. It is filled only where the answer comes from a
+ * closed vocabulary this package owns, which is the one case a gate can derive the
+ * choices honestly rather than inventing plausible-looking ones.
+ */
+export const KnowledgeQuestionOptionSchema = z.object({
+  label: z.string(),
+  description: z.string().optional(),
+})
+
+export const KnowledgeQuestionSchema = z.object({
+  /** A few words naming what is being decided, for a chip or a column heading. */
+  header: z.string(),
+  /** The question itself, in the language of the app rather than of the notes. */
+  question: z.string(),
+  /** The answers worth offering, or empty when the answer is free text. */
+  options: z.array(KnowledgeQuestionOptionSchema).default([]),
+})
+
+export type KnowledgeQuestionOption = z.infer<
+  typeof KnowledgeQuestionOptionSchema
+>
+export type KnowledgeQuestion = z.infer<typeof KnowledgeQuestionSchema>
+
+/** A question whose answer is one of a vocabulary this package closes over. */
+export const chooseFrom = (
+  header: string,
+  question: string,
+  options: readonly string[],
+  describe: (option: string) => string | undefined = () => undefined
+): KnowledgeQuestion => ({
+  header,
+  question,
+  options: options.map((label) => ({ label, description: describe(label) })),
+})
+
+/** A question with no candidate answers — the honest shape for free text. */
+export const askFreely = (
+  header: string,
+  question: string
+): KnowledgeQuestion => ({ header, question, options: [] })
+
+/**
+ * What each milestone status means to somebody who has never read the profile.
+ *
+ * Written for the person being asked, not for the note: a status is picked by
+ * somebody who knows where their app has got to, and `dispatched` is not a word they
+ * would otherwise have to learn.
+ */
+export const STATUS_DESCRIPTIONS: Record<string, string> = {
+  designing: 'still choosing how it should look',
+  proposed: 'settled, and ready to be built',
+  dispatched: 'being built right now',
+  built: 'already built',
+}
+
+/** What each surface means — where this milestone reaches the person using it. */
+export const SURFACE_DESCRIPTIONS: Record<string, string> = {
+  app: 'a page somebody opens',
+  cli: 'a command somebody runs in a terminal',
+  mcp: 'a tool another program calls',
+  agent: 'a model that holds your functions and decides when to use them',
+  backend: 'no surface of its own — something a later milestone builds on',
+}

--- a/packages/knowledge/src/reconcile.test.ts
+++ b/packages/knowledge/src/reconcile.test.ts
@@ -1,0 +1,250 @@
+import assert from 'node:assert'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, test } from 'node:test'
+import { recordNoteAttempt, setNoteScalars } from './ledger.js'
+import { readMilestones } from './milestone.js'
+import { basePlan } from './plan-fixture.js'
+import { writePlan } from './plan.js'
+import {
+  MAX_ATTEMPTS,
+  SEATS,
+  nextAction,
+  runKnowledgeReconcile,
+} from './reconcile.js'
+
+let cwd: string
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'reconcile-'))
+  mkdirSync(join(cwd, 'knowledge', 'milestones'), { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(cwd, { recursive: true, force: true })
+})
+
+const GHERKIN = [
+  '```gherkin',
+  "Given 'owner' has no entry for today",
+  "When 'owner' writes one",
+  '```',
+].join('\n')
+
+const milestone = (
+  name = '01-the-daily-entry.md',
+  frontmatter: Record<string, string> = {}
+) => {
+  const keys = {
+    type: 'milestone',
+    title: 'The daily entry',
+    status: 'proposed',
+    entities: 'entry',
+    ...frontmatter,
+  }
+  const fence = Object.entries(keys)
+    .filter(([, value]) => value !== '')
+    .map(([key, value]) => `${key}: ${value}`)
+    .join('\n')
+  writeFileSync(
+    join(cwd, 'knowledge/milestones', name),
+    `---\n${fence}\n---\n\n${GHERKIN}\n`
+  )
+  return `knowledge/milestones/${name}`
+}
+
+/**
+ * Spend a seat's whole budget against the note as it now stands.
+ *
+ * `profileScalars` has to match what the reader will pass: an attempt is recorded
+ * against a fingerprint taken over the keys the CALLER names, so burning under one
+ * profile and reading under another compares two different notes and asserts nothing.
+ */
+const burn = async (
+  path: string,
+  seat: string,
+  profileScalars: readonly string[] = []
+) => {
+  for (let i = 0; i < MAX_ATTEMPTS; i++) {
+    const note = (await readMilestones(cwd, profileScalars)).find(
+      (n) => n.path === path
+    )!
+    recordNoteAttempt(cwd, note, seat, { profileScalars })
+  }
+}
+
+/** Replace a note's body, leaving its frontmatter — the ledger included — alone. */
+const rewriteBody = (path: string, body: string) => {
+  const raw = readFileSync(join(cwd, path), 'utf8')
+  const fence = /^---\r?\n[\s\S]*?\r?\n---\r?\n/.exec(raw)![0]
+  writeFileSync(join(cwd, path), `${fence}\n${body}\n`)
+}
+
+describe('nextAction', () => {
+  test('idles on an empty knowledge base', async () => {
+    const action = await nextAction(cwd)
+    assert.equal(action.kind, 'idle')
+    assert.match(
+      action.kind === 'idle' ? action.why : '',
+      /nothing is written down yet/
+    )
+  })
+
+  test('a dispatched milestone is the whole answer', async () => {
+    milestone('01-the-daily-entry.md', { status: 'dispatched' })
+    milestone('02-the-week.md')
+    const action = await nextAction(cwd)
+    assert.equal(action.kind, 'idle')
+    assert.match(
+      action.kind === 'idle' ? action.why : '',
+      /01-the-daily-entry\.md is building/
+    )
+  })
+
+  test('a malformed note is repaired first, then asked about, then rests', async () => {
+    const path = milestone('01-the-daily-entry.md', { entities: '' })
+
+    const repair = await nextAction(cwd)
+    assert.equal(repair.kind, 'repair-note')
+    assert.match(
+      repair.kind === 'repair-note' ? repair.reason : '',
+      /no `entities:`/
+    )
+
+    await burn(path, SEATS.author)
+    const ask = await nextAction(cwd)
+    assert.equal(ask.kind, 'ask-user')
+
+    await burn(path, SEATS.user)
+    const rest = await nextAction(cwd)
+    assert.equal(rest.kind, 'idle')
+    assert.match(
+      rest.kind === 'idle' ? rest.why : '',
+      /cannot be repaired and the user has been asked/
+    )
+  })
+
+  test("the author's budget is spent across every body the note has had", async () => {
+    const path = milestone('01-the-daily-entry.md', { entities: '' })
+    await burn(path, SEATS.author)
+    assert.equal((await nextAction(cwd)).kind, 'ask-user')
+
+    // A rewrite that leaves the missing `entities:` exactly as it was must not hand the
+    // author its budget back — that is the loop this counts across bodies to stop.
+    rewriteBody(path, `Rewritten prose.\n\n${GHERKIN}`)
+    assert.equal((await nextAction(cwd)).kind, 'ask-user')
+  })
+
+  test('a ready milestone with no plan goes to the planner, then to the user', async () => {
+    const path = milestone()
+
+    const plan = await nextAction(cwd)
+    assert.equal(plan.kind, 'write-plan')
+    assert.match(plan.kind === 'write-plan' ? plan.reason : '', /No plan at/)
+
+    await burn(path, SEATS.planner)
+    assert.equal((await nextAction(cwd)).kind, 'ask-user')
+
+    await burn(path, SEATS.user)
+    const rest = await nextAction(cwd)
+    assert.equal(rest.kind, 'idle')
+    assert.match(
+      rest.kind === 'idle' ? rest.why : '',
+      /no plan the planner could write/
+    )
+  })
+
+  test('a ready milestone with a plan dispatches', async () => {
+    const path = milestone()
+    writePlan(cwd, path, basePlan(path))
+    const action = await nextAction(cwd)
+    assert.equal(action.kind, 'dispatch')
+    assert.equal(action.kind === 'dispatch' ? action.note.path : '', path)
+  })
+
+  test("a profile's hold is returned rather than swallowed as idle", async () => {
+    const path = milestone()
+    const action = await nextAction(cwd, {
+      gate: async (_cwd, note) => ({
+        ok: false,
+        reason: 'Not dispatched: nobody has agreed the screen yet.',
+        awaiting: { hold: 'screens', notes: [note] },
+      }),
+    })
+    assert.equal(action.kind, 'hold')
+    assert.equal(action.kind === 'hold' ? action.hold : '', 'screens')
+    assert.deepEqual(
+      action.kind === 'hold' ? action.notes.map((n) => n.path) : [],
+      [path]
+    )
+  })
+
+  test('a repair to a profile key refunds a per-body budget when the profile names it', async () => {
+    const path = milestone()
+    const scalars = ['design'] as const
+    const next = () => nextAction(cwd, { profileScalars: scalars })
+
+    await burn(path, SEATS.planner, scalars)
+    assert.equal((await next()).kind, 'ask-user')
+
+    // Reading again with nothing changed must NOT hand the budget back, or the refund
+    // below is only the fingerprint being unstable.
+    assert.equal((await next()).kind, 'ask-user')
+
+    // The planner is counted against the body it is answering, and `design:` belongs to
+    // a profile — so the note only reads as having moved for a caller that names it.
+    setNoteScalars(cwd, path, { design: 'the picked one' })
+    assert.equal(
+      (await next()).kind,
+      'write-plan',
+      'the key the profile named moved, so the planner gets another go'
+    )
+  })
+})
+
+describe('runKnowledgeReconcile', () => {
+  test('flattens the action to paths a driver on the other side of a command can read', async () => {
+    const path = milestone()
+    writePlan(cwd, path, basePlan(path))
+    assert.deepEqual(await runKnowledgeReconcile(cwd), {
+      kind: 'dispatch',
+      reason: `${path} has a plan and is ready to build`,
+      note: path,
+    })
+
+    rmSync(join(cwd, path.replace(/\.md$/, '.plan.json')))
+    const plan = await runKnowledgeReconcile(cwd)
+    assert.equal(plan.kind, 'write-plan')
+    assert.equal(plan.note, path)
+
+    const held = await runKnowledgeReconcile(
+      cwd,
+      {},
+      {
+        gate: async (_cwd, note) => ({
+          ok: false,
+          reason: 'Not dispatched: nobody has agreed the screen yet.',
+          awaiting: { hold: 'screens', notes: [note] },
+        }),
+      }
+    )
+    assert.equal(held.kind, 'hold')
+    assert.equal(held.hold, 'screens')
+    assert.deepEqual(held.notes, [path])
+    assert.equal(held.note, undefined)
+  })
+
+  test('an idle action carries its why as the reason', async () => {
+    const result = await runKnowledgeReconcile(cwd)
+    assert.equal(result.kind, 'idle')
+    assert.match(result.reason, /nothing is written down yet/)
+    assert.equal(result.note, undefined)
+  })
+})

--- a/packages/knowledge/src/reconcile.test.ts
+++ b/packages/knowledge/src/reconcile.test.ts
@@ -248,3 +248,71 @@ describe('runKnowledgeReconcile', () => {
     assert.equal(result.note, undefined)
   })
 })
+
+describe('the refusal as a question', () => {
+  test('a closed vocabulary becomes real options, in the language of the app', async () => {
+    const path = milestone('01-the-daily-entry.md', { status: 'ready' })
+    await burn(path, SEATS.author)
+
+    const action = await nextAction(cwd)
+    assert.equal(action.kind, 'ask-user')
+    const question = action.kind === 'ask-user' ? action.question : null
+    assert.equal(question?.header, 'Where it stands')
+    assert.match(
+      question?.question ?? '',
+      /Where has "The daily entry" got to\?/
+    )
+    assert.deepEqual(
+      question?.options.map((o) => o.label),
+      ['designing', 'proposed', 'dispatched', 'built']
+    )
+    assert.equal(
+      question?.options.find((o) => o.label === 'dispatched')?.description,
+      'being built right now'
+    )
+
+    // The machine wording stays on `reason`, and must never be what a person is shown.
+    assert.match(
+      action.kind === 'ask-user' ? action.reason : '',
+      /`status: ready`/
+    )
+    assert.doesNotMatch(question?.question ?? '', /status|note|frontmatter/i)
+  })
+
+  test('an unreadable surface offers the five surfaces', async () => {
+    const path = milestone('01-the-daily-entry.md', { surface: 'telepathy' })
+    await burn(path, SEATS.author)
+    const action = await nextAction(cwd)
+    assert.equal(action.kind, 'ask-user')
+    assert.deepEqual(
+      action.kind === 'ask-user'
+        ? action.question.options.map((o) => o.label)
+        : [],
+      ['app', 'cli', 'mcp', 'agent', 'backend']
+    )
+  })
+
+  test('a refusal about missing content offers free text rather than inventing options', async () => {
+    const path = milestone('01-the-daily-entry.md', { entities: '' })
+    await burn(path, SEATS.author)
+    const action = await nextAction(cwd)
+    assert.equal(action.kind, 'ask-user')
+    assert.deepEqual(
+      action.kind === 'ask-user' ? action.question.options : null,
+      []
+    )
+    assert.match(
+      action.kind === 'ask-user' ? action.question.question : '',
+      /What is the main thing "The daily entry" is about/
+    )
+  })
+
+  test('the question survives the flattening to a command result', async () => {
+    const path = milestone('01-the-daily-entry.md', { status: 'ready' })
+    await burn(path, SEATS.author)
+    const result = await runKnowledgeReconcile(cwd)
+    assert.equal(result.kind, 'ask-user')
+    assert.equal(result.note, path)
+    assert.equal(result.question?.options.length, 4)
+  })
+})

--- a/packages/knowledge/src/reconcile.ts
+++ b/packages/knowledge/src/reconcile.ts
@@ -7,6 +7,11 @@ import {
   type MilestoneReadiness,
 } from './milestone-gate.js'
 import type { KnowledgeNote } from './notes.js'
+import {
+  KnowledgeQuestionSchema,
+  askFreely,
+  type KnowledgeQuestion,
+} from './question.js'
 import { readPlan } from './plan.js'
 
 /**
@@ -76,7 +81,20 @@ export type ReconcileAction =
   | { kind: 'idle'; why: string }
   | { kind: 'repair-note'; note: MilestoneNote; reason: string }
   | { kind: 'write-plan'; note: MilestoneNote; reason: string }
-  | { kind: 'ask-user'; note: MilestoneNote; reason: string }
+  /**
+   * Only a person can settle this, and every seat that could have resolved it has
+   * spent its budget.
+   *
+   * `reason` is the machine wording and must not be repeated to anybody — the reader
+   * has no idea what a milestone note is. `question` is the same refusal asked about
+   * their app, which is what a harness renders.
+   */
+  | {
+      kind: 'ask-user'
+      note: MilestoneNote
+      reason: string
+      question: KnowledgeQuestion
+    }
   | { kind: 'dispatch'; note: MilestoneNote }
   /**
    * A profile's gate is holding the milestone, and no seat this loop knows about can
@@ -165,7 +183,18 @@ export async function nextAction(
       return { kind: 'write-plan', note: ready.milestone, reason: plan.reason }
     }
     if (!isSpent(ready.milestone, SEATS.user)) {
-      return { kind: 'ask-user', note: ready.milestone, reason: plan.reason }
+      return {
+        kind: 'ask-user',
+        note: ready.milestone,
+        reason: plan.reason,
+        // A plan that could not be written is not a closed question: what is missing
+        // is whatever the conversation never settled, and this package cannot know
+        // what that is. Free text is the honest offer.
+        question: askFreely(
+          'What to build',
+          `What should "${ready.milestone.title ?? ready.milestone.path}" actually do first?`
+        ),
+      }
     }
     return {
       kind: 'idle',
@@ -193,7 +222,17 @@ export async function nextAction(
       }
     }
     if (!isSpent(ready.repairable, SEATS.user)) {
-      return { kind: 'ask-user', note: ready.repairable, reason: ready.reason }
+      return {
+        kind: 'ask-user',
+        note: ready.repairable,
+        reason: ready.reason,
+        question:
+          ready.question ??
+          askFreely(
+            'What to build',
+            `What should "${ready.repairable.title ?? ready.repairable.path}" actually do?`
+          ),
+      }
     }
     return {
       kind: 'idle',
@@ -230,6 +269,8 @@ export const KnowledgeReconcileOutput = z.object({
   hold: z.string().optional(),
   /** The notes a hold is about, on `hold`. */
   notes: z.array(z.string()).optional(),
+  /** The refusal as a question for a person, on `ask-user`. */
+  question: KnowledgeQuestionSchema.optional(),
 })
 
 export type KnowledgeReconcileResult = z.infer<typeof KnowledgeReconcileOutput>
@@ -255,6 +296,13 @@ export const runKnowledgeReconcile = async (
         reason: action.reason,
         hold: action.hold,
         notes: action.notes.map((note) => note.path),
+      }
+    case 'ask-user':
+      return {
+        kind: 'ask-user',
+        reason: action.reason,
+        note: action.note.path,
+        question: action.question,
       }
     default:
       return {

--- a/packages/knowledge/src/reconcile.ts
+++ b/packages/knowledge/src/reconcile.ts
@@ -1,0 +1,266 @@
+import { z } from 'zod'
+import { attemptsSpent } from './ledger.js'
+import { readMilestones, type MilestoneNote } from './milestone.js'
+import {
+  readyMilestone,
+  type MilestoneGate,
+  type MilestoneReadiness,
+} from './milestone-gate.js'
+import type { KnowledgeNote } from './notes.js'
+import { readPlan } from './plan.js'
+
+/**
+ * What the pipeline should do next, derived entirely from what is on disk.
+ *
+ * This is the whole control plane, and it is a pure read for a reason. The shape it
+ * replaces is edge-triggered: each stage tells the next one through a sentinel beside
+ * the work, armed only from inside a "a turn just ended" callback, so every condition
+ * needs its own branch remembering to start a turn — and every branch that forgets is a
+ * run that comes to rest looking busy. Deriving the answer instead means calling this
+ * twice is free, nothing has to be armed, and a state nobody anticipated is a missing
+ * row here rather than a stall in production.
+ *
+ * It also means the pipeline is testable in a temp directory: write the notes, assert
+ * the action. Every failure this was written against — a milestone blocked on an
+ * agreement nobody could give, a plan budget that ran out in silence, a dispatch
+ * waiting on a plan that was never coming — was otherwise only findable by running a
+ * real build for twenty minutes, because there was no smaller thing to run.
+ */
+
+/**
+ * How many turns one seat may spend on one note, against the content it is answering.
+ *
+ * Two, because past that the seat is not failing on something it can read — a note
+ * writer that misread a gate rule fixes it first try, and one whose note is wrong
+ * because the conversation never settled who uses the app will rewrite the same note
+ * forever. The same split holds for a planner against the plan schema.
+ *
+ * It is a budget per READING of the note, not per note: `attemptsSpent` only counts
+ * attempts recorded against the note as it now stands, so an answer that changes it
+ * hands back a full budget and the loop tries again without anything having to notice.
+ */
+export const MAX_ATTEMPTS = 2
+
+/**
+ * The seats this loop spends attempts for, as they are written into a note's
+ * `attempts:` line.
+ *
+ * They are values rather than a profile's own names because the ledger they are
+ * recorded in belongs to this package: two profiles reading the same knowledge
+ * directory have to agree on what `knowledge@abc123` means, or one of them hands the
+ * other a budget it has already spent. A profile with seats of its own — a design
+ * round, an agreement to settle — records those under names of its own choosing and
+ * bounds them itself; nothing here reads them.
+ */
+export const SEATS = {
+  /** Rewrites the note when a gate refuses it. */
+  author: 'knowledge',
+  /** Writes the plan the milestone is built from. */
+  planner: 'architect',
+  /** The person being asked, which is finite for the same reason as the others: a
+   * question they did not answer is not improved by asking it again. */
+  user: 'ask',
+} as const
+
+export type Seat = (typeof SEATS)[keyof typeof SEATS]
+
+/**
+ * The one thing to do next.
+ *
+ * A closed union rather than a set of booleans because the whole point is that exactly
+ * one of these is true at a time. The shape it replaces — a flag per condition, each
+ * armed by whoever noticed and read by whoever remembered to look — is what lets a run
+ * rest with a milestone that can never be planned and nothing on screen saying so.
+ */
+export type ReconcileAction =
+  | { kind: 'idle'; why: string }
+  | { kind: 'repair-note'; note: MilestoneNote; reason: string }
+  | { kind: 'write-plan'; note: MilestoneNote; reason: string }
+  | { kind: 'ask-user'; note: MilestoneNote; reason: string }
+  | { kind: 'dispatch'; note: MilestoneNote }
+  /**
+   * A profile's gate is holding the milestone, and no seat this loop knows about can
+   * clear it.
+   *
+   * The escape hatch is deliberate and narrow: the caller is handed the hold's name and
+   * the notes it is about, and decides what that means. Modelling the profile's own
+   * rounds here instead would put every profile's vocabulary in this union, and a hold
+   * nothing in this package can act on is exactly the kind of state that used to become
+   * a silent stall — so it is returned rather than swallowed as `idle`.
+   */
+  | { kind: 'hold'; hold: string; notes: KnowledgeNote[]; reason: string }
+
+export interface ReconcileOptions {
+  /** A profile's own dispatch gate — see {@link MilestoneGate}. */
+  gate?: MilestoneGate
+  /**
+   * A profile's frontmatter keys, so a repair to one of them refunds the budget.
+   *
+   * Without this a note's fingerprint is taken over this package's scalars only, and a
+   * seat that fixes a profile key — and nothing else — hands itself back no budget,
+   * because as far as the ledger can see the note did not change.
+   */
+  profileScalars?: readonly string[]
+}
+
+/**
+ * The `author` seat is counted across every body the note has had, the others only
+ * against the body they are answering.
+ *
+ * The author is the seat whose own turn rewrites the note it is bounded by, so a
+ * per-body budget is one it hands back to itself: a run answered two repairs by
+ * rewriting the milestone's prose and leaving the missing `entities:` exactly as it
+ * was, which reset the budget each time and never reached the user.
+ */
+const spent = (
+  note: MilestoneNote,
+  seat: Seat,
+  profileScalars: readonly string[]
+): boolean =>
+  attemptsSpent(note, seat, {
+    profileScalars,
+    anyBody: seat === SEATS.author,
+  }) >= MAX_ATTEMPTS
+
+export async function nextAction(
+  cwd: string,
+  { gate, profileScalars = [] }: ReconcileOptions = {}
+): Promise<ReconcileAction> {
+  const isSpent = (note: MilestoneNote, seat: Seat) =>
+    spent(note, seat, profileScalars)
+
+  const milestones: MilestoneNote[] = await readMilestones(cwd, profileScalars)
+  if (milestones.length === 0) {
+    return {
+      kind: 'idle',
+      why: 'nothing is written down yet — whatever settles what to build owns this',
+    }
+  }
+
+  // Order matters from here down. Earlier rows are conditions that make the later ones
+  // meaningless: there is no point planning a second milestone while one is building,
+  // and no point asking about a note whose profile gate has not been cleared.
+  const building = milestones.find((note) => note.status === 'dispatched')
+  if (building) return { kind: 'idle', why: `${building.path} is building` }
+
+  const sketching = milestones.find((note) => note.status === 'designing')
+  if (sketching) {
+    return {
+      kind: 'idle',
+      why: `${sketching.path} is waiting on somebody to pick a look`,
+    }
+  }
+
+  const ready: MilestoneReadiness = await readyMilestone(cwd, {
+    gate,
+    profileScalars,
+    exhausted: (note) =>
+      isSpent(note, SEATS.author) && isSpent(note, SEATS.user),
+  })
+
+  if (ready.ok) {
+    const plan = readPlan(cwd, ready.milestone.path)
+    if (plan.ok) return { kind: 'dispatch', note: ready.milestone }
+    if (!isSpent(ready.milestone, SEATS.planner)) {
+      return { kind: 'write-plan', note: ready.milestone, reason: plan.reason }
+    }
+    if (!isSpent(ready.milestone, SEATS.user)) {
+      return { kind: 'ask-user', note: ready.milestone, reason: plan.reason }
+    }
+    return {
+      kind: 'idle',
+      why: `${ready.milestone.path} has no plan the planner could write and the user has been asked`,
+    }
+  }
+
+  if (ready.awaitingNote) return { kind: 'idle', why: ready.reason }
+
+  if (ready.awaiting) {
+    return {
+      kind: 'hold',
+      hold: ready.awaiting.hold,
+      notes: ready.awaiting.notes,
+      reason: ready.reason,
+    }
+  }
+
+  if (ready.repairable) {
+    if (!isSpent(ready.repairable, SEATS.author)) {
+      return {
+        kind: 'repair-note',
+        note: ready.repairable,
+        reason: ready.reason,
+      }
+    }
+    if (!isSpent(ready.repairable, SEATS.user)) {
+      return { kind: 'ask-user', note: ready.repairable, reason: ready.reason }
+    }
+    return {
+      kind: 'idle',
+      why: `${ready.repairable.path} cannot be repaired and the user has been asked`,
+    }
+  }
+
+  return { kind: 'idle', why: ready.reason }
+}
+
+export const KnowledgeReconcileInput = z.object({})
+
+/**
+ * The action, flattened to what survives a process boundary.
+ *
+ * Notes are paths rather than parsed notes on purpose: this is the shape a driver on
+ * the other side of a command reads, and a driver that has the path can read the note
+ * itself. In-process callers take {@link nextAction} and keep the notes.
+ */
+export const KnowledgeReconcileOutput = z.object({
+  kind: z.enum([
+    'idle',
+    'repair-note',
+    'write-plan',
+    'ask-user',
+    'dispatch',
+    'hold',
+  ]),
+  /** Why this is the next thing to do, in one sentence somebody can act on. */
+  reason: z.string(),
+  /** The milestone note this action is about, when it is about one. */
+  note: z.string().optional(),
+  /** Which of a profile's holds this is, on `hold`. */
+  hold: z.string().optional(),
+  /** The notes a hold is about, on `hold`. */
+  notes: z.array(z.string()).optional(),
+})
+
+export type KnowledgeReconcileResult = z.infer<typeof KnowledgeReconcileOutput>
+
+export const runKnowledgeReconcile = async (
+  root: string,
+  _input: z.infer<typeof KnowledgeReconcileInput> = {},
+  options: ReconcileOptions = {}
+): Promise<KnowledgeReconcileResult> => {
+  const action = await nextAction(root, options)
+  switch (action.kind) {
+    case 'idle':
+      return { kind: 'idle', reason: action.why }
+    case 'dispatch':
+      return {
+        kind: 'dispatch',
+        reason: `${action.note.path} has a plan and is ready to build`,
+        note: action.note.path,
+      }
+    case 'hold':
+      return {
+        kind: 'hold',
+        reason: action.reason,
+        hold: action.hold,
+        notes: action.notes.map((note) => note.path),
+      }
+    default:
+      return {
+        kind: action.kind,
+        reason: action.reason,
+        note: action.note.path,
+      }
+  }
+}

--- a/packages/skills/skills/pikku-knowledge/SKILL.md
+++ b/packages/skills/skills/pikku-knowledge/SKILL.md
@@ -243,6 +243,32 @@ pikku knowledge index --check   # report stale indexes without writing (CI gate)
 
 `index` rewrites only the block between `<!-- pikku:knowledge-index -->` markers, creating a scaffolded `index.md` for a section that has none. It is idempotent — running it twice changes nothing.
 
+### What to do next
+
+```bash
+pikku knowledge next            # the one thing to do next, derived from what is on disk
+```
+
+`next` is a pure read: it looks at the notes and answers with exactly one action —
+`repair-note`, `write-plan`, `ask-user`, `dispatch`, `hold`, or `idle`. Nothing has to
+be armed by whoever noticed a transition, so calling it twice is free and a state
+nobody anticipated is a missing answer rather than a run that quietly stops.
+
+Two things about the output matter if you are driving it:
+
+- **`reason` is machine wording.** It names the note, the frontmatter key and what the
+  gate wanted. Never repeat it to a person — they have not seen a note and it will read
+  as gibberish about files.
+- **`ask-user` carries a `question` as well.** That IS the version for a person: a
+  `header`, the question in the language of their app, and `options` when the answer
+  comes from a closed vocabulary (which `status:` it is, which `surface:` it is).
+  `options` is empty when the answer is free text, and an empty list means offer free
+  text — never invent choices to fill it.
+
+`hold` means a profile's own gate is holding the milestone and no seat this loop knows
+about can clear it. It names the hold and the notes it is about; what to do then
+belongs to that profile, not here.
+
 ### The milestone plan
 
 A milestone note says what the app must DO. Its **plan** — JSON beside the note, not prose — says what has to exist for it, and is what a finished build is measured against:

--- a/packages/skills/skills/pikku-knowledge/SKILL.md
+++ b/packages/skills/skills/pikku-knowledge/SKILL.md
@@ -141,7 +141,8 @@ And writing again replaces it rather than adding a second
 ```
 ````
 
-- **`status`** is `proposed` → `dispatched` → `built`. Nothing else. Every gate compares it literally.
+- **`status`** is `designing` → `proposed` → `dispatched` → `built`. Nothing else. Every gate compares it literally. `designing` sits BEFORE `proposed`: the slice is written down but must not be built yet, because whoever is being shown its looks has not picked one. Only `proposed` is dispatchable, so the two cannot be one status without a slice being built out from under the person still choosing.
+- **`statusAt:` and `attempts:` are bookkeeping, not content — never hand-edit them.** A loop driving this base writes both. `statusAt:` is stamped by whatever moved the status, and is what makes "how long has this been building?" answerable; the file's mtime is not the transition time, because a note is edited after dispatch for all sorts of reasons. `attempts:` is `seat@hash` entries recording which seat has already tried to move this note forward, against the content it was trying to move — it is the loop's only brake, and clearing it by hand hands back a budget that exists to stop a note nothing can satisfy being rewritten forever. Rewriting the note's real content refunds that budget on its own, which is the point: an answer that changes the note is what unsticks it.
 - **`entities`** lists what the slice touches, **at most three**. Past three it is not one buildable piece — split it.
 - **The scenario is a fenced `gherkin` block, in the third person.** `Given 'owner' has no entry` — never `Given I have no entry`. A quoted word _means a persona_, which is what lets a reader (and a test) tell who is acting. First person hides that, so it is rejected. The console draws the keywords as a column and each quoted persona as a chip, so a first-person scenario is visibly a block with no personas in it.
 


### PR DESCRIPTION
Moves the milestone dispatch gate and the reconcile loop into `@pikku/knowledge`, turns a refusal into a question a person can actually answer, and exposes the whole thing as `pikku knowledge next`.

## `readyMilestone` — the dispatch gate

The last read before something spends a build on a note. It judges the **shape** of the note and nothing else: `entities:` present, a ```gherkin block, no step in the first person, a scenario naming somebody who actually acts, a readable `surface:`, and `tools:` when that surface is `agent`.

It refuses with one sentence a seat can act on, never a list — the audience is an agent mid-turn, and a refusal it cannot act on in one step becomes a retry loop rather than a repair. The refusal also says **who it belongs to**, which is why it is a union rather than a string: `repairable` goes back to whoever writes the notes, `awaitingNote` means nothing is written down at all, and `awaiting: { hold, notes }` means a profile is holding it on something no edit resolves.

`exhausted` lets the queue walk past a note whose repair budget is gone — reading only the front means one note nobody can fix wedges every milestone behind it.

## `nextAction` — the loop

Derives the one thing to do next — `repair-note`, `write-plan`, `ask-user`, `dispatch`, `hold` or `idle` — entirely from what is on disk.

What that replaces is edge-triggered: each stage tells the next through a sentinel armed only from inside a "a turn just ended" callback, so every condition needs its own branch remembering to start a turn, and every branch that forgets is a run that comes to rest looking busy. Deriving the answer means calling it twice is free, nothing has to be armed, and a state nobody anticipated is a missing row here rather than a stall in production. It also makes the pipeline testable in a temp directory: write the notes, assert the action.

## The refusal, asked as a question

A gate refusal is machine wording — it names the note, the frontmatter key and what the gate wanted. `ask-user` now carries a `question` beside it: a header, the question in the language of the app, and options.

**The options are only filled where they can be derived honestly.** A note whose `status:` or `surface:` will not read has a closed vocabulary behind it, so those become real choices, described for the person answering rather than for the parser:

> **Where it stands** — Where has "The daily entry" got to?
> 1. designing — still choosing how it should look
> 2. proposed — settled, and ready to be built
> 3. dispatched — being built right now
> 4. built — already built

Every other refusal is about missing **content**, where there are no candidate answers and inventing some would be inventing the answer. Those carry an empty list, which means offer free text.

It is a value rather than a tool call, which is the point: a harness with a picker renders one, a harness without prints a numbered list, and something across a process boundary reads the same JSON. Nothing in the package knows which is on the other side.

## `pikku knowledge next`

`runKnowledgeReconcile` was unreachable without it, and a loop only reachable by importing TypeScript is not one another harness can drive. The renderer prints the question with its options numbered and demotes the machine wording to a `why:` line.

## The seam

Two options, and they are why this can live here at all:

- **`gate`** runs only on a note that already passed every shape check. A profile refusal typically sends somebody back to a conversation rather than back to the note, and spending that on a still-malformed note spends it on a milestone that cannot dispatch anyway. A hold it returns comes back as a `hold` action rather than being swallowed as `idle` — a hold nothing here can act on is exactly the state that used to become a silent stall.
- **`profileScalars`** are read alongside this package's own, so a gate that reads a key of its own is handed the note carrying it, and a repair to that key refunds the attempt budget. `readMilestones` takes them too.

`SEATS` names the three seats the loop spends attempts for, as written into a note's `attempts:` line. They are values rather than a profile's own names because the ledger belongs to this package: two profiles reading the same `knowledge/` directory have to agree what `knowledge@abc123` means, or one hands the other a budget it has already spent.

## Also

- `tools:` joins `MILESTONE_SCALARS`, with `toolsOf`; `addonsOf` parses the `addon:` tokens on `requires:`. The parse belongs here; resolving a name against a registry does not.
- `pikku-knowledge/SKILL.md` documents `next` — the six actions, that `reason` must never be repeated to a person, and that an empty `options` list means free text rather than "think of some".

## Testing

- `packages/knowledge` — **285 pass, 0 fail**
- `packages/cli` — **1603 pass, 0 fail** (4 skipped)
- `packages/skills` — **11 pass, 0 fail**
- `tsc --noEmit` clean in both packages, against the pre-existing worktree baseline.

## Folded in from #1597

`docs(skills): document statusAt and attempts, and fix the status vocabulary` — the note-shape half of the same story, cherry-picked here so this is one merge instead of two. It documents `statusAt:`/`attempts:` as bookkeeping never to hand-edit, and corrects the status vocabulary in the same file. #1597 is closed pointing here.
