### PR TITLE
fix(core): keep hot reload from serving stale code on Bun

### DIFF
--- a/.changeset/bun-hot-reload-relative-imports.md
+++ b/.changeset/bun-hot-reload-relative-imports.md
@@ -1,0 +1,7 @@
+---
+'@pikku/core': patch
+---
+
+Fix hot reload silently keeping old code on Bun for any file importing a relative sibling.
+
+Inside a `pikku dev` that has been running for a while, Bun stops honouring `createRequire`'s referrer: a file importing `./sibling.js` reloads as `Cannot find module './sibling.js'` even though it resolves fine in a fresh Bun script, so the reload aborts and the process goes on serving the previous version of a function whose source has visibly changed. Bun's own resolver still answers correctly when handed the importer's directory outright, so the module runner now resolves each specifier to an absolute path before requiring it, and the referrer never has to survive the trip. Specifiers Bun's resolver declines — builtins among them — fall through unchanged, and non-Bun runtimes keep the plain `createRequire`.

--- a/.changeset/bun-sqlite-open-database.md
+++ b/.changeset/bun-sqlite-open-database.md
@@ -1,0 +1,9 @@
+---
+'@pikku/kysely-bun-sqlite': patch
+---
+
+Add `openBunSqliteDatabase`, which opens a `bun:sqlite` database as the `SqliteDatabase` Kysely's `SqliteDialect` binds to.
+
+`createBunSqliteKysely` builds one Kysely over one database, so it cannot express several Kysely instances — differing only in their plugins — sharing a single underlying database. That combination is what lets a plugin-free instance (Better Auth needs unmangled column names) and a CamelCase one address the same tables, and until now an app that needed it had to reach for `better-sqlite3` instead.
+
+Under Bun that fallback is not survivable: `better-sqlite3` ships a Node-ABI addon which Bun cannot load, and rather than throwing it aborts the process with `NAPI FATAL ERROR: Error::New napi_get_last_error_info`. In a `pikku dev --watch` this killed the dev server after codegen but before it ever listened, with no error naming the driver.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -40,6 +40,7 @@
     "@pikku/core": "workspace:*",
     "@pikku/jose": "workspace:*",
     "@pikku/kysely": "workspace:*",
+    "@pikku/kysely-bun-sqlite": "workspace:*",
     "@pikku/kysely-mysql": "workspace:*",
     "@pikku/kysely-postgres": "workspace:*",
     "@pikku/kysely-sqlite": "workspace:*",

--- a/e2e/src/services.ts
+++ b/e2e/src/services.ts
@@ -9,6 +9,7 @@ import {
 } from '@pikku/core/services'
 import type { EmailService } from '@pikku/core/services'
 import { existsSync } from 'node:fs'
+import { openSqliteDatabase } from './sqlite-database.js'
 import { pikkuServices } from '#pikku/setup'
 import { pikkuState } from '@pikku/core/state'
 import { BetterAuthCredentialService } from '@pikku/better-auth'
@@ -85,7 +86,6 @@ export const createSingletonServices = pikkuServices(
     let workflowRunService: any
 
     if (backend === 'sqlite') {
-      const { default: Database } = await import('better-sqlite3')
       const { CamelCasePlugin, Kysely, SqliteDialect } = await import('kysely')
       const {
         SQLiteKyselyAgentStorageService,
@@ -107,7 +107,9 @@ export const createSingletonServices = pikkuServices(
       // file the last run left behind already has these tables.
       const freshDb = sqlitePath === ':memory:' || !existsSync(sqlitePath)
       const db = new Kysely<KyselyPikkuDB>({
-        dialect: new SqliteDialect({ database: new Database(sqlitePath) }),
+        dialect: new SqliteDialect({
+          database: await openSqliteDatabase(sqlitePath),
+        }),
         plugins: [new CamelCasePlugin(), new SerializePlugin()],
       })
       if (freshDb) {
@@ -179,14 +181,13 @@ export const createSingletonServices = pikkuServices(
     // names, so it gets its own SQLite instance rather than sharing the
     // AI/workflow db (which runs CamelCase/Serialize plugins). The auth factory
     // runs Better Auth's migrations against it on first request.
-    const { default: AuthDatabase } = await import('better-sqlite3')
     const {
       CamelCasePlugin: AuthCamelCase,
       Kysely: AuthKysely,
       SqliteDialect: AuthSqliteDialect,
     } = await import('kysely')
     const { SerializePlugin: AuthSerialize } = await import('@pikku/kysely')
-    const authDatabase = new AuthDatabase(':memory:')
+    const authDatabase = await openSqliteDatabase(':memory:')
     const kysely = new AuthKysely<KyselyPikkuDB>({
       dialect: new AuthSqliteDialect({ database: authDatabase }),
     })
@@ -208,7 +209,6 @@ export const createSingletonServices = pikkuServices(
     // deliberately plugin-free), kept separate so it works across DB_BACKEND.
     const { KyselyWebhookService, SerializePlugin: WebhookSerializePlugin } =
       await import('@pikku/kysely')
-    const { default: WebhookDatabase } = await import('better-sqlite3')
     const {
       Kysely: WebhookKysely,
       SqliteDialect: WebhookSqliteDialect,
@@ -216,7 +216,7 @@ export const createSingletonServices = pikkuServices(
     } = await import('kysely')
     const webhookDb = new WebhookKysely<KyselyPikkuDB>({
       dialect: new WebhookSqliteDialect({
-        database: new WebhookDatabase(':memory:'),
+        database: await openSqliteDatabase(':memory:'),
       }),
       plugins: [new WebhookCamelCasePlugin(), new WebhookSerializePlugin()],
     })
@@ -232,7 +232,7 @@ export const createSingletonServices = pikkuServices(
     const { KyselyAuditService } = await import('@pikku/kysely')
     const auditDb = new WebhookKysely<KyselyPikkuDB>({
       dialect: new WebhookSqliteDialect({
-        database: new WebhookDatabase(':memory:'),
+        database: await openSqliteDatabase(':memory:'),
       }),
       plugins: [new WebhookCamelCasePlugin(), new WebhookSerializePlugin()],
     })

--- a/e2e/src/sqlite-database.ts
+++ b/e2e/src/sqlite-database.ts
@@ -1,0 +1,24 @@
+import type { SqliteDatabase } from 'kysely'
+
+/**
+ * Opens the SQLite database Kysely's `SqliteDialect` binds to, using whichever
+ * driver the current runtime can actually load.
+ *
+ * `better-sqlite3` ships a Node-ABI addon. Bun cannot load it — and rather than
+ * throwing, it aborts the process with `NAPI FATAL ERROR`, which takes down
+ * `pikku dev --watch` before the server ever listens. `bun:sqlite` is built in,
+ * so under Bun it is the only driver available; `openBunSqliteDatabase` adapts
+ * it to the same `SqliteDatabase` shape better-sqlite3 already satisfies, so the
+ * dialect (and every caller here) sees one interface either way.
+ */
+export const openSqliteDatabase = async (
+  path: string
+): Promise<SqliteDatabase> => {
+  const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined'
+  if (isBun) {
+    const { openBunSqliteDatabase } = await import('@pikku/kysely-bun-sqlite')
+    return openBunSqliteDatabase(path)
+  }
+  const { default: Database } = await import('better-sqlite3')
+  return new Database(path)
+}

--- a/packages/core/src/dev/module-runner.test.ts
+++ b/packages/core/src/dev/module-runner.test.ts
@@ -209,4 +209,27 @@ describe('createModuleRunner', { concurrency: false }, () => {
       `heap grew ${growth.toFixed(1)} MB over 200 edits (expected < 15 MB)`
     )
   })
+
+  test('a .js specifier resolves to the .ts file that actually exists', async () => {
+    // How every TypeScript source in a pikku app refers to a sibling: the
+    // import is written `.js` and only the `.ts` is on disk. Nothing else here
+    // covers it — the delegated-import test writes a real `.js` — and it is the
+    // shape that breaks under Bun once `pikku dev` has been running, where the
+    // reload fails and the process quietly keeps serving the previous code.
+    await writeFile(join(tmpDir, 'dep.ts'), `export const value = 'from-dep'`)
+
+    const runner = createModuleRunner()
+    const userFile = join(tmpDir, 'importer.ts')
+    await writeFile(
+      userFile,
+      `import { value } from './dep.js'
+       export const fn = { func: async () => value }`
+    )
+
+    const result = await runner.run(userFile)
+    assert.equal(result.ok, true)
+    const mod = (result as { exports: Record<string, unknown> }).exports
+    assert.equal(await (mod.fn as { func: () => Promise<string> }).func(), 'from-dep')
+  })
+
 })

--- a/packages/core/src/dev/module-runner.ts
+++ b/packages/core/src/dev/module-runner.ts
@@ -43,6 +43,44 @@ export interface PikkuModuleRunner {
 export const isTopLevelAwaitLimitation = (error: Error): boolean =>
   /top-level await/i.test(error.message)
 
+interface BunResolver {
+  resolveSync: (specifier: string, parent: string) => string
+}
+
+/** The `require` a reloaded module is run with.
+ *
+ *  On Bun, `createRequire`'s referrer stops being honoured somewhere in a
+ *  long-running process: the same relative specifier that resolves in a fresh
+ *  script fails inside a `pikku dev` that has been up for a while, so a file
+ *  importing `./sibling.js` reloads as `Cannot find module` and the developer
+ *  is left serving the previous code from an edit that looked applied. Bun's
+ *  own resolver still answers correctly when handed the importer's directory
+ *  outright, so the specifier is resolved to an absolute path first and the
+ *  referrer never has to survive the trip. Anything Bun's resolver declines —
+ *  builtins among them — falls through to `require` unchanged.
+ */
+const createRequireForFile = (absPath: string): NodeRequire => {
+  const base = createRequire(pathToFileURL(absPath))
+  const bun = (globalThis as { Bun?: BunResolver }).Bun
+  if (!bun) return base
+
+  const importerDir = dirname(absPath)
+  const resolveThroughBun = (specifier: string): string => {
+    try {
+      return bun.resolveSync(specifier, importerDir)
+    } catch {
+      return specifier
+    }
+  }
+
+  // Only resolution is delegated; the require itself stays outside the guard so
+  // a module that throws while evaluating reports its own error rather than
+  // being retried under a second specifier.
+  const bunRequire = ((specifier: string) =>
+    base(resolveThroughBun(specifier))) as NodeRequire
+  return Object.assign(bunRequire, base)
+}
+
 export const createModuleRunner = (): PikkuModuleRunner => {
   const registry = new Map<string, Record<string, unknown>>()
 
@@ -63,7 +101,7 @@ export const createModuleRunner = (): PikkuModuleRunner => {
         { filename: absPath }
       )
 
-      const require = createRequire(pathToFileURL(absPath))
+      const require = createRequireForFile(absPath)
       const moduleObj: { exports: Record<string, unknown> } = { exports: {} }
       fn(require, moduleObj.exports, moduleObj, absPath, dirname(absPath))
 

--- a/packages/services/kysely-bun-sqlite/src/bun-sqlite-adapter.test.ts
+++ b/packages/services/kysely-bun-sqlite/src/bun-sqlite-adapter.test.ts
@@ -1,8 +1,11 @@
 import { describe, test, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { Database } from 'bun:sqlite'
-import { Kysely, SqliteDialect } from 'kysely'
-import { BunSqliteDatabase } from './bun-sqlite-adapter.js'
+import { Kysely, SqliteDialect, CamelCasePlugin } from 'kysely'
+import {
+  BunSqliteDatabase,
+  openBunSqliteDatabase,
+} from './bun-sqlite-adapter.js'
 
 interface TestDB {
   items: { id: number; name: string; active: number; score: number | null }
@@ -172,5 +175,38 @@ describe('BunSqliteDatabase', () => {
       .where('name', '=', 'meta')
       .executeTakeFirstOrThrow()
     assert.equal(updated.numUpdatedRows, 1n)
+  })
+})
+
+describe('openBunSqliteDatabase', () => {
+  test('opens a database two Kysely instances can share', async () => {
+    const database = openBunSqliteDatabase(':memory:')
+    const plain = new Kysely<TestDB>({ dialect: new SqliteDialect({ database }) })
+    const camelCase = new Kysely<TestDB>({
+      dialect: new SqliteDialect({ database }),
+      plugins: [new CamelCasePlugin()],
+    })
+
+    await plain.schema
+      .createTable('items')
+      .addColumn('id', 'integer', (c) => c.primaryKey().autoIncrement())
+      .addColumn('name', 'text', (c) => c.notNull())
+      .addColumn('active', 'integer', (c) => c.notNull())
+      .addColumn('score', 'real')
+      .execute()
+    await plain
+      .insertInto('items')
+      .values({ name: 'shared', active: 1, score: null })
+      .execute()
+
+    // The second instance addresses the same underlying database, which is the
+    // only reason a plugin-free and a CamelCase Kysely can span one schema.
+    const row = await camelCase
+      .selectFrom('items')
+      .selectAll()
+      .executeTakeFirstOrThrow()
+    assert.equal(row.name, 'shared')
+
+    await plain.destroy()
   })
 })

--- a/packages/services/kysely-bun-sqlite/src/bun-sqlite-adapter.ts
+++ b/packages/services/kysely-bun-sqlite/src/bun-sqlite-adapter.ts
@@ -1,4 +1,4 @@
-import type { Database, Statement } from 'bun:sqlite'
+import { Database, type Statement } from 'bun:sqlite'
 import type { SqliteDatabase, SqliteStatement } from 'kysely'
 
 function coerce(v: unknown): unknown {
@@ -49,3 +49,16 @@ export class BunSqliteDatabase implements SqliteDatabase {
     this.db.close()
   }
 }
+
+/**
+ * Opens a `bun:sqlite` database as the `SqliteDatabase` Kysely's `SqliteDialect`
+ * binds to.
+ *
+ * `createBunSqliteKysely` covers the common case of one database behind one
+ * Kysely. This is for the case it cannot express: several Kysely instances —
+ * differing in their plugins — sharing a single underlying database, which is
+ * what lets a plugin-free instance (Better Auth needs unmangled column names)
+ * and a CamelCase one address the same tables.
+ */
+export const openBunSqliteDatabase = (filename: string): SqliteDatabase =>
+  new BunSqliteDatabase(new Database(filename))

--- a/packages/services/kysely-bun-sqlite/src/index.ts
+++ b/packages/services/kysely-bun-sqlite/src/index.ts
@@ -1,4 +1,7 @@
-export { BunSqliteDatabase } from './bun-sqlite-adapter.js'
+export {
+  BunSqliteDatabase,
+  openBunSqliteDatabase,
+} from './bun-sqlite-adapter.js'
 export {
   createBunSqliteKysely,
   type CreateBunSqliteKyselyOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5494,6 +5494,7 @@ __metadata:
     "@pikku/core": "workspace:*"
     "@pikku/jose": "workspace:*"
     "@pikku/kysely": "workspace:*"
+    "@pikku/kysely-bun-sqlite": "workspace:*"
     "@pikku/kysely-mysql": "workspace:*"
     "@pikku/kysely-postgres": "workspace:*"
     "@pikku/kysely-sqlite": "workspace:*"
@@ -5678,7 +5679,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pikku/kysely-bun-sqlite@workspace:packages/services/kysely-bun-sqlite":
+"@pikku/kysely-bun-sqlite@workspace:*, @pikku/kysely-bun-sqlite@workspace:packages/services/kysely-bun-sqlite":
   version: 0.0.0-use.local
   resolution: "@pikku/kysely-bun-sqlite@workspace:packages/services/kysely-bun-sqlite"
   dependencies:


### PR DESCRIPTION
Closes #1614.

## The bug

Under `bun … pikku dev --watch --hmr`, editing a file that imports a relative sibling fails to reload and the process keeps serving the old code:

```
Failed to import: packages/functions/src/functions/chaos.functions.ts (keeping old code)
  ResolveMessage: Cannot find module './chaos-ledger.js'
```

Same file, same edit, under Node: `Hot-reloaded: chaosCompensate, chaosReadLedger, chaosStep (3ms)`.

Inside a long-running `pikku dev`, Bun stops honouring `createRequire`'s referrer. It is **not** a missing `.js`→`.ts` rewrite and **not** cwd-sensitive — standalone probes resolve the same specifier correctly, which is why this only shows up once the dev server has been up. Only the plain relative shape breaks; bare subpaths through package.json `imports` (`#pikku/function`) reload fine, since Bun's own resolver handles those.

## The fix

`module-runner` resolves each specifier to an absolute path through Bun's resolver, handed the importer's directory outright, so the referrer never has to survive the trip. Specifiers Bun's resolver declines — builtins among them — fall through unchanged; non-Bun runtimes keep the plain `createRequire`.

## Why the SQLite changes are here

Seeing this at all required the dev server to survive startup on Bun. The e2e app opened SQLite through `better-sqlite3`, a Node-ABI addon Bun cannot load — and rather than throwing, it aborts the process with `NAPI FATAL ERROR: Error::New napi_get_last_error_info`, killing `pikku dev` after codegen and before it ever listened, with nothing naming the driver. The app now selects its driver by runtime, and `@pikku/kysely-bun-sqlite` gains `openBunSqliteDatabase` for the case `createBunSqliteKysely` cannot express: several Kysely instances differing only in plugins over one database (Better Auth needs a plugin-free instance sharing tables with a CamelCase one).

## Verification

- The failing edit now logs `Hot-reloaded: chaosCompensate, chaosReadLedger, chaosStep` under Bun; `editableFunc` still reloads and serves the new value, so the bare-specifier path did not regress.
- `@pikku/core`: 2484 passing / 0 failing, including a new test for the uncovered shape — a `./dep.js` import where only `dep.ts` exists.
- `@pikku/kysely-bun-sqlite`: 15/15 passing, including one for the shared-database case.
- Bun 1.4.0, macOS arm64. Verified in the main checkout; this worktree was not installed, so CI is the first run here.

## Note

The workaround is robust but the underlying referrer behaviour is Bun's, not pikku's — worth reporting upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening Bun’s native SQLite databases for use with Kysely.
  * Multiple Kysely instances can now share the same SQLite database.
  * SQLite-based services automatically select the appropriate database implementation for Bun or Node.js.

* **Bug Fixes**
  * Fixed relative import resolution during long-running Bun hot-reload sessions, preventing stale code and reload failures.

* **Tests**
  * Added coverage for Bun SQLite database sharing and relative import resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->