### PR TITLE
docs(skills): MCP is served by pikku dev/serve at /mcp, not a hand-rolled server

### DIFF
--- a/.changeset/mcp-served-by-dev.md
+++ b/.changeset/mcp-served-by-dev.md
@@ -1,0 +1,18 @@
+---
+'@pikku/skills': patch
+---
+
+pikku-wiring: document how an MCP tool is actually reached
+
+`references/mcp.md` ended with a standalone `PikkuMCPServer` bootstrap — a
+`start.ts` that builds services, loads `mcp.gen.json` and calls `connectStdio()`.
+Nothing in a `pikku dev` / `pikku serve` / deployed app does that: the runtime
+mounts the MCP server itself at `/mcp` (`mcpPath` to move it) whenever
+`mcp.gen.json` has at least one entry. An agent following the old section wrote a
+server process nobody runs, and then could not tell the person who asked for the
+tool where to point their assistant.
+
+Replaces it with the reachable URL, the two things that read as breakage — the
+mount is skipped while there is nothing to serve, and correct MCP wiring has no
+`wires/mcp` directory and no `mcp` config block — and the instruction to hand over
+the URL. Swaps the stdio-logger red flag for a `/mcp` 404 one.

--- a/packages/skills/skills/pikku-wiring/references/mcp.md
+++ b/packages/skills/skills/pikku-wiring/references/mcp.md
@@ -166,49 +166,25 @@ export const deleteTodo = pikkuFunc({
 })
 ```
 
-## MCP Server Setup
+## Reaching the server
 
-`PikkuMCPServer` takes the server config and a logger — not your services. It
-loads the generated `mcp.gen.json`, and the bootstrap import is what registers
-your functions.
+You do not start an MCP server. `pikku dev`, `pikku serve` and a deployed app all
+mount one for you: codegen writes `.pikku/mcp/mcp.gen.json`, the runtime loads it,
+and the server is served at **`/mcp`** — so a tool you export is reachable at
+`https://<your-app-url>/mcp` with nothing else to wire. Set `mcpPath` to move it.
 
-```typescript
-// start.ts
-import { PikkuMCPServer } from '@pikku/modelcontextprotocol'
-import { createConfig, createSingletonServices } from './services.js'
-import mcpJSON from '../.pikku/mcp/mcp.gen.json' with { type: 'json' }
-import '../.pikku/pikku-bootstrap.gen.js'
+Two consequences worth stating outright, because both read as breakage:
 
-const config = await createConfig()
-const singletonServices = await createSingletonServices(config)
+- The mount is **conditional on there being something to serve**. An `mcp.gen.json`
+  with no tools, resources or prompts is not mounted at all, so `/mcp` 404s until
+  the first `mcp: true` function or `pikkuMCP*Func` exists.
+- There is no `wires/mcp` directory and no `mcp` block in `pikku.config.json`.
+  A tool *is* its own registration, so the absence of both is what correct MCP
+  wiring looks like — not evidence that something was missed.
 
-const server = new PikkuMCPServer(
-  {
-    name: 'pikku-mcp-server',
-    version: '1.0.0',
-    mcpJSON,
-    capabilities: { logging: {}, tools: {}, resources: {}, prompts: {} },
-  },
-  singletonServices.logger
-)
-
-await server.init()
-
-// stdio — the transport desktop MCP clients spawn
-await server.connectStdio()
-singletonServices.logger = server.createMCPLogger()
-
-// …or streamable HTTP, for a hosted server
-const { close } = await server.connectHTTP({ port: 3000, host: '127.0.0.1' })
-```
-
-`capabilities` is a filter, not documentation: a surface you leave out is not
-advertised and its endpoints are never loaded, which is how you ship a tools-only
-server.
-
-Over stdio the protocol owns stdout, so an ordinary console logger corrupts the
-frames — that is what `createMCPLogger()` is for. Swap the logger before
-anything logs.
+When you add a tool, tell whoever asked for it the URL. An assistant that cannot
+be pointed at an endpoint has not been connected to anything, and `/mcp` is the
+whole answer.
 
 ## Red flags
 
@@ -218,4 +194,4 @@ anything logs.
 | `uri`/`title` rejected on `pikkuMCPResourceFunc` | Those belong on `wireMCPResource`                               |
 | Resource returning `{ uri, blob, mimeType }`     | Resources are text only: `{ uri, text }`                        |
 | Client sees a tool with no description           | `mcp: true` without a `description` — check the codegen warning |
-| stdio client disconnects on the first log line   | Logger still writing to stdout; use `createMCPLogger()`         |
+| `/mcp` 404s                                      | Nothing to serve yet — the mount is skipped until one tool, resource or prompt exists |


### PR DESCRIPTION
`pikku-wiring/references/mcp.md` ended with a `## MCP Server Setup` section: a `start.ts` that builds services, imports `mcp.gen.json`, constructs `PikkuMCPServer` and calls `connectStdio()`.

Nothing in a `pikku dev`, `pikku serve` or deployed app does any of that. The runtime mounts the MCP server itself at **`/mcp`** (`mcpPath` to move it) whenever `mcp.gen.json` has at least one tool, resource or prompt. An agent following the old section writes a server process nobody starts — and then cannot answer the only question the person who asked for the tool actually has, which is where to point their assistant.

### Found by testing, not by reading

Driving a fresh Fabric app as a non-technical PO — *"I want to ask Claude on my laptop how many conversations are still unanswered"* — the agent correctly wrote a `pikkuMCPToolFunc`, codegen correctly emitted it into `mcp.gen.json`, and it was genuinely reachable at `/mcp`. The agent then told the PO to *"connect Claude to the app's assistant service at &lt;app URL&gt;"*, which is not a thing anyone can do. The build was right; the handover was impossible, because the endpoint is stated nowhere in the skill.

### What replaces it

- The reachable URL, said plainly.
- The mount is **conditional** — skipped while there is nothing to serve, so `/mcp` 404s until the first tool exists. Swapped into the red-flags table in place of the stdio-logger row.
- Correct MCP wiring has **no `wires/mcp` directory and no `mcp` block** in `pikku.config.json`. The absence of both is what success looks like, not evidence something was missed. (I made exactly this mistake auditing the run and wrongly called it a miss.)
- An instruction to hand over the URL.

Verified against `pikku-bun-server.ts:79` and the `node-http-server` mount tests (`mounts /mcp when mcpJson declares at least one tool`, `does not mount /mcp when mcpJson has no tools, resources, or prompts`).

Skills corpus test: 11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)