### PR TITLE
fabric link: start from a repo with no git remote

### DIFF
--- a/.changeset/fabric-link-host-flags.md
+++ b/.changeset/fabric-link-host-flags.md
@@ -1,0 +1,8 @@
+---
+'@pikku/cli': patch
+---
+
+`pikku fabric link` can now start from a repo with no remote. `--github` and
+`--gitea` name where the project lives; with no flag and no `origin` the CLI
+asks before creating anything, and a non-interactive session is told which flag
+to pass rather than being hung on a prompt.

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -154,6 +154,20 @@ export const fabricCommands = defineCLICommands({
     description:
       'Register the current git repo as a fabric project and queue an initial deploy',
     options: {
+      github: {
+        description:
+          'Assert the repo is on github.com (fails if origin points elsewhere)',
+        default: false,
+      },
+      gitea: {
+        description:
+          "Host the repo on fabric's git server — creates and pushes to it when there is no origin",
+        default: false,
+      },
+      repoName: {
+        description:
+          'Name for a repo created by --gitea (defaults to the directory name)',
+      },
       apiUrl: {
         description: 'Override the fabric-api URL stored in fabric.config.json',
       },

--- a/packages/cli/src/fabric/functions/link.function.ts
+++ b/packages/cli/src/fabric/functions/link.function.ts
@@ -1,11 +1,29 @@
 import { z } from 'zod'
+import { basename } from 'node:path'
 import { pikkuSessionlessFunc } from '../../../.pikku/function/index.js'
 import { resolveApiContext, writeProjectConfig } from '../lib/config.js'
 import { getFabricRPC } from '../lib/http.js'
-import { assertDeploySafety, getRemoteUrl } from '../lib/git.js'
+import {
+  addRemote,
+  assertDeploySafety,
+  currentBranch,
+  getRemoteUrl,
+  hasCommits,
+  hasRemote,
+  isWorkingTreeClean,
+  pushWithCredential,
+  removeRemote,
+} from '../lib/git.js'
+import { promptConfirm } from '../lib/prompt.js'
 
 export const FabricLinkInput = z.object({
   apiUrl: z.string().optional(),
+  /** Assert the project lives on GitHub. */
+  github: z.boolean().optional(),
+  /** Assert — or, with no `origin`, request — a repo on Fabric's git server. */
+  gitea: z.boolean().optional(),
+  /** Name for a repo created here. Defaults to the directory name. */
+  repoName: z.string().optional(),
 })
 
 export const FabricLinkOutput = z.object({
@@ -18,26 +36,52 @@ export const FabricLinkOutput = z.object({
 const GITHUB_POLL_INTERVAL_MS = 2000
 const GITHUB_POLL_TIMEOUT_MS = 5 * 60 * 1000
 
+/** github.com or not. Everything else Fabric supports is reached the Gitea way. */
+const isGithubUrl = (url: string): boolean => /github\.com/i.test(url)
+
 export const FabricLink = pikkuSessionlessFunc({
   description:
     'Register the current git repo as a fabric project and queue an initial deploy.',
   input: FabricLinkInput,
   output: FabricLinkOutput,
-  func: async (_services, { apiUrl: apiUrlOverride }) => {
+  func: async (_services, { apiUrl: apiUrlOverride, github, gitea, repoName }) => {
     const ctx = await resolveApiContext({ apiUrlOverride })
     if (!ctx.token) {
       throw new Error('Not logged in. Run `pikku fabric login` first.')
     }
 
-    const remoteUrl = await getRemoteUrl()
-    const safety = await assertDeploySafety()
+    if (github && gitea) {
+      throw new Error(
+        '--github and --gitea name two different places to keep one repo. Pass one, or neither to use whatever `origin` already points at.'
+      )
+    }
 
     const rpc = getFabricRPC({ apiUrl: ctx.apiUrl, token: ctx.token })
 
+    // Both of these are checked BEFORE anything is created. `assertDeploySafety`
+    // below covers them too, but it runs after the repo exists — and refusing to
+    // link because of a dirty tree, having already provisioned a repo the user
+    // now has to clean up, is a worse answer than refusing first.
+    if (!(await hasCommits())) {
+      throw new Error(
+        'Nothing to link: this repository has no commits yet. Commit your work first — fabric deploys a pushed commit, not a working directory.'
+      )
+    }
+    if (!(await isWorkingTreeClean())) {
+      throw new Error(
+        'Deployment blocked: uncommitted changes detected.\nCommit and push your changes before deploying.'
+      )
+    }
+
+    const remoteUrl = (await hasRemote())
+      ? await adoptExistingRemote({ github, gitea })
+      : await createRemote({ rpc, github, gitea, repoName })
+
+    const safety = await assertDeploySafety()
+
     // Only check GitHub App installation for github.com repos.
     // Gitea (local dev) and other hosts use shared tokens — no App needed.
-    const isGithub = /github\.com/i.test(remoteUrl)
-    if (isGithub) {
+    if (isGithubUrl(remoteUrl)) {
       const ghInstall = await rpc.invoke('checkGithubInstall', {})
       if (!ghInstall.installed) {
         if (!ghInstall.installUrl) {
@@ -100,3 +144,108 @@ export const FabricLink = pikkuSessionlessFunc({
     }
   },
 })
+
+/**
+ * The common case: `origin` exists, so that is the repo, whichever host it is on.
+ *
+ * The flags are read as ASSERTIONS here rather than as instructions. `--gitea`
+ * against a github.com origin could plausibly mean "move this to Fabric's git
+ * server", but re-pointing somebody's `origin` is not something a link command
+ * should decide on its own — so it is a question, answered by an error that says
+ * what to do instead.
+ */
+async function adoptExistingRemote({
+  github,
+  gitea,
+}: {
+  github?: boolean
+  gitea?: boolean
+}): Promise<string> {
+  const remoteUrl = await getRemoteUrl()
+  const onGithub = isGithubUrl(remoteUrl)
+
+  if (github && !onGithub) {
+    throw new Error(
+      `--github was passed, but origin is ${remoteUrl}, which is not on github.com.\nDrop the flag to link that remote, or repoint origin at the GitHub repo you meant.`
+    )
+  }
+  if (gitea && onGithub) {
+    throw new Error(
+      `--gitea was passed, but origin is already ${remoteUrl}.\nDrop the flag to link the GitHub repo. To host it on fabric instead, remove the remote first (\`git remote remove origin\`) and run link again.`
+    )
+  }
+  return remoteUrl
+}
+
+/**
+ * No `origin` — the case `link` used to fail on with a bare "no such remote".
+ *
+ * Fabric creates the repo on its own git server and pushes to it, then the
+ * caller carries on down the ordinary import path. It does NOT create GitHub
+ * repos: doing that on the user's behalf needs a separate consent (a device-flow
+ * authorization against their GitHub account), and the Fabric GitHub App cannot
+ * stand in for it without asking every existing installation to re-approve an
+ * `administration: write` permission.
+ *
+ * Nothing here happens unasked. Without a flag the user is asked, and a session
+ * with nobody at the terminal is told which flag to pass instead of hanging on a
+ * prompt no one will answer.
+ */
+async function createRemote({
+  rpc,
+  github,
+  gitea,
+  repoName,
+}: {
+  rpc: ReturnType<typeof getFabricRPC>
+  github?: boolean
+  gitea?: boolean
+  repoName?: string
+}): Promise<string> {
+  if (github) {
+    throw new Error(
+      'There is no `origin` to link, and fabric cannot create a GitHub repository for you.\nCreate it on github.com, `git remote add origin <url>`, and run `pikku fabric link` again — or pass --gitea to host it on fabric instead.'
+    )
+  }
+
+  if (!gitea) {
+    if (!process.stdin.isTTY) {
+      throw new Error(
+        'There is no `origin` to link.\nPass --gitea to create a repository on fabric and push to it, or add a remote yourself and run link again.'
+      )
+    }
+    const confirmed = await promptConfirm(
+      'This project has no git remote. Create one on fabric and push this branch to it?',
+      true
+    )
+    if (!confirmed) {
+      throw new Error(
+        'Nothing linked. Add a remote yourself (`git remote add origin <url>`) and run `pikku fabric link` again.'
+      )
+    }
+  }
+
+  const name = repoName ?? basename(process.cwd())
+  const branch = await currentBranch()
+
+  const repo = await rpc.invoke('provisionRepo', { name })
+  console.log(`[fabric] created ${repo.repoUrl}`)
+
+  await addRemote('origin', repo.cloneUrl)
+  try {
+    await pushWithCredential('origin', branch, repo)
+  } catch (error) {
+    // Leave no half-linked repository behind. The remote is ours — added a line
+    // ago — so removing it is safe, and it is what stops a retry dying on
+    // "remote origin already exists" instead of on the real problem.
+    await removeRemote('origin')
+    throw new Error(
+      `Created ${repo.repoUrl} but could not push to it: ${
+        error instanceof Error ? error.message : String(error)
+      }\nThe repository exists and is empty; push to it yourself, or run link again to get a fresh one.`
+    )
+  }
+  console.log(`[fabric] pushed ${branch} to origin`)
+
+  return repo.repoUrl
+}

--- a/packages/cli/src/fabric/lib/git.ts
+++ b/packages/cli/src/fabric/lib/git.ts
@@ -44,11 +44,15 @@ function envWithoutInheritedRepo(): NodeJS.ProcessEnv {
   return env
 }
 
-function git(args: string[], cwd = process.cwd()): Promise<string> {
+function git(
+  args: string[],
+  cwd = process.cwd(),
+  extraEnv?: NodeJS.ProcessEnv
+): Promise<string> {
   return new Promise((resolve, reject) => {
     const child = spawn('git', args, {
       cwd,
-      env: envWithoutInheritedRepo(),
+      env: { ...envWithoutInheritedRepo(), ...extraEnv },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
     let stdout = ''
@@ -279,4 +283,90 @@ export async function isGitRepo(cwd = process.cwd()): Promise<boolean> {
   } catch {
     return false
   }
+}
+
+/**
+ * Does this repository have the given remote?
+ *
+ * Separate from `getRemoteUrl` throwing, because "no origin" is an ordinary
+ * state that `link` acts on rather than an error it reports: a developer who
+ * has not pushed anywhere yet is exactly who repo provisioning is for.
+ */
+export async function hasRemote(
+  remote = 'origin',
+  cwd?: string
+): Promise<boolean> {
+  try {
+    await git(['remote', 'get-url', remote], cwd)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Does HEAD resolve? False in a repository with no commits yet. */
+export async function hasCommits(cwd?: string): Promise<boolean> {
+  try {
+    await git(['rev-parse', '--verify', 'HEAD'], cwd)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function addRemote(
+  name: string,
+  url: string,
+  cwd?: string
+): Promise<void> {
+  await git(['remote', 'add', name, url], cwd)
+}
+
+export async function removeRemote(name: string, cwd?: string): Promise<void> {
+  try {
+    await git(['remote', 'remove', name], cwd)
+  } catch {
+    /* best-effort: only used to undo a remote we just added */
+  }
+}
+
+/**
+ * Push `branch` to `remote` and set it as upstream, authenticating with a
+ * one-shot credential.
+ *
+ * The credential is passed through the ENVIRONMENT and read back by an inline
+ * credential helper, rather than embedded in the remote URL. Both a URL like
+ * `https://user:token@host/...` and `-c http.<url>.extraheader=...` put the
+ * secret in the process's argv, where any other user on the machine can read it
+ * out of `ps`. This way argv holds only the shape of the helper, and the token
+ * never reaches `.git/config` either — so it cannot outlive the push.
+ */
+export async function pushWithCredential(
+  remote: string,
+  branch: string,
+  credential: { username: string; password: string },
+  cwd?: string
+): Promise<void> {
+  await git(
+    [
+      '-c',
+      'credential.helper=',
+      '-c',
+      'credential.helper=!f() { echo "username=$PIKKU_GIT_USERNAME"; echo "password=$PIKKU_GIT_PASSWORD"; }; f',
+      'push',
+      '-u',
+      remote,
+      `HEAD:refs/heads/${branch}`,
+    ],
+    cwd,
+    {
+      PIKKU_GIT_USERNAME: credential.username,
+      PIKKU_GIT_PASSWORD: credential.password,
+      // Any configured interactive helper (osxkeychain, a GUI prompt) would be
+      // consulted first and could hang a CLI with no one at the terminal. The
+      // empty `credential.helper=` above resets the inherited list; this stops
+      // git falling back to a terminal prompt if ours somehow yields nothing.
+      GIT_TERMINAL_PROMPT: '0',
+    }
+  )
 }

--- a/packages/cli/src/fabric/sdk/rpc-map.gen.d.ts
+++ b/packages/cli/src/fabric/sdk/rpc-map.gen.d.ts
@@ -3492,6 +3492,19 @@ export type ImportProjectAssetsOutput = {
     committed: boolean;
     paths: string[];
 }
+export type ProvisionRepoInput = {
+    name?: string | undefined;
+    organizationId?: string | undefined;
+}
+export type ProvisionRepoOutput = {
+    repoUrl: string;
+    cloneUrl: string;
+    username: string;
+    password: string;
+    expiresAt: string;
+    commitName: string;
+    commitEmail: string;
+}
 export type ImportProjectInput = {
     organizationId?: string | undefined;
     repoUrl: string;
@@ -6997,6 +7010,7 @@ export type RPCMap = {
   readonly 'listHarnessRuns': RPCHandler<ListHarnessRunsInput, ListHarnessRunsOutput>,
   readonly 'listHarnessScenarios': RPCHandler<ListHarnessScenariosInput, ListHarnessScenariosOutput>,
   readonly 'preflightHarnessModels': RPCHandler<PreflightHarnessModelsInput, PreflightHarnessModelsOutput>,
+  readonly 'provisionRepo': RPCHandler<ProvisionRepoInput, ProvisionRepoOutput>,
   readonly 'publishAgentBundle': RPCHandler<PublishAgentBundleInput, PublishAgentBundleOutput>,
   readonly 'requestHarnessScreenshotUpload': RPCHandler<RequestHarnessScreenshotUploadInput, RequestHarnessScreenshotUploadOutput>,
   readonly 'sleepHarnessSandbox': RPCHandler<SleepHarnessSandboxInput, SleepHarnessSandboxOutput>,


### PR DESCRIPTION
Needs pikkufabric/fabric#437 for the `provisionRepo` endpoint.

## Why

`link` read `origin` and failed with a bare "no such remote" when there wasn't one — so the first thing a new project needs, somewhere to push, was the one thing the command could not supply.

## Flag semantics

| situation | result |
|---|---|
| `origin` exists | use it — unchanged |
| `--github` / `--gitea` **with** an origin | **assertion**, not instruction |
| no origin, `--gitea` | create on fabric, push, import |
| no origin, no flag | **ask first** |
| no origin, `--github` | error, with what to do instead |

The flags are assertions rather than instructions when an origin exists. `--gitea` against a github.com origin *could* plausibly mean "move this to fabric's git server", but repointing somebody's `origin` is not a call a link command should make on its own — so it is an error that says how to do it deliberately.

`--github` cannot create a repo. That needs a device-flow authorization against the user's own GitHub account; the Fabric GitHub App cannot stand in for it without making every existing installation re-approve an `administration: write` permission.

## Nothing happens unasked

With no flag the user is asked. A non-interactive session (`!process.stdin.isTTY`) is told which flag to pass rather than hanging on a prompt no one will answer.

## Credential handling

The push credential travels in the **environment** and is read back by an inline credential helper. Both `https://user:token@host/...` and `-c http.<url>.extraheader=` put the secret in the process's argv, where any other user on the machine can read it out of `ps`. This way it reaches neither argv nor `.git/config`, so it cannot outlive the push. `GIT_TERMINAL_PROMPT=0` and a reset of the inherited helper list stop a configured keychain helper from being consulted first and hanging.

## Ordering

Clean-tree and has-commits are checked **before** provisioning. `assertDeploySafety` covers both, but it runs after the repo exists — refusing to link because of a dirty tree, having already provisioned a repo the user now has to clean up, is a worse answer than refusing first. A push that fails after the remote is added removes that remote again, so the retry dies on the real problem and not on "remote origin already exists".

## Testing

`tsc --noEmit` clean across the four changed files. The inline credential helper is verified to yield the token via `git credential fill` with argv clean. Not yet exercised end-to-end.

The `rpc-map.gen.d.ts` entry is hand-added in the generator's exact style until fabric#437 lands and codegen runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)