### PR TITLE
feat(skills): ask which provider before writing an agent

### DIFF
--- a/.changeset/agent-provider-prompt.md
+++ b/.changeset/agent-provider-prompt.md
@@ -8,5 +8,6 @@ An agent's `provider/model` string is a hard dependency on somebody's account,
 credits and allow-list, and it fails at runtime rather than at build time — so
 choosing one silently ships an app pinned to a model its owner may have no key
 for. Adds `prompt.md` with the question to ask first, the Fabric-gateway default
-(`gateway/luna`, nothing to set up), the bring-your-own-provider path, and why a
-gateway model must not be pinned under a vendor's prefix.
+(`openai/gpt-5.6-luna` on the injected LiteLLM proxy, nothing to set up), the
+bring-your-own-provider path, and why the prefix chosen is a claim on that
+vendor's name that a later BYO key will take back.

--- a/.changeset/agent-provider-prompt.md
+++ b/.changeset/agent-provider-prompt.md
@@ -1,0 +1,12 @@
+---
+'@pikku/skills': patch
+---
+
+pikku-agent: ask which provider and model before writing an agent
+
+An agent's `provider/model` string is a hard dependency on somebody's account,
+credits and allow-list, and it fails at runtime rather than at build time — so
+choosing one silently ships an app pinned to a model its owner may have no key
+for. Adds `prompt.md` with the question to ask first, the Fabric-gateway default
+(`gateway/luna`, nothing to set up), the bring-your-own-provider path, and why a
+gateway model must not be pinned under a vendor's prefix.

--- a/packages/skills/skills/pikku-agent/SKILL.md
+++ b/packages/skills/skills/pikku-agent/SKILL.md
@@ -19,10 +19,19 @@ installed surface. This skill is the part the compiler cannot tell you: how an
 agent reaches the rest of the app, and which of its knobs mean something other
 than what they look like.
 
+## Ask before you write
+
+**The model is not your decision.** Read `prompt.md` and ask the question in it
+before the first agent file exists — a `provider/model` string is a hard
+dependency on somebody's account and allow-list, and it fails at runtime, so
+choosing one for them is how an app ships pinned to a model its owner cannot
+call.
+
 ## Pick the reference
 
 | You are… | Read |
 | --- | --- |
+| About to create an agent — which provider, which model, whose key | `prompt.md` |
 | Defining or invoking an agent — tools, memory, streaming, approval, threads, images | `references/agents.md` |
 | Wiring the runner, or pointing model strings at a provider or gateway | `references/runner-vercel.md` |
 | Adding speech in or out of an agent | `references/voice.md` |

--- a/packages/skills/skills/pikku-agent/prompt.md
+++ b/packages/skills/skills/pikku-agent/prompt.md
@@ -1,0 +1,48 @@
+# Before you write an agent: ask
+
+An agent names a model, and the model is the one decision in it that is not
+yours to make. `provider/model` is a hard dependency on somebody's account,
+credits and allow-list, and it fails at runtime rather than at build time — so
+picking one silently is how an app ships pinned to a model its owner has no key
+for. **Ask, then write.** One question, before the first agent file exists.
+
+## The question
+
+> Which model should this run on? I can use the Pikku Fabric gateway (nothing to
+> set up), or point it at your own provider — tell me which and I'll wire the key.
+
+Two answers, and they lead to different files.
+
+### They are on the Pikku Fabric gateway
+
+Nothing to set up: the gateway credentials are injected into the sandbox, so
+there is no key to ask for and no `.env` line to add. **Default to
+`gateway/luna`** unless they name something else — it is the cheap general
+route and the right first choice for drafting, extraction and chat.
+
+Do not tell them a key is missing. Do not raise a key-setup card. If a model
+call fails here it is a routing or allow-list problem, not a missing credential,
+and the fix is a different model string rather than a key.
+
+### They are bringing their own provider
+
+Ask which one, then wire exactly that provider into `providers` and read its key
+through `secrets`/`variables` — never a literal. Name the model they actually
+have access to; do not substitute a cheaper one you prefer.
+
+## Do not pin a gateway model under a vendor's prefix
+
+`providers` is public and mutable so deploy-time contributors can swap a
+gateway-routed provider in after construction — and an exact entry always beats
+`'*'`. So `openai/<a-model-only-the-gateway-serves>` works until the day
+something registers a real `openai` provider, at which point every agent in the
+app starts calling the vendor directly and gets `model does not exist`. It looks
+like the gateway refusing a model; it is the gateway no longer being in the
+call. Give a gateway model a prefix no vendor contributor will claim.
+
+## Once it is written, say how to reach it
+
+An agent is a front door, and a door nobody can find is not built. When the
+agent is in place, tell them in the same breath **how to call it** — the exact
+RPC, command or URL, written out. "The assistant is ready" is not an answer to
+"how do I use this".

--- a/packages/skills/skills/pikku-agent/prompt.md
+++ b/packages/skills/skills/pikku-agent/prompt.md
@@ -8,37 +8,48 @@ for. **Ask, then write.** One question, before the first agent file exists.
 
 ## The question
 
-> Which model should this run on? I can use the Pikku Fabric gateway (nothing to
-> set up), or point it at your own provider — tell me which and I'll wire the key.
+> Which model should this run on? If you're on a gateway I can use its default
+> and there's nothing to set up — otherwise tell me the provider and I'll wire
+> the key.
 
 Two answers, and they lead to different files.
 
-### They are on the Pikku Fabric gateway
+### They are on a gateway
 
-Nothing to set up: the gateway credentials are injected into the sandbox, so
-there is no key to ask for and no `.env` line to add. **Default to
-`gateway/luna`** unless they name something else — it is the cheap general
-route and the right first choice for drafting, extraction and chat.
+A gateway is one provider entry that accepts many model names, so there is no
+per-vendor key to ask for. Pikku Fabric injects one: it points `openai`,
+`anthropic`, `gemini`, `deepseek` and `zai` at a LiteLLM proxy, and the cheap
+general route is **`openai/gpt-5.6-luna`** — use it unless they name something
+else. It is the right first choice for drafting, extraction and chat.
 
-Do not tell them a key is missing. Do not raise a key-setup card. If a model
-call fails here it is a routing or allow-list problem, not a missing credential,
-and the fix is a different model string rather than a key.
+Read that prefix correctly: `openai/` here selects **the gateway**, not OpenAI,
+and `gpt-5.6-luna` is a name the gateway serves rather than a vendor model. A
+bare alias with no slash throws.
+
+Do not tell them a key is missing, and do not raise a key-setup card. On an
+injected gateway the credentials are already there — a failing call is a routing
+or allow-list problem, and the fix is a different model string, not a key.
 
 ### They are bringing their own provider
 
-Ask which one, then wire exactly that provider into `providers` and read its key
-through `secrets`/`variables` — never a literal. Name the model they actually
-have access to; do not substitute a cheaper one you prefer.
+Ask which one, wire exactly that provider into `providers`, and read its key
+through `secrets`/`variables` — never a literal. Name a model they actually have
+access to; do not substitute a cheaper one you prefer.
 
-## Do not pin a gateway model under a vendor's prefix
+## The prefix you pick is a claim on that vendor's name
 
-`providers` is public and mutable so deploy-time contributors can swap a
-gateway-routed provider in after construction — and an exact entry always beats
-`'*'`. So `openai/<a-model-only-the-gateway-serves>` works until the day
-something registers a real `openai` provider, at which point every agent in the
-app starts calling the vendor directly and gets `model does not exist`. It looks
-like the gateway refusing a model; it is the gateway no longer being in the
-call. Give a gateway model a prefix no vendor contributor will claim.
+`providers` is public and mutable so deploy-time contributors can swap providers
+in after construction, and an exact entry always beats `'*'`. So a gateway model
+named `openai/…` keeps working only while nothing registers a real `openai`
+provider — and adding an OpenAI key to the app is exactly what does that. From
+then on every agent under that prefix calls the vendor directly and gets
+`model does not exist`, which reads like the gateway refusing a model when it is
+really the gateway no longer being in the call.
+
+There is no prefix that is safe in the abstract, so make it a question rather
+than a guess: if they are likely to bring their own OpenAI or Anthropic key
+later, put the gateway models under one of its other names (`zai/`, `deepseek/`,
+`gemini/`) and leave `openai/` free for the key they will add.
 
 ## Once it is written, say how to reach it
 


### PR DESCRIPTION
An agent's `provider/model` string is a hard dependency on somebody's account, credits and allow-list, and it fails at **runtime**, not build time. Nothing in `pikku-agent` currently tells a build agent to ask — so it picks one, and the app ships pinned to a model its owner may have no key for.

This showed up on a fresh Fabric build: every generated agent was pinned to a gateway-only model under the `openai/` prefix. That works until something registers a real `openai` provider — exact entries beat `'*'` — at which point every agent in the app calls the vendor directly and gets `model does not exist`. It reads like the gateway refusing a model; it's the gateway no longer being in the call.

Adds `skills/pikku-agent/prompt.md`:

- the one question to ask before the first agent file exists
- the Fabric-gateway path — credentials are injected, so there is no key to ask for and no setup card to raise; default to `gateway/luna`
- the bring-your-own-provider path — ask which, wire that provider, read the key through `secrets`/`variables`
- why a gateway model must not be pinned under a vendor's prefix
- and a closing rule: once the agent exists, say how to call it, in the same breath

`SKILL.md` points at it ahead of the reference table, since it has to be read before anything gets written.

`packages/skills` corpus test: 11 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for selecting an AI provider and model before creating an agent.
  * Added support for using the Pikku Fabric gateway with `gateway/luna` as the default model.
  * Added instructions for configuring custom providers and securely supplying credentials.
  * Added guidance for explaining how to call a newly created agent.

* **Documentation**
  * Documented provider selection, model configuration, gateway usage, and related setup considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->