### PR TITLE
feat(console): per-screen help panel with anchors into the page

### DIFF
--- a/.changeset/console-screen-help.md
+++ b/.changeset/console-screen-help.md
@@ -1,0 +1,5 @@
+---
+'@pikku/console': patch
+---
+
+Add per-screen help: a `?` in every page header opens a plain-language panel explaining the concept behind the screen, whose copy can point at real controls on the page (hovering a highlighted phrase rings the control it names). Help is keyed by route — a page opts into nothing — and a unit test fails when a route is neither written, pending, nor explicitly exempt. Ships the Functions screen's copy; hosts register their own screens with `registerHelpScreens`.

--- a/packages/console/messages/en.json
+++ b/packages/console/messages/en.json
@@ -1105,5 +1105,16 @@
   "knowledge_plan_section_scenarios_browser": "Browser scenarios",
   "knowledge_plan_section_scenarios_permission": "Permission scenarios",
   "knowledge_plan_item_deferred": "deferred",
-  "knowledge_plan_item_deferred_why": "Promised by a later pass, so this build was never asked for it."
+  "knowledge_plan_item_deferred_why": "Promised by a later pass, so this build was never asked for it.",
+  "help_open": "What is this screen?",
+  "help_actions_title": "What you can do here",
+  "help_read_more": "Read the full documentation",
+  "help_functions_title": "Functions",
+  "help_functions_what": "A function is one piece of your app's logic — “create a booking”, “send the welcome email”. You write it once, and it knows nothing about how it was called.",
+  "help_functions_behaviour": "Every function your project defines is on [this list](#list), whether it is reached over HTTP, from a queue, on a schedule, or by another function. Use [the search box](#search) to find one by name, then [pick it](#list) to see what it takes in, what it gives back, and which wirings call it.",
+  "help_functions_surprise": "Functions are read from your code, not registered here — this screen is a view of what you have written, so nothing on it can be added or edited from the console. Pikku's own internal functions are hidden by default; [show them](#internals) only when you are debugging the framework itself.",
+  "help_functions_examples": "Examples: createBooking, sendWelcomeEmail, listInvoices.",
+  "help_functions_do_search": "[Find a function by name](#search)",
+  "help_functions_do_select": "[Open one to see its inputs, outputs and wirings](#list)",
+  "help_functions_do_internals": "[Show pikku's own internal functions](#internals)"
 }

--- a/packages/console/src/components/layout/PageLayout.tsx
+++ b/packages/console/src/components/layout/PageLayout.tsx
@@ -4,6 +4,7 @@ import type { Stack } from '@pikku/mantine/core'
 import type { I18nNode } from '@pikku/react'
 import { useLocale } from '@/i18n/config'
 import DocLink from '../ui/DocLink'
+import { HelpAffordance } from '../../help/HelpAffordance'
 import {
   ShellHeader,
   type ShellHeaderAction,
@@ -45,15 +46,15 @@ export function ListPageHeader<T extends string = string>({
   selection,
 }: ListPageHeaderProps<T>) {
   const docsButton = docsHref ? <DocLink href={docsHref} /> : null
-  const right =
-    filters || view || lead || docsButton ? (
-      <>
-        {filters}
-        {view}
-        {lead}
-        {docsButton}
-      </>
-    ) : undefined
+  const right = (
+    <>
+      {filters}
+      {view}
+      {lead}
+      {docsButton}
+      <HelpAffordance />
+    </>
+  )
   return (
     <ShellHeader
       title={title}
@@ -324,13 +325,13 @@ export function PageHeader<S extends string = string>({
   panel,
 }: PageHeaderProps<S>) {
   useLocale()
-  const right =
-    actions || docsHref ? (
-      <>
-        {actions}
-        {docsHref && <DocLink href={docsHref} />}
-      </>
-    ) : undefined
+  const right = (
+    <>
+      {actions}
+      {docsHref && <DocLink href={docsHref} />}
+      <HelpAffordance />
+    </>
+  )
   // Inline mode: fold the subtitle into the title row (title + count on one line)
   // so ShellHeader's stacked title/count slot renders a single row.
   const inline = countInline && subtitle != null

--- a/packages/console/src/components/ui/ActionCluster.tsx
+++ b/packages/console/src/components/ui/ActionCluster.tsx
@@ -26,6 +26,7 @@ function actionButton(a: ShellHeaderAction, mode: ActMode): ReactNode {
         leftSection={a.icon}
         onClick={a.onClick}
         disabled={a.disabled}
+        data-help={a.helpAnchor}
         styles={{
           root: { flexShrink: 0, height: CONTROL_H, minHeight: CONTROL_H },
         }}
@@ -48,6 +49,7 @@ function actionButton(a: ShellHeaderAction, mode: ActMode): ReactNode {
         size={CONTROL_H}
         onClick={a.onClick}
         disabled={a.disabled}
+        data-help={a.helpAnchor}
         aria-label={a.label}
       >
         {a.icon}
@@ -94,6 +96,7 @@ export const ActionCluster: React.FC<ActionClusterProps> = ({
                 leftSection={a.icon}
                 onClick={a.onClick}
                 disabled={a.disabled}
+                data-help={a.helpAnchor}
               >
                 {a.label}
               </Menu.Item>

--- a/packages/console/src/components/ui/shellHeaderShared.ts
+++ b/packages/console/src/components/ui/shellHeaderShared.ts
@@ -45,6 +45,11 @@ export interface ShellHeaderAction {
   tooltip?: I18nString
   /** Always render icon-only (with tooltip), never showing the label. */
   iconOnly?: boolean
+  /** Stamps `data-help` on the rendered control so the help panel can point at
+   *  it. The bar collapses labels to icons to a kebab menu and the attribute
+   *  rides all three, so an anchor survives every width except a menu item that
+   *  is not currently dropped down. */
+  helpAnchor?: string
 }
 
 export interface ShellHeaderProps<T extends string = string> {

--- a/packages/console/src/help/HelpAffordance.tsx
+++ b/packages/console/src/help/HelpAffordance.tsx
@@ -1,0 +1,57 @@
+import { lazy, Suspense, useState } from 'react'
+import { ActionIcon, Tooltip } from '@pikku/mantine/core'
+import { CircleQuestionMark } from 'lucide-react'
+import { m } from '@/i18n/messages'
+import { useLocale } from '@/i18n/config'
+import { useOptionalConsoleRouter, type ConsoleRouter } from '../router'
+import { resolveHelpScreen, type HelpScreen } from './screens'
+
+const HelpPanel = lazy(() =>
+  import('./HelpPanel').then((mod) => ({ default: mod.HelpPanel }))
+)
+
+function HelpButton({ screen }: { screen: HelpScreen }) {
+  const [open, setOpen] = useState(false)
+  useLocale()
+  return (
+    <>
+      <Tooltip label={m.help_open()}>
+        <ActionIcon
+          variant="default"
+          color="gray"
+          size="input-sm"
+          aria-label={m.help_open()}
+          onClick={() => setOpen((o) => !o)}
+          data-testid="help-open"
+        >
+          <CircleQuestionMark size={16} />
+        </ActionIcon>
+      </Tooltip>
+      {open && (
+        <Suspense fallback={null}>
+          <HelpPanel screen={screen} opened onClose={() => setOpen(false)} />
+        </Suspense>
+      )}
+    </>
+  )
+}
+
+function HelpForRoute({ router }: { router: ConsoleRouter }) {
+  const screen = resolveHelpScreen(router.useLocation().pathname)
+  if (!screen) return null
+  return <HelpButton screen={screen} />
+}
+
+/**
+ * The `?` for the current screen, and the panel it opens.
+ *
+ * Every screen gets one without opting in: the screen is resolved from the route,
+ * so a page passes nothing. A route with no entry renders nothing — a `?` that
+ * opens an empty panel is worse than no `?` — and `screens.test.ts` is what stops
+ * that staying quiet.
+ */
+export function HelpAffordance() {
+  const router = useOptionalConsoleRouter()
+  if (!router) return null
+  return <HelpForRoute router={router} />
+}

--- a/packages/console/src/help/HelpPanel.tsx
+++ b/packages/console/src/help/HelpPanel.tsx
@@ -1,0 +1,93 @@
+import {
+  Anchor,
+  Divider,
+  Drawer,
+  Group,
+  Stack,
+  Text,
+} from '@pikku/mantine/core'
+import { ExternalLink } from 'lucide-react'
+import { asI18n } from '@pikku/react'
+import { m } from '@/i18n/messages'
+import { useLocale } from '@/i18n/config'
+import { usePhone } from '../lib/breakpoints'
+import { HelpText } from './HelpText'
+import type { HelpScreen } from './screens'
+
+/**
+ * Deliberately overlay-free: the panel explains the screen behind it and its
+ * anchors ring controls out there, so a scrim would hide the thing being
+ * pointed at.
+ */
+export function HelpPanel({
+  screen,
+  opened,
+  onClose,
+}: {
+  screen: HelpScreen
+  opened: boolean
+  onClose: () => void
+}) {
+  useLocale()
+  const phone = usePhone()
+  return (
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      position={phone ? 'bottom' : 'right'}
+      size={phone ? '70%' : 360}
+      withOverlay={false}
+      lockScroll={false}
+      trapFocus={false}
+      title={asI18n(screen.title())}
+      data-testid="help-panel"
+    >
+      <Stack gap="md">
+        <Text size="sm">
+          <HelpText>{screen.what()}</HelpText>
+        </Text>
+        <Text size="sm">
+          <HelpText>{screen.behaviour()}</HelpText>
+        </Text>
+        <Text size="sm">
+          <HelpText>{screen.surprise()}</HelpText>
+        </Text>
+        <Text size="sm" c="dimmed">
+          <HelpText>{screen.examples()}</HelpText>
+        </Text>
+        <Divider />
+        <Stack gap={7}>
+          <Text fz={10.5} fw={700} tt="uppercase" lts="0.07em" c="dimmed">
+            {m.help_actions_title()}
+          </Text>
+          {screen.whatYouCanDo.map((line, i) => (
+            <Group key={i} gap={7} wrap="nowrap" align="baseline">
+              <Text c="dimmed" fz={13}>
+                {asI18n('·')}
+              </Text>
+              <Text size="sm">
+                <HelpText>{line()}</HelpText>
+              </Text>
+            </Group>
+          ))}
+        </Stack>
+        {screen.docsHref && (
+          <>
+            <Divider />
+            <Anchor
+              href={screen.docsHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              size="sm"
+            >
+              <Group gap={6} wrap="nowrap">
+                {m.help_read_more()}
+                <ExternalLink size={13} />
+              </Group>
+            </Anchor>
+          </>
+        )}
+      </Stack>
+    </Drawer>
+  )
+}

--- a/packages/console/src/help/HelpText.tsx
+++ b/packages/console/src/help/HelpText.tsx
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Text } from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+
+import { parseHelpText } from './parseHelpText'
+
+import './helpAnchor.css'
+
+const MARK = 'data-help-active'
+
+function findAnchor(name: string): HTMLElement | null {
+  return document.querySelector<HTMLElement>(
+    `[data-help="${CSS.escape(name)}"]`
+  )
+}
+
+function offScreen(el: HTMLElement): boolean {
+  const r = el.getBoundingClientRect()
+  return (
+    r.bottom < 0 ||
+    r.top > window.innerHeight ||
+    r.right < 0 ||
+    r.left > window.innerWidth
+  )
+}
+
+function canHover(): boolean {
+  return (
+    typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches
+  )
+}
+
+function reducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+/**
+ * A phrase in the help copy that points at a real control on the screen behind
+ * the panel. An anchor whose target is not in the DOM renders as ordinary text —
+ * that is what stops the panel promising something the screen does not show.
+ */
+export function HelpAnchor({
+  name,
+  children,
+}: {
+  name: string
+  children: string
+}) {
+  const [live, setLive] = useState(false)
+  const marked = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    setLive(canHover() && findAnchor(name) != null)
+  }, [name])
+
+  const clear = useCallback(() => {
+    marked.current?.removeAttribute(MARK)
+    marked.current = null
+  }, [])
+
+  useEffect(() => clear, [clear])
+
+  const enter = useCallback(() => {
+    const el = findAnchor(name)
+    if (!el) {
+      setLive(false)
+      return
+    }
+    if (offScreen(el)) {
+      el.scrollIntoView({
+        block: 'center',
+        behavior: reducedMotion() ? 'auto' : 'smooth',
+      })
+    }
+    el.setAttribute(MARK, '')
+    marked.current = el
+  }, [name])
+
+  if (!live) return <>{asI18n(children)}</>
+
+  return (
+    <Text
+      span
+      inherit
+      style={{
+        textDecoration: 'underline',
+        textDecorationStyle: 'dotted',
+        textUnderlineOffset: 3,
+        textDecorationColor: 'var(--app-accent)',
+        cursor: 'help',
+      }}
+      onMouseEnter={enter}
+      onMouseLeave={clear}
+      onFocus={enter}
+      onBlur={clear}
+      tabIndex={0}
+    >
+      {asI18n(children)}
+    </Text>
+  )
+}
+
+export function HelpText({ children }: { children: string }) {
+  return (
+    <>
+      {parseHelpText(children).map((seg, i) =>
+        seg.anchor ? (
+          <HelpAnchor key={i} name={seg.anchor}>
+            {seg.text}
+          </HelpAnchor>
+        ) : (
+          <span key={i}>{asI18n(seg.text)}</span>
+        )
+      )}
+    </>
+  )
+}

--- a/packages/console/src/help/helpAnchor.css
+++ b/packages/console/src/help/helpAnchor.css
@@ -1,0 +1,19 @@
+[data-help-active] {
+  outline: 2px solid var(--app-accent, var(--mantine-primary-color-filled));
+  outline-offset: 3px;
+  border-radius: 6px;
+  box-shadow: 0 0 0 6px color-mix(
+      in srgb,
+      var(--app-accent, var(--mantine-primary-color-filled)) 16%,
+      transparent
+    );
+  transition:
+    outline-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-help-active] {
+    transition: none;
+  }
+}

--- a/packages/console/src/help/parseHelpText.test.ts
+++ b/packages/console/src/help/parseHelpText.test.ts
@@ -1,0 +1,40 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseHelpText } from './parseHelpText.js'
+
+test('plain copy is one text segment', () => {
+  assert.deepEqual(parseHelpText('no anchors here.'), [
+    { text: 'no anchors here.' },
+  ])
+})
+
+test('an anchor splits out of the surrounding text', () => {
+  assert.deepEqual(parseHelpText('see [this list](#list) now'), [
+    { text: 'see ' },
+    { text: 'this list', anchor: 'list' },
+    { text: ' now' },
+  ])
+})
+
+test('several anchors in one paragraph', () => {
+  assert.deepEqual(parseHelpText('[a](#one) and [b](#two-b)'), [
+    { text: 'a', anchor: 'one' },
+    { text: ' and ' },
+    { text: 'b', anchor: 'two-b' },
+  ])
+})
+
+test('malformed anchors stay literal text', () => {
+  for (const input of [
+    'empty [label](#) target',
+    'unclosed [label without a bracket',
+    'bare (#anchor) with no label',
+    'spaces [label](# anchor) inside',
+  ]) {
+    assert.deepEqual(parseHelpText(input), [{ text: input }], input)
+  }
+})
+
+test('empty copy yields no segments', () => {
+  assert.deepEqual(parseHelpText(''), [])
+})

--- a/packages/console/src/help/parseHelpText.ts
+++ b/packages/console/src/help/parseHelpText.ts
@@ -1,0 +1,26 @@
+export interface HelpSegment {
+  text: string
+  anchor?: string
+}
+
+const ANCHOR = /\[([^[\]]+)\]\(#([A-Za-z0-9_-]+)\)/g
+
+/**
+ * Total by construction: anything that is not an exact `[label](#anchor)` match
+ * falls through as literal text, so a typo in hand-written copy renders as a
+ * sentence rather than an error.
+ */
+export function parseHelpText(input: string): HelpSegment[] {
+  const out: HelpSegment[] = []
+  let last = 0
+  ANCHOR.lastIndex = 0
+  let match = ANCHOR.exec(input)
+  while (match) {
+    if (match.index > last) out.push({ text: input.slice(last, match.index) })
+    out.push({ text: match[1]!, anchor: match[2]! })
+    last = match.index + match[0].length
+    match = ANCHOR.exec(input)
+  }
+  if (last < input.length) out.push({ text: input.slice(last) })
+  return out
+}

--- a/packages/console/src/help/screens.test.ts
+++ b/packages/console/src/help/screens.test.ts
@@ -1,0 +1,85 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import {
+  HELP_EXEMPT,
+  HELP_PENDING,
+  HELP_SCREENS,
+  resolveHelpScreen,
+} from './screens.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+function routesFromApp(): string[] {
+  const src = readFileSync(join(here, '..', 'App.tsx'), 'utf8')
+  const found = new Set<string>()
+  for (const m of src.matchAll(/<Route\s+path="([^"]+)"/g)) found.add(m[1]!)
+  return [...found]
+}
+
+test('App.tsx still declares routes we can read', () => {
+  const routes = routesFromApp()
+  assert.ok(routes.length > 10, `only found ${routes.length} routes`)
+  assert.ok(routes.includes('/functions'))
+})
+
+test('every route has help, is pending, or is explicitly exempt', () => {
+  const pending = new Set(HELP_PENDING)
+  const unclassified = routesFromApp().filter(
+    (r) => !(r in HELP_SCREENS) && !pending.has(r) && !(r in HELP_EXEMPT)
+  )
+  assert.deepEqual(
+    unclassified,
+    [],
+    `route(s) with no help entry, no pending marker and no exemption: ${unclassified.join(', ')}. ` +
+      `Add copy to HELP_SCREENS, or list it in HELP_PENDING / HELP_EXEMPT with a reason.`
+  )
+})
+
+test('a route is classified exactly once', () => {
+  const pending = new Set(HELP_PENDING)
+  for (const route of routesFromApp()) {
+    const places = [
+      route in HELP_SCREENS && 'HELP_SCREENS',
+      pending.has(route) && 'HELP_PENDING',
+      route in HELP_EXEMPT && 'HELP_EXEMPT',
+    ].filter(Boolean)
+    assert.equal(places.length, 1, `${route} is in ${places.join(' and ')}`)
+  }
+})
+
+test('no classification names a route that no longer exists', () => {
+  const routes = new Set(routesFromApp())
+  const stale = [
+    ...Object.keys(HELP_SCREENS),
+    ...HELP_PENDING,
+    ...Object.keys(HELP_EXEMPT),
+  ].filter((r) => !routes.has(r))
+  assert.deepEqual(stale, [], `stale route classification: ${stale.join(', ')}`)
+})
+
+test('every written screen fills all four prose slots', () => {
+  for (const [route, screen] of Object.entries(HELP_SCREENS)) {
+    for (const slot of ['what', 'behaviour', 'surprise', 'examples'] as const) {
+      assert.ok(
+        String(screen[slot]()).length > 0,
+        `${route} has an empty ${slot}`
+      )
+    }
+    assert.ok(
+      screen.whatYouCanDo.length > 0,
+      `${route} lists nothing under whatYouCanDo`
+    )
+  }
+})
+
+test('resolveHelpScreen matches a host app’s nested mount', () => {
+  assert.equal(
+    resolveHelpScreen('/acme/projects/site/main/functions'),
+    HELP_SCREENS['/functions']
+  )
+  assert.equal(resolveHelpScreen('/functions/'), HELP_SCREENS['/functions'])
+  assert.equal(resolveHelpScreen('/overview'), null)
+})

--- a/packages/console/src/help/screens.ts
+++ b/packages/console/src/help/screens.ts
@@ -1,0 +1,117 @@
+import { m } from '@/i18n/messages'
+
+/**
+ * Plain-language help for one screen, for someone who has never met the concept.
+ * The four prose slots are fixed so every screen says the same kind of thing in
+ * the same order; copy carries `[label](#anchor)` spans that point at real
+ * controls (see HelpText).
+ */
+export interface HelpScreen {
+  title: () => string
+  what: () => string
+  behaviour: () => string
+  surprise: () => string
+  examples: () => string
+  whatYouCanDo: Array<() => string>
+  docsHref?: string
+}
+
+export const HELP_SCREENS: Record<string, HelpScreen> = {
+  '/functions': {
+    title: m.help_functions_title,
+    what: m.help_functions_what,
+    behaviour: m.help_functions_behaviour,
+    surprise: m.help_functions_surprise,
+    examples: m.help_functions_examples,
+    whatYouCanDo: [
+      m.help_functions_do_search,
+      m.help_functions_do_select,
+      m.help_functions_do_internals,
+    ],
+    docsHref: 'https://pikku.dev/docs/core-features/functions',
+  },
+}
+
+/**
+ * Routes that will never carry help, with the reason. A redirect or an embed
+ * target has no screen for a reader to be oriented on.
+ */
+export const HELP_EXEMPT: Record<string, string> = {
+  '/': 'redirects to /overview',
+  '/config': 'redirects to /secrets',
+  '/render/workflow': 'headless embed target, no chrome',
+  '*': 'not-found',
+}
+
+/**
+ * Routes whose copy has not been written yet.
+ *
+ * This list is the point of the route-keyed registry: an unwritten screen is
+ * enumerated here rather than silently rendering nothing, and a NEW route fails
+ * `screens.test.ts` until someone classifies it. Deleting an entry from here and
+ * adding it to HELP_SCREENS is how this shrinks.
+ */
+export const HELP_PENDING: readonly string[] = [
+  '/overview',
+  '/workflow',
+  '/agents',
+  '/agents/playground',
+  '/scorers',
+  '/changes',
+  '/scenarios',
+  '/personas',
+  '/virtual-users',
+  '/knowledge',
+  '/surface',
+  '/database',
+  '/apis',
+  '/jobs',
+  '/runtime',
+  '/emails',
+  '/webhooks',
+  '/secrets',
+  '/variables',
+  '/security',
+  '/credentials',
+  '/users',
+  '/scopes',
+  '/audit',
+  '/auth-providers',
+  '/addons',
+]
+
+const HOST_SCREENS: Record<string, HelpScreen> = {}
+
+/**
+ * Screens for a host app's own routes (Fabric's project chrome, say). Host keys
+ * win over the console's, so a host can also replace one of these screens.
+ */
+export function registerHelpScreens(screens: Record<string, HelpScreen>): void {
+  Object.assign(HOST_SCREENS, screens)
+}
+
+/**
+ * Resolve a pathname to its screen.
+ *
+ * Exact match first, then the longest registry key the path ENDS with: a host
+ * app mounts these screens under its own prefix (`/acme/projects/x/main/functions`),
+ * and the console's own route is the tail of it.
+ */
+export function resolveHelpScreen(pathname: string): HelpScreen | null {
+  const path = pathname.replace(/\/+$/, '') || '/'
+  for (const table of [HOST_SCREENS, HELP_SCREENS]) {
+    const exact = table[path]
+    if (exact) return exact
+  }
+  let best: HelpScreen | null = null
+  let bestLen = -1
+  for (const table of [HOST_SCREENS, HELP_SCREENS]) {
+    for (const [key, screen] of Object.entries(table)) {
+      if (path.endsWith(key) && key.length > bestLen) {
+        best = screen
+        bestLen = key.length
+      }
+    }
+  }
+  return best
+}

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -677,3 +677,14 @@ export type {
   ScenarioFlowEntries,
   ScenarioPersonaEntries,
 } from './hooks/useScenarioEntries'
+
+// Help — the per-screen `?` panel. The affordance is wired into PageLayout and
+// resolves its copy from the route, so pages pass nothing; a host registers
+// screens for its own routes and marks up controls with `data-help="<anchor>"`.
+export { HelpText } from './help/HelpText'
+export { HelpPanel } from './help/HelpPanel'
+export { HelpAffordance } from './help/HelpAffordance'
+export { registerHelpScreens, resolveHelpScreen } from './help/screens'
+export type { HelpScreen } from './help/screens'
+export { parseHelpText } from './help/parseHelpText'
+export type { HelpSegment } from './help/parseHelpText'

--- a/packages/console/src/pages/FunctionsPage.tsx
+++ b/packages/console/src/pages/FunctionsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { useSearchParams } from '../router'
-import { Group, TextInput } from '@pikku/mantine/core'
+import { Box, Group, TextInput } from '@pikku/mantine/core'
 import { Search } from 'lucide-react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
@@ -51,6 +51,7 @@ export const FunctionsPage: React.FC<{
             filters={
               <Group gap="sm" wrap="nowrap">
                 <TextInput
+                  data-help="search"
                   placeholder={m.functions_search_placeholder()}
                   leftSection={<Search size={14} />}
                   value={searchQuery}
@@ -58,11 +59,13 @@ export const FunctionsPage: React.FC<{
                   size="xs"
                   style={{ width: 240 }}
                 />
-                <PikkuToggle
-                  checked={showPikkuFunctions}
-                  onChange={setShowPikkuFunctions}
-                  tooltip={m.common_show_pikku_internals()}
-                />
+                <Box data-help="internals">
+                  <PikkuToggle
+                    checked={showPikkuFunctions}
+                    onChange={setShowPikkuFunctions}
+                    tooltip={m.common_show_pikku_internals()}
+                  />
+                </Box>
                 {headerRight}
               </Group>
             }
@@ -75,13 +78,15 @@ export const FunctionsPage: React.FC<{
           (rawFunctions as unknown as any[]).length === 0
         }
       >
-        <FunctionsListPanel
-          searchQuery={searchQuery}
-          showPikkuFunctions={showPikkuFunctions}
-          extraColumns={extraColumns}
-          testsByFunction={testsByFunction}
-          emptyHero={emptyHero}
-        />
+        <Box data-help="list" style={{ height: '100%' }}>
+          <FunctionsListPanel
+            searchQuery={searchQuery}
+            showPikkuFunctions={showPikkuFunctions}
+            extraColumns={extraColumns}
+            testsByFunction={testsByFunction}
+            emptyHero={emptyHero}
+          />
+        </Box>
       </ResizablePanelLayout>
     </ConsoleSurface>
   )

--- a/packages/console/src/router.tsx
+++ b/packages/console/src/router.tsx
@@ -41,6 +41,14 @@ export const useConsoleRouter = (): ConsoleRouter => {
   return ctx
 }
 
+/**
+ * The router if one is mounted, else null — for chrome that renders in both a
+ * routed app and a bare host embed, where `useConsoleRouter` throwing would take
+ * the page down over an optional feature.
+ */
+export const useOptionalConsoleRouter = (): ConsoleRouter | null =>
+  useContext(RouterContext)
+
 export const useLink = (): LinkComponent => useConsoleRouter().Link
 export const useNavigate = () => useConsoleRouter().useNavigate()
 export const useLocation = () => useConsoleRouter().useLocation()


### PR DESCRIPTION
Every page header gets a `?` that opens a plain-language panel explaining the concept behind the screen — written for people who do not already know what a secret, a stage or a scenario is.

The part that makes it more than a docs link: copy carries `[label](#anchor)` spans, and hovering one rings the control marked `data-help="anchor"` on the page behind the panel. So the explanation doubles as a way to find the actions, in plain English, without a product tour. The panel is deliberately overlay-free, since a scrim would hide the thing being pointed at.

**The honesty rule.** An anchor whose target is not in the DOM renders as ordinary text — no underline, no affordance, no dead hover. That is what stops the panel promising a button an empty state, a permission check or the phone layout does not show.

**Help is per screen, and nothing opts in.** The registry is keyed by route. A route that is neither written, pending, nor explicitly exempt fails `screens.test.ts`; at runtime an unwritten route still renders nothing. Missing help is allowed to exist, but not to stay quiet.

Hosts register their own screens:

```ts
import { registerHelpScreens } from '@pikku/console'
registerHelpScreens({ '/secrets': { title, what, behaviour, surprise, examples, whatYouCanDo, docsHref } })
```

Route matching is exact-then-longest-suffix, so a host mounting the console under its own path picks up these entries for free, and host keys win over console keys so a host can override one.

`ShellHeaderAction` gains an optional `helpAnchor` that lands as `data-help` on all three ActionCluster shapes — without it a header's primary action is unanchorable, which is most of what a newcomer wants pointed at.

Ships the Functions screen end to end as the proof; the rest are enumerated in `HELP_PENDING`.

### Verified

Beyond the unit tests, this was rendered in a browser and driven headlessly: the live anchor underlines and rings the correct element on hover, leaving clears it, an off-screen target scrolls into view before ringing, and a deliberately-dead anchor renders as bare text and does nothing.

That check earned its keep. The ring initially did not draw at all — `helpAnchor.css` used bare `var(--app-accent)`, but that variable is host-supplied and undefined in the console itself, which made the whole `outline` declaration invalid. The attribute was being set correctly on the right element and nothing was visible. Every other use in `console.module.css` carries `var(--app-accent, var(--mantine-primary-color-filled))`; this now does too. It would have looked fine in a host that defines the variable and shipped broken everywhere else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual, per-screen help accessible from a new help button in the console.
  * Added a Functions screen help panel with explanations, examples, available actions, and documentation links.
  * Help guidance can highlight and navigate to relevant controls, including search, filters, and function lists.
  * Help panels adapt to phone and desktop layouts without obscuring the current screen.
  * Added support for registering help content for host application screens.

* **Accessibility**
  * Added tooltips, keyboard focus support, reduced-motion handling, and accessible labels for help interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->