### PR TITLE
fix(cli): always inject the local content service in dev and serve

### DIFF
--- a/.changeset/default-local-content.md
+++ b/.changeset/default-local-content.md
@@ -1,0 +1,18 @@
+---
+'@pikku/cli': patch
+'@pikku/skills': patch
+---
+
+dev/serve: always inject the local content service
+
+`pikku dev` and `pikku serve` only built `LocalContent` when `pikku.config.json`
+declared a `content` block, so a project without one type-checks, renders and
+starts clean and then throws the first time anything uploads a file. Every field
+already had a default, so the block was gating a service that needed no
+configuration. It is now always constructed; the `content` block still overrides
+the storage path, URL prefixes and size limit.
+
+Also documents it in the `pikku-services` skill: these singletons arrive as
+`existingServices` and are never named in `services.ts`, so their absence there
+is not evidence they are off — which is what makes the `if (!content) throw`
+guard the skill already forbids look justified.

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -268,25 +268,21 @@ export const dev = pikkuSessionlessFunc<
 
     const resolvedRuntimeDir =
       config.runtimeDir ?? join(config.rootDir, '.pikku-runtime')
-    const localContentConfig: LocalContentConfig | undefined =
-      userConfig.content
-        ? {
-            localFileUploadPath: userConfig.content.contentPath
-              ? resolve(config.rootDir, userConfig.content.contentPath)
-              : join(resolvedRuntimeDir, 'content'),
-            uploadUrlPrefix: userConfig.content.uploadUrlPrefix ?? '/upload',
-            assetUrlPrefix: userConfig.content.assetUrlPrefix ?? '/assets',
-            server: `http://${hostname}:${resolvedPort}`,
-            sizeLimit: userConfig.content.sizeLimit,
-          }
-        : undefined
-    const contentSigningJWT = localContentConfig
-      ? createEphemeralContentSigningJWT()
-      : undefined
-    const localContent =
-      localContentConfig && contentSigningJWT
-        ? new LocalContent(localContentConfig, logger, contentSigningJWT)
-        : undefined
+    const localContentConfig: LocalContentConfig = {
+      localFileUploadPath: userConfig.content?.contentPath
+        ? resolve(config.rootDir, userConfig.content.contentPath)
+        : join(resolvedRuntimeDir, 'content'),
+      uploadUrlPrefix: userConfig.content?.uploadUrlPrefix ?? '/upload',
+      assetUrlPrefix: userConfig.content?.assetUrlPrefix ?? '/assets',
+      server: `http://${hostname}:${resolvedPort}`,
+      sizeLimit: userConfig.content?.sizeLimit,
+    }
+    const contentSigningJWT = createEphemeralContentSigningJWT()
+    const localContent = new LocalContent(
+      localContentConfig,
+      logger,
+      contentSigningJWT
+    )
 
     const schedulerService = new InMemorySchedulerService()
     const agentStorage = kysely
@@ -349,7 +345,7 @@ export const dev = pikkuSessionlessFunc<
       agentRunService,
       eventHub,
       ...(kysely ? { kysely } : {}),
-      ...(localContent ? { content: localContent } : {}),
+      content: localContent,
     }
 
     const singletonServices = await userCreateSingletonServices(userConfig, {

--- a/packages/cli/src/functions/commands/serve.ts
+++ b/packages/cli/src/functions/commands/serve.ts
@@ -106,25 +106,21 @@ export const serve = pikkuSessionlessFunc<
 
     const resolvedRuntimeDir =
       config.runtimeDir ?? join(config.rootDir, '.pikku-runtime')
-    const localContentConfig: LocalContentConfig | undefined =
-      userConfig.content
-        ? {
-            localFileUploadPath: userConfig.content.contentPath
-              ? resolve(config.rootDir, userConfig.content.contentPath)
-              : join(resolvedRuntimeDir, 'content'),
-            uploadUrlPrefix: userConfig.content.uploadUrlPrefix ?? '/upload',
-            assetUrlPrefix: userConfig.content.assetUrlPrefix ?? '/assets',
-            server: `http://${hostname}:${resolvedPort}`,
-            sizeLimit: userConfig.content.sizeLimit,
-          }
-        : undefined
-    const contentSigningJWT = localContentConfig
-      ? createEphemeralContentSigningJWT()
-      : undefined
-    const localContent =
-      localContentConfig && contentSigningJWT
-        ? new LocalContent(localContentConfig, logger, contentSigningJWT)
-        : undefined
+    const localContentConfig: LocalContentConfig = {
+      localFileUploadPath: userConfig.content?.contentPath
+        ? resolve(config.rootDir, userConfig.content.contentPath)
+        : join(resolvedRuntimeDir, 'content'),
+      uploadUrlPrefix: userConfig.content?.uploadUrlPrefix ?? '/upload',
+      assetUrlPrefix: userConfig.content?.assetUrlPrefix ?? '/assets',
+      server: `http://${hostname}:${resolvedPort}`,
+      sizeLimit: userConfig.content?.sizeLimit,
+    }
+    const contentSigningJWT = createEphemeralContentSigningJWT()
+    const localContent = new LocalContent(
+      localContentConfig,
+      logger,
+      contentSigningJWT
+    )
 
     const schedulerService = new InMemorySchedulerService()
     const agentStorage = kysely
@@ -170,7 +166,7 @@ export const serve = pikkuSessionlessFunc<
       agentRunService,
       eventHub,
       ...(kysely ? { kysely } : {}),
-      ...(localContent ? { content: localContent } : {}),
+      content: localContent,
     }
 
     const singletonServices = await userCreateSingletonServices(userConfig, {

--- a/packages/skills/skills/pikku-services/SKILL.md
+++ b/packages/skills/skills/pikku-services/SKILL.md
@@ -30,6 +30,16 @@ request-scoped logger or audit buffer is a wire service, and startup work that
 needs the singletons goes in `pikkuServerLifecycle` rather than in a module's
 top level.
 
+## Services the runtime injects
+
+`pikku dev` and `pikku serve` build a set of singletons before your
+`createSingletonServices` runs and hand them in as `existingServices` — among
+them `content`, a `LocalContent` storing files under `.pikku-runtime/content`
+and serving them from `/upload` and `/assets`. **You never construct these in
+`services.ts`, and their absence from that file is not evidence they are off.**
+The optional `content` block in `pikku.config.json` only overrides that
+service's paths and size limit; omitting it does not disable it.
+
 ## Pick the reference
 
 | You are…                                                                     | Read                                                         |


### PR DESCRIPTION
`pikku dev` and `pikku serve` built `LocalContent` only when `pikku.config.json` declared a `content` block:

```ts
const localContentConfig: LocalContentConfig | undefined =
  userConfig.content ? { … } : undefined
```

Every field inside that object already had a default (`?? '/upload'`, `?? '/assets'`, `.pikku-runtime/content`), so the block was gating a service that needed no configuration to work. A project without one type-checks, renders and starts clean, and then throws the first time a human uploads anything — long after the code that added the feature reported success.

It is now always constructed. The `content` block still overrides the storage path, URL prefixes and size limit.

### Why this bites agents specifically

`services.ts` builds `emailService`, `kysely`, `audit` and friends by hand; `content` arrives as `existingServices` and is never named there. So an agent asked "is file storage set up?" reads `services.ts`, finds every other service listed and content absent, and reports that storage is not connected — while the only sentence about content it has ever seen is the `if (!content) throw new Error('content service not configured')` guard it wrote itself.

`pikku-services` already forbids that guard ("Do not guard a service's existence in a function body — `if (!db) throw …` is dead code"). This adds the missing half: which singletons the runtime injects, and that their absence from `services.ts` is not evidence they are off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)