### PR TITLE
test(inspector): cover the mcp: true path for a declared tool name

### DIFF
--- a/packages/inspector/src/add/add-functions.test.ts
+++ b/packages/inspector/src/add/add-functions.test.ts
@@ -708,4 +708,36 @@ describe('MCP tool naming', () => {
       await rm(rootDir, { recursive: true, force: true })
     }
   })
+  test('a plain func with mcp: true is published under its declared name', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'pikku-mcp-flag-name-'))
+    const file = join(rootDir, 'tool.ts')
+    await writeFile(
+      file,
+      [
+        "import { pikkuFunc } from '@pikku/core'",
+        'export const countUnanswered = pikkuFunc({',
+        '  mcp: true,',
+        "  name: 'getUnansweredConversationCount',",
+        "  description: 'How many conversations are unanswered.',",
+        '  func: async () => ({ ok: true })',
+        '})',
+      ].join('\n')
+    )
+
+    try {
+      const state = await inspect(quietLogger(), [file], { rootDir })
+      const tools = state.mcpEndpoints.toolsMeta
+      assert.ok(
+        tools['getUnansweredConversationCount'],
+        `expected the declared name, got: ${Object.keys(tools).join(', ')}`
+      )
+      assert.strictEqual(tools['countUnanswered'], undefined)
+      assert.strictEqual(
+        tools['getUnansweredConversationCount']!.pikkuFuncId,
+        'countUnanswered'
+      )
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
Follow-up to #1629.

`mcpEnabled` is `mcp || isMCPToolFunc`, so a plain `pikkuFunc` carrying `mcp: true` is published as a tool on exactly the same branch as `pikkuMCPToolFunc` — and it is the shorter way to declare one. #1629 reads the declared `name` off the config object literal, which is the same node in both spellings, so it already fixes both; only the `pikkuMCPToolFunc` spelling had a test.

No production change — one test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)