### PR TITLE
feat(cli): remoteJobs scaffold for externally dispatched queue and scheduled work

### DIFF
--- a/.changeset/remote-jobs-scaffold.md
+++ b/.changeset/remote-jobs-scaffold.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Add a `scaffold.remoteJobs` flag that generates HTTP routes an external dispatcher posts to, so a runtime holding neither a queue consumer nor a clock still runs its queue workers and scheduled tasks.

--- a/.changeset/remote-jobs-scaffold.md
+++ b/.changeset/remote-jobs-scaffold.md
@@ -1,5 +1,6 @@
 ---
+'@pikku/core': patch
 '@pikku/cli': patch
 ---
 
-Add a `scaffold.remoteJobs` flag that generates HTTP routes an external dispatcher posts to, so a runtime holding neither a queue consumer nor a clock still runs its queue workers and scheduled tasks.
+Add a `scaffold.remoteJobs` flag that generates HTTP routes an external dispatcher posts to, so a runtime holding neither a queue consumer nor a clock still runs its queue workers and scheduled tasks. The runners and the secret guard live in `@pikku/core`; the scaffold only wires them.

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -91,6 +91,7 @@ import {
   enableWorkflow,
   enableEvents,
   enableRemoteRpc,
+  enableRemoteJobs,
   enableWebhook,
 } from './functions/commands/enable.js'
 import { pikkuRealtime } from './functions/wirings/realtime/pikku-command-realtime.js'
@@ -951,6 +952,11 @@ wireCLI({
           func: enableWebhook,
           description:
             'Enable the outgoing webhook delivery queue worker (scaffolds webhook.gen.ts)',
+        }),
+        'remote-jobs': pikkuCLICommand({
+          func: enableRemoteJobs,
+          description:
+            'Enable the remote job inbox routes for queue and scheduled work (scaffolds remote-jobs.gen.ts)',
         }),
       },
     },

--- a/packages/cli/src/functions/commands/enable.ts
+++ b/packages/cli/src/functions/commands/enable.ts
@@ -11,6 +11,7 @@ type SurfaceFeature =
   | 'workflow'
   | 'events'
   | 'remoteRpc'
+  | 'remoteJobs'
 
 type WorkerFeature = 'webhook'
 
@@ -76,6 +77,11 @@ export const enableEvents = pikkuVoidFunc({
 export const enableRemoteRpc = pikkuVoidFunc({
   func: async ({ logger, config }) =>
     enableFeature('remoteRpc', logger, config),
+})
+
+export const enableRemoteJobs = pikkuVoidFunc({
+  func: async ({ logger, config }) =>
+    enableFeature('remoteJobs', logger, config),
 })
 
 export const enableWebhook = pikkuVoidFunc({

--- a/packages/cli/src/functions/wirings/remote-jobs/pikku-command-remote-jobs.ts
+++ b/packages/cli/src/functions/wirings/remote-jobs/pikku-command-remote-jobs.ts
@@ -1,0 +1,32 @@
+import { pikkuSessionlessFunc } from '#pikku/function'
+import { getLeafImportPath } from '../../../utils/leaf-import-path.js'
+import { writeFileInDir } from '../../../utils/file-writer.js'
+import { logCommandInfoAndTime } from '../../../middleware/log-command-info-and-time.js'
+import { removeLegacyScaffoldFile } from '../../../utils/remove-legacy-scaffold-file.js'
+import { serializeRemoteJobs } from './serialize-remote-jobs.js'
+import { isDeployCodegen } from '../../../utils/is-deploy-codegen.js'
+
+export const pikkuRemoteJobs = pikkuSessionlessFunc<void, boolean>({
+  func: async ({ logger, config, variables }) => {
+    if (await isDeployCodegen(variables)) {
+      return false
+    }
+
+    if (config.remoteJobsFile && config.remoteJobsSchemasFile) {
+      const leaf = (name: string) =>
+        getLeafImportPath(config.remoteJobsFile!, name, config)
+      const { schemas, functions } = serializeRemoteJobs(leaf)
+      await writeFileInDir(logger, config.remoteJobsSchemasFile, schemas)
+      await writeFileInDir(logger, config.remoteJobsFile, functions)
+      await removeLegacyScaffoldFile(config.remoteJobsFile)
+      return true
+    }
+    return false
+  },
+  middleware: [
+    logCommandInfoAndTime({
+      commandStart: 'Generating Remote Jobs',
+      commandEnd: 'Generated Remote Jobs',
+    }),
+  ],
+})

--- a/packages/cli/src/functions/wirings/remote-jobs/pikku-command-remote-jobs.ts
+++ b/packages/cli/src/functions/wirings/remote-jobs/pikku-command-remote-jobs.ts
@@ -3,6 +3,7 @@ import { getLeafImportPath } from '../../../utils/leaf-import-path.js'
 import { writeFileInDir } from '../../../utils/file-writer.js'
 import { logCommandInfoAndTime } from '../../../middleware/log-command-info-and-time.js'
 import { removeLegacyScaffoldFile } from '../../../utils/remove-legacy-scaffold-file.js'
+import { remoteJobsSchemasFile } from '../../../utils/remote-jobs-schemas-file.js'
 import { serializeRemoteJobs } from './serialize-remote-jobs.js'
 import { isDeployCodegen } from '../../../utils/is-deploy-codegen.js'
 
@@ -12,11 +13,12 @@ export const pikkuRemoteJobs = pikkuSessionlessFunc<void, boolean>({
       return false
     }
 
-    if (config.remoteJobsFile && config.remoteJobsSchemasFile) {
+    const schemasFile = remoteJobsSchemasFile(config.remoteJobsFile)
+    if (config.remoteJobsFile && schemasFile) {
       const leaf = (name: string) =>
         getLeafImportPath(config.remoteJobsFile!, name, config)
       const { schemas, functions } = serializeRemoteJobs(leaf)
-      await writeFileInDir(logger, config.remoteJobsSchemasFile, schemas)
+      await writeFileInDir(logger, schemasFile, schemas)
       await writeFileInDir(logger, config.remoteJobsFile, functions)
       await removeLegacyScaffoldFile(config.remoteJobsFile)
       return true

--- a/packages/cli/src/functions/wirings/remote-jobs/serialize-remote-jobs.test.ts
+++ b/packages/cli/src/functions/wirings/remote-jobs/serialize-remote-jobs.test.ts
@@ -1,0 +1,80 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import { serializeRemoteJobs } from './serialize-remote-jobs.js'
+
+const leaf = (name: string) => `./${name}/index.js`
+
+describe('serializeRemoteJobs', () => {
+  test('wires both inbox routes on the paths a dispatcher already posts to', () => {
+    const { functions } = serializeRemoteJobs(leaf)
+    assert.ok(functions.includes("route: '/__pikku/queue-job'"))
+    assert.ok(functions.includes("route: '/__pikku/scheduler-job'"))
+    assert.ok(functions.includes('runQueueJob'))
+    assert.ok(functions.includes('runScheduledTask'))
+  })
+
+  test('guards both routes with the dispatch secret', () => {
+    const { functions } = serializeRemoteJobs(leaf)
+    assert.equal(
+      functions.split('middleware: [remoteJobsSecretMiddleware]').length - 1,
+      2,
+      'both routes carry the guard'
+    )
+    assert.ok(functions.includes("variables?.get?.('PIKKU_DISPATCH_SECRET')"))
+    assert.ok(functions.includes("http?.request?.header?.('x-pikku-dispatch')"))
+  })
+
+  test('rejects when no secret is configured', () => {
+    const { functions } = serializeRemoteJobs(leaf)
+    assert.ok(
+      functions.includes(
+        "if (!expected || typeof provided !== 'string' || !safeEqual(provided, expected))"
+      ),
+      'an unset secret must reject rather than open the inbox'
+    )
+  })
+
+  test('separates a permanent failure from one worth redelivering', () => {
+    const { functions } = serializeRemoteJobs(leaf)
+    assert.ok(functions.includes('PikkuMissingMetaError'))
+    assert.ok(functions.includes('QueueJobDiscardedError'))
+    assert.ok(functions.includes('ScheduledTaskNotFoundError'))
+    assert.equal(
+      functions.split('throw new BadRequestError').length - 1,
+      2,
+      'each route acks its own permanent failure'
+    )
+  })
+
+  test('imports each wiring helper from its own leaf', () => {
+    const { functions } = serializeRemoteJobs(leaf)
+    assert.ok(
+      functions.includes(
+        "import { pikkuSessionlessFunc, type SingletonServices } from './function/index.js'"
+      )
+    )
+    assert.ok(functions.includes("import { wireHTTP } from './http/index.js'"))
+    assert.ok(
+      functions.includes(
+        "import { pikkuMiddleware } from './middleware/index.js'"
+      )
+    )
+  })
+
+  test('describes both payloads with zod schemas from the sibling module', () => {
+    const { schemas, functions } = serializeRemoteJobs(leaf)
+    assert.ok(schemas.includes("import { z } from 'zod'"))
+    assert.ok(schemas.includes('export const RemoteQueueJob = z.object({'))
+    assert.ok(schemas.includes('export const RemoteScheduledJob = z.object({'))
+    assert.ok(functions.includes('input: RemoteQueueJob'))
+    assert.ok(functions.includes('input: RemoteScheduledJob'))
+    assert.ok(functions.includes("from './remote-jobs.schemas.gen.js'"))
+    assert.ok(!functions.includes('pikkuSessionlessFunc<'))
+  })
+
+  test('keeps the schemas module free of anything but zod', () => {
+    const { schemas } = serializeRemoteJobs(leaf)
+    assert.ok(!schemas.includes('pikku-types.gen.js'))
+    assert.ok(!schemas.includes('@pikku/core'))
+  })
+})

--- a/packages/cli/src/functions/wirings/remote-jobs/serialize-remote-jobs.test.ts
+++ b/packages/cli/src/functions/wirings/remote-jobs/serialize-remote-jobs.test.ts
@@ -9,56 +9,46 @@ describe('serializeRemoteJobs', () => {
     const { functions } = serializeRemoteJobs(leaf)
     assert.ok(functions.includes("route: '/__pikku/queue-job'"))
     assert.ok(functions.includes("route: '/__pikku/scheduler-job'"))
-    assert.ok(functions.includes('runQueueJob'))
-    assert.ok(functions.includes('runScheduledTask'))
+    assert.ok(functions.includes("tags: ['pikku']"))
   })
 
-  test('guards both routes with the dispatch secret', () => {
-    const { functions } = serializeRemoteJobs(leaf)
-    assert.equal(
-      functions.split('middleware: [remoteJobsSecretMiddleware]').length - 1,
-      2,
-      'both routes carry the guard'
-    )
-    assert.ok(functions.includes("variables?.get?.('PIKKU_DISPATCH_SECRET')"))
-    assert.ok(functions.includes("http?.request?.header?.('x-pikku-dispatch')"))
-  })
-
-  test('rejects when no secret is configured', () => {
+  test('spells the routes out so the inspector can read them', () => {
     const { functions } = serializeRemoteJobs(leaf)
     assert.ok(
-      functions.includes(
-        "if (!expected || typeof provided !== 'string' || !safeEqual(provided, expected))"
-      ),
-      'an unset secret must reject rather than open the inbox'
+      !functions.includes('REMOTE_QUEUE_JOB_PATH'),
+      'a constant would leave the HTTP map without a route'
     )
   })
 
-  test('separates a permanent failure from one worth redelivering', () => {
+  test('delegates the work to core rather than generating it', () => {
     const { functions } = serializeRemoteJobs(leaf)
-    assert.ok(functions.includes('PikkuMissingMetaError'))
-    assert.ok(functions.includes('QueueJobDiscardedError'))
-    assert.ok(functions.includes('ScheduledTaskNotFoundError'))
+    assert.ok(functions.includes('pikkuRemoteQueueJobFunc'))
+    assert.ok(functions.includes('pikkuRemoteScheduledJobFunc'))
+    assert.ok(functions.includes("from '@pikku/core/services'"))
+    assert.ok(
+      !functions.includes('runQueueJob') && !functions.includes('runScheduledTask'),
+      'the runners belong to core, not to generated source'
+    )
+  })
+
+  test('guards both routes with the middleware core exports', () => {
+    const { functions } = serializeRemoteJobs(leaf)
+    assert.ok(
+      functions.includes("import { remoteJobsSecret } from '@pikku/core/middleware'")
+    )
     assert.equal(
-      functions.split('throw new BadRequestError').length - 1,
+      functions.split('middleware: [remoteJobsSecret]').length - 1,
       2,
-      'each route acks its own permanent failure'
+      'both routes carry the guard'
     )
   })
 
   test('imports each wiring helper from its own leaf', () => {
     const { functions } = serializeRemoteJobs(leaf)
     assert.ok(
-      functions.includes(
-        "import { pikkuSessionlessFunc, type SingletonServices } from './function/index.js'"
-      )
+      functions.includes("import { pikkuSessionlessFunc } from './function/index.js'")
     )
     assert.ok(functions.includes("import { wireHTTP } from './http/index.js'"))
-    assert.ok(
-      functions.includes(
-        "import { pikkuMiddleware } from './middleware/index.js'"
-      )
-    )
   })
 
   test('describes both payloads with zod schemas from the sibling module', () => {

--- a/packages/cli/src/functions/wirings/remote-jobs/serialize-remote-jobs.test.ts
+++ b/packages/cli/src/functions/wirings/remote-jobs/serialize-remote-jobs.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert'
 import { serializeRemoteJobs } from './serialize-remote-jobs.js'
+import { remoteJobsSchemasFile } from '../../../utils/remote-jobs-schemas-file.js'
 
 const leaf = (name: string) => `./${name}/index.js`
 
@@ -60,6 +61,22 @@ describe('serializeRemoteJobs', () => {
     assert.ok(functions.includes('input: RemoteScheduledJob'))
     assert.ok(functions.includes("from './remote-jobs.schemas.gen.js'"))
     assert.ok(!functions.includes('pikkuSessionlessFunc<'))
+  })
+
+  test('imports the schemas by the name the command writes them under', () => {
+    const { functions } = serializeRemoteJobs(leaf)
+    const written = remoteJobsSchemasFile('/app/.pikku/remote-jobs/remote-jobs.gen.ts')
+    assert.ok(
+      functions.includes(`from './${written!.split('/').pop()!.replace('.ts', '.js')}'`)
+    )
+  })
+
+  test('follows the routes file wherever a path override moves it', () => {
+    assert.equal(
+      remoteJobsSchemasFile('/app/generated/jobs/remote-jobs.gen.ts'),
+      '/app/generated/jobs/remote-jobs.schemas.gen.ts'
+    )
+    assert.equal(remoteJobsSchemasFile(undefined), undefined)
   })
 
   test('keeps the schemas module free of anything but zod', () => {

--- a/packages/cli/src/functions/wirings/remote-jobs/serialize-remote-jobs.ts
+++ b/packages/cli/src/functions/wirings/remote-jobs/serialize-remote-jobs.ts
@@ -1,0 +1,163 @@
+export interface RemoteJobsGenOutput {
+  schemas: string
+  functions: string
+}
+
+/**
+ * Generate the remote-jobs inbox: the HTTP routes an external dispatcher posts
+ * to so a runtime that holds neither a queue consumer nor a clock still runs
+ * its queue workers and scheduled tasks.
+ *
+ * Ordinary `wireHTTP` routes rather than runtime-level handlers, so every
+ * runtime serves them from one implementation, and the secret check is
+ * middleware a deployment can sit its own scheme in front of.
+ */
+export const serializeRemoteJobs = (
+  leaf: (name: string) => string
+): RemoteJobsGenOutput => {
+  const schemas = `/**
+ * Auto-generated remote job inbox schemas
+ * Do not edit manually - regenerate with 'npx pikku'
+ */
+import { z } from 'zod'
+
+export const RemoteQueueJob = z.object({
+  queueName: z.string(),
+  data: z.unknown().optional(),
+  jobId: z.string().optional(),
+  traceId: z.string().optional(),
+})
+
+export const RemoteScheduledJob = z.object({
+  taskName: z.string(),
+})
+`
+
+  const functions = `/**
+ * Auto-generated remote job inbox
+ * Do not edit manually - regenerate with 'npx pikku'
+ */
+import { pikkuSessionlessFunc, type SingletonServices } from '${leaf('function')}'
+import { pikkuMiddleware } from '${leaf('middleware')}'
+import { wireHTTP } from '${leaf('http')}'
+import { type PikkuWire } from '@pikku/core/types'
+import { runQueueJob, type QueueJob } from '@pikku/core/queue'
+import { runScheduledTask } from '@pikku/core/scheduler'
+import { BadRequestError, UnauthorizedError } from '@pikku/core/errors'
+import { RemoteQueueJob, RemoteScheduledJob } from './remote-jobs.schemas.gen.js'
+
+interface RemoteJobsWire extends PikkuWire {
+  http?: { request?: { header?: (name: string) => string | undefined | null } }
+}
+
+const safeEqual = (a: string, b: string): boolean => {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  return diff === 0
+}
+
+/**
+ * Fails closed: an unset secret rejects every caller, so the inbox is never
+ * open just because the deployment forgot to configure it.
+ */
+const remoteJobsSecretMiddleware = pikkuMiddleware(
+  async ({ variables }: SingletonServices, { http }: RemoteJobsWire, next) => {
+    const expected = variables?.get?.('PIKKU_DISPATCH_SECRET') as string | undefined
+    const provided = http?.request?.header?.('x-pikku-dispatch')
+    if (!expected || typeof provided !== 'string' || !safeEqual(provided, expected)) {
+      throw new UnauthorizedError('invalid dispatch secret')
+    }
+    return next()
+  }
+)
+
+/**
+ * A dispatched job is delivered, not owned: the sender retries, so a permanent
+ * failure has to read differently from a transient one. An unknown worker or a
+ * discarded job answers 4xx so the sender stops; anything else propagates as
+ * 5xx and is delivered again.
+ */
+const runRemoteQueueJob = pikkuSessionlessFunc({
+  auth: false,
+  input: RemoteQueueJob,
+  tags: ['pikku'],
+  description: 'Runs one queue worker for a job delivered by an external dispatcher.',
+  func: async ({ logger }, body) => {
+    const job: QueueJob = {
+      queueName: body.queueName,
+      data: body.data,
+      id: body.jobId ?? body.traceId ?? \`remote-\${Date.now()}\`,
+      status: async () => 'active',
+      metadata: () => ({
+        processedAt: new Date(),
+        attemptsMade: 0,
+        maxAttempts: undefined,
+        result: undefined,
+        progress: 0,
+        createdAt: new Date(),
+        completedAt: undefined,
+        failedAt: undefined,
+        error: undefined,
+      }),
+      waitForCompletion: async () => {
+        throw new Error('remote jobs do not support waitForCompletion')
+      },
+    }
+    try {
+      await runQueueJob({ job, traceId: body.traceId })
+    } catch (err) {
+      const name = err instanceof Error ? err.name : 'Error'
+      if (name === 'PikkuMissingMetaError' || name === 'QueueJobDiscardedError') {
+        throw new BadRequestError(err instanceof Error ? err.message : String(err))
+      }
+      logger.error(
+        \`remote-jobs: queue '\${body.queueName}' failed: \${err instanceof Error ? err.message : String(err)}\`
+      )
+      throw err
+    }
+  },
+})
+
+const runRemoteScheduledJob = pikkuSessionlessFunc({
+  auth: false,
+  input: RemoteScheduledJob,
+  tags: ['pikku'],
+  description: 'Runs one scheduled task for a tick delivered by an external scheduler.',
+  func: async ({ logger }, body) => {
+    try {
+      await runScheduledTask({ name: body.taskName, traceId: \`cron-\${body.taskName}\` })
+    } catch (err) {
+      const name = err instanceof Error ? err.name : 'Error'
+      if (name === 'ScheduledTaskNotFoundError') {
+        throw new BadRequestError(err instanceof Error ? err.message : String(err))
+      }
+      logger.error(
+        \`remote-jobs: task '\${body.taskName}' failed: \${err instanceof Error ? err.message : String(err)}\`
+      )
+      throw err
+    }
+  },
+})
+
+wireHTTP({
+  method: 'post',
+  route: '/__pikku/queue-job',
+  auth: false,
+  tags: ['pikku'],
+  func: runRemoteQueueJob,
+  middleware: [remoteJobsSecretMiddleware],
+})
+
+wireHTTP({
+  method: 'post',
+  route: '/__pikku/scheduler-job',
+  auth: false,
+  tags: ['pikku'],
+  func: runRemoteScheduledJob,
+  middleware: [remoteJobsSecretMiddleware],
+})
+`
+
+  return { schemas, functions }
+}

--- a/packages/cli/src/functions/wirings/remote-jobs/serialize-remote-jobs.ts
+++ b/packages/cli/src/functions/wirings/remote-jobs/serialize-remote-jobs.ts
@@ -10,7 +10,9 @@ export interface RemoteJobsGenOutput {
  *
  * Ordinary `wireHTTP` routes rather than runtime-level handlers, so every
  * runtime serves them from one implementation, and the secret check is
- * middleware a deployment can sit its own scheme in front of.
+ * middleware a deployment can sit its own scheme in front of. The routes are
+ * literals rather than the constants core exports, because the inspector reads
+ * them statically to build the HTTP map.
  */
 export const serializeRemoteJobs = (
   leaf: (name: string) => string
@@ -37,86 +39,21 @@ export const RemoteScheduledJob = z.object({
  * Auto-generated remote job inbox
  * Do not edit manually - regenerate with 'npx pikku'
  */
-import { pikkuSessionlessFunc, type SingletonServices } from '${leaf('function')}'
-import { pikkuMiddleware } from '${leaf('middleware')}'
+import { pikkuSessionlessFunc } from '${leaf('function')}'
 import { wireHTTP } from '${leaf('http')}'
-import { type PikkuWire } from '@pikku/core/types'
-import { runQueueJob, type QueueJob } from '@pikku/core/queue'
-import { runScheduledTask } from '@pikku/core/scheduler'
-import { BadRequestError, UnauthorizedError } from '@pikku/core/errors'
+import {
+  pikkuRemoteQueueJobFunc,
+  pikkuRemoteScheduledJobFunc,
+} from '@pikku/core/services'
+import { remoteJobsSecret } from '@pikku/core/middleware'
 import { RemoteQueueJob, RemoteScheduledJob } from './remote-jobs.schemas.gen.js'
 
-interface RemoteJobsWire extends PikkuWire {
-  http?: { request?: { header?: (name: string) => string | undefined | null } }
-}
-
-const safeEqual = (a: string, b: string): boolean => {
-  if (a.length !== b.length) return false
-  let diff = 0
-  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
-  return diff === 0
-}
-
-/**
- * Fails closed: an unset secret rejects every caller, so the inbox is never
- * open just because the deployment forgot to configure it.
- */
-const remoteJobsSecretMiddleware = pikkuMiddleware(
-  async ({ variables }: SingletonServices, { http }: RemoteJobsWire, next) => {
-    const expected = variables?.get?.('PIKKU_DISPATCH_SECRET') as string | undefined
-    const provided = http?.request?.header?.('x-pikku-dispatch')
-    if (!expected || typeof provided !== 'string' || !safeEqual(provided, expected)) {
-      throw new UnauthorizedError('invalid dispatch secret')
-    }
-    return next()
-  }
-)
-
-/**
- * A dispatched job is delivered, not owned: the sender retries, so a permanent
- * failure has to read differently from a transient one. An unknown worker or a
- * discarded job answers 4xx so the sender stops; anything else propagates as
- * 5xx and is delivered again.
- */
 const runRemoteQueueJob = pikkuSessionlessFunc({
   auth: false,
   input: RemoteQueueJob,
   tags: ['pikku'],
   description: 'Runs one queue worker for a job delivered by an external dispatcher.',
-  func: async ({ logger }, body) => {
-    const job: QueueJob = {
-      queueName: body.queueName,
-      data: body.data,
-      id: body.jobId ?? body.traceId ?? \`remote-\${Date.now()}\`,
-      status: async () => 'active',
-      metadata: () => ({
-        processedAt: new Date(),
-        attemptsMade: 0,
-        maxAttempts: undefined,
-        result: undefined,
-        progress: 0,
-        createdAt: new Date(),
-        completedAt: undefined,
-        failedAt: undefined,
-        error: undefined,
-      }),
-      waitForCompletion: async () => {
-        throw new Error('remote jobs do not support waitForCompletion')
-      },
-    }
-    try {
-      await runQueueJob({ job, traceId: body.traceId })
-    } catch (err) {
-      const name = err instanceof Error ? err.name : 'Error'
-      if (name === 'PikkuMissingMetaError' || name === 'QueueJobDiscardedError') {
-        throw new BadRequestError(err instanceof Error ? err.message : String(err))
-      }
-      logger.error(
-        \`remote-jobs: queue '\${body.queueName}' failed: \${err instanceof Error ? err.message : String(err)}\`
-      )
-      throw err
-    }
-  },
+  func: async ({ logger }, data) => pikkuRemoteQueueJobFunc({ logger }, data),
 })
 
 const runRemoteScheduledJob = pikkuSessionlessFunc({
@@ -124,20 +61,7 @@ const runRemoteScheduledJob = pikkuSessionlessFunc({
   input: RemoteScheduledJob,
   tags: ['pikku'],
   description: 'Runs one scheduled task for a tick delivered by an external scheduler.',
-  func: async ({ logger }, body) => {
-    try {
-      await runScheduledTask({ name: body.taskName, traceId: \`cron-\${body.taskName}\` })
-    } catch (err) {
-      const name = err instanceof Error ? err.name : 'Error'
-      if (name === 'ScheduledTaskNotFoundError') {
-        throw new BadRequestError(err instanceof Error ? err.message : String(err))
-      }
-      logger.error(
-        \`remote-jobs: task '\${body.taskName}' failed: \${err instanceof Error ? err.message : String(err)}\`
-      )
-      throw err
-    }
-  },
+  func: async ({ logger }, data) => pikkuRemoteScheduledJobFunc({ logger }, data),
 })
 
 wireHTTP({
@@ -146,7 +70,7 @@ wireHTTP({
   auth: false,
   tags: ['pikku'],
   func: runRemoteQueueJob,
-  middleware: [remoteJobsSecretMiddleware],
+  middleware: [remoteJobsSecret],
 })
 
 wireHTTP({
@@ -155,7 +79,7 @@ wireHTTP({
   auth: false,
   tags: ['pikku'],
   func: runRemoteScheduledJob,
-  middleware: [remoteJobsSecretMiddleware],
+  middleware: [remoteJobsSecret],
 })
 `
 

--- a/packages/cli/src/functions/workflows/all.workflow.ts
+++ b/packages/cli/src/functions/workflows/all.workflow.ts
@@ -347,10 +347,12 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
 
     let remoteRPC = false
     let webhook = false
+    let remoteJobs = false
     let workflowRoutes = false
     if (!config.addon) {
       remoteRPC = await workflow.do('Remote RPC', 'pikkuRemoteRPC', null)
       webhook = await workflow.do('Webhook', 'pikkuWebhook', null)
+      remoteJobs = await workflow.do('Remote jobs', 'pikkuRemoteJobs', null)
       if (workflows) {
         workflowRoutes = await workflow.do(
           'Workflow routes',
@@ -379,6 +381,7 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
       workflows ||
       remoteRPC ||
       webhook ||
+      remoteJobs ||
       workflowRoutes ||
       unresolvedSchemas
     ) {

--- a/packages/cli/src/services.ts
+++ b/packages/cli/src/services.ts
@@ -328,6 +328,7 @@ export const createSingletonServices: CreateSingletonServices<
         config.consoleFunctionsFile,
         config.remoteRpcWorkersFile,
         config.webhookWorkersFile,
+        config.remoteJobsFile,
         config.workflowRoutesFile,
         config.publicRpcFile,
         config.publicAgentFile,

--- a/packages/cli/src/utils/pikku-cli-config.ts
+++ b/packages/cli/src/utils/pikku-cli-config.ts
@@ -613,15 +613,6 @@ const _getPikkuCLIConfig = async (
         'remote-jobs.gen.ts'
       )
     }
-    if (result.scaffold?.remoteJobs && !result.remoteJobsSchemasFile) {
-      // Derived from the routes file rather than the scaffold dir: the routes
-      // import the schemas as a sibling, so a `path` override that moved one
-      // without the other would generate an import of a file nothing writes.
-      result.remoteJobsSchemasFile = join(
-        dirname(result.remoteJobsFile!),
-        'remote-jobs.schemas.gen.ts'
-      )
-    }
     if (result.scaffold?.workflow && !result.workflowRoutesFile) {
       result.workflowRoutesFile = join(
         resolvedScaffoldDir,

--- a/packages/cli/src/utils/pikku-cli-config.ts
+++ b/packages/cli/src/utils/pikku-cli-config.ts
@@ -555,6 +555,7 @@ const _getPikkuCLIConfig = async (
       workflow: 'workflowRoutesFile',
       events: 'eventsChannelFile',
       remoteRpc: 'remoteRpcWorkersFile',
+      remoteJobs: 'remoteJobsFile',
     }
     const scaffoldBlock = result.scaffold as
       Record<string, PikkuScaffoldFeature> | undefined
@@ -603,6 +604,22 @@ const _getPikkuCLIConfig = async (
         resolvedScaffoldDir,
         'webhook',
         'webhook.schemas.gen.ts'
+      )
+    }
+    if (result.scaffold?.remoteJobs && !result.remoteJobsFile) {
+      result.remoteJobsFile = join(
+        resolvedScaffoldDir,
+        'remote-jobs',
+        'remote-jobs.gen.ts'
+      )
+    }
+    if (result.scaffold?.remoteJobs && !result.remoteJobsSchemasFile) {
+      // Derived from the routes file rather than the scaffold dir: the routes
+      // import the schemas as a sibling, so a `path` override that moved one
+      // without the other would generate an import of a file nothing writes.
+      result.remoteJobsSchemasFile = join(
+        dirname(result.remoteJobsFile!),
+        'remote-jobs.schemas.gen.ts'
       )
     }
     if (result.scaffold?.workflow && !result.workflowRoutesFile) {

--- a/packages/cli/src/utils/remote-jobs-schemas-file.ts
+++ b/packages/cli/src/utils/remote-jobs-schemas-file.ts
@@ -1,0 +1,13 @@
+import { dirname, join } from 'node:path'
+
+/**
+ * The schemas module always sits beside the routes that import it, so there is
+ * nothing to configure: a settable path could be moved out from under the
+ * generated `./remote-jobs.schemas.gen.js` import and nothing would write it.
+ */
+export const remoteJobsSchemasFile = (
+  remoteJobsFile: string | undefined
+): string | undefined =>
+  remoteJobsFile
+    ? join(dirname(remoteJobsFile), 'remote-jobs.schemas.gen.ts')
+    : undefined

--- a/packages/cli/src/utils/remove-legacy-scaffold-file.ts
+++ b/packages/cli/src/utils/remove-legacy-scaffold-file.ts
@@ -15,6 +15,8 @@ const scaffoldFiles = (config: PikkuCLIConfig): (string | undefined)[] => {
     config.publicRpcSchemasFile,
     config.remoteRpcWorkersFile,
     config.remoteRpcSchemasFile,
+    config.remoteJobsFile,
+    config.remoteJobsSchemasFile,
     config.publicAgentFile,
     config.publicAgentSchemasFile,
     config.consoleFunctionsFile,

--- a/packages/cli/src/utils/remove-legacy-scaffold-file.ts
+++ b/packages/cli/src/utils/remove-legacy-scaffold-file.ts
@@ -2,6 +2,7 @@ import { rm } from 'node:fs/promises'
 import { existsSync, readFileSync } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
 import type { PikkuCLIConfig } from '../../types/config.js'
+import { remoteJobsSchemasFile } from './remote-jobs-schemas-file.js'
 
 const scaffoldFiles = (config: PikkuCLIConfig): (string | undefined)[] => {
   const authDir = config.authFile ? dirname(config.authFile) : undefined
@@ -16,7 +17,7 @@ const scaffoldFiles = (config: PikkuCLIConfig): (string | undefined)[] => {
     config.remoteRpcWorkersFile,
     config.remoteRpcSchemasFile,
     config.remoteJobsFile,
-    config.remoteJobsSchemasFile,
+    remoteJobsSchemasFile(config.remoteJobsFile),
     config.publicAgentFile,
     config.publicAgentSchemasFile,
     config.consoleFunctionsFile,

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -85,6 +85,11 @@ export interface PikkuCLICoreOutputFiles {
   webhookWorkersFile?: string
   webhookSchemasFile?: string
 
+  // Remote job inbox routes (derived from scaffold.pikkuDir when scaffold.remoteJobs is enabled).
+  // Optional: left undefined when scaffold.remoteJobs is not enabled, so consumers must guard.
+  remoteJobsFile?: string
+  remoteJobsSchemasFile?: string
+
   // Feature-generated files (derived from scaffold.pikkuDir when enabled)
   publicRpcFile: string
   publicRpcSchemasFile?: string
@@ -614,6 +619,13 @@ export type PikkuCLIInput = {
     workflow?: PikkuScaffoldFeature
     events?: PikkuScaffoldFeature
     remoteRpc?: PikkuScaffoldFeature
+    /**
+     * HTTP routes an external dispatcher posts to so a runtime that holds
+     * neither a queue consumer nor a clock still runs its queue workers and
+     * scheduled tasks. Guarded by `PIKKU_DISPATCH_SECRET`, which must be set
+     * for the routes to serve anyone at all.
+     */
+    remoteJobs?: PikkuScaffoldFeature
     /**
      * The outgoing webhook delivery worker exposes no endpoint of its own and
      * has no output path to override — it is on or off.

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -88,7 +88,6 @@ export interface PikkuCLICoreOutputFiles {
   // Remote job inbox routes (derived from scaffold.pikkuDir when scaffold.remoteJobs is enabled).
   // Optional: left undefined when scaffold.remoteJobs is not enabled, so consumers must guard.
   remoteJobsFile?: string
-  remoteJobsSchemasFile?: string
 
   // Feature-generated files (derived from scaffold.pikkuDir when enabled)
   publicRpcFile: string

--- a/packages/core/api-report.md
+++ b/packages/core/api-report.md
@@ -5,8 +5,8 @@ signature, so a member-level change is a reviewable diff. Do not edit.
 
 ## What a compatibility promise covers
 
-**2878 observable things**: 913 exported names, plus
-1965 members on the classes and interfaces among them, reachable
+**2894 observable things**: 923 exported names, plus
+1971 members on the classes and interfaces among them, reachable
 through 53 entry points.
 
 An entry point whose exports are mostly *exclusive* is a self-contained
@@ -14,7 +14,7 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 
 | entry point | exports | exclusive | members on those |
 | --- | ---: | ---: | ---: |
-| `./services` | 148 | 116 | 419 |
+| `./services` | 156 | 124 | 424 |
 | `./virtual-user` | 66 | 66 | 212 |
 | `./scenario` | 45 | 45 | 134 |
 | `./workflow` | 84 | 35 | 140 |
@@ -32,8 +32,8 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | `./classification` | 22 | 22 | 14 |
 | `./agent-scorer` | 18 | 18 | 12 |
 | `./actor-flow` | 6 | 6 | 22 |
+| `./middleware` | 27 | 25 | 0 |
 | `./gateway` | 11 | 11 | 14 |
-| `./middleware` | 26 | 24 | 0 |
 | `./crypto-utils` | 20 | 20 | 2 |
 | `./utils` | 21 | 20 | 2 |
 | `./channel/local` | 3 | 3 | 18 |
@@ -49,11 +49,11 @@ subsystem rather than shared machinery — which tends to mean a newer one.
 | `./addon` | 8 | 8 | 2 |
 | `./safe-fetch` | 6 | 6 | 3 |
 | `./role` | 9 | 9 | 0 |
+| `./scheduler` | 7 | 7 | 1 |
 | `./state` | 9 | 8 | 0 |
 | `./channel/serverless` | 4 | 4 | 3 |
 | `./cli/command-parser` | 3 | 1 | 6 |
 | `./secret` | 7 | 7 | 0 |
-| `./scheduler` | 6 | 6 | 0 |
 | `./variable` | 6 | 6 | 0 |
 | `./schema` | 6 | 6 | 0 |
 | `./dev` | 4 | 4 | 2 |
@@ -478,6 +478,7 @@ pikkuChannelMiddlewareFactory: <In = any>(factory: CorePikkuChannelMiddlewareFac
 pikkuMiddleware: <SingletonServices extends CoreSingletonServices = CoreSingletonServices<{ logLevel?: LogLevel | undefined; secrets?: { requireAllowedHosts?: boolean | undefined; } | undefined; workflow?: WorkflowServiceConfig | undefined; webhook?: WebhookServiceConfig | undefined; postgres?: PostgresConfig | undefined; }>, UserSession extends CoreUserSession = CoreUserSession>(middleware: CorePikkuMiddleware<SingletonServices, UserSession> | CorePikkuMiddlewareConfig<SingletonServices, UserSession>) => CorePikkuMiddleware<SingletonServices, UserSession>
 pikkuMiddlewareFactory: <In = any>(factory: CorePikkuMiddlewareFactory<In>) => CorePikkuMiddlewareFactory<In>
 pikkuRemoteAuthMiddleware: CorePikkuMiddleware<CoreSingletonServices<{ logLevel?: LogLevel | undefined; secrets?: { requireAllowedHosts?: boolean | undefined; } | undefined; workflow?: WorkflowServiceConfig | undefined; webhook?: WebhookServiceConfig | undefined; postgres?: PostgresConfig | undefined; }>, CoreUserSession>
+remoteJobsSecret: CorePikkuMiddleware<CoreSingletonServices<{ logLevel?: LogLevel | undefined; secrets?: { requireAllowedHosts?: boolean | undefined; } | undefined; workflow?: WorkflowServiceConfig | undefined; webhook?: WebhookServiceConfig | undefined; postgres?: PostgresConfig | undefined; }>, CoreUserSession>
 requireOrigin: CorePikkuMiddlewareFactory<{ origins?: string[] | ((services: CoreSingletonServices<{ logLevel?: LogLevel | undefined; secrets?: { requireAllowedHosts?: boolean | undefined; } | undefined; workflow?: WorkflowServiceConfig | undefined; webhook?: WebhookServiceConfig | undefined; postgres?: PostgresConfig | undefined; }>) => string[] | Promise<string[]>) | undefined; }>
 runMiddleware: <Middleware extends CorePikkuMiddleware<any, any>>(services: Parameters<Middleware>[0], wire: Parameters<Middleware>[1], middlewares: readonly Middleware[], main?: (() => Promise<unknown>) | undefined) => Promise<unknown>
 telemetryInner: CorePikkuMiddlewareFactory<void | { environmentId?: string | undefined; orgId?: string | undefined; }>
@@ -2823,6 +2824,9 @@ export type CoreScheduledTask<
 getScheduledTasks: () => Map<string, CoreScheduledTask>
 logSchedulers: (logger: Logger) => void
 runScheduledTask: ({ name, session, traceId, }: RunScheduledTasksParams) => Promise<void>
+export class ScheduledTaskNotFoundError extends PikkuError {
+  constructor(title: string)
+}
 export type ScheduledTasksMeta<UserSession extends CoreUserSession = any> =
   Record<
     string,
@@ -4816,6 +4820,8 @@ export class PikkuCredentialWireService {
   getAll(): Record<string, unknown> | Promise<Record<string, unknown>>
   getScoped(allowedNames: string[]): Record<string, unknown> | Promise<Record<string, unknown>>
 }
+pikkuRemoteQueueJobFunc: ({ logger }: { logger: Logger; }, { queueName, data, jobId, traceId }: RemoteQueueJobData) => Promise<void>
+pikkuRemoteScheduledJobFunc: ({ logger }: { logger: Logger; }, { taskName }: RemoteScheduledJobData) => Promise<void>
 export class PikkuSessionService< UserSession extends CoreUserSession, > implements SessionService<UserSession> {
   public sessionChanged: boolean
   public initial: UserSession | undefined
@@ -4834,6 +4840,19 @@ export class QueueWebhookService extends WebhookService {
   constructor(protected queueService: QueueService)
   public async send(input: SendWebhookInput): Promise<SendWebhookResult>
   protected async prepareDelivery(input: SendWebhookInput): Promise<{ jobData: WebhookJobData; options: JobOptions }>
+}
+REMOTE_JOBS_SECRET_HEADER: "x-pikku-dispatch"
+REMOTE_JOBS_SECRET_VARIABLE: "PIKKU_DISPATCH_SECRET"
+REMOTE_QUEUE_JOB_PATH: "/__pikku/queue-job"
+REMOTE_SCHEDULER_JOB_PATH: "/__pikku/scheduler-job"
+export interface RemoteQueueJobData {
+  queueName: string
+  data?: unknown
+  jobId?: string
+  traceId?: string
+}
+export interface RemoteScheduledJobData {
+  taskName: string
 }
 export interface RenderedEmailResult {
   locale: string

--- a/packages/core/src/middleware/index.ts
+++ b/packages/core/src/middleware/index.ts
@@ -1,6 +1,7 @@
 export { authAPIKey } from './auth-apikey.js'
 export { authCookie } from './auth-cookie.js'
 export { authBearer } from './auth-bearer.js'
+export { remoteJobsSecret } from './remote-jobs-secret.js'
 export { pikkuRemoteAuthMiddleware } from './remote-auth.js'
 export { cors } from './cors.js'
 export { requireOrigin, isAllowedOrigin, toOrigin } from './require-origin.js'

--- a/packages/core/src/middleware/remote-jobs-secret.ts
+++ b/packages/core/src/middleware/remote-jobs-secret.ts
@@ -1,0 +1,35 @@
+import { UnauthorizedError } from '../errors/errors.js'
+import {
+  REMOTE_JOBS_SECRET_HEADER,
+  REMOTE_JOBS_SECRET_VARIABLE,
+} from '../services/remote-jobs.js'
+import { pikkuMiddleware } from './middleware-factories.js'
+
+const constantTimeEqual = (a: string, b: string): boolean => {
+  if (a.length !== b.length) return false
+  let result = 0
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return result === 0
+}
+
+/**
+ * Guards the remote job inbox. Fails closed: an unset secret rejects every
+ * caller, so the routes are never open just because the deployment forgot to
+ * configure one.
+ */
+export const remoteJobsSecret = pikkuMiddleware(
+  async ({ variables }, { http }, next) => {
+    const expected = await variables.get(REMOTE_JOBS_SECRET_VARIABLE)
+    const provided = http?.request?.header(REMOTE_JOBS_SECRET_HEADER)
+    if (
+      !expected ||
+      typeof provided !== 'string' ||
+      !constantTimeEqual(provided, expected)
+    ) {
+      throw new UnauthorizedError('invalid dispatch secret')
+    }
+    return next()
+  }
+)

--- a/packages/core/src/public-surface.json
+++ b/packages/core/src/public-surface.json
@@ -16,6 +16,7 @@
     "pikkuMiddleware",
     "pikkuMiddlewareFactory",
     "pikkuRemoteAuthMiddleware",
+    "remoteJobsSecret",
     "requireOrigin",
     "runMiddleware",
     "telemetryInner",
@@ -98,7 +99,9 @@
     "reconstructStateAt"
   ],
   "./workflow/types": [],
-  "./actor-flow": ["runConversation"],
+  "./actor-flow": [
+    "runConversation"
+  ],
   "./virtual-user": [
     "DEFAULT_MAX_INTERVAL_MS",
     "DEFAULT_MIN_INTERVAL_MS",
@@ -161,7 +164,9 @@
     "wireHTTP",
     "wireHTTPRoutes"
   ],
-  "./remote": ["buildRemoteHeaders"],
+  "./remote": [
+    "buildRemoteHeaders"
+  ],
   "./queue": [
     "QueueJobDiscardedError",
     "QueueJobFailedError",
@@ -171,12 +176,17 @@
     "wireQueueWorker"
   ],
   "./scheduler": [
+    "ScheduledTaskNotFoundError",
     "getScheduledTasks",
     "logSchedulers",
     "runScheduledTask",
     "wireScheduler"
   ],
-  "./trigger": ["PikkuTriggerService", "wireTrigger", "wireTriggerSource"],
+  "./trigger": [
+    "PikkuTriggerService",
+    "wireTrigger",
+    "wireTriggerSource"
+  ],
   "./rpc": [
     "PikkuRPCService",
     "RPCNotFoundError",
@@ -196,7 +206,10 @@
     "safeFetch",
     "setDefaultHostResolver"
   ],
-  "./node-host-resolver": ["installNodeHostResolver", "nodeHostResolver"],
+  "./node-host-resolver": [
+    "installNodeHostResolver",
+    "nodeHostResolver"
+  ],
   "./mcp": [
     "MCPEndpointRegistry",
     "MCPError",
@@ -265,7 +278,10 @@
     "runCLICommand",
     "wireCLI"
   ],
-  "./cli/command-parser": ["generateCommandHelp", "parseCLIArguments"],
+  "./cli/command-parser": [
+    "generateCommandHelp",
+    "parseCLIArguments"
+  ],
   "./cli/channel": [
     "executeCLIViaChannel",
     "executeRawCLIViaChannel",
@@ -318,8 +334,14 @@
     "verifyActorSecret",
     "verifyPersonaRoles"
   ],
-  "./secret": ["defineSecret", "validateAndBuildSecretDefinitionsMeta"],
-  "./variable": ["defineVariable", "validateAndBuildVariableDefinitionsMeta"],
+  "./secret": [
+    "defineSecret",
+    "validateAndBuildSecretDefinitionsMeta"
+  ],
+  "./variable": [
+    "defineVariable",
+    "validateAndBuildVariableDefinitionsMeta"
+  ],
   "./oauth2": [],
   "./errors": [
     "AIProviderAuthError",
@@ -394,6 +416,10 @@
     "PikkuCredentialWireService",
     "PikkuSessionService",
     "QueueWebhookService",
+    "REMOTE_JOBS_SECRET_HEADER",
+    "REMOTE_JOBS_SECRET_VARIABLE",
+    "REMOTE_QUEUE_JOB_PATH",
+    "REMOTE_SCHEDULER_JOB_PATH",
     "SchedulerService",
     "ScopedCredentialService",
     "ScopedSecretService",
@@ -412,6 +438,8 @@
     "deriveActorSecret",
     "getStubTracker",
     "isTestRun",
+    "pikkuRemoteQueueJobFunc",
+    "pikkuRemoteScheduledJobFunc",
     "pikkuWebhookWorkerFunc",
     "renderEmail",
     "scenarioArtifactContentType",
@@ -421,10 +449,19 @@
     "verifyActorSecret",
     "withoutSecrets"
   ],
-  "./services/local-meta": ["LocalMetaService"],
-  "./services/v8-coverage": ["V8CoverageService"],
-  "./services/istanbul-coverage": ["IstanbulCoverageService"],
-  "./services/local-content": ["LocalContent", "signedContentPath"],
+  "./services/local-meta": [
+    "LocalMetaService"
+  ],
+  "./services/v8-coverage": [
+    "V8CoverageService"
+  ],
+  "./services/istanbul-coverage": [
+    "IstanbulCoverageService"
+  ],
+  "./services/local-content": [
+    "LocalContent",
+    "signedContentPath"
+  ],
   "./services/local-content-request-handler": [
     "createLocalContentRequestHandler",
     "verifySignedContentRequest"
@@ -454,7 +491,10 @@
     "verifyWithKeyMaterial",
     "wrapDEK"
   ],
-  "./hmac": ["hmacSha256Hex", "timingSafeStringEqual"],
+  "./hmac": [
+    "hmacSha256Hex",
+    "timingSafeStringEqual"
+  ],
   "./state": [
     "addPackageServiceFactories",
     "getAllPackageStates",
@@ -501,6 +541,13 @@
     "getSchema",
     "validateSchema"
   ],
-  "./testing": ["clearPikkuRuntimeState", "defineServiceTests"],
-  "./dev": ["pikkuDevReloader", "reconcileAddonRegistry", "reloadGeneratedMeta"]
+  "./testing": [
+    "clearPikkuRuntimeState",
+    "defineServiceTests"
+  ],
+  "./dev": [
+    "pikkuDevReloader",
+    "reconcileAddonRegistry",
+    "reloadGeneratedMeta"
+  ]
 }

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -18,6 +18,16 @@ export {
   QueueWebhookService,
   pikkuWebhookWorkerFunc,
 } from './queue-webhook-service.js'
+export {
+  REMOTE_JOBS_SECRET_HEADER,
+  REMOTE_JOBS_SECRET_VARIABLE,
+  REMOTE_QUEUE_JOB_PATH,
+  REMOTE_SCHEDULER_JOB_PATH,
+  pikkuRemoteQueueJobFunc,
+  pikkuRemoteScheduledJobFunc,
+  type RemoteQueueJobData,
+  type RemoteScheduledJobData,
+} from './remote-jobs.js'
 export { InMemoryQueueService } from './in-memory-queue-service.js'
 export { InMemoryTriggerService } from './in-memory-trigger-service.js'
 export { InMemoryAgentRunStateService } from './in-memory-agent-run-state-service.js'

--- a/packages/core/src/services/remote-jobs.test.ts
+++ b/packages/core/src/services/remote-jobs.test.ts
@@ -1,0 +1,106 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { BadRequestError, UnauthorizedError } from '../errors/errors.js'
+import { resetPikkuState, setSingletonServices } from '../pikku-state.js'
+import { remoteJobsSecret } from '../middleware/remote-jobs-secret.js'
+import {
+  REMOTE_JOBS_SECRET_HEADER,
+  pikkuRemoteScheduledJobFunc,
+} from './remote-jobs.js'
+
+const silentLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as any
+
+const wire = (header?: string) =>
+  ({
+    http: { request: { header: () => header ?? null } },
+  }) as any
+
+const services = (secret?: string) =>
+  ({ variables: { get: async () => secret } }) as any
+
+describe('remoteJobsSecret', () => {
+  test('lets a caller holding the secret through', async () => {
+    let reached = false
+    await remoteJobsSecret(services('s3cret'), wire('s3cret'), async () => {
+      reached = true
+    })
+    assert.equal(reached, true)
+  })
+
+  test('rejects a caller presenting the wrong secret', async () => {
+    await assert.rejects(
+      remoteJobsSecret(services('s3cret'), wire('nope'), async () => {}),
+      UnauthorizedError
+    )
+  })
+
+  test('rejects when the deployment configured no secret at all', async () => {
+    await assert.rejects(
+      remoteJobsSecret(services(undefined), wire('anything'), async () => {}),
+      UnauthorizedError
+    )
+  })
+
+  test('rejects a caller presenting no header', async () => {
+    await assert.rejects(
+      remoteJobsSecret(services('s3cret'), wire(), async () => {}),
+      UnauthorizedError
+    )
+  })
+
+  test('reads the header the dispatchers already send', async () => {
+    const seen: string[] = []
+    await assert.rejects(
+      remoteJobsSecret(
+        services('s3cret'),
+        {
+          http: {
+            request: {
+              header: (name: string) => {
+                seen.push(name)
+                return null
+              },
+            },
+          },
+        } as any,
+        async () => {}
+      ),
+      UnauthorizedError
+    )
+    assert.deepEqual(seen, [REMOTE_JOBS_SECRET_HEADER])
+  })
+
+  test('awaits a variables service that resolves asynchronously', async () => {
+    let reached = false
+    await remoteJobsSecret(
+      {
+        variables: {
+          get: () => new Promise((resolve) => setTimeout(() => resolve('s3cret'), 1)),
+        },
+      } as any,
+      wire('s3cret'),
+      async () => {
+        reached = true
+      }
+    )
+    assert.equal(reached, true)
+  })
+})
+
+describe('pikkuRemoteScheduledJobFunc', () => {
+  test('acks a task this deployment does not have rather than asking for a retry', async () => {
+    resetPikkuState()
+    setSingletonServices({ logger: silentLogger } as any)
+    await assert.rejects(
+      pikkuRemoteScheduledJobFunc({ logger: silentLogger }, {
+        taskName: 'not-a-task',
+      }),
+      BadRequestError
+    )
+  })
+})

--- a/packages/core/src/services/remote-jobs.ts
+++ b/packages/core/src/services/remote-jobs.ts
@@ -1,0 +1,92 @@
+import { BadRequestError, PikkuMissingMetaError } from '../errors/errors.js'
+import { QueueJobDiscardedError, runQueueJob } from '../wirings/queue/queue-runner.js'
+import type { QueueJob, QueueJobStatus } from '../wirings/queue/queue.types.js'
+import {
+  ScheduledTaskNotFoundError,
+  runScheduledTask,
+} from '../wirings/scheduler/scheduler-runner.js'
+import type { Logger } from './logger.js'
+
+/** The variable holding the shared secret every remote job must present. */
+export const REMOTE_JOBS_SECRET_VARIABLE = 'PIKKU_DISPATCH_SECRET'
+
+export const REMOTE_JOBS_SECRET_HEADER = 'x-pikku-dispatch'
+
+export const REMOTE_QUEUE_JOB_PATH = '/__pikku/queue-job'
+
+export const REMOTE_SCHEDULER_JOB_PATH = '/__pikku/scheduler-job'
+
+export interface RemoteQueueJobData {
+  queueName: string
+  data?: unknown
+  jobId?: string
+  traceId?: string
+}
+
+export interface RemoteScheduledJobData {
+  taskName: string
+}
+
+/**
+ * A dispatched job is delivered, not owned: the sender retries, so a permanent
+ * failure has to read differently from a transient one. An unknown worker or a
+ * discarded job answers 4xx so the sender stops; anything else propagates and
+ * is delivered again.
+ */
+export async function pikkuRemoteQueueJobFunc(
+  { logger }: { logger: Logger },
+  { queueName, data, jobId, traceId }: RemoteQueueJobData
+): Promise<void> {
+  const job: QueueJob = {
+    queueName,
+    data,
+    id: jobId ?? traceId ?? `remote-${Date.now()}`,
+    status: async (): Promise<QueueJobStatus> => 'active',
+    metadata: () => ({
+      processedAt: new Date(),
+      attemptsMade: 0,
+      maxAttempts: undefined,
+      result: undefined,
+      progress: 0,
+      createdAt: new Date(),
+      completedAt: undefined,
+      failedAt: undefined,
+      error: undefined,
+    }),
+    waitForCompletion: async () => {
+      throw new Error('remote jobs do not support waitForCompletion')
+    },
+  }
+
+  try {
+    await runQueueJob({ job, traceId })
+  } catch (error) {
+    if (
+      error instanceof PikkuMissingMetaError ||
+      error instanceof QueueJobDiscardedError
+    ) {
+      throw new BadRequestError(error.message)
+    }
+    logger.error(
+      `remote-jobs: queue '${queueName}' failed: ${error instanceof Error ? error.message : String(error)}`
+    )
+    throw error
+  }
+}
+
+export async function pikkuRemoteScheduledJobFunc(
+  { logger }: { logger: Logger },
+  { taskName }: RemoteScheduledJobData
+): Promise<void> {
+  try {
+    await runScheduledTask({ name: taskName, traceId: `cron-${taskName}` })
+  } catch (error) {
+    if (error instanceof ScheduledTaskNotFoundError) {
+      throw new BadRequestError(error.message)
+    }
+    logger.error(
+      `remote-jobs: task '${taskName}' failed: ${error instanceof Error ? error.message : String(error)}`
+    )
+    throw error
+  }
+}

--- a/packages/core/src/wirings/scheduler/index.ts
+++ b/packages/core/src/wirings/scheduler/index.ts
@@ -1,4 +1,5 @@
 export {
+  ScheduledTaskNotFoundError,
   runScheduledTask,
   wireScheduler,
   getScheduledTasks,

--- a/packages/core/src/wirings/scheduler/scheduler-runner.ts
+++ b/packages/core/src/wirings/scheduler/scheduler-runner.ts
@@ -52,7 +52,7 @@ export const wireScheduler = <
   tasks.set(scheduledTask.name, scheduledTask)
 }
 
-class ScheduledTaskNotFoundError extends PikkuError {
+export class ScheduledTaskNotFoundError extends PikkuError {
   constructor(title: string) {
     super(`Scheduled task not found: ${title}`)
   }


### PR DESCRIPTION
A runtime that holds neither a queue consumer nor a clock — a container behind a platform dispatcher, a Worker, a Lambda — still has to run its queue workers and scheduled tasks.

Today that inbox is a runtime-level concern: `@pikku/node-http-server` intercepts `/__pikku/queue-job` and `/__pikku/scheduler-job` before routing and runs `runQueueJob` / `runScheduledTask` itself. Every other runtime either reimplements it or goes without, and the `x-pikku-dispatch` bearer check is hardcoded where a deployment cannot put its own scheme in front of it.

`scaffold.remoteJobs: true` generates the same two routes as ordinary `wireHTTP` wirings:

- every runtime serves them from one implementation
- the secret check is middleware, so a deployment can add signing on top
- the payloads are zod schemas, so they show up in the OpenAPI surface like anything else

It fails closed: an unset `PIKKU_DISPATCH_SECRET` rejects every caller. A permanent failure (unknown worker, discarded job, unknown task) answers 4xx so the sender stops retrying; anything else propagates and is redelivered.

Enable with `npx pikku enable remote-jobs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `enable remote-jobs` CLI command to generate remote job routes.
  - Remote job scaffolding now supports queue and scheduled tasks through protected HTTP endpoints.
  - Requests require the configured dispatch secret and reject unauthorized or missing-secret requests.
  - Added handling for retryable, permanent, and missing-task failures.
- **Documentation**
  - Added configuration support and release notes for enabling remote job scaffolding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->