### PR TITLE
fix(inspector): a unit bootstraps only the addons it kept

### DIFF
--- a/.changeset/prune-addon-wiring-files-per-unit.md
+++ b/.changeset/prune-addon-wiring-files-per-unit.md
@@ -1,0 +1,8 @@
+---
+'@pikku/inspector': patch
+---
+
+Prune a unit's addon wiring files alongside its addon declarations, so a
+deployment unit no longer imports (and registers) addons whose functions the
+unit filter dropped. `wireAddon` now records the app file that declared it, and
+a file is dropped only when every addon it wires is dropped.

--- a/packages/inspector/src/add/add-wire-addon.test.ts
+++ b/packages/inspector/src/add/add-wire-addon.test.ts
@@ -53,6 +53,7 @@ describe('addWireAddon', () => {
 
     assert.deepEqual(declarations.get('console'), {
       package: '@pikku/addon-console',
+      file: 'wiring.ts',
       rpcEndpoint: '/rpc',
       mcp: undefined,
       auth: true,

--- a/packages/inspector/src/add/add-wire-addon.ts
+++ b/packages/inspector/src/add/add-wire-addon.ts
@@ -128,6 +128,7 @@ export function addWireAddon(
   logger.debug(`• Found wireAddon: ${name} → ${pkg}`)
   state.rpc.wireAddonDeclarations.set(name, {
     package: pkg,
+    file: node.getSourceFile().fileName,
     rpcEndpoint,
     mcp,
     auth,

--- a/packages/inspector/src/add/add-wire-remote-addon.ts
+++ b/packages/inspector/src/add/add-wire-remote-addon.ts
@@ -70,6 +70,7 @@ export function addWireRemoteAddon(
   logger.debug(`• Found wireRemoteAddon: ${name} → ${pkg} (remote)`)
   state.rpc.wireAddonDeclarations.set(name, {
     package: pkg,
+    file: node.getSourceFile().fileName,
     remote: true,
     hasAuth,
     authCredentialId,

--- a/packages/inspector/src/types.ts
+++ b/packages/inspector/src/types.ts
@@ -614,6 +614,8 @@ export interface InspectorState {
       string,
       {
         package: string
+        /** The app source file whose `wireAddon` call declared this instance. */
+        file?: string
         rpcEndpoint?: string
         mcp?: boolean
         /**

--- a/packages/inspector/src/utils/filter-inspector-state.test.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.test.ts
@@ -2146,10 +2146,26 @@ describe('invokedAgentsByFile', () => {
     const withAddons = () => {
       const state = createMockInspectorState()
       state.rpc.wireAddonDeclarations = new Map([
-        ['admin', { package: '@pikku/addon-admin' } as any],
-        ['console', { package: '@pikku/addon-console' } as any],
+        [
+          'admin',
+          {
+            package: '@pikku/addon-admin',
+            file: '/test/project/src/addons/admin.addon.ts',
+          } as any,
+        ],
+        [
+          'console',
+          {
+            package: '@pikku/addon-console',
+            file: '/test/project/src/addons/console.addon.ts',
+          } as any,
+        ],
       ])
       state.rpc.usedAddons = new Set(['admin', 'console'])
+      state.rpc.wireAddonFiles = new Set([
+        '/test/project/src/addons/admin.addon.ts',
+        '/test/project/src/addons/console.addon.ts',
+      ])
       return state
     }
 
@@ -2227,6 +2243,76 @@ describe('invokedAgentsByFile', () => {
         [...result.rpc.wireAddonDeclarations.keys()],
         ['admin']
       )
+    })
+
+    test('prunes the wiring file of a dropped addon so the unit never imports it', () => {
+      const result = filterInspectorState(
+        withAddons(),
+        {
+          names: [
+            'console:runSecurityAudit',
+            '/rpc/:rpcName',
+            'http:post:/rpc/:rpcName',
+            'rpcCaller',
+          ],
+        },
+        mockLogger
+      )
+      assert.deepStrictEqual(
+        [...result.rpc.wireAddonFiles],
+        ['/test/project/src/addons/console.addon.ts']
+      )
+    })
+
+    test('a unit referencing no addon imports no wiring file', () => {
+      const result = filterInspectorState(
+        withAddons(),
+        { names: ['getUsers'] },
+        mockLogger
+      )
+      assert.deepStrictEqual([...result.rpc.wireAddonFiles], [])
+    })
+
+    test('one file wiring both addons survives while either is kept', () => {
+      const state = withAddons()
+      const shared = '/test/project/src/addons/all.addon.ts'
+      for (const decl of state.rpc.wireAddonDeclarations.values()) {
+        ;(decl as any).file = shared
+      }
+      state.rpc.wireAddonFiles = new Set([shared])
+      const result = filterInspectorState(
+        state,
+        {
+          names: [
+            'console:runSecurityAudit',
+            '/rpc/:rpcName',
+            'http:post:/rpc/:rpcName',
+            'rpcCaller',
+          ],
+        },
+        mockLogger
+      )
+      assert.deepStrictEqual([...result.rpc.wireAddonFiles], [shared])
+    })
+
+    test('a wiring file no declaration claims is left alone', () => {
+      const state = withAddons()
+      state.rpc.wireAddonFiles.add('/test/project/src/addons/legacy.addon.ts')
+      const result = filterInspectorState(
+        state,
+        { names: ['getUsers'] },
+        mockLogger
+      )
+      assert.deepStrictEqual(
+        [...result.rpc.wireAddonFiles],
+        ['/test/project/src/addons/legacy.addon.ts']
+      )
+    })
+
+    test('the original state keeps every wiring file', () => {
+      const state = withAddons()
+      filterInspectorState(state, { names: ['getUsers'] }, mockLogger)
+      assert.strictEqual(state.rpc.wireAddonFiles.size, 2)
     })
   })
 })

--- a/packages/inspector/src/utils/filter-inspector-state.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.ts
@@ -1287,6 +1287,22 @@ export function filterInspectorState(
         keptNamespaces.has(namespace)
       )
     )
+    const keptAddonFiles = new Set<string>()
+    for (const decl of filteredState.rpc.wireAddonDeclarations.values()) {
+      if (decl.file) keptAddonFiles.add(decl.file)
+    }
+    const droppedAddonFiles = new Set<string>()
+    for (const [namespace, decl] of state.rpc.wireAddonDeclarations) {
+      if (keptNamespaces.has(namespace)) continue
+      if (decl.file && !keptAddonFiles.has(decl.file)) {
+        droppedAddonFiles.add(decl.file)
+      }
+    }
+    filteredState.rpc.wireAddonFiles = new Set(
+      [...(filteredState.rpc.wireAddonFiles ?? [])].filter(
+        (file) => !droppedAddonFiles.has(file)
+      )
+    )
   }
 
   // Recalculate requiredServices based on filtered functions/middleware/permissions

--- a/packages/inspector/src/utils/serialize-inspector-state.ts
+++ b/packages/inspector/src/utils/serialize-inspector-state.ts
@@ -164,6 +164,7 @@ export interface SerializableInspectorState {
         string,
         {
           package: string
+          file?: string
           rpcEndpoint?: string
           remote?: boolean
           hasAuth?: boolean

--- a/packages/skills/skills/pikku-addon/SKILL.md
+++ b/packages/skills/skills/pikku-addon/SKILL.md
@@ -324,6 +324,11 @@ wireAddon({ name: 'todos', package: '@my-org/addon-todos' })
 
 After registration, run `yarn pikku all` to generate types for the addon's functions.
 
+Give each addon its own wiring file. A deployment unit imports a `wireAddon`
+file only while at least one addon that file wires survives the unit's filter,
+so wiring two addons from one file means a unit needing either one registers
+both and bundles both packages' dependencies.
+
 If the addon ships tables, `pikku db generate` then writes one migration per
 addon — named after the package, carrying the addon's own SQL — after Better
 Auth's and the runtime's, so an addon table may reference `user` or a runtime

--- a/verifiers/addon-treeshake/README.md
+++ b/verifiers/addon-treeshake/README.md
@@ -2,7 +2,8 @@
 
 Verifies per-unit deploy codegen against `@pikku/templates-function-addon`:
 
-- a unit that never touches the addon does not import its bootstrap
+- a unit that never touches the addon imports neither its bootstrap nor the
+  app file whose `wireAddon` call declared it
 - a unit using an addon function imports the bootstrap, and its
   `requiredSingletonServices` flags only the parent services that function's
   meta declares — not the addon's full `requiredParentServices`

--- a/verifiers/addon-treeshake/src/treeshake-services.assert.ts
+++ b/verifiers/addon-treeshake/src/treeshake-services.assert.ts
@@ -6,6 +6,7 @@ import { dirname, join } from 'node:path'
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
 const ADDON_BOOTSTRAP_IMPORT =
   '@pikku/templates-function-addon/.pikku/pikku-bootstrap.gen.js'
+const WIRE_ADDON_FILE_IMPORT = 'src/function/treeshake.wiring.js'
 
 interface Scenario {
   name: string
@@ -108,6 +109,11 @@ for (const scenario of scenarios) {
     scenario.name,
     `addon bootstrap ${scenario.addonImported ? 'imported' : 'NOT imported'} (${scenario.why})`,
     bootstrap.includes(ADDON_BOOTSTRAP_IMPORT) === scenario.addonImported
+  )
+  check(
+    scenario.name,
+    `wireAddon file ${scenario.addonImported ? 'imported' : 'NOT imported'}`,
+    bootstrap.includes(WIRE_ADDON_FILE_IMPORT) === scenario.addonImported
   )
   check(
     scenario.name,


### PR DESCRIPTION
**No typed surface moves** — `packages/core/api-report.md` is untouched. What changes is the *generated* output every deployment unit carries, which no one imports but every bundle contains; the before/after of that file is quoted below.

## The bug

Every deployment unit's generated `pikku-bootstrap.gen.ts` imported **every** `wireAddon` file the app had — so a unit holding none of an addon's functions still registered them at module top level and bundled the addon's dependencies:

```diff
 // .deploy/<unit>/.pikku/pikku-bootstrap.gen.ts, for a unit that uses neither
-import '../../../../../packages/functions/src/addons/admin.addon.js'
-import '../../../../../packages/functions/src/pikku/console/console.gen.js'
```

`filterInspectorState` already pruned `rpc.wireAddonDeclarations` and `rpc.usedAddons` to the namespaces a unit references. `rpc.wireAddonFiles` rode through the `rpc: { ...state.rpc }` spread untouched, and `pikku-command-bootstrap.ts` turns that set straight into imports.

## The fix

The file that declared an instance is now part of what the inspector records, which is the whole of the new state:

```ts
// packages/inspector/src/add/add-wire-addon.ts
state.rpc.wireAddonDeclarations.set(name, {
  package: pkg,
  file: node.getSourceFile().fileName,
  …
})
```

```ts
// packages/inspector/src/types.ts
/** The app source file whose `wireAddon` call declared this instance. */
file?: string
```

Attribution is per file, so the filter drops a wiring file only once **every** addon it wires has been dropped:

```ts
// packages/inspector/src/utils/filter-inspector-state.ts
const keptAddonFiles = new Set<string>()
for (const decl of filteredState.rpc.wireAddonDeclarations.values()) {
  if (decl.file) keptAddonFiles.add(decl.file)
}
const droppedAddonFiles = new Set<string>()
for (const [namespace, decl] of state.rpc.wireAddonDeclarations) {
  if (keptNamespaces.has(namespace)) continue
  if (decl.file && !keptAddonFiles.has(decl.file)) {
    droppedAddonFiles.add(decl.file)
  }
}
filteredState.rpc.wireAddonFiles = new Set(
  [...(filteredState.rpc.wireAddonFiles ?? [])].filter(
    (file) => !droppedAddonFiles.has(file)
  )
)
```

A file wiring several addons survives while any one of them is kept, and a wiring file no declaration claims is left alone — `file` is optional, so an older serialized state prunes nothing rather than pruning everything. `wireRemoteAddon` records it the same way, and `SerializableInspectorState` carries it so a state written to disk and read back still knows.

Which is why the skill now says to keep them apart:

```markdown
Give each addon its own wiring file. A deployment unit imports a `wireAddon`
file only while at least one addon that file wires survives the unit's filter,
so wiring two addons from one file means a unit needing either one registers
both and bundles both packages' dependencies.
```

## What pins it

The verifier already had a scenario table saying which units should reach the addon; it now asserts the app-side file alongside the addon's bootstrap, so the import cannot come back through the other door:

```ts
// verifiers/addon-treeshake/src/treeshake-services.assert.ts
const WIRE_ADDON_FILE_IMPORT = 'src/function/treeshake.wiring.js'

check(
  scenario.name,
  `wireAddon file ${scenario.addonImported ? 'imported' : 'NOT imported'}`,
  bootstrap.includes(WIRE_ADDON_FILE_IMPORT) === scenario.addonImported
)
```

## Measured on a real app

Rebuilt perauset's Cloudflare deploy (182 units, ~197 MB of bundles) with this CLI. The addon imports are gone from every unit that does not use them.

**The honest result: the byte win is small for that app** — most units moved ~0.3%, two moved 17–37%. perauset registers global HTTP middleware (`betterAuthStatelessSession` + `kysely`), so `auth`, `kysely`, `agentRunService` and `scopeService` stay required in every unit regardless of addons; that app-level middleware, not the addons, is what sets its ~900 KB floor. This PR fixes a real correctness problem — a unit registering functions it was filtered out of — and removes one of the two things standing between per-unit filtering and a smaller service set. The other is a separate issue.

## Checklist

- **Unit tests** — 5 new cases in `filter-inspector-state.test.ts`: the dropped addon's file is pruned, a no-addon unit imports none, a shared file survives, an unclaimed file is left alone, and the original state is not mutated. Full inspector suite: 791 pass, 8 fail — the same 8 that fail on `origin/main` (fixture-dir collisions under a parallel full run; all pass in isolation, verified against a pristine `origin/main` worktree).
- **Verifier** — `verifiers/addon-treeshake`, the assertion above, run for every scenario in its table. Green, plus `addon`, `addon-registry`, `treeshaking`, `deploy-serverless`, `deploy-grouping`, `deploy-standalone`.
- **E2E** — the verifier above *is* the e2e: it runs real per-unit codegen and reads the generated bootstrap.
- **Skills** — `pikku-addon/SKILL.md`, quoted above: the file is the unit of attribution, so give each addon its own.
- **Docs** — `docs/deploy/index.md` (website repo) documents that a unit bootstraps only the addons it uses, and the file-granularity caveat.
- **Changeset** — patch, `@pikku/inspector`.

CodeRabbit has produced no findings on this PR: it hit its OSS review limit on the first push and reported the same on a re-request (`Review rate limited`), so there are no threads to address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

