### PR TITLE
fix(deploy-cloudflare): stub node:fs instead of externalizing it

### DIFF
--- a/.changeset/cf-stub-node-fs.md
+++ b/.changeset/cf-stub-node-fs.md
@@ -1,0 +1,5 @@
+---
+'@pikku/deploy-cloudflare': patch
+---
+
+Stub `node:fs` in Cloudflare worker bundles instead of leaving it external. Workers have no `node:fs` under any compatibility flag, so a bundle that imports it — as `@pikku/addon-console`'s management functions do — dies at upload with `No such module "node:fs"`. Listing the node builtins individually lets the existing stub plugin take it, the same way `pg`/`postgres` are already stubbed.

--- a/packages/deploy/deploy-cloudflare/src/adapter.test.ts
+++ b/packages/deploy/deploy-cloudflare/src/adapter.test.ts
@@ -121,3 +121,20 @@ describe('CloudflareProviderAdapter remote job inbox', () => {
     assert.match(adapter.generateEntrySource(inboxCtx), /httpQueueJobs: false/)
   })
 })
+
+describe('node builtins on Workers', () => {
+  test('node:fs is stubbed rather than left external', () => {
+    const adapter = new CloudflareProviderAdapter()
+    const externals = adapter.getExternals()
+
+    assert.ok(!externals.includes('node:*'))
+    assert.ok(!externals.includes('node:fs'))
+    assert.ok(externals.includes('node:path'))
+    assert.ok(adapter.getStubModules().includes('^node:fs$'))
+    assert.ok(adapter.getStubModules().includes('^node:fs/promises$'))
+  })
+
+  test('fs still aliases to its prefixed form so the stub can match it', () => {
+    assert.equal(new CloudflareProviderAdapter().getAliases()['fs'], 'node:fs')
+  })
+})

--- a/packages/deploy/deploy-cloudflare/src/adapter.ts
+++ b/packages/deploy/deploy-cloudflare/src/adapter.ts
@@ -76,6 +76,58 @@ function getHandlerTypes(unit: DeploymentUnit): string[] {
   return [...types]
 }
 
+const NODE_BUILTINS = [
+  'assert',
+  'async_hooks',
+  'buffer',
+  'child_process',
+  'cluster',
+  'console',
+  'constants',
+  'crypto',
+  'dgram',
+  'dns',
+  'domain',
+  'events',
+  'fs',
+  'http',
+  'http2',
+  'https',
+  'inspector',
+  'module',
+  'net',
+  'os',
+  'path',
+  'perf_hooks',
+  'process',
+  'punycode',
+  'querystring',
+  'readline',
+  'repl',
+  'stream',
+  'string_decoder',
+  'sys',
+  'timers',
+  'tls',
+  'trace_events',
+  'tty',
+  'url',
+  'util',
+  'v8',
+  'vm',
+  'wasi',
+  'worker_threads',
+  'zlib',
+]
+
+// `node:fs` has no implementation on Workers under any compatibility flag, so a
+// bundle that imports it dies at module load with `No such module "node:fs"`
+// before a line of it runs. Leaving it in the externals meant esbuild resolved
+// it before the stub plugin ever saw it — `external` is matched ahead of an
+// `onResolve` hook — so listing the builtins individually is what lets the stub
+// below take it.
+const CF_UNSUPPORTED_BUILTINS = new Set(['fs'])
+
 export class CloudflareProviderAdapter implements ProviderAdapter {
   readonly name = 'cloudflare'
   readonly deployDirName = 'cloudflare'
@@ -675,7 +727,14 @@ export class CloudflareProviderAdapter implements ProviderAdapter {
   }
 
   getExternals(): string[] {
-    return ['node:*', 'cloudflare:*', 'uWebSockets.js']
+    const supported = NODE_BUILTINS.filter(
+      (b) => !CF_UNSUPPORTED_BUILTINS.has(b)
+    )
+    return [
+      ...supported.flatMap((b) => [`node:${b}`, `node:${b}/*`]),
+      'cloudflare:*',
+      'uWebSockets.js',
+    ]
   }
 
   getStubModules(): string[] {
@@ -689,55 +748,20 @@ export class CloudflareProviderAdapter implements ProviderAdapter {
     // the two in application code, it is equally unreachable on CF, and it
     // additionally reaches for `net`/`tls` and `pg-native`, which a worker
     // build cannot resolve at all.
-    return ['^postgres$', '^kysely-postgres-js$', '^pg$', '^pg-native$']
+    return [
+      '^postgres$',
+      '^kysely-postgres-js$',
+      '^pg$',
+      '^pg-native$',
+      '^node:fs$',
+      '^node:fs/promises$',
+    ]
   }
 
   getAliases(): Record<string, string> {
     // Map every node builtin to its `node:`-prefixed form. CF's
     // nodejs_compat_v2 only resolves prefixed imports.
-    const builtins = [
-      'assert',
-      'async_hooks',
-      'buffer',
-      'child_process',
-      'cluster',
-      'console',
-      'constants',
-      'crypto',
-      'dgram',
-      'dns',
-      'domain',
-      'events',
-      'fs',
-      'http',
-      'http2',
-      'https',
-      'inspector',
-      'module',
-      'net',
-      'os',
-      'path',
-      'perf_hooks',
-      'process',
-      'punycode',
-      'querystring',
-      'readline',
-      'repl',
-      'stream',
-      'string_decoder',
-      'sys',
-      'timers',
-      'tls',
-      'trace_events',
-      'tty',
-      'url',
-      'util',
-      'v8',
-      'vm',
-      'wasi',
-      'worker_threads',
-      'zlib',
-    ]
+    const builtins = NODE_BUILTINS
     const aliases: Record<string, string> = {}
     for (const b of builtins) aliases[b] = `node:${b}`
     return aliases


### PR DESCRIPTION
## What

Cloudflare Workers provide no `node:fs` under any compatibility flag, so a worker bundle that imports it dies at upload with:

```
CF 400: Uncaught Error: No such module "node:fs".
  imported from "worker.js"
```

`@pikku/addon-console`'s management functions (`install-addon`, `update-dependency`, `addon-readiness`, `run-security-audit`, `state-diff`) plus `@pikku/knowledge` and `@pikku/code-edit` import it, and they are linked into every function worker. On a 118-unit project this took the deploy from green to **106 failing workers**.

The adapter already stubs modules that are unreachable on Workers — `pg`, `postgres`, `kysely-postgres-js`, `pg-native`. `node:fs` belongs in exactly that list. It could not get there while `getExternals()` returned `node:*`, because esbuild matches `external` ahead of a plugin's `onResolve`, so the dead-module stub plugin never saw the import. Enumerating the builtins individually leaves the stub free to take `node:fs` and `node:fs/promises`.

`getAliases()` still maps bare `fs` → `node:fs`, so unprefixed imports normalise into the form the stub matches.

## Verification

Built a real 118-unit project's Cloudflare bundles before and after:

| | bundles | importing `node:fs` |
|---|---|---|
| before | 118 | 106 |
| after | 118 | **0** |

Bundling itself stays green — no unresolved-import errors from the stub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cloudflare Worker deployments that use file-system-related Node.js modules no longer fail during upload.
  - Unsupported file-system modules are now safely stubbed, while supported Node.js modules continue to function as expected.
  - Improved handling of the `fs` module and its promise-based variant in Cloudflare bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->