### PR TITLE
fix(cli): order a partial source's new tables the way its SQL creates them

### DIFF
--- a/.changeset/db-generate-orders-tables.md
+++ b/.changeset/db-generate-orders-tables.md
@@ -1,0 +1,6 @@
+---
+'@pikku/migrator-sql': patch
+'@pikku/cli': patch
+---
+
+`db generate` now creates a referenced table before the one referencing it

--- a/packages/cli/src/functions/db/local-db.test.ts
+++ b/packages/cli/src/functions/db/local-db.test.ts
@@ -1047,6 +1047,56 @@ test('db generate adds only the columns a partially covered source is missing', 
   assert.match(body, /-- REVIEW: owner is NOT NULL with no default/)
 })
 
+test('a partially covered source creates a referenced table before the one referencing it', async () => {
+  const resolved = resolveDb({ sqliteDb: '.pikku-runtime/dev.db' }, root, root)!
+
+  // Introspection hands a source's tables back alphabetically, so
+  // `basket_items` arrives before the `baskets` it references. Emitting them in
+  // that order writes a migration that cannot be applied.
+  publishAddonSchema(
+    'addon-baskets',
+    {
+      sqlite: {
+        sql: [
+          'CREATE TABLE todos (id INTEGER PRIMARY KEY);',
+          'CREATE TABLE baskets (basket_id TEXT NOT NULL PRIMARY KEY);',
+          'CREATE TABLE basket_items (basket_id TEXT NOT NULL REFERENCES baskets (basket_id), sku TEXT NOT NULL);',
+        ].join('\n'),
+        tables: {
+          todos: [column('id', 'INTEGER', { notNull: true, pk: true })],
+          basket_items: [
+            column('basket_id', 'TEXT', { notNull: true }),
+            column('sku', 'TEXT', { notNull: true }),
+          ],
+          baskets: [column('basket_id', 'TEXT', { notNull: true, pk: true })],
+        },
+      },
+    } satisfies SchemaArtifact,
+    root
+  )
+
+  const { written } = await generateMigrations(
+    resolved,
+    root,
+    ['src'],
+    { error: (msg: string) => assert.fail(`unexpected error log: ${msg}`) },
+    [{ package: 'addon-baskets' }]
+  )
+
+  const migration = written.find((w) => w.source === 'addon-baskets')
+  assert.ok(migration, 'the missing tables were written')
+  const body = readFileSync(migration.file, 'utf8')
+  assert.ok(
+    body.indexOf('CREATE TABLE baskets') <
+      body.indexOf('CREATE TABLE basket_items'),
+    'baskets is created before the table referencing it'
+  )
+
+  // The proof the order is right is that it applies.
+  await migrateAndCodegen(resolved)
+  assert.equal((await driftOf(resolved)).inSync, true)
+})
+
 /**
  * Publish an addon's schema artifact under `root/node_modules`, overwriting any
  * earlier one.

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -33,7 +33,7 @@ import {
 import { loadAuthOptions, getAuthMigrations } from './better-auth-schema.js'
 import { generateSchemaTypes, type CodegenResult } from './db-codegen.js'
 import { generateZodTypes, type ZodCodegenResult } from './zod-codegen.js'
-import { tableCreationSql } from '@pikku/migrator-sql'
+import { tableCreationSql, tablesInSourceOrder } from '@pikku/migrator-sql'
 import { SqliteMigrationExecutor } from '@pikku/migrator-sql/sqlite'
 import { SqliteIntrospector } from './sqlite/sqlite-introspector.js'
 import { createSqliteKysely } from './sqlite/sqlite-kysely.js'
@@ -1867,7 +1867,7 @@ export async function generateMigrations(
       body = source.desired.sql
     } else {
       const statements: string[] = []
-      for (const table of missingTables) {
+      for (const table of tablesInSourceOrder(source.desired.sql, missingTables)) {
         // A wholly new table is the first-time case in miniature: nothing to
         // diff against, and the source's own SQL already says exactly how to
         // build it. Rendering the column map instead would drop the primary

--- a/packages/migrator-sql/src/index.ts
+++ b/packages/migrator-sql/src/index.ts
@@ -31,4 +31,5 @@ export {
   splitStatements,
   bareTableName,
   tableCreationSql,
+  tablesInSourceOrder,
 } from './schema-sql.js'

--- a/packages/migrator-sql/src/schema-sql.test.ts
+++ b/packages/migrator-sql/src/schema-sql.test.ts
@@ -1,7 +1,11 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { splitStatements, tableCreationSql } from './schema-sql.js'
+import {
+  splitStatements,
+  tableCreationSql,
+  tablesInSourceOrder,
+} from './schema-sql.js'
 
 test('a semicolon inside a string literal is not a statement boundary', () => {
   const sql = `CREATE TABLE a (id TEXT, note TEXT DEFAULT 'one; two');
@@ -63,4 +67,26 @@ test('a table the SQL never creates yields nothing to copy', () => {
 CREATE INDEX "orphan_idx" ON "orders" ("id");`
 
   assert.deepEqual(tableCreationSql(sql, 'orders'), [])
+})
+
+test('a referencing table is created after the one it references, not alphabetically', () => {
+  const sql = `create table "channels" ("channel_id" text primary key);
+create table "channel_subscriptions" ("channel_id" text not null references "channels" ("channel_id"));`
+
+  assert.deepEqual(
+    tablesInSourceOrder(sql, ['channel_subscriptions', 'channels']),
+    ['channels', 'channel_subscriptions']
+  )
+})
+
+test('a table the source does not create is left at the end', () => {
+  const sql = 'create table "a" ("id" text);'
+  assert.deepEqual(tablesInSourceOrder(sql, ['unknown', 'a']), ['a', 'unknown'])
+})
+
+test('source order survives a schema qualifier on either side', () => {
+  const sql = `create table app."b" ("id" text);
+create table "a" ("id" text);`
+
+  assert.deepEqual(tablesInSourceOrder(sql, ['a', 'app.b']), ['app.b', 'a'])
 })

--- a/packages/migrator-sql/src/schema-sql.ts
+++ b/packages/migrator-sql/src/schema-sql.ts
@@ -153,3 +153,27 @@ export function tableCreationSql(sql: string, table: string): string[] {
   // and their presence says the table came from somewhere this cannot read.
   return creates ? statements : []
 }
+
+/**
+ * `tables`, in the order `sql` creates them.
+ *
+ * A diff hands its missing tables back in whatever order it walked them, which
+ * is usually alphabetical and is never the order they can be created in: a
+ * table that references another has to come after it, and `channel_subscriptions`
+ * sorts before `channels`. The source's own SQL already has a workable order —
+ * it was applied in it — so that is the order used, with anything the source
+ * does not visibly create left at the end for the caller to render its own way.
+ */
+export function tablesInSourceOrder(sql: string, tables: string[]): string[] {
+  const position = new Map<string, number>()
+  let index = 0
+  for (const statement of splitStatements(sql)) {
+    const create = CREATE_TABLE.exec(statement)
+    if (create) {
+      const name = bareTableName(create[1]!)
+      if (!position.has(name)) position.set(name, index++)
+    }
+  }
+  const rank = (table: string) => position.get(bareTableName(table)) ?? Number.MAX_SAFE_INTEGER
+  return [...tables].sort((a, b) => rank(a) - rank(b))
+}


### PR DESCRIPTION
## Issue

`db generate` emitted the missing tables of a partially covered source in diff order — the order introspection walked them, which is alphabetical and never the order they can be created in. A source declaring `channels` and `channel_subscriptions` produced a migration whose foreign key had nothing to point at, so `pikku db generate` could not apply its own output.

## Action

1. `tablesInSourceOrder(sql, tables)` in `@pikku/migrator-sql` ranks tables by where the source's own SQL creates them, leaving anything it does not visibly create at the end.
2. `generateMigrations`'s partial branch iterates through it.
3. Regression test in `local-db.test.ts`: a partially covered addon whose tables arrive alphabetically now writes `baskets` before `basket_items`, and the migration applies (`driftOf(...).inSync`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)