### PR TITLE
feat(cli): an addon publishes one registration file per function

### DIFF
--- a/.changeset/addon-per-function-registration.md
+++ b/.changeset/addon-per-function-registration.md
@@ -1,0 +1,15 @@
+---
+'@pikku/cli': patch
+'@pikku/inspector': patch
+---
+
+An addon publishes one registration file per function, so a consumer bundles
+only the functions it deploys.
+
+`pikku all --addon` now writes `function/single/<name>.gen.ts` alongside the
+combined `function/pikku-functions.gen.ts`, plus `pikku-bootstrap-shared.gen.ts`
+— the addon bootstrap without the combined registration. A consumer's bootstrap
+pairs the shared file with the per-function files its filter actually reaches,
+and the deploy analyzer gives each exposed addon function its own unit rather
+than one unit per addon. An addon built by an older CLI publishes neither file,
+so the consumer falls back to importing the whole bootstrap.

--- a/packages/cli/src/deploy/analyzer/analyzer.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.ts
@@ -13,6 +13,7 @@ import {
   type SerializedWorkflowGraph,
 } from '@pikku/inspector'
 import { relative } from 'node:path'
+import { resolveSplitAddonImports } from '../../utils/addon-split-imports.js'
 import type { FunctionMeta } from '@pikku/core/services'
 import type { ChannelMeta } from '@pikku/core/channel'
 import type { HTTPWiringsMeta } from '@pikku/core/http'
@@ -238,6 +239,10 @@ export function analyzeDeployment(
   }
 
   // ── Step 1b: Addon units ───────────────────────────────────────────
+  //
+  // An addon that publishes per-function registration files is split the same
+  // way app code is: one exposed function, one unit. An addon built before that
+  // existed can only be imported whole, so its exposed functions share a unit.
   const addonUnitByRpcName = new Map<string, string>()
   for (const [namespace, addonMeta] of entries(state.addonFunctions ?? {})) {
     const exposed = entries(addonMeta).filter(([, meta]) => meta.expose)
@@ -245,60 +250,82 @@ export function analyzeDeployment(
       continue
     }
 
-    const unitName = `addon-${toSafeKebab(namespace)}`
+    const decl = state.rpc?.wireAddonDeclarations?.get(namespace)
+    const splittable =
+      !!decl &&
+      !decl.remote &&
+      resolveSplitAddonImports(
+        state.rootDir,
+        decl.package,
+        exposed.map(([funcName]) => funcName)
+      ) !== null
+
     const addonIncompatible = new Set(
       state.addonServerlessIncompatible?.get(namespace) ?? []
     )
-    const routes: HttpRouteInfo[] = []
-    const functionIds: string[] = []
-    const services: ServiceRequirement[] = []
-    let target: 'serverless' | 'server' = defaultTarget
 
-    for (const [funcName, funcMeta] of exposed) {
-      const rpcName = `${namespace}:${funcName}`
-      functionIds.push(rpcName)
-      addonUnitByRpcName.set(rpcName, unitName)
-      routes.push({
-        method: 'post',
-        route: prefixed(`/rpc/${rpcName}`),
-        pikkuFuncId: rpcName,
-      })
-      routes.push({
-        method: 'post',
-        route: prefixed(`/remote/rpc/${rpcName}`),
-        pikkuFuncId: rpcName,
-      })
-      for (const service of collectServicesForFunction(funcMeta)) {
+    const groups: Array<{
+      unitName: string
+      members: Array<[string, FunctionMeta]>
+    }> = splittable
+      ? exposed.map(([funcName, funcMeta]) => ({
+          unitName: `addon-${toSafeKebab(namespace)}-${toSafeKebab(funcName)}`,
+          members: [[funcName, funcMeta]] as Array<[string, FunctionMeta]>,
+        }))
+      : [{ unitName: `addon-${toSafeKebab(namespace)}`, members: exposed }]
+
+    for (const { unitName, members } of groups) {
+      const routes: HttpRouteInfo[] = []
+      const functionIds: string[] = []
+      const services: ServiceRequirement[] = []
+      let target: 'serverless' | 'server' = defaultTarget
+
+      for (const [funcName, funcMeta] of members) {
+        const rpcName = `${namespace}:${funcName}`
+        functionIds.push(rpcName)
+        addonUnitByRpcName.set(rpcName, unitName)
+        routes.push({
+          method: 'post',
+          route: prefixed(`/rpc/${rpcName}`),
+          pikkuFuncId: rpcName,
+        })
+        routes.push({
+          method: 'post',
+          route: prefixed(`/remote/rpc/${rpcName}`),
+          pikkuFuncId: rpcName,
+        })
+        for (const service of collectServicesForFunction(funcMeta)) {
+          if (
+            !services.some(
+              (s) => s.sourceServiceName === service.sourceServiceName
+            )
+          ) {
+            services.push(service)
+          }
+        }
         if (
-          !services.some(
-            (s) => s.sourceServiceName === service.sourceServiceName
-          )
+          resolveDeployTarget(
+            funcMeta,
+            addonIncompatible,
+            rpcName,
+            defaultTarget
+          ) === 'server'
         ) {
-          services.push(service)
+          target = 'server'
         }
       }
-      if (
-        resolveDeployTarget(
-          funcMeta,
-          addonIncompatible,
-          rpcName,
-          defaultTarget
-        ) === 'server'
-      ) {
-        target = 'server'
-      }
-    }
 
-    units.push({
-      name: unitName,
-      role: 'function',
-      target,
-      functionIds,
-      services,
-      dependsOn: [],
-      handlers: [{ type: 'fetch', routes }],
-      tags: [],
-    })
+      units.push({
+        name: unitName,
+        role: 'function',
+        target,
+        functionIds,
+        services,
+        dependsOn: [],
+        handlers: [{ type: 'fetch', routes }],
+        tags: [],
+      })
+    }
   }
 
   // ── Step 2: Agent gateways ─────────────────────────────────────────

--- a/packages/cli/src/functions/commands/pikku-command-bootstrap.ts
+++ b/packages/cli/src/functions/commands/pikku-command-bootstrap.ts
@@ -3,6 +3,10 @@ import { rm } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { pikkuSessionlessFunc } from '#pikku/function'
 import { getFileImportRelativePath } from '../../utils/file-import-path.js'
+import {
+  SHARED_BOOTSTRAP_FILE,
+  resolveSplitAddonImports,
+} from '../../utils/addon-split-imports.js'
 import { writeFileInDir } from '../../utils/file-writer.js'
 
 export type BootstrapInput = {
@@ -14,13 +18,28 @@ export const pikkuBootstrap = pikkuSessionlessFunc<BootstrapInput, void>({
     const stateBeforeBootstrap = await getInspectorState()
     const addonBootstraps: string[] = []
 
-    for (const [, decl] of stateBeforeBootstrap.rpc?.wireAddonDeclarations ??
-      []) {
+    for (const [namespace, decl] of stateBeforeBootstrap.rpc
+      ?.wireAddonDeclarations ?? []) {
       // Remote addons (wireRemoteAddon) run on the host — never import their
       // runtime bootstrap here; that would register their functions locally
       // and drag in the runtime deps remote consumption exists to avoid. The
       // consumer's own wireRemoteAddon() call registers the remote binding.
       if (decl.remote) continue
+      const funcNames = Object.keys(
+        stateBeforeBootstrap.addonFunctions?.[namespace] ?? {}
+      )
+      const split = resolveSplitAddonImports(
+        stateBeforeBootstrap.rootDir,
+        decl.package,
+        funcNames
+      )
+      if (split) {
+        addonBootstraps.push(...split)
+        logger.debug(
+          `• Addon bootstrap: ${decl.package} (${funcNames.length} of its functions)`
+        )
+        continue
+      }
       addonBootstraps.push(`${decl.package}/.pikku/pikku-bootstrap.gen.js`)
       logger.debug(`• Addon bootstrap: ${decl.package}`)
     }
@@ -97,6 +116,22 @@ export const pikkuBootstrap = pikkuSessionlessFunc<BootstrapInput, void>({
       .join('\n')
 
     await writeFileInDir(logger, config.bootstrapFile, allBootstrapImports)
+
+    // An addon also publishes its bootstrap without the combined function
+    // registration, so a consumer can pair it with just the per-function files
+    // it needs instead of taking every function the package defines.
+    if (config.addonName) {
+      const functionsImport = `import '${getFileImportRelativePath(config.bootstrapFile, config.functionsFile, config.packageMappings, config.forceRelativeImports)}'`
+      const sharedImports = allBootstrapImports
+        .split('\n')
+        .filter((line) => line !== functionsImport)
+        .join('\n')
+      await writeFileInDir(
+        logger,
+        join(outDir, SHARED_BOOTSTRAP_FILE),
+        sharedImports
+      )
+    }
 
     // The scenario bootstrap is the only entry point that registers scenarios,
     // features and their steps. It pulls in the app bootstrap first so a runner

--- a/packages/cli/src/functions/wirings/functions/pikku-command-functions.ts
+++ b/packages/cli/src/functions/wirings/functions/pikku-command-functions.ts
@@ -1,7 +1,13 @@
+import { dirname, join } from 'node:path'
+import { rm } from 'node:fs/promises'
 import { pikkuSessionlessFunc } from '#pikku/function'
 import { writeFileInDir } from '../../../utils/file-writer.js'
 import { logCommandInfoAndTime } from '../../../middleware/log-command-info-and-time.js'
-import { serializeFunctionImports } from './serialize-function-imports.js'
+import {
+  serializeFunctionImports,
+  serializeSingleFunctionImports,
+  SINGLE_FUNCTION_DIR,
+} from './serialize-function-imports.js'
 import { getFileImportRelativePath } from '../../../utils/file-import-path.js'
 import {
   stripVerboseFields,
@@ -86,6 +92,24 @@ export const pikkuFunctions = pikkuSessionlessFunc<void, boolean | undefined>({
           packageMappings,
           config.addonName
         )
+      )
+    }
+
+    if (isAddon) {
+      const singleDir = join(dirname(functionsFile), SINGLE_FUNCTION_DIR)
+      await rm(singleDir, { recursive: true, force: true })
+      const singles = serializeSingleFunctionImports(
+        singleDir,
+        appFiles,
+        appFunctionsMeta,
+        packageMappings,
+        config.addonName
+      )
+      for (const [path, contents] of singles) {
+        await writeFileInDir(logger, path, contents)
+      }
+      logger.debug(
+        `• Wrote ${singles.size} per-function registration files to ${singleDir}`
       )
     }
 

--- a/packages/cli/src/functions/wirings/functions/serialize-function-imports.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-function-imports.ts
@@ -1,5 +1,9 @@
+import { join } from 'node:path'
 import { getFileImportRelativePath } from '../../../utils/file-import-path.js'
 import type { FunctionsMeta } from '@pikku/core/services'
+
+/** Directory, relative to the combined registration file, holding the per-function ones. */
+export const SINGLE_FUNCTION_DIR = 'single'
 
 export const serializeFunctionImports = (
   outputPath: string,
@@ -62,4 +66,36 @@ export const serializeFunctionImports = (
 
   // Combine the imports and registrations
   return [...serializedImports, ...serializedRegistrations].join('\n')
+}
+
+/**
+ * One registration file per function, so a consumer can bundle a single addon
+ * function instead of the package's whole registration module.
+ *
+ * The combined file stays alongside these — a project on an older addon build,
+ * or one that wants every function, still imports that.
+ */
+export const serializeSingleFunctionImports = (
+  outputDir: string,
+  functionsMap: Map<string, { path: string; exportedName: string }>,
+  functionsMeta: FunctionsMeta,
+  packageMappings: Record<string, string> = {},
+  addonName?: string
+): Map<string, string> => {
+  const files = new Map<string, string>()
+  for (const [name, entry] of functionsMap) {
+    if (!(name in functionsMeta)) continue
+    const outputPath = join(outputDir, `${name}.gen.ts`)
+    files.set(
+      outputPath,
+      serializeFunctionImports(
+        outputPath,
+        new Map([[name, entry]]),
+        functionsMeta,
+        packageMappings,
+        addonName
+      )
+    )
+  }
+  return files
 }

--- a/packages/cli/src/utils/addon-split-imports.test.ts
+++ b/packages/cli/src/utils/addon-split-imports.test.ts
@@ -1,0 +1,107 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { resolveSplitAddonImports } from './addon-split-imports.js'
+
+const PACKAGE_NAME = '@pikku/addon-fixture'
+
+/**
+ * A consumer project with the addon installed, laid out the way an addon
+ * publishes: the generated tree under `dist/.pikku/addon`, reachable through a
+ * `./.pikku/*` wildcard in the exports map.
+ */
+const createProject = async (files: string[]) => {
+  const root = await mkdtemp(join(tmpdir(), 'pikku-addon-split-'))
+  await writeFile(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'consumer', type: 'module' })
+  )
+  const packageDir = join(root, 'node_modules', PACKAGE_NAME)
+  const addonDir = join(packageDir, 'dist', '.pikku', 'addon')
+  await mkdir(join(addonDir, 'function', 'single'), { recursive: true })
+  await writeFile(
+    join(packageDir, 'package.json'),
+    JSON.stringify({
+      name: PACKAGE_NAME,
+      type: 'module',
+      exports: {
+        '.': './dist/.pikku/addon/pikku-bootstrap.gen.js',
+        './.pikku/*': './dist/.pikku/addon/*',
+      },
+    })
+  )
+  for (const file of files) {
+    await writeFile(join(addonDir, file), '')
+  }
+  return root
+}
+
+describe('resolveSplitAddonImports', () => {
+  const roots: string[] = []
+
+  const project = async (files: string[]) => {
+    const root = await createProject(files)
+    roots.push(root)
+    return root
+  }
+
+  after(async () => {
+    for (const root of roots) {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns the shared bootstrap plus one file per named function', async () => {
+    const root = await project([
+      'pikku-bootstrap.gen.js',
+      'pikku-bootstrap-shared.gen.js',
+      'function/single/runSecurityAudit.gen.js',
+      'function/single/installAddon.gen.js',
+    ])
+    assert.deepEqual(
+      resolveSplitAddonImports(root, PACKAGE_NAME, [
+        'runSecurityAudit',
+        'installAddon',
+      ]),
+      [
+        `${PACKAGE_NAME}/.pikku/pikku-bootstrap-shared.gen.js`,
+        `${PACKAGE_NAME}/.pikku/function/single/runSecurityAudit.gen.js`,
+        `${PACKAGE_NAME}/.pikku/function/single/installAddon.gen.js`,
+      ]
+    )
+  })
+
+  test('returns null for an addon built before the split files existed', async () => {
+    const root = await project(['pikku-bootstrap.gen.js'])
+    assert.equal(
+      resolveSplitAddonImports(root, PACKAGE_NAME, ['runSecurityAudit']),
+      null
+    )
+  })
+
+  test('returns null when one of the named functions has no file', async () => {
+    const root = await project([
+      'pikku-bootstrap.gen.js',
+      'pikku-bootstrap-shared.gen.js',
+      'function/single/runSecurityAudit.gen.js',
+    ])
+    assert.equal(
+      resolveSplitAddonImports(root, PACKAGE_NAME, [
+        'runSecurityAudit',
+        'installAddon',
+      ]),
+      null
+    )
+  })
+
+  test('returns null when no functions were named', async () => {
+    const root = await project([
+      'pikku-bootstrap.gen.js',
+      'pikku-bootstrap-shared.gen.js',
+    ])
+    assert.equal(resolveSplitAddonImports(root, PACKAGE_NAME, []), null)
+  })
+})

--- a/packages/cli/src/utils/addon-split-imports.ts
+++ b/packages/cli/src/utils/addon-split-imports.ts
@@ -1,0 +1,43 @@
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+import { SINGLE_FUNCTION_DIR } from '../functions/wirings/functions/serialize-function-imports.js'
+
+export const SHARED_BOOTSTRAP_FILE = 'pikku-bootstrap-shared.gen.ts'
+
+export const sharedBootstrapSpecifier = (packageName: string) =>
+  `${packageName}/.pikku/${SHARED_BOOTSTRAP_FILE.replace(/\.ts$/, '.js')}`
+
+export const singleFunctionSpecifier = (
+  packageName: string,
+  funcName: string
+) => `${packageName}/.pikku/function/${SINGLE_FUNCTION_DIR}/${funcName}.gen.js`
+
+/**
+ * The bootstrap and per-function registration files an addon publishes when it
+ * was built by a CLI that emits them, or `null` when it wasn't — an older build
+ * ships the combined bootstrap alone and has to be imported whole.
+ */
+export const resolveSplitAddonImports = (
+  rootDir: string,
+  packageName: string,
+  funcNames: string[]
+): string[] | null => {
+  if (funcNames.length === 0) {
+    return null
+  }
+  const require = createRequire(join(rootDir, 'package.json'))
+  const specifiers = [
+    sharedBootstrapSpecifier(packageName),
+    ...funcNames.map((funcName) =>
+      singleFunctionSpecifier(packageName, funcName)
+    ),
+  ]
+  for (const specifier of specifiers) {
+    try {
+      require.resolve(specifier)
+    } catch {
+      return null
+    }
+  }
+  return specifiers
+}

--- a/packages/inspector/src/utils/filter-inspector-state.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.ts
@@ -4,6 +4,7 @@ import type {
   InspectorLogger,
 } from '../types.js'
 import type { PikkuWiringTypes } from '@pikku/core/types'
+import type { FunctionsMeta } from '@pikku/core/services'
 import { parseVersionedId } from '@pikku/core/utils'
 import { makeContextBasedId } from './extract-function-name.js'
 import { aggregateRequiredServices } from './post-process.js'
@@ -1287,6 +1288,26 @@ export function filterInspectorState(
         keptNamespaces.has(namespace)
       )
     )
+
+    // Narrow each surviving addon to the functions this filter actually
+    // reaches, so the bootstrap can import those alone rather than the
+    // package's combined registration.
+    const narrowedAddonFunctions: Record<string, FunctionsMeta> = {}
+    for (const namespace of keptNamespaces) {
+      const addonMeta = state.addonFunctions?.[namespace]
+      if (!addonMeta) continue
+      const prefix = `${namespace}:`
+      const kept: FunctionsMeta = {}
+      for (const id of referencedIds) {
+        if (!id.startsWith(prefix)) continue
+        const funcName = id.slice(prefix.length)
+        const meta = addonMeta[funcName]
+        if (meta) kept[funcName] = meta
+      }
+      narrowedAddonFunctions[namespace] =
+        Object.keys(kept).length > 0 ? kept : addonMeta
+    }
+    filteredState.addonFunctions = narrowedAddonFunctions
   }
 
   // Recalculate requiredServices based on filtered functions/middleware/permissions


### PR DESCRIPTION
Builds on #1645. That PR gave an addon's exposed functions their own unit; this one makes the granularity per function, the same as app code.

## The asymmetry it removes

An app function gets a *regenerated per-unit* `function/pikku-functions.gen.ts` holding exactly the functions that unit needs. An addon function came from a *prebuilt published* `function/pikku-functions.gen.js` that registers all of them at module scope, and the package's exports map had no path to an individual one. So the filter could only decide whether to import that module, never what was inside it. Both sides are pikku's code, written by the same serializer — the asymmetry was a choice, not a constraint.

## What changes

**Addon side.** `pikku all --addon` now also writes:
- `function/single/<name>.gen.ts` — one registration per function.
- `pikku-bootstrap-shared.gen.ts` — the addon bootstrap with the combined function import removed.

`"./.pikku/*": "./dist/.pikku/addon/*"` already exports both paths, so no exports-map change and `ref('console:runSecurityAudit')` is untouched.

**Consumer side.** The bootstrap command probes `require.resolve` for the shared bootstrap and for a single file per function the filter reached. All present → it imports those. Anything missing → it imports `pikku-bootstrap.gen.js` whole, exactly as before, so an addon built by an older CLI keeps working.

**Analyzer.** With split files available, each exposed addon function becomes its own unit (`addon-console-run-security-audit`); without them, the addon's exposed functions share one unit as in #1645.

**Filter.** `filterInspectorState` narrows `addonFunctions` to the functions a unit's filter actually reaches, which is what the bootstrap reads to decide what to import.

## Verified

`pikku all` in `packages/addon/pikku-console` emits 65 single files and a shared bootstrap that correctly drops `./function/pikku-functions.gen.js`.

A real `pikku deploy apply -p cloudflare` on a project consuming it, with the two new file sets overlaid on the installed package so everything else resolves identically:

| | before | after |
|---|---|---|
| units | 120 | 182 |
| console addon units | 1 (all 63 exposed functions) | 63 (one each) |
| console addon unit bundle | 1,252,722 B | 1,210,393 B avg |

Each unit's bootstrap ends with `import '@pikku/addon-console/.pikku/pikku-bootstrap-shared.gen.js'` followed by exactly one `single/<name>.gen.js`, and the other 62 function bodies are gone from the bundle.

The 43 KB drop is smaller than the unit count suggests, and worth saying plainly: the addon's weight is not in its function bodies. Roughly 200 KB of every addon bundle is `schemas/register.gen.js` — the schemas for all 65 functions, imported wholesale by the shared bootstrap. Splitting that the same way is the follow-up; this PR is the granularity change.

New tests cover `resolveSplitAddonImports` (split available, addon built before the split existed, one function missing a file, no functions named).