### PR TITLE
fix(node-http-server): serve a built frontend's assets before the content service

### DIFF
--- a/.changeset/static-assets-before-content.md
+++ b/.changeset/static-assets-before-content.md
@@ -1,0 +1,11 @@
+---
+'@pikku/node-http-server': patch
+---
+
+serve a built frontend's `/assets/*` before the content service claims the prefix
+
+`LocalContent` defaults its asset prefix to `/assets`, which is also where Vite puts a
+built bundle. Content ran first and answered every `GET /assets/*` itself, so once the
+content service was always injected the frontend's own scripts 404'd. Static mounts now
+get the request first; a miss still falls through to content, so signed asset URLs are
+unaffected.

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
@@ -410,11 +410,11 @@ export class PikkuNodeHTTPServer {
         return
       }
 
-      if (await this.handleContentRequest(req, res)) {
+      if (await this.handleStaticFileRequest(req, res)) {
         return
       }
 
-      if (await this.handleStaticFileRequest(req, res)) {
+      if (await this.handleContentRequest(req, res)) {
         return
       }
 

--- a/packages/runtimes/node-http-server/src/static-mount.test.ts
+++ b/packages/runtimes/node-http-server/src/static-mount.test.ts
@@ -384,3 +384,69 @@ describe(
     })
   }
 )
+
+describe(
+  'PikkuNodeHTTPServer static mounts with a content service',
+  { concurrency: false },
+  () => {
+    let tmpDir: string
+    let server: PikkuNodeHTTPServer | undefined
+    let origin: string
+
+    beforeEach(async () => {
+      resetPikkuState()
+      tmpDir = await mkdtemp(join(tmpdir(), 'pikku-static-content-'))
+      pikkuState(null, 'package', 'singletonServices', {
+        logger: createMockLogger(),
+        schema: {
+          compileSchema: async () => {},
+          getSchemaNames: () => new Set<string>(),
+        },
+      } as any)
+
+      await writeFile(
+        join(tmpDir, 'index.html'),
+        '<!doctype html><title>app</title>'
+      )
+      await mkdir(join(tmpDir, 'assets'))
+      await writeFile(join(tmpDir, 'assets', 'app.js'), 'console.log("app")')
+
+      server = new PikkuNodeHTTPServer(
+        {
+          hostname: '127.0.0.1',
+          port: 0,
+          content: {
+            localFileUploadPath: join(tmpDir, 'uploads'),
+            uploadUrlPrefix: '/upload',
+            assetUrlPrefix: '/assets',
+          },
+          staticMounts: [
+            { urlPrefix: '/', directory: tmpDir, spaFallback: true },
+          ],
+        } as any,
+        createMockLogger() as any
+      )
+      await server.init()
+      await server.start()
+      const address = server.server.address()
+      assert.ok(address && typeof address === 'object')
+      origin = `http://127.0.0.1:${address.port}`
+    })
+
+    afterEach(async () => {
+      if (server) {
+        await server.stop()
+        server = undefined
+      }
+      await rm(tmpDir, { recursive: true, force: true })
+    })
+
+    test('a built frontend bundle wins over the content asset prefix', async () => {
+      const response = await fetch(`${origin}/assets/app.js`, {
+        headers: { connection: 'close' },
+      })
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'console.log("app")')
+    })
+  }
+)


### PR DESCRIPTION
`pikku serve` stopped serving the tanstack template's JS bundle, which is why `Templates (24, tanstack, yarn)` has been red on main since #1626 and no release has published since 0.12.141.

`LocalContent` defaults `assetUrlPrefix` to `/assets`, which is also where Vite writes a built bundle. `handleContentRequest` ran before static mounts and claimed every `GET /assets/*`, so as soon as the content service was always injected the frontend's own scripts 404'd: the shell rendered, hydration never ran, and the browser test timed out waiting for the `Todos` heading.

Static mounts now get the request first. A static miss already falls through, so signed content asset URLs and uploads are unchanged — covered by a test that fails with the old order.