### PR TITLE
fix(deploy-cloudflare): stand the runtime dispatch inbox down where the app wires its own

### DIFF
--- a/.changeset/remote-jobs-inbox-shim.md
+++ b/.changeset/remote-jobs-inbox-shim.md
@@ -1,0 +1,6 @@
+---
+'@pikku/deploy-cloudflare': patch
+'@pikku/deploy': patch
+---
+
+the runtime's built-in remote job inbox stands down on units that wire the inbox themselves, so `scaffold.remoteJobs` routes and their middleware actually serve dispatch

--- a/packages/deploy/deploy-cloudflare/src/adapter.test.ts
+++ b/packages/deploy/deploy-cloudflare/src/adapter.test.ts
@@ -77,3 +77,47 @@ describe('CloudflareProviderAdapter contributors', () => {
     assert.doesNotMatch(source, /new Kysely/)
   })
 })
+
+const inboxUnit = {
+  ...(unit as object),
+  handlers: [
+    {
+      type: 'fetch',
+      routes: [
+        {
+          method: 'post',
+          route: '/__pikku/queue-job',
+          pikkuFuncId: 'runRemoteQueueJob',
+        },
+      ],
+    },
+    { type: 'queue', queueName: 'emails' },
+  ],
+} as never
+
+const inboxCtx = { ...(ctx as object), unit: inboxUnit } as never
+
+describe('CloudflareProviderAdapter remote job inbox', () => {
+  test('the container entry mounts the runtime inbox by default', () => {
+    const source = new CloudflareProviderAdapter().generateServerEntrySource(
+      ctx
+    )
+
+    assert.match(source, /dispatchJobs: true/)
+  })
+
+  test('the container entry stands down where the unit wires the inbox', () => {
+    const source = new CloudflareProviderAdapter().generateServerEntrySource(
+      inboxCtx
+    )
+
+    assert.match(source, /dispatchJobs: false/)
+  })
+
+  test('httpQueueJobs stands down where the unit wires the inbox', () => {
+    const adapter = new CloudflareProviderAdapter({ httpQueueJobs: true })
+
+    assert.match(adapter.generateEntrySource(ctx), /httpQueueJobs: true/)
+    assert.match(adapter.generateEntrySource(inboxCtx), /httpQueueJobs: false/)
+  })
+})

--- a/packages/deploy/deploy-cloudflare/src/adapter.ts
+++ b/packages/deploy/deploy-cloudflare/src/adapter.ts
@@ -28,6 +28,7 @@ import {
   collectContributorLines,
   dedupeContributors,
   partitionContributors,
+  unitWiresRemoteJobInbox,
 } from '@pikku/deploy'
 
 export type { PlatformServiceContributor } from '@pikku/deploy'
@@ -101,6 +102,16 @@ export class CloudflareProviderAdapter implements ProviderAdapter {
       CLOUDFLARE_BINDING_SOURCES,
       this.name
     )
+  }
+
+  /**
+   * The runtime's own inbox is mounted ahead of route dispatch, so it would
+   * shadow the one `scaffold.remoteJobs` wires — along with any middleware in
+   * front of it. Where the unit wires the inbox itself, the runtime shim
+   * stands down and the wired routes serve dispatch.
+   */
+  private resolveHttpQueueJobs(unit: DeploymentUnit): boolean {
+    return this.httpQueueJobs && !unitWiresRemoteJobInbox(unit)
   }
 
   getPlatform(): 'browser' {
@@ -241,7 +252,7 @@ export class CloudflareProviderAdapter implements ProviderAdapter {
       `  const server = new PikkuNodeHTTPServer(`,
       `    { ...config, hostname: HOST, port: PORT, healthCheckPath: '/__pikku/health' },`,
       `    singletonServices.logger,`,
-      `    { dispatchJobs: true, dispatchSecret: process.env.PIKKU_DISPATCH_SECRET },`,
+      `    { dispatchJobs: ${!unitWiresRemoteJobInbox(ctx.unit)}, dispatchSecret: process.env.PIKKU_DISPATCH_SECRET },`,
       `  )`,
       `  server.enableExitOnSignals()`,
       `  await server.init()`,
@@ -335,7 +346,7 @@ export class CloudflareProviderAdapter implements ProviderAdapter {
       `export default createCloudflareHandler(`,
       `  { createConfig: ${ctx.configVar}, createSingletonServices: ${ctx.servicesVar}, createPlatformServices },`,
       `  ${JSON.stringify(handlerTypes)},`,
-      `  { httpQueueJobs: ${this.httpQueueJobs} }`,
+      `  { httpQueueJobs: ${this.resolveHttpQueueJobs(ctx.unit)} }`,
       `)`,
       ``,
     ]
@@ -425,8 +436,10 @@ export class CloudflareProviderAdapter implements ProviderAdapter {
 
     const handlerTypes = includeQueueHandler ? `["fetch", "queue"]` : ''
 
+    const httpQueueJobs = this.resolveHttpQueueJobs(ctx.unit)
+
     const exportLine = includeQueueHandler
-      ? `export default createCloudflareHandler(\n  { createConfig: ${ctx.configVar}, createSingletonServices: ${ctx.servicesVar}, createPlatformServices },\n  ${handlerTypes},\n  { httpQueueJobs: ${this.httpQueueJobs} }\n)`
+      ? `export default createCloudflareHandler(\n  { createConfig: ${ctx.configVar}, createSingletonServices: ${ctx.servicesVar}, createPlatformServices },\n  ${handlerTypes},\n  { httpQueueJobs: ${httpQueueJobs} }\n)`
       : `export default createCloudflareWorkerHandler({ createConfig: ${ctx.configVar}, createSingletonServices: ${ctx.servicesVar}, createPlatformServices })`
 
     const handlerImport = includeQueueHandler

--- a/packages/deploy/deploy-core/src/index.ts
+++ b/packages/deploy/deploy-core/src/index.ts
@@ -20,6 +20,11 @@ export type {
   WorkflowStepDefinition,
 } from './manifest.js'
 
+export {
+  REMOTE_JOB_INBOX_PATHS,
+  unitWiresRemoteJobInbox,
+} from './remote-job-inbox.js'
+
 export type {
   EntryGenerationContext,
   ProviderAdapter,

--- a/packages/deploy/deploy-core/src/remote-job-inbox.ts
+++ b/packages/deploy/deploy-core/src/remote-job-inbox.ts
@@ -1,0 +1,29 @@
+import type { DeploymentUnit } from './manifest.js'
+
+/**
+ * The two paths `scaffold.remoteJobs` wires into the app itself. Kept as
+ * literals rather than imported from `@pikku/core` because deploy-core is
+ * dependency-free; they are the values of `REMOTE_QUEUE_JOB_PATH` and
+ * `REMOTE_SCHEDULER_JOB_PATH`.
+ */
+export const REMOTE_JOB_INBOX_PATHS = [
+  '/__pikku/queue-job',
+  '/__pikku/scheduler-job',
+]
+
+/**
+ * Whether the unit serves the remote job inbox through its own wirings.
+ *
+ * Runtimes mount an inbox of their own ahead of route dispatch, which would
+ * shadow the wired one along with any middleware in front of it. A generator
+ * asks this so the runtime-level shim stands down where the app has already
+ * wired the inbox.
+ */
+export const unitWiresRemoteJobInbox = (unit: DeploymentUnit): boolean =>
+  unit.handlers.some(
+    (handler) =>
+      handler.type === 'fetch' &&
+      handler.routes.some((route) =>
+        REMOTE_JOB_INBOX_PATHS.includes(route.route)
+      )
+  )


### PR DESCRIPTION
The node and Cloudflare runtimes both handle `/__pikku/queue-job` and `/__pikku/scheduler-job` ahead of route dispatch. With `scaffold.remoteJobs` on, that shadows the wired inbox — and any middleware in front of it — so the generated routes are dead code.

The generators now emit `dispatchJobs: false` (container entry) and `httpQueueJobs: false` (worker entries) for a unit whose own fetch handler already serves those paths. Units that don't wire the inbox are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployments now prevent duplicate remote job inbox handling when an application provides its own inbox routes and queue handlers.
  * Custom remote job inbox wiring is preserved without being shadowed by built-in runtime handling.
  * Cloudflare deployments now correctly coordinate HTTP queue processing and job dispatch based on the application’s configured inbox behavior.

* **Documentation**
  * Added release documentation describing the updated remote job inbox behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->