### PR TITLE
feat(cli): deploy.grouping decides how many units an app deploys as

### DIFF
--- a/.changeset/deploy-grouping-tags.md
+++ b/.changeset/deploy-grouping-tags.md
@@ -1,0 +1,14 @@
+---
+'@pikku/cli': patch
+---
+
+fix(deploy): read tags from wirings, and keep the server container's queues wired
+
+`deploy.grouping` and every unit's `tags` field read `FunctionMeta.tags`, but
+tags are written on the wiring — `wireHTTP({ tags: [...] })` — so in a typical
+project they were empty and a `tags` rule matched nothing. The analyzer now
+unions a function's own tags with those of every wiring that reaches it.
+
+Separately, folding server units into `pikku-server-container` left
+`queues[].consumerUnit`, `scheduledTasks[].unitName` and `dependsOn` pointing at
+the unit names it had just removed. The merge rewrites them.

--- a/.changeset/deploy-grouping.md
+++ b/.changeset/deploy-grouping.md
@@ -1,0 +1,9 @@
+---
+'@pikku/cli': patch
+---
+
+Add `deploy.grouping` to `pikku.config.json`, deciding how many deployment units an app's functions collapse into.
+
+`strategy` sets what happens to a function no rule matches — `function` (the default, and today's behaviour) gives it its own unit, `single` puts it in one shared unit. `rules` are evaluated in order, first match wins, matching on `tags`, `addon` or `routes` globs. Under `function` a rule merges functions together; under `single` it carves them out.
+
+Functions whose deploy target differs cannot share a unit, and the build fails naming them rather than promoting one to `server`.

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -210,6 +210,7 @@ jobs:
             dev-bun,
             deploy-cloudflare,
             deploy-serverless,
+            deploy-grouping,
             deploy-azure,
             deploy-standalone,
             better-auth,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,6 +223,7 @@ jobs:
             dev-bun,
             deploy-cloudflare,
             deploy-serverless,
+            deploy-grouping,
             deploy-azure,
             deploy-standalone,
             better-auth,

--- a/packages/cli/src/deploy/analyzer/analyzer.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.ts
@@ -21,6 +21,8 @@ import {
   withoutScenarios,
   withoutScenarioWorkflows,
 } from '../../functions/wirings/scenarios/scenario-partition.js'
+import { toSafeKebab } from './naming.js'
+import { createUnitResolver, type GroupingConfig } from './grouping.js'
 
 import type {
   DeploymentManifest,
@@ -72,6 +74,12 @@ export interface AnalyzerOptions {
    */
   workflowQueues?: boolean
   globalHTTPPrefix?: string
+  /**
+   * Sourced from `pikku.config.json` → `deploy.grouping`. Decides how many
+   * deployment units the `role: 'function'` units collapse into. Omitted
+   * means one unit per function.
+   */
+  grouping?: GroupingConfig
 }
 
 export function analyzeDeployment(
@@ -99,6 +107,98 @@ export function analyzeDeployment(
   const functionsMeta = withoutScenarios(state.functions.meta)
   const graphMeta = withoutScenarioWorkflows(state.workflows.graphMeta)
   const httpMeta = state.http.meta
+
+  const tagIndex = buildFunctionTagIndex(state, functionsMeta)
+  const tagsFor = (funcId: string) => tagIndex.get(funcId) ?? []
+
+  const resolver = createUnitResolver(options.grouping, {
+    routesForFunction: (funcId) =>
+      collectHttpRoutes(httpMeta, funcId).flatMap((r) => [
+        r.route,
+        prefixed(r.route),
+      ]),
+    tagsForFunction: tagsFor,
+  })
+
+  const addFunctionUnit = (unit: DeploymentUnit) => {
+    const existing = units.find((u) => u.name === unit.name)
+    if (!existing) {
+      units.push(unit)
+      return
+    }
+    if (existing.target !== unit.target) {
+      const rule = resolver.ruleForUnit(unit.name)
+      throw new Error(
+        `deploy.grouping: unit "${unit.name}" would hold both serverless and server functions ` +
+          `(${existing.functionIds.join(', ')} vs ${unit.functionIds.join(', ')}). ` +
+          (rule
+            ? `Give the server-target functions their own rule, or drop them from "${unit.name}".`
+            : `A grouping rule cannot change a function's target.`)
+      )
+    }
+    for (const id of unit.functionIds) {
+      if (!existing.functionIds.includes(id)) {
+        existing.functionIds.push(id)
+      }
+    }
+    for (const service of unit.services) {
+      if (
+        !existing.services.some(
+          (s) =>
+            s.capability === service.capability &&
+            s.sourceServiceName === service.sourceServiceName
+        )
+      ) {
+        existing.services.push(service)
+      }
+    }
+    for (const dep of unit.dependsOn) {
+      if (dep !== existing.name && !existing.dependsOn.includes(dep)) {
+        existing.dependsOn.push(dep)
+      }
+    }
+    for (const tag of unit.tags) {
+      if (!existing.tags.includes(tag)) {
+        existing.tags.push(tag)
+      }
+    }
+    for (const handler of unit.handlers) {
+      if (handler.type === 'fetch') {
+        const fetchHandler = existing.handlers.find(
+          (h): h is Extract<DeploymentHandler, { type: 'fetch' }> =>
+            h.type === 'fetch'
+        )
+        if (fetchHandler) {
+          fetchHandler.routes.push(...handler.routes)
+        } else {
+          existing.handlers.push(handler)
+        }
+      } else {
+        existing.handlers.push(handler)
+      }
+    }
+    if (unit.invokedAgents?.length) {
+      const merged = new Set([
+        ...(existing.invokedAgents ?? []),
+        ...unit.invokedAgents,
+      ])
+      existing.invokedAgents = [...merged]
+    }
+  }
+
+  const unitFunctionIds = new Map<string, string[]>()
+  const unitFor = (funcId: string) => {
+    const name = resolver.forFunction(funcId)
+    const existing = unitFunctionIds.get(name)
+    if (existing) {
+      if (!existing.includes(funcId)) {
+        existing.push(funcId)
+      }
+    } else {
+      unitFunctionIds.set(name, [funcId])
+    }
+    return name
+  }
 
   // ── Step 1: Create function units ──────────────────────────────────
   // Each function gets one unit. Collect all its triggers.
@@ -149,7 +249,7 @@ export function analyzeDeployment(
         handlers.push({ type: 'queue', queueName: queueMeta.name ?? queueName })
         queues.push({
           name: queueMeta.name ?? queueName,
-          consumerUnit: toSafeKebab(funcId),
+          consumerUnit: unitFor(funcId),
           consumerFunctionId: funcId,
         })
       }
@@ -166,7 +266,7 @@ export function analyzeDeployment(
         scheduledTasks.push({
           name: schedMeta.name,
           schedule: schedMeta.schedule,
-          unitName: toSafeKebab(funcId),
+          unitName: unitFor(funcId),
           functionId: funcId,
         })
       }
@@ -216,8 +316,8 @@ export function analyzeDeployment(
 
     const invokedAgents = collectInvokedAgents(state, funcId)
 
-    units.push({
-      name: toSafeKebab(funcId),
+    addFunctionUnit({
+      name: unitFor(funcId),
       role: 'function',
       target: resolveDeployTarget(
         funcMeta,
@@ -232,7 +332,7 @@ export function analyzeDeployment(
       ),
       dependsOn: [],
       handlers,
-      tags: funcMeta.tags ?? [],
+      tags: tagsFor(funcId),
       ...(invokedAgents.length > 0 && { invokedAgents }),
     })
   }
@@ -245,7 +345,7 @@ export function analyzeDeployment(
       continue
     }
 
-    const unitName = `addon-${toSafeKebab(namespace)}`
+    const unitName = resolver.forAddon(namespace)
     const addonIncompatible = new Set(
       state.addonServerlessIncompatible?.get(namespace) ?? []
     )
@@ -289,7 +389,7 @@ export function analyzeDeployment(
       }
     }
 
-    units.push({
+    addFunctionUnit({
       name: unitName,
       role: 'function',
       target,
@@ -308,7 +408,7 @@ export function analyzeDeployment(
     const unitName = `agent-${toSafeKebab(agentName)}`
 
     // Agent gateway depends on its tool function units
-    const toolUnitNames = toolIds.map((id) => toSafeKebab(id))
+    const toolUnitNames = toolIds.map((id) => unitFor(id))
     const subAgentUnitNames = subAgentNames.map(
       (sa) => `agent-${toSafeKebab(sa)}`
     )
@@ -398,7 +498,7 @@ export function analyzeDeployment(
   const allMcpIds = [...mcpToolIds, ...mcpResourceIds, ...mcpPromptIds]
   if (allMcpIds.length > 0) {
     const unitName = 'mcp-server'
-    const mcpFuncUnitNames = allMcpIds.map((id) => toSafeKebab(id))
+    const mcpFuncUnitNames = allMcpIds.map((id) => unitFor(id))
 
     units.push({
       name: unitName,
@@ -408,7 +508,7 @@ export function analyzeDeployment(
       services: [],
       dependsOn: mcpFuncUnitNames,
       handlers: [{ type: 'fetch', routes: [] }],
-      tags: collectTags(allMcpIds, functionsMeta),
+      tags: collectTags(allMcpIds, tagsFor),
     })
 
     mcpEndpoints.push({
@@ -425,7 +525,7 @@ export function analyzeDeployment(
     if (funcIds.length === 0) continue
 
     const unitName = `channel-${toSafeKebab(channelName)}`
-    const funcUnitNames = funcIds.map((id) => toSafeKebab(id))
+    const funcUnitNames = funcIds.map((id) => unitFor(id))
 
     units.push({
       name: unitName,
@@ -455,45 +555,46 @@ export function analyzeDeployment(
     units,
     workflows,
     queues,
-    workflowQueues
+    workflowQueues,
+    unitFor
   )
 
   // ── Step 6: Ensure function units exist for gateway dependencies ───
   // Gateways depend on function units. If a function is only used via
   // a gateway (not directly wired to HTTP/queue/cron), it still needs
   // a unit with a fetch handler for RPC access.
-  const existingUnitNames = new Set(units.map((u) => u.name))
-
   const unitsSnapshot = Array.from(units)
   for (const unit of unitsSnapshot) {
     for (const dep of unit.dependsOn) {
-      if (!existingUnitNames.has(dep)) {
-        // Find the function ID for this dependency
-        const funcId = fromKebab(dep)
-        const funcMeta = functionsMeta[funcId]
-        if (funcMeta) {
-          const invokedAgents = collectInvokedAgents(state, funcId)
-          units.push({
-            name: dep,
-            role: 'function',
-            target: resolveDeployTarget(
-              funcMeta,
-              serverlessIncompatible,
-              funcId,
-              defaultTarget
-            ),
-            functionIds: [funcId],
-            services: withAgentServices(
-              collectServicesForFunction(funcMeta),
-              invokedAgents
-            ),
-            dependsOn: [],
-            handlers: [{ type: 'fetch', routes: [] }],
-            tags: funcMeta.tags ?? [],
-            ...(invokedAgents.length > 0 && { invokedAgents }),
-          })
-          existingUnitNames.add(dep)
+      for (const funcId of unitFunctionIds.get(dep) ?? []) {
+        const existing = units.find((u) => u.name === dep)
+        if (existing?.functionIds.includes(funcId)) {
+          continue
         }
+        const funcMeta = functionsMeta[funcId]
+        if (!funcMeta) {
+          continue
+        }
+        const invokedAgents = collectInvokedAgents(state, funcId)
+        addFunctionUnit({
+          name: dep,
+          role: 'function',
+          target: resolveDeployTarget(
+            funcMeta,
+            serverlessIncompatible,
+            funcId,
+            defaultTarget
+          ),
+          functionIds: [funcId],
+          services: withAgentServices(
+            collectServicesForFunction(funcMeta),
+            invokedAgents
+          ),
+          dependsOn: [],
+          handlers: [{ type: 'fetch', routes: [] }],
+          tags: tagsFor(funcId),
+          ...(invokedAgents.length > 0 && { invokedAgents }),
+        })
       }
     }
   }
@@ -755,7 +856,8 @@ function buildWorkflows(
   units: DeploymentUnit[],
   workflows: WorkflowDefinition[],
   queues: QueueDefinition[],
-  workflowQueues: boolean
+  workflowQueues: boolean,
+  unitFor: (funcId: string) => string
 ): void {
   for (const [_wfName, graph] of entries(graphMeta)) {
     const steps: WorkflowStepDefinition[] = []
@@ -765,7 +867,7 @@ function buildWorkflows(
       if ('flow' in node) continue
       if (!('rpcName' in node)) continue
 
-      const stepUnitName = toSafeKebab(node.rpcName)
+      const stepUnitName = unitFor(node.rpcName)
       // Step dispatch is decided per-function: a step runs inline unless its
       // function is marked `workflowQueued: true` (then it dispatches via queue).
       const stepFuncId = rpcMeta[node.rpcName] ?? node.rpcName
@@ -862,7 +964,7 @@ function buildWorkflows(
 
         queues.push({
           name: stepQueueName,
-          consumerUnit: toSafeKebab(step.functionId),
+          consumerUnit: unitFor(step.functionId),
           consumerFunctionId: `pikkuWorkflowWorker:${step.functionId}`,
         })
       }
@@ -1029,19 +1131,7 @@ function collectChannelFunctionIds(channelMeta: ChannelMeta): string[] {
 // Naming helpers
 // ---------------------------------------------------------------------------
 
-export function toSafeKebab(str: string): string {
-  return str
-    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
-    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
-    .replace(/[:/\\]/g, '-')
-    .replace(/--+/g, '-')
-    .replace(/^-|-$/g, '')
-    .toLowerCase()
-}
-
-function fromKebab(str: string): string {
-  return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase())
-}
+export { toSafeKebab } from './naming.js'
 
 // ---------------------------------------------------------------------------
 // Tag helpers
@@ -1049,16 +1139,75 @@ function fromKebab(str: string): string {
 
 function collectTags(
   funcIds: string[],
-  functionsMeta: Record<string, FunctionMeta>
+  tagsFor: (funcId: string) => string[]
 ): string[] {
   const tags = new Set<string>()
   for (const id of funcIds) {
-    const meta = functionsMeta[id]
-    if (meta?.tags) {
-      for (const tag of meta.tags) tags.add(tag)
-    }
+    for (const tag of tagsFor(id)) tags.add(tag)
   }
   return [...tags]
+}
+
+/**
+ * Every tag that applies to a function, from the function itself and from every
+ * wiring that reaches it.
+ *
+ * Tags are almost always written on the wiring — `wireHTTP({ tags: ['todos'] })`
+ * — not on the `pikkuFunc`, so reading `FunctionMeta.tags` alone sees nothing in
+ * a typical project. `deploy.grouping` matches on the tags a user actually
+ * wrote, which means the union.
+ */
+function buildFunctionTagIndex(
+  state: InspectorState,
+  functionsMeta: Record<string, FunctionMeta>
+): Map<string, string[]> {
+  const index = new Map<string, Set<string>>()
+
+  const add = (funcId: string | undefined, tags: string[] | undefined) => {
+    if (!funcId || !tags?.length) return
+    let set = index.get(funcId)
+    if (!set) {
+      set = new Set()
+      index.set(funcId, set)
+    }
+    for (const tag of tags) set.add(tag)
+  }
+
+  for (const [funcId, meta] of entries(functionsMeta)) {
+    add(funcId, meta.tags)
+  }
+
+  for (const method of HTTP_METHODS) {
+    const methodRoutes = state.http?.meta?.[method]
+    if (!methodRoutes) continue
+    for (const routeMeta of values(methodRoutes)) {
+      add(routeMeta.pikkuFuncId, routeMeta.tags)
+    }
+  }
+
+  for (const meta of values(state.queueWorkers?.meta ?? {})) {
+    add(meta.pikkuFuncId, meta.tags)
+  }
+
+  for (const meta of values(state.scheduledTasks?.meta ?? {})) {
+    add(meta.pikkuFuncId, meta.tags)
+  }
+
+  for (const meta of [
+    ...values(state.mcpEndpoints?.toolsMeta ?? {}),
+    ...values(state.mcpEndpoints?.resourcesMeta ?? {}),
+    ...values(state.mcpEndpoints?.promptsMeta ?? {}),
+  ]) {
+    add(meta.pikkuFuncId, meta.tags)
+  }
+
+  for (const channelMeta of values(state.channels?.meta ?? {})) {
+    for (const funcId of collectChannelFunctionIds(channelMeta)) {
+      add(funcId, channelMeta.tags)
+    }
+  }
+
+  return new Map([...index].map(([funcId, tags]) => [funcId, [...tags]]))
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/deploy/analyzer/grouping.test.ts
+++ b/packages/cli/src/deploy/analyzer/grouping.test.ts
@@ -1,0 +1,354 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { analyzeDeployment } from './analyzer.js'
+import type { GroupingConfig } from './grouping.js'
+import type { InspectorState } from '@pikku/inspector'
+
+function state(): InspectorState {
+  return {
+    functions: {
+      meta: {
+        listRetreats: {
+          pikkuFuncId: 'listRetreats',
+          name: 'listRetreats',
+          tags: ['retreats'],
+        },
+        bookRetreat: {
+          pikkuFuncId: 'bookRetreat',
+          name: 'bookRetreat',
+          tags: ['bookings'],
+          services: { services: ['kysely'] },
+        },
+        adminPurge: {
+          pikkuFuncId: 'adminPurge',
+          name: 'adminPurge',
+          tags: ['admin', 'heavy'],
+          services: { services: ['fileStore'] },
+        },
+        handleWebhook: {
+          pikkuFuncId: 'handleWebhook',
+          name: 'handleWebhook',
+        },
+        sendEmail: {
+          pikkuFuncId: 'sendEmail',
+          name: 'sendEmail',
+          tags: ['retreats'],
+        },
+        nightlyReport: {
+          pikkuFuncId: 'nightlyReport',
+          name: 'nightlyReport',
+          tags: ['admin'],
+        },
+      },
+    },
+    http: {
+      meta: {
+        get: {
+          '/api/retreats': {
+            pikkuFuncId: 'listRetreats',
+            method: 'get',
+            route: '/api/retreats',
+          },
+        },
+        post: {
+          '/api/bookings': {
+            pikkuFuncId: 'bookRetreat',
+            method: 'post',
+            route: '/api/bookings',
+          },
+          '/api/admin/purge': {
+            pikkuFuncId: 'adminPurge',
+            method: 'post',
+            route: '/api/admin/purge',
+          },
+          '/api/webhooks/stripe': {
+            pikkuFuncId: 'handleWebhook',
+            method: 'post',
+            route: '/api/webhooks/stripe',
+          },
+        },
+      },
+    },
+    addonFunctions: {
+      console: {
+        installAddon: {
+          pikkuFuncId: 'installAddon',
+          name: 'installAddon',
+          expose: true,
+        },
+      },
+    },
+    agents: { agentsMeta: {} },
+    mcpEndpoints: { toolsMeta: {}, resourcesMeta: {}, promptsMeta: {} },
+    channels: { meta: {} },
+    queueWorkers: {
+      meta: { emails: { name: 'emails', pikkuFuncId: 'sendEmail' } },
+    },
+    scheduledTasks: {
+      meta: {
+        nightly: {
+          name: 'nightly',
+          schedule: '0 3 * * *',
+          pikkuFuncId: 'nightlyReport',
+        },
+      },
+    },
+    workflows: { graphMeta: {} },
+    secrets: { definitions: [] },
+    variables: { definitions: [] },
+  } as unknown as InspectorState
+}
+
+const analyze = (grouping?: GroupingConfig) =>
+  analyzeDeployment(state(), {
+    projectId: 'test',
+    serverlessIncompatible: ['fileStore'],
+    grouping,
+  })
+
+const unitNames = (grouping?: GroupingConfig) =>
+  analyze(grouping)
+    .units.filter((u) => u.role === 'function')
+    .map((u) => u.name)
+    .sort()
+
+describe('deploy.grouping - the default', () => {
+  test('no config leaves one unit per function', () => {
+    assert.deepEqual(unitNames(), [
+      'addon-console',
+      'admin-purge',
+      'book-retreat',
+      'handle-webhook',
+      'list-retreats',
+      'nightly-report',
+      'send-email',
+    ])
+  })
+
+  test("strategy 'function' with no rules is the same thing", () => {
+    assert.deepEqual(unitNames({ strategy: 'function' }), unitNames())
+  })
+})
+
+describe('deploy.grouping - tag rules merge', () => {
+  const grouping: GroupingConfig = {
+    rules: [{ unit: 'retreats', tags: ['retreats', 'bookings'] }],
+  }
+
+  test('functions carrying any listed tag land in the rule unit', () => {
+    const unit = analyze(grouping).units.find((u) => u.name === 'retreats')
+    assert.ok(unit)
+    assert.deepEqual(unit.functionIds.sort(), [
+      'bookRetreat',
+      'listRetreats',
+      'sendEmail',
+    ])
+  })
+
+  test('the merged unit keeps every route in one fetch handler', () => {
+    const unit = analyze(grouping).units.find((u) => u.name === 'retreats')
+    const fetchHandlers = unit!.handlers.filter((h) => h.type === 'fetch')
+    assert.equal(fetchHandlers.length, 1)
+    assert.deepEqual(
+      (fetchHandlers[0] as { routes: Array<{ route: string }> }).routes
+        .map((r) => r.route)
+        .sort(),
+      ['/api/bookings', '/api/retreats']
+    )
+  })
+
+  test('a queue handler stays its own entry beside the fetch handler', () => {
+    const unit = analyze(grouping).units.find((u) => u.name === 'retreats')
+    assert.ok(
+      unit!.handlers.some((h) => h.type === 'queue' && h.queueName === 'emails')
+    )
+  })
+
+  test('the queue is wired to the grouped unit, not the function name', () => {
+    const queue = analyze(grouping).queues.find((q) => q.name === 'emails')
+    assert.equal(queue?.consumerUnit, 'retreats')
+  })
+
+  test('services are unioned across the members', () => {
+    const unit = analyze(grouping).units.find((u) => u.name === 'retreats')
+    assert.ok(unit!.services.some((s) => s.capability === 'database'))
+  })
+
+  test('tags are unioned across the members', () => {
+    const unit = analyze(grouping).units.find((u) => u.name === 'retreats')
+    assert.deepEqual(unit!.tags.sort(), ['bookings', 'retreats'])
+  })
+
+  test('unmatched functions keep their own units', () => {
+    assert.deepEqual(unitNames(grouping), [
+      'addon-console',
+      'admin-purge',
+      'handle-webhook',
+      'nightly-report',
+      'retreats',
+    ])
+  })
+})
+
+describe('deploy.grouping - ordering', () => {
+  test('the first matching rule wins', () => {
+    const first = analyze({
+      rules: [
+        { unit: 'everything', tags: ['retreats'] },
+        { unit: 'later', tags: ['retreats'] },
+      ],
+    })
+    assert.ok(first.units.some((u) => u.name === 'everything'))
+    assert.ok(!first.units.some((u) => u.name === 'later'))
+  })
+})
+
+describe('deploy.grouping - route rules', () => {
+  test('a glob matches a function with no tags at all', () => {
+    const unit = analyze({
+      rules: [{ unit: 'webhooks', routes: ['/api/webhooks/*'] }],
+    }).units.find((u) => u.name === 'webhooks')
+    assert.deepEqual(unit?.functionIds, ['handleWebhook'])
+  })
+
+  test('a non-matching glob leaves the function alone', () => {
+    assert.ok(
+      !analyze({
+        rules: [{ unit: 'webhooks', routes: ['/api/nothing/*'] }],
+      }).units.some((u) => u.name === 'webhooks')
+    )
+  })
+
+  test('predicates within one rule are ANDed', () => {
+    const units = analyze({
+      rules: [
+        { unit: 'both', tags: ['retreats'], routes: ['/api/webhooks/*'] },
+      ],
+    }).units
+    assert.ok(!units.some((u) => u.name === 'both'))
+  })
+})
+
+describe('deploy.grouping - addons', () => {
+  test('an addon rule renames the addon unit', () => {
+    const units = analyze({
+      rules: [{ unit: 'console', addon: 'console' }],
+    }).units
+    const unit = units.find((u) => u.name === 'console')
+    assert.deepEqual(unit?.functionIds, ['console:installAddon'])
+    assert.ok(!units.some((u) => u.name === 'addon-console'))
+  })
+
+  test('an addon rule never captures app functions', () => {
+    const unit = analyze({
+      rules: [{ unit: 'console', addon: 'console' }],
+    }).units.find((u) => u.name === 'console')
+    assert.deepEqual(unit?.functionIds, ['console:installAddon'])
+  })
+})
+
+describe("deploy.grouping - strategy 'single'", () => {
+  test('everything serverless collapses into one unit', () => {
+    const names = unitNames({
+      strategy: 'single',
+      rules: [{ unit: 'purge', tags: ['heavy'] }],
+    })
+    assert.deepEqual(names, ['addon-console', 'app', 'purge'])
+  })
+
+  test('the single unit holds every unmatched function', () => {
+    const unit = analyze({
+      strategy: 'single',
+      rules: [{ unit: 'purge', tags: ['heavy'] }],
+    }).units.find((u) => u.name === 'app')
+    assert.deepEqual(unit!.functionIds.sort(), [
+      'bookRetreat',
+      'handleWebhook',
+      'listRetreats',
+      'nightlyReport',
+      'sendEmail',
+    ])
+  })
+
+  test('the scheduled task follows its function into the group', () => {
+    const task = analyze({
+      strategy: 'single',
+      rules: [{ unit: 'purge', tags: ['heavy'] }],
+    }).scheduledTasks.find((t) => t.name === 'nightly')
+    assert.equal(task?.unitName, 'app')
+  })
+})
+
+describe('deploy.grouping - refusals', () => {
+  test('a serverless and a server function cannot share a unit', () => {
+    assert.throws(
+      () => analyze({ strategy: 'single' }),
+      /would hold both serverless and server functions/
+    )
+  })
+
+  test('the refusal names the functions that disagree', () => {
+    assert.throws(() => analyze({ strategy: 'single' }), /adminPurge/)
+  })
+
+  test('two rules cannot name the same unit', () => {
+    assert.throws(
+      () =>
+        analyze({
+          rules: [
+            { unit: 'a', tags: ['retreats'] },
+            { unit: 'a', tags: ['admin'] },
+          ],
+        }),
+      /two rules both name the unit "a"/
+    )
+  })
+
+  test('a rule with no predicate is refused', () => {
+    assert.throws(
+      () => analyze({ rules: [{ unit: 'a' }] }),
+      /rule "a" matches nothing/
+    )
+  })
+})
+
+describe('deploy.grouping - tags written on a wiring', () => {
+  const wiringTagged = (grouping?: GroupingConfig) => {
+    const s = state() as any
+    s.http.meta.post['/api/webhooks/stripe'].tags = ['webhooks']
+    s.queueWorkers.meta.emails.tags = ['webhooks']
+    s.scheduledTasks.meta.nightly.tags = ['webhooks']
+    return analyzeDeployment(s as InspectorState, {
+      projectId: 'test',
+      serverlessIncompatible: ['fileStore'],
+      grouping,
+    })
+  }
+
+  test('an http wiring tag groups the function it wires', () => {
+    const units = wiringTagged({
+      rules: [{ unit: 'webhooks', tags: ['webhooks'] }],
+    }).units.filter((u) => u.role === 'function')
+    const webhooks = units.find((u) => u.name === 'webhooks')
+    assert.ok(webhooks, 'no unit named webhooks')
+    assert.ok(webhooks.functionIds.includes('handleWebhook'))
+  })
+
+  test('queue and cron wiring tags group too', () => {
+    const webhooks = wiringTagged({
+      rules: [{ unit: 'webhooks', tags: ['webhooks'] }],
+    }).units.find((u) => u.name === 'webhooks')
+    assert.deepEqual(webhooks?.functionIds.sort(), [
+      'handleWebhook',
+      'nightlyReport',
+      'sendEmail',
+    ])
+  })
+
+  test('the wiring tag reaches the unit it lands on', () => {
+    const unit = wiringTagged()
+      .units.filter((u) => u.role === 'function')
+      .find((u) => u.name === 'handle-webhook')
+    assert.deepEqual(unit?.tags, ['webhooks'])
+  })
+})

--- a/packages/cli/src/deploy/analyzer/grouping.ts
+++ b/packages/cli/src/deploy/analyzer/grouping.ts
@@ -1,0 +1,125 @@
+import { toSafeKebab } from './naming.js'
+
+export type GroupingStrategy = 'function' | 'single'
+
+export interface GroupingRule {
+  unit: string
+  tags?: string[]
+  addon?: string
+  routes?: string[]
+}
+
+export interface GroupingConfig {
+  strategy?: GroupingStrategy
+  rules?: GroupingRule[]
+}
+
+export interface UnitResolverInput {
+  routesForFunction: (funcId: string) => string[]
+  tagsForFunction: (funcId: string) => string[]
+}
+
+export interface UnitResolver {
+  forFunction: (funcId: string) => string
+  forAddon: (namespace: string) => string
+  isGrouped: boolean
+  ruleForUnit: (unitName: string) => GroupingRule | undefined
+}
+
+const SINGLE_UNIT_NAME = 'app'
+
+const routeMatcher = (pattern: string): RegExp => {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`^${escaped.replace(/\*/g, '.*')}$`)
+}
+
+export const validateGrouping = (config: GroupingConfig): void => {
+  const rules = config.rules ?? []
+  const seen = new Set<string>()
+  for (const rule of rules) {
+    if (!rule.unit) {
+      throw new Error(
+        `deploy.grouping: every rule needs a "unit" name (offending rule: ${JSON.stringify(rule)})`
+      )
+    }
+    if (seen.has(rule.unit)) {
+      throw new Error(
+        `deploy.grouping: two rules both name the unit "${rule.unit}". Merge them into one rule.`
+      )
+    }
+    seen.add(rule.unit)
+    if (!rule.tags?.length && !rule.addon && !rule.routes?.length) {
+      throw new Error(
+        `deploy.grouping: rule "${rule.unit}" matches nothing. Give it at least one of "tags", "addon" or "routes".`
+      )
+    }
+  }
+}
+
+export const createUnitResolver = (
+  config: GroupingConfig | undefined,
+  input: UnitResolverInput
+): UnitResolver => {
+  const strategy = config?.strategy ?? 'function'
+  const rules = config?.rules ?? []
+
+  if (config) {
+    validateGrouping(config)
+  }
+
+  const compiled = rules.map((rule) => ({
+    rule,
+    unit: toSafeKebab(rule.unit),
+    tags: rule.tags,
+    addon: rule.addon,
+    routes: rule.routes?.map(routeMatcher),
+  }))
+
+  const byUnitName = new Map(compiled.map((c) => [c.unit, c.rule]))
+
+  const matches = (
+    c: (typeof compiled)[number],
+    tags: string[],
+    routes: string[],
+    addon: string | undefined
+  ): boolean => {
+    if (c.tags && !c.tags.some((tag) => tags.includes(tag))) {
+      return false
+    }
+    if (c.addon && c.addon !== addon) {
+      return false
+    }
+    if (c.routes && !c.routes.some((re) => routes.some((r) => re.test(r)))) {
+      return false
+    }
+    return true
+  }
+
+  const fallback = (funcId: string) =>
+    strategy === 'single' ? SINGLE_UNIT_NAME : toSafeKebab(funcId)
+
+  return {
+    isGrouped: strategy !== 'function' || compiled.length > 0,
+    ruleForUnit: (unitName) => byUnitName.get(unitName),
+    forFunction: (funcId) => {
+      if (compiled.length > 0) {
+        const tags = input.tagsForFunction(funcId)
+        const routes = input.routesForFunction(funcId)
+        for (const c of compiled) {
+          if (matches(c, tags, routes, undefined)) {
+            return c.unit
+          }
+        }
+      }
+      return fallback(funcId)
+    },
+    forAddon: (namespace) => {
+      for (const c of compiled) {
+        if (c.addon === namespace && !c.tags && !c.routes) {
+          return c.unit
+        }
+      }
+      return `addon-${toSafeKebab(namespace)}`
+    },
+  }
+}

--- a/packages/cli/src/deploy/analyzer/index.ts
+++ b/packages/cli/src/deploy/analyzer/index.ts
@@ -1,2 +1,7 @@
 export { analyzeDeployment } from './analyzer.js'
 export type { AnalyzerOptions } from './analyzer.js'
+export type {
+  GroupingConfig,
+  GroupingRule,
+  GroupingStrategy,
+} from './grouping.js'

--- a/packages/cli/src/deploy/analyzer/naming.ts
+++ b/packages/cli/src/deploy/analyzer/naming.ts
@@ -1,0 +1,9 @@
+export function toSafeKebab(str: string): string {
+  return str
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+    .replace(/[:/\\]/g, '-')
+    .replace(/--+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase()
+}

--- a/packages/cli/src/deploy/build-pipeline.ts
+++ b/packages/cli/src/deploy/build-pipeline.ts
@@ -12,6 +12,7 @@ import type { InspectorState } from '@pikku/inspector'
 import { PikkuError } from '@pikku/core/errors'
 
 import { analyzeDeployment } from './analyzer/index.js'
+import type { GroupingConfig } from './analyzer/index.js'
 import { withoutScenarios } from '../functions/wirings/scenarios/scenario-partition.js'
 import type { DeploymentManifest } from '@pikku/deploy'
 import { generatePerUnitCodegen } from './codegen/per-unit-codegen.js'
@@ -203,6 +204,7 @@ export async function runBuildPipeline(options: {
   inspectorState: InspectorState
   serverlessIncompatible?: string[]
   defaultTarget?: 'serverless' | 'server'
+  grouping?: GroupingConfig
   globalHTTPPrefix?: string
   getEntryContext: (
     unitDir: string,
@@ -247,6 +249,7 @@ export async function runBuildPipeline(options: {
     projectId,
     serverlessIncompatible: options.serverlessIncompatible,
     defaultTarget: options.defaultTarget,
+    grouping: options.grouping,
     globalHTTPPrefix: options.globalHTTPPrefix,
     workflowQueues,
   })
@@ -425,7 +428,31 @@ export async function runBuildPipeline(options: {
       codegenErrors.push(...serverCodegenErrors)
 
       // Replace individual server units with the merged one in the manifest
+      const mergedNames = new Set(serverUnits.map((u) => u.name))
       manifest.units = [...serverlessUnits, mergedServerUnit]
+
+      // Anything that named one of the units just folded away has to follow it,
+      // or the manifest ships a queue consumer and a cron pointing at a unit
+      // that no longer exists.
+      for (const queue of manifest.queues) {
+        if (mergedNames.has(queue.consumerUnit)) {
+          queue.consumerUnit = serverUnitName
+        }
+      }
+      for (const task of manifest.scheduledTasks) {
+        if (mergedNames.has(task.unitName)) {
+          task.unitName = serverUnitName
+        }
+      }
+      for (const unit of manifest.units) {
+        unit.dependsOn = [
+          ...new Set(
+            unit.dependsOn.map((dep) =>
+              mergedNames.has(dep) ? serverUnitName : dep
+            )
+          ),
+        ].filter((dep) => dep !== unit.name)
+      }
 
       logger.info(
         `  Server container: ${serverUnits.length} functions merged into one unit`

--- a/packages/cli/src/functions/commands/deploy-apply.ts
+++ b/packages/cli/src/functions/commands/deploy-apply.ts
@@ -328,6 +328,7 @@ export const deployApply = pikkuSessionlessFunc<
       inspectorState,
       serverlessIncompatible: config.deploy?.serverlessIncompatible,
       defaultTarget: config.deploy?.defaultTarget,
+      grouping: config.deploy?.grouping,
       globalHTTPPrefix: config.globalHTTPPrefix,
       getEntryContext,
       frontend: config.frontend,

--- a/packages/cli/src/functions/commands/deploy-plan.ts
+++ b/packages/cli/src/functions/commands/deploy-plan.ts
@@ -79,6 +79,7 @@ export const deployPlan = pikkuSessionlessFunc<
       inspectorState,
       serverlessIncompatible: config.deploy?.serverlessIncompatible,
       defaultTarget: config.deploy?.defaultTarget,
+      grouping: config.deploy?.grouping,
       globalHTTPPrefix: config.globalHTTPPrefix,
       getEntryContext,
       frontend: config.frontend,

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -748,6 +748,31 @@ export type PikkuCLIInput = {
      * Defaults to 'serverless'.
      */
     defaultTarget?: 'serverless' | 'server'
+    /**
+     * How many deployment units the app's functions collapse into.
+     *
+     * `strategy` decides what happens to a function no rule matches:
+     * 'function' (the default) gives it its own unit, 'single' puts it in
+     * one shared unit. `rules` are evaluated in order, first match wins —
+     * under 'function' a rule merges functions together, under 'single' it
+     * carves them out.
+     *
+     * A rule's predicates are ANDed; `tags` is ORed across its own list.
+     * Functions whose deploy target differs cannot share a unit.
+     */
+    grouping?: {
+      strategy?: 'function' | 'single'
+      rules?: Array<{
+        /** Deployment unit name. Must be unique across rules. */
+        unit: string
+        /** Matches a function carrying any one of these tags. */
+        tags?: string[]
+        /** Matches an addon namespace, placing all its exposed functions here. */
+        addon?: string
+        /** Glob patterns matched against a function's wired HTTP routes. */
+        routes?: string[]
+      }>
+    }
     /** Desktop shell settings, used by `pikku deploy apply --desktop`. */
     desktop?: {
       /**

--- a/packages/skills/skills/pikku-build/references/ship.md
+++ b/packages/skills/skills/pikku-build/references/ship.md
@@ -23,6 +23,45 @@ how a worker deploy fails at runtime instead of at build.
 Always run `plan` before `apply`, and read it. It names what will be created,
 updated and deleted — the deletions are the reason to look.
 
+### How many workers you get
+
+By default every function is its own deployment unit. That is the right default
+— maximum isolation — but on a large app it means a hundred workers whose
+bundles are mostly the same framework code repeated, and a build and an upload
+for each. `deploy.grouping` in `pikku.config.json` sets the shape:
+
+```json
+"deploy": {
+  "grouping": {
+    "strategy": "single",
+    "rules": [
+      { "unit": "console", "addon": "console" },
+      { "unit": "pdf", "tags": ["pdf"] }
+    ]
+  }
+}
+```
+
+`strategy` is the fallback for a function no rule matches — `function` (one unit
+each, the default) or `single` (one shared unit). Rules are ordered, first match
+wins, and match on `tags`, an `addon` namespace or `routes` globs; under
+`function` a rule merges, under `single` it carves out.
+
+`tags` matches the tags a function inherits from its wirings — `wireHTTP({ ...,
+tags: ['pdf'] })` — as well as any on the function itself, which is where almost
+every project writes them.
+
+Two things that bite:
+
+- **Grouping cannot change a deploy target.** Put a `serverlessIncompatible`
+  function in a group with serverless ones and the build fails naming both
+  sides. Give it its own rule — that refusal is the design, not a bug.
+- **Grouping widens secret scope.** Every function in a unit reads every secret
+  that unit is granted, so treat a merge as a security decision too.
+
+Group by something that means something — a domain, a secret scope, a deploy
+cadence. There is deliberately no automatic packing by bundle size.
+
 The frontends build independently (`bun run build` at the root builds every
 workspace). Serve each behind its own hostname, and put the API behind `/api` on
 **all of them**, mirroring the Vite proxy from the multi-app reference: `/api/auth/*` keeps its

--- a/verifiers/deploy-grouping/package.json
+++ b/verifiers/deploy-grouping/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@pikku/verifiers-deploy-grouping",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "pikku": "echo 'skip'",
+    "tsc": "echo 'skip'",
+    "build": "echo 'skip'",
+    "test": "npx tsx test-grouping.ts"
+  },
+  "devDependencies": {
+    "@pikku/cli": "workspace:*",
+    "@pikku/core": "workspace:*",
+    "@types/node": "^24",
+    "typescript": "^6.0.3"
+  }
+}

--- a/verifiers/deploy-grouping/test-grouping.ts
+++ b/verifiers/deploy-grouping/test-grouping.ts
@@ -1,0 +1,271 @@
+/**
+ * Offline verifier for `deploy.grouping`.
+ *
+ * Runs a real `pikku` + `deploy plan` against templates/functions three times —
+ * ungrouped, grouped by tag, and with a grouping that spans deploy targets —
+ * and asserts on the manifest and the bundles that actually got built. The unit
+ * tests cover the resolver in isolation; this covers everything downstream of
+ * it, which is where the assumptions a unit test mocks away break.
+ */
+
+import { execSync } from 'child_process'
+import { readFileSync, writeFileSync, existsSync, statSync } from 'fs'
+import { join } from 'path'
+
+const REPO_ROOT = join(process.cwd(), '..', '..')
+const FUNCTIONS_DIR = join(REPO_ROOT, 'templates', 'functions')
+const PIKKU_BIN = join(REPO_ROOT, 'packages', 'cli', 'dist', 'bin', 'pikku.js')
+const CONFIG_FILE = join(FUNCTIONS_DIR, 'pikku.config.json')
+const DEPLOY_DIR = join(FUNCTIONS_DIR, '.deploy', 'cloudflare')
+const MANIFEST_FILE = join(DEPLOY_DIR, 'deployment-manifest.json')
+const UNITS_DIR = join(DEPLOY_DIR, 'units')
+
+type Unit = {
+  name: string
+  role: string
+  target: string
+  functionIds: string[]
+  services: Array<{ capability: string; sourceServiceName: string }>
+  handlers: Array<Record<string, unknown>>
+  tags: string[]
+}
+type Manifest = {
+  units: Unit[]
+  queues: Array<{ name: string; consumerUnit: string }>
+  scheduledTasks: Array<{ name: string; unitName: string }>
+}
+
+let failures = 0
+let passes = 0
+
+function check(name: string, fn: () => void) {
+  try {
+    fn()
+    passes++
+    console.log(`  ✔ ${name}`)
+  } catch (e) {
+    failures++
+    console.log(`  ✖ ${name}`)
+    console.log(`      ${(e as Error).message}`)
+  }
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message)
+}
+
+const originalConfig = readFileSync(CONFIG_FILE, 'utf-8')
+
+function withGrouping(grouping: unknown | undefined): void {
+  const config = JSON.parse(originalConfig)
+  if (grouping === undefined) {
+    delete config.deploy.grouping
+  } else {
+    config.deploy.grouping = grouping
+  }
+  writeFileSync(CONFIG_FILE, `${JSON.stringify(config, null, 2)}\n`)
+}
+
+function runPlan(): { ok: true; manifest: Manifest } | { ok: false; output: string } {
+  try {
+    execSync(`node ${PIKKU_BIN} deploy plan --provider cloudflare`, {
+      cwd: FUNCTIONS_DIR,
+      stdio: 'pipe',
+      timeout: 600_000,
+    })
+  } catch (e) {
+    const err = e as { stdout?: Buffer; stderr?: Buffer; message: string }
+    return {
+      ok: false,
+      output: `${err.stdout?.toString() ?? ''}${err.stderr?.toString() ?? ''}${err.message}`,
+    }
+  }
+  return { ok: true, manifest: JSON.parse(readFileSync(MANIFEST_FILE, 'utf-8')) }
+}
+
+function functionUnits(manifest: Manifest): Unit[] {
+  return manifest.units.filter((u) => u.role === 'function')
+}
+
+function restore() {
+  writeFileSync(CONFIG_FILE, originalConfig)
+}
+
+process.on('exit', restore)
+process.on('SIGINT', () => {
+  restore()
+  process.exit(130)
+})
+
+try {
+  console.log('Setting up: pikku codegen against templates/functions...')
+  execSync('rm -rf .deploy src/scaffold', { cwd: FUNCTIONS_DIR, stdio: 'pipe' })
+  execSync(`node ${PIKKU_BIN}`, {
+    cwd: FUNCTIONS_DIR,
+    stdio: 'pipe',
+    timeout: 120_000,
+  })
+
+  console.log('\nBaseline: no grouping block')
+  withGrouping(undefined)
+  const baseline = runPlan()
+  assert(baseline.ok, `baseline plan failed:\n${!baseline.ok ? baseline.output : ''}`)
+  const baseUnits = functionUnits(baseline.manifest)
+  const baseNames = new Set(baseUnits.map((u) => u.name))
+
+  check('the ungrouped build gives every function its own unit', () => {
+    assert(
+      baseUnits.every((u) => u.functionIds.length <= 1 || u.name.startsWith('addon-') || u.name.startsWith('run-remote')),
+      'an ungrouped unit holds more than one function without being an addon or job inbox'
+    )
+  })
+
+  const todoUnits = baseUnits.filter((u) => u.tags.includes('todos'))
+  check('the template has several todos-tagged units to merge', () => {
+    assert(
+      todoUnits.length > 1,
+      `expected >1 todos-tagged units to merge, found ${todoUnits.length}`
+    )
+  })
+
+  console.log('\nGrouped: one unit for everything tagged todos')
+  withGrouping({ rules: [{ unit: 'todos', tags: ['todos'] }] })
+  const grouped = runPlan()
+  assert(grouped.ok, `grouped plan failed:\n${!grouped.ok ? grouped.output : ''}`)
+  const groupedUnits = functionUnits(grouped.manifest)
+  const todos = groupedUnits.find((u) => u.name === 'todos')
+
+  check('the rule produces a single named unit', () => {
+    assert(todos, 'no unit named "todos" in the manifest')
+  })
+
+  check('it holds every function the rule matched', () => {
+    assert(
+      todos!.functionIds.length === todoUnits.length,
+      `expected ${todoUnits.length} functionIds, got ${todos!.functionIds.length}`
+    )
+  })
+
+  check('the units it replaced are gone', () => {
+    for (const replaced of todoUnits) {
+      assert(
+        !groupedUnits.some((u) => u.name === replaced.name),
+        `${replaced.name} still has its own unit`
+      )
+    }
+  })
+
+  check('the build ends up with fewer units than ungrouped', () => {
+    assert(
+      groupedUnits.length < baseUnits.length,
+      `grouped ${groupedUnits.length} is not fewer than baseline ${baseUnits.length}`
+    )
+  })
+
+  check('every other unit is untouched', () => {
+    for (const unit of groupedUnits) {
+      if (unit.name === 'todos') continue
+      assert(baseNames.has(unit.name), `${unit.name} appeared only in the grouped build`)
+    }
+  })
+
+  check('routes from every member are on one fetch handler', () => {
+    const fetchHandlers = todos!.handlers.filter((h) => h.type === 'fetch')
+    assert(fetchHandlers.length === 1, `expected 1 fetch handler, got ${fetchHandlers.length}`)
+    const routes = (fetchHandlers[0] as { routes: unknown[] }).routes
+    const baselineRoutes = todoUnits.flatMap((u) =>
+      u.handlers
+        .filter((h) => h.type === 'fetch')
+        .flatMap((h) => (h as { routes: unknown[] }).routes)
+    )
+    assert(
+      routes.length === baselineRoutes.length,
+      `expected ${baselineRoutes.length} routes on the merged handler, got ${routes.length}`
+    )
+  })
+
+  check('services are the union of the members', () => {
+    const expected = new Set(
+      todoUnits.flatMap((u) => u.services.map((s) => s.sourceServiceName))
+    )
+    const actual = new Set(todos!.services.map((s) => s.sourceServiceName))
+    for (const name of expected) {
+      assert(actual.has(name), `merged unit lost the ${name} service`)
+    }
+  })
+
+  check('the merged unit actually bundles', () => {
+    const bundle = join(UNITS_DIR, 'todos', 'bundle.js')
+    assert(existsSync(bundle), `no bundle at ${bundle}`)
+    assert(statSync(bundle).size > 0, 'the merged bundle is empty')
+  })
+
+  check('no queue or cron points at a unit that no longer exists', () => {
+    const names = new Set(grouped.manifest.units.map((u) => u.name))
+    for (const queue of grouped.manifest.queues) {
+      assert(names.has(queue.consumerUnit), `queue ${queue.name} points at missing unit ${queue.consumerUnit}`)
+    }
+    for (const task of grouped.manifest.scheduledTasks) {
+      assert(names.has(task.unitName), `cron ${task.name} points at missing unit ${task.unitName}`)
+    }
+  })
+
+  check('no unit depends on a unit that no longer exists', () => {
+    const names = new Set(grouped.manifest.units.map((u) => u.name))
+    for (const unit of grouped.manifest.units) {
+      for (const dep of (unit as unknown as { dependsOn: string[] }).dependsOn) {
+        assert(names.has(dep), `${unit.name} depends on missing unit ${dep}`)
+      }
+    }
+  })
+
+  console.log('\nRefusal: a group spanning both deploy targets')
+  withGrouping({ strategy: 'single' })
+  const mixed = runPlan()
+
+  check('a group spanning serverless and server is refused', () => {
+    assert(!mixed.ok, 'the build succeeded when it should have refused')
+  })
+
+  check('the refusal names the unit and both sides', () => {
+    assert(!mixed.ok, 'no output to inspect')
+    assert(
+      mixed.output.includes('would hold both serverless and server functions'),
+      `unexpected failure:\n${mixed.output.slice(-2000)}`
+    )
+  })
+
+  console.log('\nRefusal: two rules naming one unit')
+  withGrouping({
+    rules: [
+      { unit: 'dup', tags: ['todos'] },
+      { unit: 'dup', tags: ['realtime'] },
+    ],
+  })
+  const dup = runPlan()
+
+  check('a duplicate unit name is refused', () => {
+    assert(!dup.ok, 'the build succeeded with two rules naming one unit')
+    assert(
+      dup.output.includes('two rules both name the unit'),
+      `unexpected failure:\n${dup.output.slice(-2000)}`
+    )
+  })
+
+  console.log('\nRefusal: a rule with no predicate')
+  withGrouping({ rules: [{ unit: 'empty' }] })
+  const empty = runPlan()
+
+  check('a rule matching nothing is refused', () => {
+    assert(!empty.ok, 'the build succeeded with a predicate-less rule')
+    assert(
+      empty.output.includes('matches nothing'),
+      `unexpected failure:\n${empty.output.slice(-2000)}`
+    )
+  })
+} finally {
+  restore()
+}
+
+console.log(`\n${passes} passed, ${failures} failed`)
+process.exit(failures > 0 ? 1 : 0)

--- a/verifiers/deploy-grouping/tsconfig.json
+++ b/verifiers/deploy-grouping/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../packages/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "module": "Node18",
+    "outDir": "dist",
+    "target": "esnext"
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6738,6 +6738,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@pikku/verifiers-deploy-grouping@workspace:verifiers/deploy-grouping":
+  version: 0.0.0-use.local
+  resolution: "@pikku/verifiers-deploy-grouping@workspace:verifiers/deploy-grouping"
+  dependencies:
+    "@pikku/cli": "workspace:*"
+    "@pikku/core": "workspace:*"
+    "@types/node": "npm:^24"
+    typescript: "npm:^6.0.3"
+  languageName: unknown
+  linkType: soft
+
 "@pikku/verifiers-deploy-serverless@workspace:verifiers/deploy-serverless":
   version: 0.0.0-use.local
   resolution: "@pikku/verifiers-deploy-serverless@workspace:verifiers/deploy-serverless"


### PR DESCRIPTION
> Re-raise of #1647, which was squash-merged into its base branch `fix/prune-addon-bootstrap-per-unit` instead of main, so none of it reached main. Same commit, cherry-picked onto main; no content change.

---

Based on #1645.

One function per deployment unit is the right default but the wrong floor. perauset builds 119 function units, and ~92% of every one of them is the same ~920 KB of framework and third-party code — 109 MB of a 121 MB artifact is the same bytes repeated, plus a build, an upload and a set of bindings each.

`deploy.grouping` lets the project say how many units it wants:

```jsonc
"deploy": {
  "defaultTarget": "serverless",
  "serverlessIncompatible": ["pdfService"],
  "grouping": {
    "strategy": "single",
    "rules": [
      { "unit": "console",  "addon": "console" },
      { "unit": "pdf",      "tags": ["pdf"] },
      { "unit": "webhooks", "routes": ["/api/webhooks/*"] }
    ]
  }
}
```

- **`strategy`** is the fallback for a function no rule matches. `function` (default) gives it its own unit — today's behaviour, unchanged when the block is absent. `single` puts it in one shared `app` unit.
- **`rules`** are ordered, first match wins. Predicates within a rule are ANDed; `tags` is ORed across its own list. Under `function` a rule merges functions together; under `single` it carves them out.
- **`routes`** globs match a function's wired HTTP routes, with or without `globalHTTPPrefix`. Inert for RPC-only projects, which is fine — they use tags.
- Addons stay their own unit by default; an `addon` rule renames or repoints it.

Merging unions `functionIds`, `services`, `dependsOn` (minus self) and `tags`; HTTP routes fold into a single fetch handler while queue and scheduled handlers stay separate entries.

**Target is not negotiable.** Functions resolving to different targets cannot share a unit — the build fails naming both sides and pointing at the rule, rather than quietly promoting the group to `server`.

### Note on the analyzer refactor

Grouping breaks the assumption that a unit name is invertible back to a function id, which step 6 relied on via `fromKebab`. The analyzer now records the `unitName → functionIds` mapping as units are created and uses that instead; `fromKebab` is gone. `toSafeKebab` moved to `naming.ts` to break the import cycle and is re-exported from `analyzer.ts` unchanged.

### What the verifier found

Writing `verifiers/deploy-grouping` — a real `pikku` + four real `deploy plan` runs against `templates/functions` — turned up two defects that the unit tests could not, because a unit test writes its own fixture.

**Tags are written on the wiring, not the function.** `templates/functions` has **0 of 52** functions carrying a tag in `FunctionMeta`, while its HTTP, queue, scheduled, channel and MCP wirings carry plenty. The analyzer read only `FunctionMeta.tags` — in four places — so a `tags` rule matched nothing and every unit's own `tags` field was near-empty too. It now builds a `funcId → tags` index unioning function meta with every wiring that reaches the function. Without this the headline feature of this PR was inert against the tags users actually write.

**The server container orphaned its queues** (pre-existing, unrelated to grouping). `build-pipeline.ts` folds every `target: 'server'` unit into one `pikku-server-container` but left `queues[].consumerUnit`, `scheduledTasks[].unitName` and other units' `dependsOn` naming the units it had just deleted — `templates/functions` shipped a `todo-reminders` queue pointing at `process-reminder@v2`, a unit not in the manifest. The merge now rewrites all three. Fixed here because this is where it was found.

### Checklist

- **Unit tests** — 25 in `grouping.test.ts`: the default, tag merges, ordering, route globs, ANDed predicates, addon rules, `single`, wiring-tag propagation, and all four refusals. Existing analyzer tests unchanged; `packages/cli` green.
- **Verifier** — `verifiers/deploy-grouping`, 16/16. Asserts baseline vs grouped unit counts, merged unit contents, one fetch handler, the service union, that the merged unit really bundles, that no queue/cron/`dependsOn` dangles, and the four refusals through the real CLI. It failed 8/16 before this commit.
- **E2E** — none. `e2e/` runs a live app; grouping is a build-time packaging decision with no runtime surface, and the verifier already covers the bundles it produces. Skipped deliberately.
- **Skills** — `packages/skills/skills/pikku-build/references/ship.md` gains "How many workers you get".
- **Docs** — `docs/deploy/index.md` and `docs/pikku-cli/configuration.md` in the website repo (`dfd705e`).
- **Knowledge** — `knowledge/projects/pikku/decisions/decision-deploy-unit-grouping.md`, including the rejected alternatives and both findings above.
- **Changeset** — two, both `patch`.

### Not in this PR

`deploy plan` does not yet print the union of secret/credential scope per grouped unit. Grouping widens that scope by construction, so it should be visible before anyone leans on it — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable deployment grouping by function, tags, addons, or route patterns.
  - Supports grouping functions into named units or consolidating them into a single deployment unit.
  - Added validation for conflicting or invalid grouping rules.

- **Bug Fixes**
  - Tags from HTTP, queue, and scheduled-task wiring now correctly influence grouping.
  - Deployment references are updated when units are merged, preventing broken queue, schedule, and dependency links.

- **Documentation**
  - Added configuration guidance, grouping behavior, deployment constraints, and secret-scope considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->