### PR TITLE
fix(inspector): publish an MCP tool under its declared name

### DIFF
--- a/.changeset/mcp-tool-declared-name.md
+++ b/.changeset/mcp-tool-declared-name.md
@@ -1,0 +1,10 @@
+---
+'@pikku/inspector': patch
+---
+
+Publish an MCP tool under its declared `name`
+
+`pikkuMCPToolFunc`'s config accepts a `name`, and it is the name an AI client
+calls the tool by, but the inspector never read it — the tool was always
+published under whatever the export happened to be called. The declared name
+now keys `toolsMeta`; `pikkuFuncId` is unchanged.

--- a/packages/inspector/src/add/add-functions.test.ts
+++ b/packages/inspector/src/add/add-functions.test.ts
@@ -643,3 +643,69 @@ describe('pikkuRemoteChannelFunc', () => {
     )
   })
 })
+
+describe('MCP tool naming', () => {
+  const quietLogger = (): InspectorLogger => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    diagnostic: () => {},
+    critical: () => {},
+    hasCriticalErrors: () => false,
+  })
+
+  test('a declared name is what the tool is published as', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'pikku-mcp-tool-name-'))
+    const file = join(rootDir, 'tool.ts')
+    await writeFile(
+      file,
+      [
+        "import { pikkuMCPToolFunc } from '@pikku/core'",
+        'export const createUnansweredCountTool = pikkuMCPToolFunc({',
+        "  name: 'getUnansweredConversationCount',",
+        "  description: 'How many conversations are unanswered.',",
+        '  func: async () => ({ ok: true })',
+        '})',
+      ].join('\n')
+    )
+
+    try {
+      const state = await inspect(quietLogger(), [file], { rootDir })
+      const tools = state.mcpEndpoints.toolsMeta
+      assert.ok(
+        tools['getUnansweredConversationCount'],
+        `expected the declared name, got: ${Object.keys(tools).join(', ')}`
+      )
+      assert.strictEqual(tools['createUnansweredCountTool'], undefined)
+      assert.strictEqual(
+        tools['getUnansweredConversationCount']!.pikkuFuncId,
+        'createUnansweredCountTool'
+      )
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  test('with no declared name the export still names the tool', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'pikku-mcp-tool-export-'))
+    const file = join(rootDir, 'tool.ts')
+    await writeFile(
+      file,
+      [
+        "import { pikkuMCPToolFunc } from '@pikku/core'",
+        'export const listOpenTickets = pikkuMCPToolFunc({',
+        "  description: 'Tickets still open.',",
+        '  func: async () => ({ ok: true })',
+        '})',
+      ].join('\n')
+    )
+
+    try {
+      const state = await inspect(quietLogger(), [file], { rootDir })
+      assert.ok(state.mcpEndpoints.toolsMeta['listOpenTickets'])
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/inspector/src/add/add-functions.ts
+++ b/packages/inspector/src/add/add-functions.ts
@@ -1431,13 +1431,26 @@ export const addFunctions: AddWiring = (
   }
 
   if (mcpEnabled) {
+    // `pikkuMCPToolFunc`'s config accepts `name`, and it is the name an AI client
+    // calls the tool by — `runMCPTool` looks the tool up in `toolsMeta` by exactly
+    // this key and then dispatches through `pikkuFuncId`, so it is a public label
+    // rather than an identity. It was never read here, so a declared `name` was
+    // silently dropped and the tool published under whatever the export happened to
+    // be called. It does NOT become the `pikkuFuncId`: renaming an export's rpc id
+    // is a different decision, and the scenario-step wrappers are the only place
+    // `name` carries that weight.
+    const declaredName = objectNode
+      ? getPropertyValue(objectNode, 'name')
+      : undefined
+    const toolName =
+      typeof declaredName === 'string' && declaredName ? declaredName : name
     if (!description) {
-      logger.warn(`MCP tool '${name}' is missing a description.`)
+      logger.warn(`MCP tool '${toolName}' is missing a description.`)
     }
     state.mcpEndpoints.files.add(node.getSourceFile().fileName)
-    state.mcpEndpoints.toolsMeta[name] = {
+    state.mcpEndpoints.toolsMeta[toolName] = {
       pikkuFuncId,
-      name,
+      name: toolName,
       title: title || undefined,
       description: description || undefined,
       summary,


### PR DESCRIPTION
`pikkuMCPToolFunc`'s config accepts a `name`, and it is the name an AI client calls the tool by — `runMCPTool` (`packages/core/src/wirings/mcp/mcp-runner.ts`) looks the tool up in `toolsMeta` by exactly that key and then dispatches through `meta.pikkuFuncId`, so it is a public label rather than an identity.

The inspector never read it. A declared `name` was silently dropped and the tool was published under whatever the export happened to be called, so an AI client calling the documented name got "tool not found".

The declared name now keys `state.mcpEndpoints.toolsMeta` and fills `meta.name`. It deliberately does **not** become the `pikkuFuncId` — renaming an export's rpc id is a separate decision, and the scenario-step wrappers (`SCENARIO_STEP_WRAPPERS` in `extract-function-name.ts`) stay the only place `name` carries that weight.

Two tests in `add-functions.test.ts` cover it: a declared name is what the tool is published as (and the `pikkuFuncId` still tracks the export), and with no declared name the export still names the tool. Verified non-vacuous — the first fails against the unpatched inspector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - MCP tools are now published using their declared configuration name when provided.
  - Tools without a declared name continue to use their exported function name.
  - Tool references remain correctly associated with their underlying function.
  - Missing-description warnings now identify the published tool name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->