### PR TITLE
fix(knowledge): restore a milestone's `statusAt` when only the stamp was dropped

### DIFF
--- a/.changeset/milestone-status-at-restore.md
+++ b/.changeset/milestone-status-at-restore.md
@@ -1,0 +1,9 @@
+---
+'@pikku/knowledge': patch
+---
+
+`holdMilestoneLifecycle` now restores a milestone's `statusAt` when a note-rewriting
+turn drops it, not only when the `status` itself drifted. A rewrite that kept `built`
+and lost the stamp beside it passed the old status-only comparison, leaving a note
+whose state nothing could tell from a milestone that was really dispatched, built and
+closed by the gates.

--- a/packages/knowledge/src/milestone-lifecycle.test.ts
+++ b/packages/knowledge/src/milestone-lifecycle.test.ts
@@ -105,6 +105,24 @@ describe('the milestone lifecycle', () => {
     assert.match(raw, /status: dispatched/)
     assert.match(raw, /Re-filed from a later answer/)
   })
+
+  test('a dropped `statusAt` is restored even when the status came back unchanged', async () => {
+    const path = milestone('01-tonight.md', ['status: dispatched'])
+    setMilestoneStatus(cwd, path, 'built')
+    const stamped = readFileSync(join(cwd, path), 'utf8').match(/statusAt: (\S+)/)?.[1]
+    const release = await holdMilestoneLifecycle(cwd)
+
+    writeFileSync(
+      join(cwd, path),
+      '---\ntype: milestone\nstatus: built\n---\n\nRe-filed from a later answer.\n'
+    )
+    await release()
+
+    const raw = readFileSync(join(cwd, path), 'utf8')
+    assert.match(raw, /status: built/)
+    assert.equal(readFileSync(join(cwd, path), 'utf8').match(/statusAt: (\S+)/)?.[1], stamped)
+    assert.match(raw, /Re-filed from a later answer/)
+  })
 })
 
 describe('nominatedMilestone', () => {

--- a/packages/knowledge/src/milestone.ts
+++ b/packages/knowledge/src/milestone.ts
@@ -347,9 +347,23 @@ export async function holdMilestoneLifecycle(
     try {
       for (const note of await readMilestones(cwd)) {
         const was = held.get(note.path)
-        if (!was || note.status === was.status) continue
+        if (!was) continue
+        // BOTH held scalars are compared, because the pair is what the state machine
+        // owns. Comparing `status` alone lets through the rewrite that keeps `built`
+        // and drops the `statusAt` beside it, and the stamp is not decoration: it is
+        // the only evidence that this status was reached by a transition rather than
+        // typed into the frontmatter by whoever filed the note, and the only thing
+        // "how long has this been building?" can be answered from. Seen on a four
+        // milestone run — one note came back `built` carrying no stamp, and nothing
+        // downstream could tell it from a milestone that was really dispatched, built
+        // and closed by the gates.
+        const statusDrifted = note.status !== was.status
+        const stampDropped = (note.statusAt ?? null) !== was.statusAt
+        if (!statusDrifted && !stampDropped) continue
         console.warn(
-          `[milestone] ${note.path} came back \`${note.status ?? 'none'}\` from a turn that rewrites notes — restoring \`${was.status}\``
+          statusDrifted
+            ? `[milestone] ${note.path} came back \`${note.status ?? 'none'}\` from a turn that rewrites notes — restoring \`${was.status}\``
+            : `[milestone] ${note.path} came back \`${was.status}\` without its \`statusAt\` from a turn that rewrites notes — restoring the stamp`
         )
         setNoteScalars(cwd, note.path, {
           status: was.status,


### PR DESCRIPTION
`holdMilestoneLifecycle` snapshots both scalars the milestone state machine owns — `status` and `statusAt` — but decided whether to restore on the status alone:

```ts
if (!was || note.status === was.status) continue
```

A turn that rewrites notes could therefore keep `status: built` and drop the `statusAt` beside it: the guard read "status unchanged, nothing to do" and skipped the note, and the stamp never came back.

That stamp is not decoration. `setMilestoneStatus` is the only sanctioned route to `built` and always writes the pair, so the stamp is the evidence that a status was reached by a transition rather than typed into the frontmatter by whoever filed the note — and it is what "how long has this been building?" is answered from.

Seen on a four-milestone run: one note came back `built` carrying no stamp, and nothing downstream could distinguish it from a milestone that had really been dispatched, built and closed by the gates.

Both held scalars are now compared, and the warning says which one moved. Covered by a new case in `milestone-lifecycle.test.ts`; `@pikku/knowledge` is 288/288 with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
