### PR TITLE
feat(react): usePhotoCapture, a photo ready to send to a model

### DIFF
--- a/.changeset/photo-capture-in-react.md
+++ b/.changeset/photo-capture-in-react.md
@@ -1,0 +1,5 @@
+---
+'@pikku/react': minor
+---
+
+`usePhotoCapture` — take or choose a photo with no markup to write. `open({ camera: true })` creates the file input, opens the rear camera on a phone (and an ordinary file dialog on the laptop you develop on), and throws the input away again; what comes back is already downscaled and base64-encoded, because a phone frame is several megabytes and every byte of it is paid for on the upload, in the row it is stored in, and again in a vision model's context. Two traps that cost accuracy are handled on the way: EXIF orientation is applied during decode, so a portrait photo does not reach the model on its side, and an iPhone HEIC that `createImageBitmap` refuses falls back to decoding through an `<img>`. `prepareImage(file, options)` does the same work for a file you already have, from a drop target or a paste.

--- a/packages/frontend/react/README.md
+++ b/packages/frontend/react/README.md
@@ -103,6 +103,37 @@ saying so, and does not.
 `<html lang>` → `defaultLocale`. Pass your own when locale comes from somewhere
 else, such as the route or the signed-in user.
 
+## Photo capture
+
+```tsx
+import { usePhotoCapture } from '@pikku/react'
+
+const { photo, open, preparing, error, clear } = usePhotoCapture({ maxEdge: 1024 })
+
+<button onClick={() => open({ camera: true })}>Take a photo</button>
+<button onClick={() => open()}>Choose one</button>
+{photo ? <img src={photo.dataUrl} /> : null}
+```
+
+There is no input to render. `open()` creates one, opens the dialog and throws it
+away again — a hidden `<input type="file">` plus a ref plus a change handler is
+the same fifteen lines in every app that has ever needed this. `{ camera: true }`
+sets `capture="environment"`, which phones honour by opening the rear camera and
+desktop browsers ignore, so the same button works while you develop on a laptop.
+
+`photo` is already downscaled: a phone frame is several megabytes and every byte
+is paid for more than once — the upload, the row it is stored in, and a vision
+model's context window. A model reads a 1024px JPEG as well as it reads a 12MP
+one. `photo.data` is base64 with no `data:` prefix, which is what an agent
+attachment takes; `photo.dataUrl` is the same bytes ready for an `<img src>`.
+
+Two phone-specific traps are handled: EXIF orientation is applied during decode,
+so a portrait photo does not reach the model on its side, and an iPhone HEIC that
+`createImageBitmap` refuses falls back to decoding through an `<img>`.
+
+`prepareImage(file, options)` is the same work without the hook, for a file you
+already have — a drop target, a paste handler.
+
 ## Docs
 
 https://pikku.dev/docs

--- a/packages/frontend/react/src/index.ts
+++ b/packages/frontend/react/src/index.ts
@@ -45,3 +45,16 @@ export type {
 // The app owns the union and the endpoint; this package owns the transport.
 export { createAnalytics } from './analytics.js'
 export type { AnalyticsClient, CreateAnalyticsOptions } from './analytics.js'
+
+// Take or choose a photo, downscaled and base64-encoded in the browser before it
+// costs anything to send. The hidden input is created on demand rather than
+// handed back as props — it is the same fifteen lines in every app.
+export { usePhotoCapture, prepareImage, fitWithin } from './photo-capture.js'
+export type {
+  PreparedImage,
+  PreparedImageType,
+  PrepareImageOptions,
+  UsePhotoCaptureOptions,
+  UsePhotoCaptureResult,
+  OpenPhotoPickerOptions,
+} from './photo-capture.js'

--- a/packages/frontend/react/src/photo-capture.test.ts
+++ b/packages/frontend/react/src/photo-capture.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Run: node --test packages/frontend/react/src/photo-capture.test.ts
+ */
+import { test, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { fitWithin, prepareImage } from './photo-capture.ts'
+
+test('fitWithin scales the longest edge down', () => {
+  assert.deepEqual(fitWithin(4032, 3024, 1024), { width: 1024, height: 768 })
+  assert.deepEqual(fitWithin(3024, 4032, 1024), { width: 768, height: 1024 })
+})
+
+test('fitWithin never scales up', () => {
+  assert.deepEqual(fitWithin(400, 300, 1024), { width: 400, height: 300 })
+})
+
+test('fitWithin keeps a hairline image at least one pixel', () => {
+  assert.deepEqual(fitWithin(4000, 1, 1024), { width: 1024, height: 1 })
+})
+
+test('fitWithin rejects an image with no dimensions', () => {
+  assert.throws(() => fitWithin(0, 0, 1024), /no readable dimensions/)
+})
+
+/**
+ * `prepareImage` is DOM-bound, so the DOM is faked the same way the locale store
+ * test fakes `window`. What is being checked is the wiring — that the canvas is
+ * sized from `fitWithin`, that the encode is asked for the requested type, and
+ * that the `data:` prefix is stripped off `data` but kept on `dataUrl`.
+ */
+const drawn: Array<{ width: number; height: number; type: string; quality: number }> = []
+let closed = false
+
+const installDom = (bitmap: { width: number; height: number }) => {
+  ;(globalThis as any).createImageBitmap = async () => ({
+    ...bitmap,
+    close: () => {
+      closed = true
+    },
+  })
+  ;(globalThis as any).document = {
+    createElement: () => {
+      const canvas: any = { width: 0, height: 0 }
+      canvas.getContext = () => ({ drawImage: () => {} })
+      canvas.toDataURL = (type: string, quality: number) => {
+        drawn.push({ width: canvas.width, height: canvas.height, type, quality })
+        return `data:${type};base64,QUJD`
+      }
+      return canvas
+    },
+  }
+}
+
+afterEach(() => {
+  drawn.length = 0
+  closed = false
+  delete (globalThis as any).createImageBitmap
+  delete (globalThis as any).document
+})
+
+test('prepareImage downscales, encodes and strips the data prefix', async () => {
+  installDom({ width: 4032, height: 3024 })
+  const photo = await prepareImage({ name: 'fridge.jpg' } as unknown as File)
+
+  assert.deepEqual(drawn, [{ width: 1024, height: 768, type: 'image/jpeg', quality: 0.8 }])
+  assert.equal(photo.data, 'QUJD')
+  assert.equal(photo.dataUrl, 'data:image/jpeg;base64,QUJD')
+  assert.equal(photo.mediaType, 'image/jpeg')
+  assert.equal(photo.width, 1024)
+  assert.equal(photo.height, 768)
+  assert.equal(photo.bytes, 3)
+  assert.equal(closed, true, 'the decoded bitmap is released')
+})
+
+test('prepareImage honours maxEdge, quality and mediaType', async () => {
+  installDom({ width: 2000, height: 1000 })
+  const photo = await prepareImage({} as File, {
+    maxEdge: 500,
+    quality: 0.5,
+    mediaType: 'image/webp',
+  })
+
+  assert.deepEqual(drawn, [{ width: 500, height: 250, type: 'image/webp', quality: 0.5 }])
+  assert.equal(photo.mediaType, 'image/webp')
+})

--- a/packages/frontend/react/src/photo-capture.ts
+++ b/packages/frontend/react/src/photo-capture.ts
@@ -1,0 +1,236 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * An image that has been decoded, downscaled and re-encoded in the browser,
+ * ready to be sent somewhere that charges by the byte.
+ */
+export type PreparedImage = {
+  /** Base64 with no `data:` prefix — what an agent attachment and most APIs take. */
+  data: string
+  /** The same bytes as a `data:` URL, for an `<img src>` preview. */
+  dataUrl: string
+  mediaType: PreparedImageType
+  /** Dimensions after the downscale, not of the original file. */
+  width: number
+  height: number
+  /** Decoded size of `data` in bytes — what the request body will cost. */
+  bytes: number
+  /** The file the user chose, in case the caller wants its name or original size. */
+  file: File
+}
+
+export type PreparedImageType = 'image/jpeg' | 'image/png' | 'image/webp'
+
+export type PrepareImageOptions = {
+  /** Longest edge of the result, in CSS pixels. Default 1024. */
+  maxEdge?: number
+  /** JPEG/WebP quality, 0–1. Ignored for PNG. Default 0.8. */
+  quality?: number
+  /** Default 'image/jpeg' — the only one of the three that is small AND universal. */
+  mediaType?: PreparedImageType
+}
+
+const DEFAULT_MAX_EDGE = 1024
+const DEFAULT_QUALITY = 0.8
+
+/**
+ * The scale arithmetic, split out because it is the only part worth testing and
+ * the only part that runs without a DOM.
+ *
+ * Never scales up: a 400px photo stays 400px rather than being interpolated into
+ * a blurry 1024px one that costs six times as much to send.
+ */
+export const fitWithin = (
+  width: number,
+  height: number,
+  maxEdge: number,
+): { width: number; height: number } => {
+  const longest = Math.max(width, height)
+  if (!Number.isFinite(longest) || longest <= 0) {
+    throw new Error('That image has no readable dimensions.')
+  }
+  const scale = Math.min(1, maxEdge / longest)
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  }
+}
+
+/**
+ * Decode a file to something `drawImage` accepts.
+ *
+ * `createImageBitmap` is the fast path and the one phones take. `imageOrientation`
+ * is passed explicitly because the default was 'none' for years before the spec
+ * changed to 'from-image': without it a portrait photo arrives on its side, which
+ * costs a vision model accuracy for no reason at all.
+ *
+ * The `<img>` fallback covers browsers with no `createImageBitmap` and the decodes
+ * it refuses — most often an iPhone HEIC picked out of the library rather than
+ * taken with the camera, which Safari will happily decode through an element.
+ */
+const decode = async (file: File): Promise<CanvasImageSource & { width: number; height: number }> => {
+  if (typeof createImageBitmap === 'function') {
+    try {
+      return await createImageBitmap(file, { imageOrientation: 'from-image' })
+    } catch {
+      // fall through to the <img> path
+    }
+  }
+  const url = URL.createObjectURL(file)
+  try {
+    const image = new Image()
+    image.src = url
+    await image.decode()
+    return image
+  } finally {
+    // Safe to revoke here: the element holds its own decoded copy, and the
+    // caller draws from that rather than re-fetching the URL.
+    URL.revokeObjectURL(url)
+  }
+}
+
+/**
+ * Downscale and re-encode an image file entirely in the browser.
+ *
+ * A phone camera frame is several megabytes and every byte is paid for more than
+ * once — the upload, whatever row it is stored in, and a model's context window.
+ * A vision model reads a 1024px JPEG as well as it reads a 12MP one, so this runs
+ * before the bytes ever leave the device rather than after.
+ */
+export const prepareImage = async (
+  file: File,
+  options: PrepareImageOptions = {},
+): Promise<PreparedImage> => {
+  const mediaType = options.mediaType ?? 'image/jpeg'
+  const quality = options.quality ?? DEFAULT_QUALITY
+  const source = await decode(file)
+  const size = fitWithin(source.width, source.height, options.maxEdge ?? DEFAULT_MAX_EDGE)
+
+  const canvas = document.createElement('canvas')
+  canvas.width = size.width
+  canvas.height = size.height
+
+  const context = canvas.getContext('2d')
+  if (!context) throw new Error('This browser cannot resize the photo.')
+  context.drawImage(source, 0, 0, size.width, size.height)
+  // Free the decoded bitmap now rather than at the next GC — on a phone this is
+  // tens of megabytes and the preview is about to allocate more.
+  if ('close' in source && typeof source.close === 'function') source.close()
+
+  const dataUrl = canvas.toDataURL(mediaType, quality)
+  const data = dataUrl.slice(dataUrl.indexOf(',') + 1)
+  return {
+    data,
+    dataUrl,
+    mediaType,
+    width: size.width,
+    height: size.height,
+    // Base64 carries 3 bytes in every 4 characters, less the '=' padding.
+    bytes: Math.floor((data.length * 3) / 4) - (data.endsWith('==') ? 2 : data.endsWith('=') ? 1 : 0),
+    file,
+  }
+}
+
+export type UsePhotoCaptureOptions = PrepareImageOptions & {
+  /** `accept` for the file dialog. Default 'image/*'. */
+  accept?: string
+  onPhoto?: (photo: PreparedImage) => void
+  onError?: (error: Error) => void
+}
+
+export type OpenPhotoPickerOptions = {
+  /**
+   * Ask for the rear camera instead of the photo library. Phones honour this and
+   * open the camera directly; desktop browsers ignore it and show a file dialog,
+   * which is exactly what you want when testing on a laptop.
+   */
+  camera?: boolean
+}
+
+export type UsePhotoCaptureResult = {
+  photo: PreparedImage | null
+  error: Error | null
+  /** True between choosing a file and the downscale finishing. */
+  preparing: boolean
+  open: (options?: OpenPhotoPickerOptions) => void
+  clear: () => void
+}
+
+/**
+ * Take or choose a photo, downscaled and base64-encoded, with no markup to write.
+ *
+ * The file input is created on demand and thrown away again rather than returned
+ * as props to render: a hidden input plus a ref plus a change handler is the same
+ * fifteen lines in every app that has ever needed this, and none of them are
+ * interesting. Call `open()` from your own button.
+ *
+ * ```tsx
+ * const { photo, open, preparing } = usePhotoCapture({ maxEdge: 1024 })
+ * <Button onClick={() => open({ camera: true })}>Take a photo</Button>
+ * {photo ? <img src={photo.dataUrl} /> : null}
+ * ```
+ */
+export const usePhotoCapture = (options: UsePhotoCaptureOptions = {}): UsePhotoCaptureResult => {
+  const [photo, setPhoto] = useState<PreparedImage | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+  const [preparing, setPreparing] = useState(false)
+
+  // Read through a ref so a caller passing an inline options object does not
+  // rebuild `open` on every render.
+  const latest = useRef(options)
+  latest.current = options
+
+  // A picker opened and then abandoned when the component unmounts must not call
+  // setState on the way back.
+  const live = useRef(true)
+  useEffect(() => {
+    live.current = true
+    return () => {
+      live.current = false
+    }
+  }, [])
+
+  const open = useCallback((openOptions: OpenPhotoPickerOptions = {}) => {
+    const settings = latest.current
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = settings.accept ?? 'image/*'
+    if (openOptions.camera) input.capture = 'environment'
+    input.style.display = 'none'
+    // Appended because Safari will not open a dialog for a detached input.
+    document.body.appendChild(input)
+
+    const done = () => input.remove()
+
+    input.addEventListener('cancel', done)
+    input.addEventListener('change', async () => {
+      const file = input.files?.[0]
+      done()
+      if (!file) return
+      if (live.current) {
+        setError(null)
+        setPreparing(true)
+      }
+      try {
+        const prepared = await prepareImage(file, settings)
+        if (live.current) setPhoto(prepared)
+        settings.onPhoto?.(prepared)
+      } catch (thrown) {
+        const failure = thrown instanceof Error ? thrown : new Error(String(thrown))
+        if (live.current) setError(failure)
+        settings.onError?.(failure)
+      } finally {
+        if (live.current) setPreparing(false)
+      }
+    })
+
+    input.click()
+  }, [])
+
+  const clear = useCallback(() => {
+    setPhoto(null)
+    setError(null)
+  }, [])
+
+  return { photo, error, preparing, open, clear }
+}


### PR DESCRIPTION
A hidden `<input type="file">`, a ref, a change handler, an EXIF-orientation flag and a canvas downscale is the same fifteen lines in every app that wants to show a picture to a vision model — and the two that are easy to get wrong, orientation and the HEIC decode `createImageBitmap` refuses, are invisible until a model reads a photo sideways.

```tsx
const { photo, open, preparing } = usePhotoCapture({ maxEdge: 1024 })
<button onClick={() => open({ camera: true })}>Take a photo</button>
{photo ? <img src={photo.dataUrl} /> : null}
```

- `open()` creates the input on demand and discards it, so there is nothing to render. `{ camera: true }` sets `capture="environment"`, which phones honour by opening the rear camera and desktops ignore — the same button works while you develop on a laptop.
- `photo.data` is base64 with no `data:` prefix (what an agent `attachment` takes); `photo.dataUrl` is the same bytes for a preview.
- Downscaled to 1024px/0.8 by default: a model reads a 1024px JPEG as well as a 12MP one, and the difference is paid for three times — upload, storage row, context window.
- `prepareImage(file, options)` is the same work without the hook, for a drop target or a paste handler. `fitWithin` is exported because it is the only part worth testing without a DOM.

Tests fake the DOM the way `locale-store.test.ts` fakes `window`; `yarn tsc` and `node --test` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)