### PR TITLE
feat(skills): offer to mock the screens before building them

### DIFF
--- a/.changeset/design-mock-first.md
+++ b/.changeset/design-mock-first.md
@@ -6,5 +6,6 @@ Offer to mock the screens before building them
 
 `pikku-build` now asks, in §1's single question round, whether the user wants
 the main screens drawn as one self-contained HTML page before any milestone is
-built. On approval that page becomes source of truth for the screens: the
-milestones are read off it, and it doubles as the theme spec.
+built. The theme is authored first and the mock drawn from its values, so
+approving the mock approves what actually ships; the page then becomes source of
+truth for the screens and the milestones are read off it.

--- a/.changeset/design-mock-first.md
+++ b/.changeset/design-mock-first.md
@@ -1,0 +1,10 @@
+---
+'@pikku/skills': patch
+---
+
+Offer to mock the screens before building them
+
+`pikku-build` now asks, in §1's single question round, whether the user wants
+the main screens drawn as one self-contained HTML page before any milestone is
+built. On approval that page becomes source of truth for the screens: the
+milestones are read off it, and it doubles as the theme spec.

--- a/packages/skills/skills/pikku-build/SKILL.md
+++ b/packages/skills/skills/pikku-build/SKILL.md
@@ -33,9 +33,10 @@ plus more effort" — it is App plus a deliberate surface checklist, so read the
 base first and follow it in full rather than blending the two into one plan.
 
 The supporting references belong to whichever mode sends you to them:
-`references/multi-app.md` (a second frontend), `references/design.md` (committing
-to a design direction and judging whether the screens realise it — read before
-the first screen is built, not after the last), `references/theming.md`
+`references/multi-app.md` (a second frontend), `references/design.md` (offering
+to mock the screens first, committing to a design direction, and judging whether
+the screens realise it — read before the first screen is built, not after the
+last), `references/theming.md`
 (authoring the theme),
 `references/ship.md` (deploying, and the Fabric-readiness contract).
 

--- a/packages/skills/skills/pikku-build/references/app.md
+++ b/packages/skills/skills/pikku-build/references/app.md
@@ -65,8 +65,8 @@ in one message. Then stop; do not interview the user.
   this same round, as a question and not a gate: one HTML page mocking the main
   screens, a few minutes, far cheaper to change than built screens. If they say
   yes, `references/design.md` owns what to make and what it then binds — the
-  approved page becomes source of truth for the screens and the milestones are
-  read off it. If they say no or say nothing, build.
+  approved page becomes source of truth for the screens, and the theme is written
+  before it so what they approve is what ships. If they say no, build.
 - **What language should the app speak, and what language does the team work
   in?** Two answers, not one — see §1a, which is where they go. Ask only if the
   request is not obviously English; a brief written in English about an English

--- a/packages/skills/skills/pikku-build/references/app.md
+++ b/packages/skills/skills/pikku-build/references/app.md
@@ -61,6 +61,12 @@ in one message. Then stop; do not interview the user.
   Neutral (fine for an internal tool, but say so out loud); a direction in words;
   a reference (brand guide, screenshots, a site whose register they want); or
   their own design agent/prompt, whose output you take as the direction.
+- **Do they want to see the screens before you build them?** Offer it here, in
+  this same round, as a question and not a gate: one HTML page mocking the main
+  screens, a few minutes, far cheaper to change than built screens. If they say
+  yes, `references/design.md` owns what to make and what it then binds — the
+  approved page becomes source of truth for the screens and the milestones are
+  read off it. If they say no or say nothing, build.
 - **What language should the app speak, and what language does the team work
   in?** Two answers, not one — see §1a, which is where they go. Ask only if the
   request is not obviously English; a brief written in English about an English
@@ -331,6 +337,10 @@ What a milestone is:
 - **It ends in something a person can do**, in a browser, signed in as a named
   persona. If you cannot write the gherkin, you cannot build it yet — that is a
   `questions/` note, not a milestone.
+
+If §1's screen mock was made and approved, the milestones are read off it: every
+screen on that page belongs to some milestone, and a screen no milestone builds
+is a hole in this plan. Say which milestone covers which screen.
 
 How to order them:
 

--- a/packages/skills/skills/pikku-build/references/design.md
+++ b/packages/skills/skills/pikku-build/references/design.md
@@ -30,6 +30,64 @@ and so is the commitment.
 Be ambitious with it. A direction that could describe any SaaS app has not been
 chosen — it has been defaulted to in words instead of in components.
 
+## Offer to draw the screens before you build them
+
+Before the first milestone, **ask** whether they want to see the screens first.
+One question, in §1's round, not a gate of its own:
+
+> Want me to mock the main screens as a page you can look at before I build
+> anything? It takes a few minutes and it is much cheaper to change a picture
+> than a built screen.
+
+If they decline, build; the direction in words is enough to be accountable to.
+If they accept, this is the cheapest decision in the project — a picture of eight
+screens costs a fraction of eight built screens, and it is the only point where
+"that is not what I meant" is free.
+
+**What to make.** One self-contained HTML page holding every screen the app
+needs — not a prototype, not a click-through. Static markup, real content from
+their domain (never lorem), the empty and error states beside the happy path,
+laid out so the whole app is legible by scrolling. Plain hand-written CSS.
+Whatever your host offers for showing a page is how you show it — a Claude
+Artifact, a file they open, a preview server. The page is the deliverable; how it
+gets in front of them is not this file's business.
+
+Write it to `knowledge/decisions/design/screens.html` and treat it as **source of
+truth for the screens** once they approve it. That has consequences worth
+stating:
+
+- The milestones are read off it. A screen in the mock that no milestone builds
+  is a gap in the plan, not a spare drawing.
+- A screen the build turns out to need that the mock does not have means the
+  mock was wrong. Update it, and say you did. Do not let the app and the mock
+  drift and then quietly prefer the app.
+- The knowledge graph still owns the domain — objects, roles, rules. The mock
+  owns what the screens look like. When they disagree about a *fact*, knowledge
+  wins; when they disagree about a *layout*, the mock wins.
+
+**Then realise it in Mantine — in the theme, not in overrides.** The mock is
+plain CSS and knows nothing about Mantine, so closing the gap is real work, and
+there are two ways to do it. Only one of them is worth having:
+
+- **In the theme.** Push the mock's decisions into the Mantine theme object and
+  its CSS variables — the palette, the radius scale, the spacing rhythm, the
+  font stack, the default props components inherit. Do this and you end up with a
+  component library that is actually themed, and the next screen is free.
+- **In per-component overrides.** A stack of one-off `className`s and
+  `!important` fighting Mantine's defaults screen by screen. This looks like
+  progress on screen one and is unmaintainable by screen five, and the screens
+  drift apart because nothing central holds them together.
+
+Author the mock's CSS as custom properties on `:root` from the start, using the
+names `references/theming.md` gives the theme. Then the gap is largely a mapping
+rather than a translation, and the mock doubles as the theme spec.
+
+**Checking the built screen against the mock** is a structural comparison, not a
+pixel one: the same regions in the same order, the same hierarchy, the same
+states present, the same tokens used. Do not chase pixel equality — Mantine's
+components have their own metrics and the mock was drawn without them. A built
+screen that reads as the same screen has passed.
+
 ## One screen, designed properly, before the rest exist
 
 Design the first real screen as if it were the only one, and take it further than

--- a/packages/skills/skills/pikku-build/references/design.md
+++ b/packages/skills/skills/pikku-build/references/design.md
@@ -53,11 +53,23 @@ the palette, `structure.radius`, the spacing scale, the fonts, the component
 `defaultProps`. Approving the mock then approves the theme, and the built screens
 inherit it rather than chase it.
 
-Draw only what Mantine can actually build, at the metrics it actually uses —
-its control heights, its input shapes, its table and menu behaviour. A control
-the mock invents is a promise the app cannot keep. If the mock wants something
-Mantine does not do, that is a real finding: change the theme so it does, or
-change the mock, and say which.
+**The mock has two halves, and only one of them is Mantine's.** This is the same
+split the built screen lives under, applied a step earlier so the two agree by
+construction. The PAGE — the shell, the regions, the columns, the rhythm, the
+material behind the content, what overlaps what — is plain HTML and your own
+CSS, arranged however the layout decision demands; that half is free, and it is
+where the design actually happens. The COMPONENTS — anything a person would
+point at and call a control, and that the app will adopt as itself: buttons,
+inputs, selects, tables, badges, menus, modals — are drawn as *Mantine's*, at the
+metrics Mantine actually uses: its control heights, its input shapes, its table
+and menu behaviour. The test is the one the build will apply too: is this thing
+the SHAPE OF THE PAGE, or a COMPONENT someone would point at?
+
+Getting that second half wrong is what makes a mock a lie. A control the mock
+invents is a promise the app cannot keep, and a beautiful hand-rolled input sets
+a bar the real one misses on screen one. If the mock wants something Mantine
+does not do, that is a real finding, and finding it here is the point: change the
+theme so it does, or change the mock, and say which.
 
 **What to make.** One self-contained HTML page holding every screen the app
 needs — not a prototype, not a click-through. Static markup, real content from

--- a/packages/skills/skills/pikku-build/references/design.md
+++ b/packages/skills/skills/pikku-build/references/design.md
@@ -44,11 +44,31 @@ If they accept, this is the cheapest decision in the project — a picture of ei
 screens costs a fraction of eight built screens, and it is the only point where
 "that is not what I meant" is free.
 
+**Author the theme first, then draw the mock from it.** This order is the whole
+point. A beautiful page in hand-rolled CSS sets a bar Mantine then misses, and
+what the user approved is not what ships — they signed off on a picture and
+received an approximation of it. So write `themes/<name>.json` first
+(`references/theming.md`), and let the mock take its every value from that file:
+the palette, `structure.radius`, the spacing scale, the fonts, the component
+`defaultProps`. Approving the mock then approves the theme, and the built screens
+inherit it rather than chase it.
+
+Draw only what Mantine can actually build, at the metrics it actually uses —
+its control heights, its input shapes, its table and menu behaviour. A control
+the mock invents is a promise the app cannot keep. If the mock wants something
+Mantine does not do, that is a real finding: change the theme so it does, or
+change the mock, and say which.
+
 **What to make.** One self-contained HTML page holding every screen the app
 needs — not a prototype, not a click-through. Static markup, real content from
 their domain (never lorem), the empty and error states beside the happy path,
-laid out so the whole app is legible by scrolling. Plain hand-written CSS.
-Whatever your host offers for showing a page is how you show it — a Claude
+laid out so the whole app is legible by scrolling. Its CSS is custom properties
+on `:root` carrying the theme JSON's values, so a change to either is a change
+to one number in both. Mantine itself will not load here — it is a React library
+and a page like this has no bundler, and on hosts that sandbox the page (a Claude
+Artifact) external stylesheets are blocked outright — so do not try; the mock
+reproduces the theme's values by hand, which is why they have to be written down
+first. Whatever your host offers for showing a page is how you show it: an
 Artifact, a file they open, a preview server. The page is the deliverable; how it
 gets in front of them is not this file's business.
 
@@ -65,22 +85,22 @@ stating:
   owns what the screens look like. When they disagree about a *fact*, knowledge
   wins; when they disagree about a *layout*, the mock wins.
 
-**Then realise it in Mantine — in the theme, not in overrides.** The mock is
-plain CSS and knows nothing about Mantine, so closing the gap is real work, and
-there are two ways to do it. Only one of them is worth having:
+**Building it is then a transcription, not a translation.** Because the theme
+already exists and the mock was drawn from it, the screen is Mantine components
+arranged the way the mock arranges them — the look arrives with the theme. Two
+rules keep it that way:
 
-- **In the theme.** Push the mock's decisions into the Mantine theme object and
-  its CSS variables — the palette, the radius scale, the spacing rhythm, the
-  font stack, the default props components inherit. Do this and you end up with a
-  component library that is actually themed, and the next screen is free.
-- **In per-component overrides.** A stack of one-off `className`s and
-  `!important` fighting Mantine's defaults screen by screen. This looks like
+- **Layout is yours to write; components are Mantine's.** The page shape — the
+  regions, the columns, the rhythm, what sits beside what — is ordinary markup
+  and your own CSS. Anything a person would point at and call a control comes
+  from Mantine: buttons, inputs, selects, tables, badges, menus. Those carry
+  focus rings, keyboard behaviour and i18n, and hand-rolling one throws all of
+  it away.
+- **A gap goes back to the theme, never into a component override.** If a screen
+  does not match the mock, the fix is a value in `themes/<name>.json`. A stack of
+  one-off `className`s and `!important` fighting Mantine's defaults looks like
   progress on screen one and is unmaintainable by screen five, and the screens
   drift apart because nothing central holds them together.
-
-Author the mock's CSS as custom properties on `:root` from the start, using the
-names `references/theming.md` gives the theme. Then the gap is largely a mapping
-rather than a translation, and the mock doubles as the theme spec.
 
 **Checking the built screen against the mock** is a structural comparison, not a
 pixel one: the same regions in the same order, the same hierarchy, the same


### PR DESCRIPTION
`design.md` already said to commit to a design direction before the first screen — but the direction was words only. The first thing anyone actually *sees* is a built screen, and by then changing it is a repaint.

`pikku-build` now offers to draw the main screens as one self-contained HTML page before any milestone is built. It is an **offer, not a gate**, and it goes in §1's existing single question round rather than adding a new one (prompt.md is explicit that the agent must not open with a questionnaire). Decline it and the build proceeds exactly as before.

## The theme is authored first, and the mock is drawn from it

This ordering is the point. The obvious version of this idea — mock in hand-rolled CSS, then make Mantine match — sets a bar Mantine misses, and what the user approved is not what ships: they sign off on a picture and receive an approximation of it.

So `themes/<name>.json` is written first (`references/theming.md`), and the mock takes its every value from that file — palette, `structure.radius`, spacing, fonts, component `defaultProps` — as custom properties on `:root`. Approving the mock approves the theme, and the built screens inherit it rather than chase it. The mock draws only what Mantine can build at the metrics it uses; a control the mock invents is a promise the app cannot keep, and spotting one is a finding.

Building is then transcription rather than translation: layout is ordinary markup and your own CSS, anything a person would point at and call a control is Mantine, and a gap goes back into the theme JSON — never into per-component overrides, which look like progress on screen one and are unmaintainable by screen five.

The file also records *why* the mock cannot simply be Mantine: it is a React library and the page has no bundler, and a sandboxed host (a Claude Artifact) blocks external stylesheets outright. That constraint is exactly why the theme's values have to be written down first.

## What approval binds

- §5 reads the milestones off the page — a screen no milestone builds is a hole in the plan.
- A screen the build turns out to need that the mock lacks means the mock was wrong; update it and say so, rather than letting the two drift.
- The knowledge graph still owns the domain. Facts → knowledge, layout → the mock.

Comparing a built screen to the mock is **structural** — same regions in the same order, same hierarchy, same states, same tokens — not pixel equality.

`platform.md` is a delta on `app.md` and inherits the question with no change.

Docs only — no code, no API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional workflow in `pikku-build` to create self-contained HTML mockups of main screens before implementation.
  - Themes are defined first, with mockups using real content and key screen states for review.
  - Approved mockups become the visual source of truth for building screens and planning milestones.

- **Documentation**
  - Clarified design guidance, theme-driven styling, component usage, and alignment checks between approved mockups and completed screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->