### PR TITLE
fix(cli): a fabric refusal is an instruction, not a stack trace

### DIFF
--- a/.changeset/deploy-refusal-is-not-a-crash.md
+++ b/.changeset/deploy-refusal-is-not-a-crash.md
@@ -1,0 +1,7 @@
+---
+'@pikku/cli': patch
+---
+
+A fabric refusal reads as an instruction, not a crash. `pikku fabric deploy apply` and `pikku fabric logs` raised their preconditions — a branch out of sync with its remote, a detached HEAD, a dirty tree at link time, a missing `--branch`, a non-interactive deploy without `--auto-approve` — as plain `Error`s, so the CLI printed ten frames of `@pikku/core` function-runner and cli-runner internals in front of the one sentence that says what to do about it.
+
+They now throw `FabricPreconditionError`, a `PikkuError` — the marker the CLI already uses to decide that a message is the whole output (`PikkuTypecheckFailedError`, `PikkuDeployBuildFailedError` and the persona commands do the same). The message and the non-zero exit are unchanged, and `--verbose` / `PIKKU_DEBUG` still shows the stack.

--- a/packages/cli/src/fabric/functions/deploy.function.ts
+++ b/packages/cli/src/fabric/functions/deploy.function.ts
@@ -7,6 +7,7 @@ import {
   currentBranch,
   resolveRef,
 } from '../lib/git.js'
+import { FabricPreconditionError } from '../lib/errors.js'
 import { promptConfirm } from '../lib/prompt.js'
 import { added, changed, removed, dim, table } from '../lib/output.js'
 import {
@@ -186,7 +187,7 @@ const EXIT_BY_OUTCOME: Record<ApplyOutput['outcome'], number> = {
  */
 export const branchFromHead = (head: string): string => {
   if (head === 'HEAD' || head === '') {
-    throw new Error(
+    throw new FabricPreconditionError(
       'Deployment blocked: HEAD is detached, so there is no current branch to deploy.\nCheck out a branch, or name the target: `pikku fabric deploy apply <branch>`.'
     )
   }
@@ -205,11 +206,13 @@ export const FabricDeployApply = pikkuSessionlessFunc({
 
     const timeoutSeconds = input.timeout ?? DEFAULT_TIMEOUT_SECONDS
     if (timeoutSeconds <= 0) {
-      throw new Error('--timeout must be a positive number of seconds.')
+      throw new FabricPreconditionError(
+        '--timeout must be a positive number of seconds.'
+      )
     }
 
     if (input.deploymentId && (input.branch || input.production)) {
-      throw new Error(
+      throw new FabricPreconditionError(
         '--deployment-id already names its target — drop the branch/--production.'
       )
     }
@@ -256,12 +259,12 @@ export const FabricDeployApply = pikkuSessionlessFunc({
       if (!input.autoApprove) {
         const target = `${branch} @ ${resolved.slice(0, 8)}`
         if (!process.stdin.isTTY) {
-          throw new Error(
+          throw new FabricPreconditionError(
             `Refusing to deploy ${target} without confirmation — re-run with --auto-approve to deploy non-interactively.`
           )
         }
         if (!(await promptConfirm(`Deploy ${target}?`))) {
-          throw new Error('Deploy aborted.')
+          throw new FabricPreconditionError('Deploy aborted.')
         }
       }
 

--- a/packages/cli/src/fabric/functions/link.function.ts
+++ b/packages/cli/src/fabric/functions/link.function.ts
@@ -14,6 +14,7 @@ import {
   pushWithCredential,
   removeRemote,
 } from '../lib/git.js'
+import { FabricPreconditionError } from '../lib/errors.js'
 import { promptConfirm } from '../lib/prompt.js'
 
 export const FabricLinkInput = z.object({
@@ -63,12 +64,12 @@ export const FabricLink = pikkuSessionlessFunc({
     // link because of a dirty tree, having already provisioned a repo the user
     // now has to clean up, is a worse answer than refusing first.
     if (!(await hasCommits())) {
-      throw new Error(
+      throw new FabricPreconditionError(
         'Nothing to link: this repository has no commits yet. Commit your work first — fabric deploys a pushed commit, not a working directory.'
       )
     }
     if (!(await isWorkingTreeClean())) {
-      throw new Error(
+      throw new FabricPreconditionError(
         'Deployment blocked: uncommitted changes detected.\nCommit and push your changes before deploying.'
       )
     }

--- a/packages/cli/src/fabric/functions/logs.function.ts
+++ b/packages/cli/src/fabric/functions/logs.function.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { pikkuSessionlessFunc } from '../../../.pikku/function/index.js'
 import { resolveApiContext } from '../lib/config.js'
 import { getFabricRPC } from '../lib/http.js'
+import { FabricPreconditionError } from '../lib/errors.js'
 
 export const FabricLogsInput = z.object({
   branch: z.string().optional(),
@@ -48,7 +49,8 @@ export const FabricLogs = pikkuSessionlessFunc({
       throw new Error(
         'No fabric project linked. Run `pikku fabric link` first.'
       )
-    if (!branch) throw new Error('Specify --branch <branch-name>.')
+    if (!branch)
+      throw new FabricPreconditionError('Specify --branch <branch-name>.')
 
     const seen = new Set<string>()
     const cursorWindow = 5_000

--- a/packages/cli/src/fabric/lib/errors.test.ts
+++ b/packages/cli/src/fabric/lib/errors.test.ts
@@ -1,0 +1,55 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import { execFileSync } from 'node:child_process'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { isExpectedError } from '@pikku/core/errors'
+
+import { FabricPreconditionError } from './errors.js'
+import { assertNamedBranchDeploySafety } from './git.js'
+
+/**
+ * The refusals a user is meant to hit and act on have to read as instructions,
+ * not as a crash in pikku. What makes that true is the class: the CLI runner
+ * prints the message alone for an expected error and the whole stack for
+ * anything else.
+ */
+describe('a fabric precondition refusal is an expected error', () => {
+  test('the class carries the marker', () => {
+    assert.strictEqual(
+      isExpectedError(new FabricPreconditionError('Specify --branch.')),
+      true
+    )
+  })
+
+  test('a bug is still unexpected', () => {
+    assert.strictEqual(isExpectedError(new TypeError('boom')), false)
+  })
+
+  test('deploy safety refuses a branch with no upstream as one', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'pikku-deploy-safety-'))
+    const git = (...args: string[]) =>
+      execFileSync('git', args, {
+        cwd,
+        encoding: 'utf8',
+        env: { PATH: process.env.PATH ?? '' },
+      })
+    git('init', '-q', '-b', 'main')
+    git('config', 'user.email', 'test@example.com')
+    git('config', 'user.name', 'Test')
+    await writeFile(join(cwd, 'README.md'), 'hi\n')
+    git('add', '.')
+    git('commit', '-qm', 'first')
+
+    await assert.rejects(
+      () => assertNamedBranchDeploySafety('main', cwd),
+      (error: unknown) => {
+        assert.ok(error instanceof FabricPreconditionError)
+        assert.strictEqual(isExpectedError(error), true)
+        assert.match((error as Error).message, /has no upstream/)
+        return true
+      }
+    )
+  })
+})

--- a/packages/cli/src/fabric/lib/errors.ts
+++ b/packages/cli/src/fabric/lib/errors.ts
@@ -1,0 +1,21 @@
+import { PikkuError } from '@pikku/core/errors'
+
+/**
+ * A fabric command refusing to run because something the user controls is not
+ * ready yet — a dirty tree, a branch with no upstream, a local head that is not
+ * the remote's, a required argument left off.
+ *
+ * These are not crashes. They are the outcomes the command exists to check for,
+ * and every message is already written as an instruction ("Push or pull main
+ * before deploying"). Raised as a `PikkuError`, which is how the rest of the
+ * repo marks an error whose message is the whole output: `formatCLIError` prints
+ * it alone, and keeps the full stack for everything else — an unexpected
+ * `TypeError` with its frames removed is a bug nobody can diagnose. `--verbose`
+ * or `PIKKU_DEBUG` still shows the stack when someone wants it.
+ *
+ * Thrown as a plain `Error` these read as a crash in pikku: ten frames of
+ * `@pikku/core` function-runner and cli-runner internals in front of the one
+ * sentence that says what to do. The exit code is unchanged — non-zero either
+ * way.
+ */
+export class FabricPreconditionError extends PikkuError {}

--- a/packages/cli/src/fabric/lib/git.ts
+++ b/packages/cli/src/fabric/lib/git.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { FabricPreconditionError } from './errors.js'
 
 /**
  * Local git probes for the deploy safety checks (clean tree, HEAD == remote,
@@ -180,28 +181,29 @@ export interface DeploySafetyResult {
 }
 
 /**
- * Spec §10 deploy ref safety checks. Throws on any failure with a CLI-friendly
- * message; returns the resolved commit context on pass.
+ * Spec §10 deploy ref safety checks. Throws `FabricPreconditionError` on any
+ * failure, with a message written to be the whole output; returns the resolved
+ * commit context on pass.
  */
 export async function assertDeploySafety(
   cwd?: string
 ): Promise<DeploySafetyResult> {
   if (!(await isWorkingTreeClean(cwd))) {
-    throw new Error(
+    throw new FabricPreconditionError(
       'Deployment blocked: uncommitted changes detected.\nCommit and push your changes before deploying.'
     )
   }
   const branch = await currentBranch(cwd)
   const upstream = await upstreamBranch(cwd)
   if (!upstream) {
-    throw new Error(
+    throw new FabricPreconditionError(
       `Deployment blocked: branch ${branch} has no upstream.\nPush it (\`git push -u origin ${branch}\`) before deploying.`
     )
   }
   const head = await headSha(cwd)
   const remote = await remoteHeadSha(upstream, cwd)
   if (head !== remote) {
-    throw new Error(
+    throw new FabricPreconditionError(
       `Deployment blocked: local HEAD ${head.slice(0, 8)} ≠ remote ${remote.slice(0, 8)} (${upstream}).\nPush or pull before deploying.`
     )
   }
@@ -221,21 +223,21 @@ export async function assertNamedBranchDeploySafety(
   try {
     head = await localBranchHeadSha(branch, cwd)
   } catch (error: any) {
-    throw new Error(
+    throw new FabricPreconditionError(
       `Deployment blocked: local branch ${branch} does not exist (${error.message}).\nFetch or create it before deploying.`
     )
   }
 
   const upstream = await upstreamForBranch(branch, cwd)
   if (!upstream) {
-    throw new Error(
+    throw new FabricPreconditionError(
       `Deployment blocked: branch ${branch} has no upstream.\nPush it (\`git push -u origin ${branch}\`) before deploying.`
     )
   }
 
   const remote = await remoteHeadSha(upstream, cwd)
   if (head !== remote) {
-    throw new Error(
+    throw new FabricPreconditionError(
       `Deployment blocked: ${branch} ${head.slice(0, 8)} ≠ remote ${remote.slice(0, 8)} (${upstream}).\nPush or pull ${branch} before deploying.`
     )
   }


### PR DESCRIPTION
## Why

`pikku fabric deploy apply --production` refusing to deploy a branch that is ahead of / behind its remote is **correct**, and that behaviour is unchanged here. The problem was purely how the refusal was reported.

These are preconditions the user is *expected* to hit, and the message is already written as an instruction — "Push or pull main before deploying". Raised as a plain `Error`, the CLI printed that one actionable sentence underneath ten frames of `@pikku/core` function-runner and cli-runner internals. Nothing in those frames helps the person reading them, and their presence says *"pikku crashed"* about an outcome the command exists to check for.

## The mechanism — one that already existed

No new convention. `packages/core/src/wirings/cli/format-cli-error.ts` already draws exactly this line:

```ts
if (!isExpectedError(error)) {
  return typeof stack === 'string' && stack ? stack : String(error)
}
```

`isExpectedError` is `error instanceof PikkuError || error.expected === true`. `PikkuTypecheckFailedError`, `PikkuDeployBuildFailedError`, `PikkuInspectionFailedError` and the persona commands all rely on it, each with a comment saying "a PikkuError makes the runner log the message alone, not a stack trace". The fabric commands simply never opted in.

So this adds `FabricPreconditionError extends PikkuError` (`packages/cli/src/fabric/lib/errors.ts`) and raises the same-category refusals through it.

**On fixing it at the runner boundary instead:** the boundary fix is already there — and it is the right place, because it is the only place that can keep the stack for a real crash. What the boundary cannot do is tell a deliberate `throw new Error('Specify --branch')` from a `TypeError` thrown by a bug: both are bare `Error`s. Deciding at the boundary that any thrown `Error` is user-actionable would strip the frames off genuine crashes too, which is the failure mode the comment in `format-cli-error.ts` explicitly warns about. Marking the throw site is what the repo already does, and it is what the boundary needs in order to work.

## What changed

| Where | Refusal |
| --- | --- |
| `fabric/lib/git.ts` | the six `Deployment blocked:` checks — dirty tree, no upstream, local head ≠ remote (both `assertDeploySafety` and `assertNamedBranchDeploySafety`), branch does not exist locally |
| `fabric/functions/deploy.function.ts` | detached HEAD; `--timeout` not positive; `--deployment-id` given a target twice; non-interactive deploy without `--auto-approve`; declined at the confirm prompt |
| `fabric/functions/link.function.ts` | repository has no commits; dirty tree at link time |
| `fabric/functions/logs.function.ts` | `--branch` missing |

Messages and exit codes are unchanged (still non-zero). `--verbose` / `PIKKU_DEBUG` still prints the stack. Nothing that represents a real internal failure was touched.

## Before / after

Both captured by running the built CLI against a real linked fabric project.

**`pikku fabric deploy apply <branch>` — branch out of sync / missing**

Before:
```
◇◆ pikku ::

Error: Deployment blocked: local branch nonexistent-branch does not exist (git rev-parse --verify nonexistent-branch^{commit} failed (128): fatal: Needed a single revision).
Fetch or create it before deploying.
    at assertNamedBranchDeploySafety (.../@pikku/cli/dist/src/fabric/lib/git.js:170:15)
    at async prepDeploy (.../@pikku/cli/dist/src/fabric/functions/deploy.function.js:108:20)
    at async Object.func (.../@pikku/cli/dist/src/fabric/functions/deploy.function.js:184:87)
    at async executeFunction (.../@pikku/core/dist/function/function-runner.js:257:20)
    at async runPikkuFunc (.../@pikku/core/dist/function/function-runner.js:286:17)
    at async runCLICommand (.../@pikku/core/dist/wirings/cli/cli-runner.js:226:24)
    at async executeCLI (.../@pikku/core/dist/wirings/cli/cli-runner.js:314:9)
```

After (exit 1):
```
◇◆ pikku ::

Deployment blocked: local branch nonexistent-branch does not exist (git rev-parse --verify nonexistent-branch^{commit} failed (128): fatal: Needed a single revision).
Fetch or create it before deploying.
```

**`pikku fabric logs --deployment <id> --since 2h` — `--branch` omitted**

Before:
```
◇◆ pikku ::

Error: Specify --branch <branch-name>.
    at Object.func (.../@pikku/cli/dist/src/fabric/functions/logs.function.js:37:19)
    at async executeFunction (.../@pikku/core/dist/function/function-runner.js:257:20)
    at async runPikkuFunc (.../@pikku/core/dist/function/function-runner.js:286:17)
    at async runCLICommand (.../@pikku/core/dist/wirings/cli/cli-runner.js:226:24)
    at async executeCLI (.../@pikku/core/dist/wirings/cli/cli-runner.js:314:9)
    at async PikkuCLI (.../@pikku/cli/dist/.pikku/cli/pikku-cli.gen.js:11:9)
    at async .../@pikku/cli/dist/bin/pikku.js:75:9
```

After (exit 1):
```
◇◆ pikku ::

Specify --branch <branch-name>.
```

**`PIKKU_DEBUG=1` still shows the machinery:**
```
Deployment blocked: local branch nonexistent-branch does not exist (...).
Fetch or create it before deploying.
FabricPreconditionError: Deployment blocked: local branch nonexistent-branch does not exist (...).
Fetch or create it before deploying.
    at assertNamedBranchDeploySafety (.../src/fabric/lib/git.js:172:15)
    ...
```

## Verification

- `bun run build:packages` — exit 0
- `bun run tsc` in `packages/cli` (`tsc && tsc -p tsconfig.type-tests.json`) — exit 0
- `bun test src/fabric/` in `packages/cli` — 249 pass, 0 fail
- Full `packages/cli` suite — 1659 pass, 1 fail: `local-db.test.ts` › `the same holds on postgres`, a pre-existing pglite/postgres environment failure unrelated to this change
- Before/after output above captured by running both the published `@pikku/cli@0.12.143` and this branch's build against the same project

New test: `packages/cli/src/fabric/lib/errors.test.ts` pins that a precondition refusal is an expected error, that a `TypeError` is not, and that `assertNamedBranchDeploySafety` on a real temp repo with no upstream rejects with one.

## Deliberately not in scope

`'Not logged in. Run \`pikku fabric login\` first.'` and `'No fabric project linked. Run \`pikku fabric link\` first.'` are the same category and print the same noise, but appear verbatim at ~27 sites across ~20 fabric command files. Sweeping them is mechanical and worth doing, but it belongs in its own change rather than burying this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Fabric CLI handling for deployment, linking, and log command precondition failures.
  * Normal command output now shows only the actionable error message instead of unnecessary technical details.
  * Verbose and debug modes continue to provide stack traces for troubleshooting.
  * Deployment safety checks retain their existing validation rules and messages while presenting failures more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->