### PR TITLE
fix(cli): stop an embedded-postgres boot from failing the command

### DIFF
--- a/.changeset/pglite-boot-leaves-exit-code.md
+++ b/.changeset/pglite-boot-leaves-exit-code.md
@@ -1,0 +1,18 @@
+---
+'@pikku/cli': patch
+---
+
+db: stop an embedded-postgres boot from failing the command
+
+PGlite runs Postgres as an Emscripten module, and Emscripten's exit handler
+writes the WASM program's status straight to `process.exitCode`. Booting the
+embedded database left it at 99 with nothing wrong, and the CLI's bin ends with
+`process.exit(process.exitCode ?? 0)` — so any command that merely touched the
+embedded database exited 99 *after* completing all of its work and printing a
+green summary. `pikku all` in a package with a Postgres schema failed this way
+in CI while passing locally, where a real `DATABASE_URL` meant PGlite never
+booted.
+
+Restore the previous exit code once the database is ready. The restore uses
+`?? 0` because assigning `undefined` does not clear an already-set `exitCode`
+under bun.

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -422,7 +422,14 @@ async function createEmbeddedPostgres(
     loadPGliteExtensions(context.rootDir, context.pgliteExtensions),
   ])
 
-  return new PGlite({
+  // PGlite runs Postgres as an Emscripten module, and Emscripten's exit handler
+  // writes the WASM program's status straight to `process.exitCode` — booting a
+  // database leaves it at 99 even though nothing failed. The CLI's bin then
+  // ends with `process.exit(process.exitCode ?? 0)`, so any command that merely
+  // touched the embedded database reported failure after doing all of its work
+  // correctly. Restore whatever the process had before the boot.
+  const exitCodeBeforeBoot = process.exitCode
+  const db = new PGlite({
     ...(dataDir ? { dataDir } : {}),
     ...wasm,
     extensions: {
@@ -430,6 +437,13 @@ async function createEmbeddedPostgres(
       ...declared,
     },
   })
+  await db.waitReady
+  if (process.exitCode !== exitCodeBeforeBoot) {
+    // `?? 0` because assigning `undefined` does not clear an already-set
+    // exitCode under bun, which is the runtime the boot pollutes it on.
+    process.exitCode = exitCodeBeforeBoot ?? 0
+  }
+  return db
 }
 
 /**


### PR DESCRIPTION
PGlite runs Postgres as an Emscripten module, and Emscripten's exit handler writes the WASM program's status straight to `process.exitCode`. Booting the embedded database leaves it at 99 with nothing wrong, and `bin/pikku.js` ends with `process.exit(process.exitCode ?? 0)` — so any command that merely touched the embedded database exited 99 *after* completing all of its work and printing a green summary.

Found on a fabric deploy: `pikku all` for a package with a Postgres schema exited 99 in the CI container with a complete, green transcript and no error anywhere, while passing locally — locally a real `DATABASE_URL` meant PGlite never booted.

`createEmbeddedPostgres` now restores the previous exit code once `waitReady` resolves. The restore uses `?? 0` because assigning `undefined` does not clear an already-set `exitCode` under bun, which is the runtime this shows up on.

Verified in that same CI image against the same repo: the step goes from exit 99 to exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)