### PR TITLE
fix(core): a credential read during a lazy load must not answer null

### DIFF
--- a/packages/core/src/services/credential-wire-service.test.ts
+++ b/packages/core/src/services/credential-wire-service.test.ts
@@ -122,6 +122,69 @@ describe('PikkuCredentialWireService', () => {
     assert.deepStrictEqual(r1, r2)
   })
 
+  /**
+   * The regression the `loaded` flag was written to avoid.
+   *
+   * `get` answers synchronously once `loaded` is set, so setting the flag
+   * before the fetch resolved gave every caller that arrived during the load a
+   * confident `null` for a credential that exists. `getAll` hid it: it hands
+   * back the live `credentials` object, which is filled in before anyone
+   * asserts on it, so only a reader that copies a VALUE out sees the gap.
+   */
+  test('should not answer null while a lazy load is still in flight', async () => {
+    const credService = mockCredentialService({ stripe: { key: 'sk_live' } })
+    const wire: PikkuWire = { session: { userId: 'user-1' } as any }
+    const service = new PikkuCredentialWireService(credService, wire)
+
+    // Issued in one tick, exactly as `Promise.all` over sibling RPC calls does.
+    const results = await Promise.all([
+      service.get('stripe'),
+      service.get('stripe'),
+      service.get('stripe'),
+    ])
+
+    for (const [index, result] of results.entries()) {
+      assert.deepStrictEqual(
+        result,
+        { key: 'sk_live' },
+        `concurrent reader ${index} lost the credential`
+      )
+    }
+  })
+
+  test('should not answer null during a slow lazy load', async () => {
+    const credService: CredentialService = {
+      get: async () => null,
+      set: async () => {},
+      delete: async () => {},
+      has: async () => true,
+      getAll: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        return { stripe: { key: 'sk_live' } }
+      },
+    }
+    const wire: PikkuWire = { session: { userId: 'user-1' } as any }
+    const service = new PikkuCredentialWireService(credService, wire)
+
+    const first = service.get('stripe')
+    const second = service.get('stripe')
+    assert.deepStrictEqual(await first, { key: 'sk_live' })
+    assert.deepStrictEqual(await second, { key: 'sk_live' })
+  })
+
+  test('should still take the sync path when there is nothing to load', async () => {
+    // Both early returns are settled states, so they must set `loaded` too.
+    const service = new PikkuCredentialWireService(
+      mockCredentialService({ stripe: { key: '1' } }),
+      {}
+    )
+    await service.getAll()
+    assert.ok(
+      !(service.getAll() instanceof Promise),
+      'expected sync return after an unresolvable user'
+    )
+  })
+
   test('getScoped should only return allowed names', async () => {
     const credService = mockCredentialService({
       stripe: { key: '1' },

--- a/packages/core/src/services/credential-wire-service.ts
+++ b/packages/core/src/services/credential-wire-service.ts
@@ -62,17 +62,35 @@ export class PikkuCredentialWireService {
     return this.loadPromise
   }
 
+  /**
+   * `loaded` means "the credentials are in hand", never "a load has started".
+   *
+   * The distinction matters because `get`, `getAll` and `getScoped` all answer
+   * SYNCHRONOUSLY once it is set. Setting it before the await let every caller
+   * that arrived while the fetch was still in flight take that synchronous path
+   * over an empty map and receive `null` for a credential that exists — the
+   * first of N concurrent readers got the value and the rest silently did not.
+   * `loadPromise` is what guards against loading twice; this flag is only ever
+   * about whether the fast path is safe to take.
+   *
+   * `finally` rather than a trailing assignment: the two early returns (no
+   * service or wire, no resolvable user) are settled states as well — there is
+   * nothing to fetch — so they should reach the fast path too.
+   */
   private async doLoad(): Promise<void> {
-    this.loaded = true
-    if (!this.credentialService || !this.wire) return
-    const userId = defaultPikkuUserIdResolver(this.wire)
-    if (!userId) return
-    this.wire.pikkuUserId = userId
-    const allCreds = await this.credentialService.getAll(userId)
-    for (const [name, value] of Object.entries(allCreds)) {
-      if (!(name in this.credentials)) {
-        this.credentials[name] = value
+    try {
+      if (!this.credentialService || !this.wire) return
+      const userId = defaultPikkuUserIdResolver(this.wire)
+      if (!userId) return
+      this.wire.pikkuUserId = userId
+      const allCreds = await this.credentialService.getAll(userId)
+      for (const [name, value] of Object.entries(allCreds)) {
+        if (!(name in this.credentials)) {
+          this.credentials[name] = value
+        }
       }
+    } finally {
+      this.loaded = true
     }
   }
 }


### PR DESCRIPTION
## The bug

`PikkuCredentialWireService.doLoad` sets `this.loaded = true` on its first line, *before* awaiting `credentialService.getAll(userId)`:

```ts
private async doLoad(): Promise<void> {
  this.loaded = true                                    // ← flag set here
  if (!this.credentialService || !this.wire) return
  const userId = defaultPikkuUserIdResolver(this.wire)
  if (!userId) return
  this.wire.pikkuUserId = userId
  const allCreds = await this.credentialService.getAll(userId)   // ← credentials arrive here
  for (const [name, value] of Object.entries(allCreds)) { ... }
}
```

`get`, `getAll` and `getScoped` all short-circuit to a **synchronous** answer once `loaded` is set:

```ts
get(name) {
  const key = this.resolveName(name)
  if (this.loaded) return this.credentials[key] ?? null
  return this.lazyLoad().then(() => this.credentials[key] ?? null)
}
```

So between the flag being set and the fetch resolving, there is a window in which `loaded` is `true` but `credentials` is still `{}`. Any caller arriving in that window takes the fast path and gets `null` for a credential that exists.

With N callers in one tick:

1. Caller A → `loaded` false → `lazyLoad()` → `doLoad()` runs synchronously to the `await`, setting `loaded = true`, and suspends. A awaits properly and gets the right value.
2. Callers B…N → `loaded` is now `true` → synchronous branch over an empty map → **`null`**.

First reader wins, the rest silently lose.

## Why it matters

It doesn't present as a race — it presents as an authorization failure, deterministically. Sibling calls under a `Promise.all` fan out in a single tick, so a `createWireServices` factory that binds an upstream client to `wire.getCredential('session')` binds the first call and leaves the others unauthenticated:

```ts
const session = await wire.getCredential<{ token: string } | null>('session')
if (session?.token) return { api: api.withSession(session.token) }
return { api: api.withToken(undefined) }   // ← unauthenticated singleton
```

Against a permissive local fixture nothing happens. Against a real upstream, every sibling call after the first is refused — in our case a fan-out of five taxonomy reads gave exactly 25×200 on the first route and 25×403 on the other four across a test run, which is what ruled out an ordinary race and pointed here.

## The fix

`loadPromise` already guards against loading twice, so the early `loaded = true` bought nothing. Setting it in a `finally` gives the flag the meaning the fast path actually requires — *"the credentials are in hand"*, not *"a load has started"*.

`finally` rather than a trailing assignment so the two early returns (no service or wire; no resolvable user) reach the fast path too: those are settled states with nothing to fetch, and the existing `should not load when no userId resolvable` / sync-return tests depend on it.

## Tests

The existing `should deduplicate concurrent lazy load calls` cannot catch this — `getAll` returns the live `credentials` object by reference, and it is populated before the assertion runs. Only a reader that copies a *value* out, as `get` does, observes the gap. The new tests therefore go through `get`.

Verified against the unfixed implementation: the two race tests fail, the other 13 pass. With the fix, all 15 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed credential lookups during loading so concurrent requests no longer return `null` when credentials are available.
  * Ensured synchronous credential access is used only after loading has fully completed.
  * Preserved synchronous behavior when no credentials need to be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->