### PR TITLE
fix(cli): an addon that cannot say whether it ships tables is an error

### DIFF
--- a/.changeset/addon-schema-artifact-loud.md
+++ b/.changeset/addon-schema-artifact-loud.md
@@ -1,0 +1,13 @@
+---
+'@pikku/cli': patch
+---
+
+An addon now publishes its schema artifact on every `pikku all`, empty when it
+has no tables, and `db generate` refuses an addon that publishes none at all.
+
+The two used to be one case. A wired addon whose artifact could not be resolved
+was read as an addon that ships no schema — no error, no migration — so a
+mispackaged `exports` entry surfaced much later, as an addon function querying a
+table nobody had created. Making the file unconditional separates "needs
+nothing" from "cannot say", and a malformed artifact is now rejected rather than
+half-applied.

--- a/packages/cli/src/functions/commands/db-export.ts
+++ b/packages/cli/src/functions/commands/db-export.ts
@@ -1,7 +1,5 @@
-import { mkdirSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
 import { pikkuSessionlessFunc } from '#pikku/function'
-import { exportSchema } from '../db/local-db.js'
+import { writeSchemaArtifact } from '../db/local-db.js'
 
 /**
  * Publish this package's schema so a project consuming it as an addon can
@@ -17,22 +15,19 @@ import { exportSchema } from '../db/local-db.js'
 export const dbExport = pikkuSessionlessFunc<{}, void>({
   remote: true,
   func: async ({ logger, config }) => {
-    const artifact = await exportSchema(
+    const { file, dialects } = await writeSchemaArtifact(
       config.rootDir,
+      config.outDir,
       config.db?.pgliteExtensions
     )
-    const dialects = Object.keys(artifact)
 
     if (dialects.length === 0) {
       logger.info(
-        'db export: no db/sqlite or db/postgres migrations — nothing to publish'
+        `db export: no db/sqlite or db/postgres migrations — wrote ${file} empty, ` +
+          'which is how a consumer tells "no tables" from "never published"'
       )
       return
     }
-
-    const file = join(config.outDir, 'db', 'pikku-db-meta.gen.json')
-    mkdirSync(dirname(file), { recursive: true })
-    writeFileSync(file, `${JSON.stringify(artifact, null, 2)}\n`, 'utf8')
 
     logger.info(`db export: wrote ${file} for ${dialects.join(', ')}`)
     logger.info(

--- a/packages/cli/src/functions/db/local-db.test.ts
+++ b/packages/cli/src/functions/db/local-db.test.ts
@@ -21,6 +21,7 @@ import {
   computeSchemaDrift,
   baseline,
   exportSchema,
+  writeSchemaArtifact,
   generateMigrations,
   parseDatabaseUrl,
   migrateAndCodegen,
@@ -861,6 +862,17 @@ describe('the addon schema channel', () => {
     )
   })
 
+  test('an addon with no tables still publishes, so the file always ships', async () => {
+    const outDir = join(root, 'out-empty')
+    rmSync(join(root, 'db'), { recursive: true, force: true })
+
+    const { file, dialects } = await writeSchemaArtifact(root, outDir)
+
+    assert.deepEqual(dialects, [])
+    assert.equal(existsSync(file), true)
+    assert.deepEqual(JSON.parse(readFileSync(file, 'utf8')), {})
+  })
+
   test('a wired addon becomes a schema source the consumer can migrate', async () => {
     publishAddon('addon-labels', labels)
 
@@ -888,12 +900,10 @@ describe('the addon schema channel', () => {
   })
 
   test('an addon that publishes no schema at all is not a finding', async () => {
-    const dir = join(root, 'node_modules', 'addon-quiet')
-    mkdirSync(dir, { recursive: true })
-    writeFileSync(
-      join(dir, 'package.json'),
-      JSON.stringify({ name: 'addon-quiet', version: '1.0.0' })
-    )
+    // The artifact is always written, so an addon with no tables says so with
+    // an empty one. That is what separates it from an addon whose schema never
+    // shipped, which is a mistake and must not read as this case.
+    publishAddon('addon-quiet', {})
 
     const sources = await addonSchemaSources(
       root,
@@ -902,6 +912,71 @@ describe('the addon schema channel', () => {
       silent
     )
     assert.deepEqual(sources, [])
+  })
+
+  test('an addon whose artifact never shipped fails loudly', async () => {
+    const dir = join(root, 'node_modules', 'addon-mispackaged')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: 'addon-mispackaged', version: '1.0.0' })
+    )
+
+    await assert.rejects(
+      addonSchemaSources(
+        root,
+        'sqlite',
+        [{ package: 'addon-mispackaged' }],
+        silent
+      ),
+      /addon-mispackaged.*pikku-db-meta\.gen\.json/s
+    )
+  })
+
+  test('a remote addon with no artifact is still silent', async () => {
+    const dir = join(root, 'node_modules', 'addon-remote-quiet')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: 'addon-remote-quiet', version: '1.0.0' })
+    )
+
+    const sources = await addonSchemaSources(
+      root,
+      'sqlite',
+      [{ package: 'addon-remote-quiet', remote: true }],
+      silent
+    )
+    assert.deepEqual(sources, [])
+  })
+
+  test('an unparseable artifact names the file it could not read', async () => {
+    const dir = join(root, 'node_modules', 'addon-broken')
+    mkdirSync(join(dir, '.pikku', 'db'), { recursive: true })
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: 'addon-broken', version: '1.0.0' })
+    )
+    writeFileSync(
+      join(dir, '.pikku', 'db', 'pikku-db-meta.gen.json'),
+      '{ this is not json'
+    )
+
+    await assert.rejects(
+      addonSchemaSources(root, 'sqlite', [{ package: 'addon-broken' }], silent),
+      /addon-broken.*pikku-db-meta\.gen\.json/s
+    )
+  })
+
+  test('an artifact missing the sql it claims to carry is rejected', async () => {
+    publishAddon('addon-hollow', {
+      sqlite: { tables: { labels: [] } },
+    } as unknown as SchemaArtifact)
+
+    await assert.rejects(
+      addonSchemaSources(root, 'sqlite', [{ package: 'addon-hollow' }], silent),
+      /addon-hollow.*sqlite/s
+    )
   })
 
   test('an addon with no schema for this dialect is reported, not skipped quietly', async () => {

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -1617,6 +1617,80 @@ export async function exportSchema(
 }
 
 /**
+ * Write the artifact a consumer reads, whether or not this package has tables.
+ *
+ * An addon with no tables still publishes, because the consumer's only other
+ * reading of an absent file is "this package cannot say", which it must treat
+ * as a broken publish. The empty artifact is the addon stating, in a file that
+ * ships, that it needs nothing.
+ */
+export async function writeSchemaArtifact(
+  rootDir: string,
+  outDir: string,
+  pgliteExtensions?: string[]
+): Promise<{ file: string; dialects: string[] }> {
+  const artifact = await exportSchema(rootDir, pgliteExtensions)
+  const file = join(outDir, 'db', 'pikku-db-meta.gen.json')
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, `${JSON.stringify(artifact, null, 2)}\n`, 'utf8')
+  return { file, dialects: Object.keys(artifact) }
+}
+
+/**
+ * Read and check one addon's published artifact.
+ *
+ * The file is generated, so a malformed one is not an authoring mistake to be
+ * explained away — it is a broken publish, and every branch here says which
+ * package to go and rebuild. Answering with half an artifact would be worse
+ * than refusing: a dialect carrying tables but no SQL generates a migration
+ * that creates nothing, and the schema silently drifts from what the addon's
+ * own functions expect.
+ */
+function readSchemaArtifact(
+  artifactPath: string,
+  pkg: string
+): SchemaArtifact {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(artifactPath, 'utf8'))
+  } catch (error: any) {
+    throw new Error(
+      `The '${pkg}' addon publishes an unreadable ${ADDON_DB_ARTIFACT} ` +
+        `(${artifactPath}): ${error.message}. Rebuild the addon.`
+    )
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      `The '${pkg}' addon publishes a ${ADDON_DB_ARTIFACT} that is not an ` +
+        'object of dialects. Rebuild the addon.'
+    )
+  }
+
+  for (const [dialect, exported] of Object.entries(
+    parsed as Record<string, unknown>
+  )) {
+    const entry = exported as { sql?: unknown; tables?: unknown }
+    const hasSql = typeof entry?.sql === 'string' && entry.sql.trim().length > 0
+    const hasTables =
+      typeof entry?.tables === 'object' &&
+      entry.tables !== null &&
+      !Array.isArray(entry.tables)
+
+    if (!hasSql || !hasTables) {
+      throw new Error(
+        `The '${pkg}' addon publishes a ${dialect} schema that is incomplete — ` +
+          `it needs both the SQL to run and the tables that SQL creates, and it ` +
+          `has ${!hasSql ? 'no sql' : 'sql'} and ${!hasTables ? 'no tables' : 'tables'}. ` +
+          'Rebuild the addon.'
+      )
+    }
+  }
+
+  return parsed as SchemaArtifact
+}
+
+/**
  * The schema every wired addon publishes, as sources.
  *
  * An addon never creates its own tables. It has no database of its own — it
@@ -1644,14 +1718,26 @@ export async function addonSchemaSources(
     try {
       artifactPath = require.resolve(`${addon.package}/${ADDON_DB_ARTIFACT}`)
     } catch {
-      // Most addons have no schema at all, so an unresolvable artifact is the
-      // ordinary case and says nothing is contributed — not that anything failed.
-      continue
+      // Every addon publishes this file, and one with no tables publishes an
+      // empty one. Absence is therefore never "contributes nothing" — it is a
+      // package that cannot say, and the two used to be indistinguishable:
+      // the addon was skipped in silence and the mistake surfaced much later,
+      // as a function querying a table nobody created.
+      throw new Error(
+        `The '${addon.package}' addon does not publish ${ADDON_DB_ARTIFACT}, so ` +
+          'there is no way to tell whether it ships tables. Build it with a ' +
+          "current CLI (`pikku all` writes the file, empty when there are no " +
+          'tables), and make sure the package exports and packs it:\n' +
+          `  "exports": { "./${ADDON_DB_ARTIFACT}": "./dist/.pikku/addon/db/pikku-db-meta.gen.json" }\n` +
+          '  "files": ["dist"]'
+      )
     }
 
-    const artifact = JSON.parse(
-      readFileSync(artifactPath, 'utf8')
-    ) as SchemaArtifact
+    const artifact = readSchemaArtifact(artifactPath, addon.package)
+    // An addon with no tables says so with an empty artifact, which is the
+    // ordinary case and contributes nothing.
+    if (Object.keys(artifact).length === 0) continue
+
     const exported = artifact[dialect]
     if (!exported) {
       logger.error(

--- a/packages/cli/src/functions/workflows/all.workflow.ts
+++ b/packages/cli/src/functions/workflows/all.workflow.ts
@@ -9,6 +9,7 @@ import {
   removeRetiredScaffoldFiles,
 } from '../../utils/remove-legacy-scaffold-file.js'
 import { writeSurfaceUsage } from '../surface/write-surface-usage.js'
+import { writeSchemaArtifact } from '../db/local-db.js'
 import {
   PikkuTypecheckFailedError,
   renderTscFull,
@@ -434,6 +435,15 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
         workflow.do('Channels', 'pikkuCommandChannels', null),
         workflow.do('CLI', 'pikkuCLI', null),
       ])
+
+      // Written on every build, empty when the addon has no tables: the
+      // consumer reads an absent file as a package that cannot say whether it
+      // ships a schema, which is a broken publish rather than a quiet no.
+      await writeSchemaArtifact(
+        config.rootDir,
+        config.outDir,
+        config.db?.pgliteExtensions
+      )
     }
 
     const hasFunctionRegistrations = await workflow.do(

--- a/packages/skills/skills/pikku-addon/SKILL.md
+++ b/packages/skills/skills/pikku-addon/SKILL.md
@@ -271,20 +271,19 @@ consumer, against the consumer's database, so a boot-time `CREATE TABLE` puts a
 second authority on a schema the consumer's migrations own. It declares instead,
 and the consumer's migration history absorbs the declaration.
 
-Author the DDL per dialect, and publish it from the build:
+Author the DDL per dialect:
 
 ```text
 db/sqlite/0001-labels.sql
 db/postgres/0001-labels.sql
 ```
 
-```json
-{ "scripts": { "prebuild": "pikku all && pikku db export" } }
-```
-
-`pikku db export` writes `<outDir>/db/pikku-db-meta.gen.json` — per dialect, the
-SQL verbatim plus a table/column map. The consumer resolves it **through the
-package name**, so it must be exported and packed, or it never arrives:
+`pikku all` publishes `<outDir>/db/pikku-db-meta.gen.json` on every build — per
+dialect, the SQL verbatim plus a table/column map — and writes it **empty** when
+the addon has no tables, because a consumer reads an absent file as a package
+that cannot say. (`pikku db export` writes the same file on demand.) The
+consumer resolves it **through the package name**, so it must be exported and
+packed, or it never arrives:
 
 ```json
 {
@@ -295,14 +294,15 @@ package name**, so it must be exported and packed, or it never arrives:
 }
 ```
 
-**An unresolvable artifact is silent.** A wired addon whose artifact cannot be
-resolved is indistinguishable from the majority that publish no schema at all —
-no error, no migration, and a runtime failure much later against a table nobody
-created. When an addon that ships tables generates no migration, suspect the
-`exports` entry and `files` before suspecting the pipeline.
+**An unresolvable artifact stops `db generate`.** Because the file is
+unconditional, absence means the package cannot say whether it ships tables —
+either it was built with an older CLI, or `exports`/`files` do not carry it. The
+error names both causes. An addon with genuinely no tables is *not* this case:
+it publishes `{}` and is waved through.
 
-An addon that publishes only one dialect *does* fail loudly: a consumer on
-another dialect gets an error naming what the addon supports.
+Two more loud ones: a malformed artifact (missing the SQL for a dialect it
+claims) is rejected rather than half-applied, and an addon publishing only a
+dialect the consumer does not use gets an error naming what it does support.
 
 `verifiers/db-schema` runs this end to end on both dialects — copy its addon
 `package.json` when wiring a new one.

--- a/packages/skills/skills/pikku-addon/references/addon-package-manifest.md
+++ b/packages/skills/skills/pikku-addon/references/addon-package-manifest.md
@@ -66,7 +66,7 @@ package that declared them, and the extra segment is what stops a linked addon's
     "zod": "^4"
   },
   "scripts": {
-    "prebuild": "pikku all && pikku db export",
+    "prebuild": "pikku all",
     "pikku": "pikku all",
     "build": "tsc && cp -r .pikku types dist/"
   }

--- a/verifiers/db-schema/run.mjs
+++ b/verifiers/db-schema/run.mjs
@@ -47,6 +47,7 @@ import {
   readdirSync,
   rmSync,
   symlinkSync,
+  writeFileSync,
 } from 'node:fs'
 import { createRequire } from 'node:module'
 import { dirname, join, relative, resolve } from 'node:path'
@@ -233,6 +234,15 @@ await store.reset()
 
 // 1. Both addons publish what they need. Neither creates it.
 run('addon: pikku all', 'node', [PIKKU, 'all'], addonDir)
+// `pikku all` publishes the artifact by itself. A consumer reads an absent one
+// as a package that cannot say whether it ships tables, so an addon must never
+// depend on the author remembering a second command for the file to exist.
+check(
+  existsSync(
+    join(addonDir, '.pikku', 'addon', 'db', 'pikku-db-meta.gen.json')
+  ),
+  'pikku all published the schema artifact on its own'
+)
 run('addon: pikku db export', 'node', [PIKKU, 'db', 'export'], addonDir)
 run('remote addon: pikku all', 'node', [PIKKU, 'all'], remoteAddonDir)
 run(
@@ -541,6 +551,44 @@ check(
   (await store.appliedCount()) === 0,
   'the refusal recorded nothing (a partial baseline is the worst outcome)'
 )
+
+// 15. An addon whose artifact never shipped must stop the command, not be read
+//     as an addon with no tables. The two were indistinguishable until the file
+//     became unconditional, and the silence surfaced much later — as an addon
+//     function querying a table nobody had created.
+console.log('\n▶ a mispackaged addon is refused, not skipped')
+const linkedArtifact = join(
+  linkPath,
+  '.pikku',
+  'addon',
+  'db',
+  'pikku-db-meta.gen.json'
+)
+const savedArtifact = readFileSync(linkedArtifact, 'utf8')
+rmSync(linkedArtifact)
+const mispackaged = expectFailure('app: pikku db generate (artifact missing)', [
+  PIKKU,
+  'db',
+  'generate',
+])
+check(
+  mispackaged.status !== 0,
+  'db generate refused an addon that publishes no artifact at all'
+)
+writeFileSync(linkedArtifact, savedArtifact)
+
+// And an addon that genuinely has no tables says so, and is waved through.
+writeFileSync(linkedArtifact, '{}\n')
+const empty = expectFailure('app: pikku db generate (empty artifact)', [
+  PIKKU,
+  'db',
+  'generate',
+])
+check(
+  empty.status === 0,
+  'an empty artifact still means "this addon needs no tables"'
+)
+writeFileSync(linkedArtifact, savedArtifact)
 
 await store.close()
 


### PR DESCRIPTION
Stacked on #1605 (base `docs/1604-addon-db-schema`). Closes #1604.

`addonSchemaSources` treated an unresolvable artifact as an addon that ships no schema — which is what the majority genuinely are, so there was no error, no migration, and the mistake surfaced much later as an addon function querying a table nobody had created.

The fix is to remove the ambiguity rather than guess at it:

- **`pikku all` writes the artifact on every addon build**, empty when the addon has no tables. "Needs nothing" is now something the package *says*, in a file that ships.
- **`db generate` refuses an addon that publishes none** — that can only mean an older CLI or an `exports`/`files` that doesn't carry the file, and the error names both.
- **A malformed artifact is rejected**, not half-applied. A dialect carrying tables but no SQL would otherwise generate a migration that creates nothing, drifting the schema from what the addon's own functions expect.
- `pikku db export` still writes the same artifact on demand, now through the shared writer.

## Tests

`local-db.test.ts` — red before, green after (66/66): the missing artifact throws and names the package; a remote addon with no artifact stays silent; an unparseable artifact names the file; a dialect with tables but no SQL is rejected; an empty artifact contributes nothing; and the writer emits `{}` when there are no migration directories.

`verifiers/db-schema/run.mjs` gains two cases: `pikku all` alone publishes the artifact, and `db generate` refuses a mispackaged addon while waving through an empty one.

**The verifier could not be run locally** — in a fresh worktree the CLI's own build resolves `@pikku/knowledge` to the main checkout's stale build and won't boot (`does not provide an export named 'KnowledgeReconcileInput'`), which fails `console-command-removed.test.ts` there too, before and after this change. CI is the first real run of those two cases.

## Note

This is a deliberate behaviour change for addons built with an older CLI: they publish no artifact, so a consumer's `db generate` now fails until they rebuild. Pre-0.13, that's the intended trade — the alternative is keeping the silent path that made the bug invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)