### PR TITLE
ci: run each verifier once

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -217,7 +217,7 @@ jobs:
             webhooks,
             db-schema,
           ]
-        package-manager: [yarn, bun]
+        package-manager: [yarn]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,7 +230,7 @@ jobs:
             webhooks,
             db-schema,
           ]
-        package-manager: [yarn, bun]
+        package-manager: [yarn]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup


### PR DESCRIPTION
Verifier matrices ran every verifier twice, once under yarn and once under bun, for the same script. Drops the bun row: ~26 duplicate jobs per run.