### PR TITLE
fix(cli): only a unit that holds an agent requires agentRunService

### DIFF
--- a/.changeset/agent-run-service-per-unit.md
+++ b/.changeset/agent-run-service-per-unit.md
@@ -1,0 +1,11 @@
+---
+'@pikku/cli': patch
+---
+
+Only require `agentRunService` in deployment units that hold an agent
+
+`scaffold.agent` is a project-wide config flag, so forcing `agentRunService`
+into `requiredSingletonServices` whenever it was set marked the service required
+in every unit — including units with no agent at all, whose sibling
+`agentStorage` / `agentRunState` / `agentRunner` flags were correctly `false`.
+The force now also requires the (filtered) inspector state to carry an agent.

--- a/packages/cli/src/functions/wirings/functions/pikku-command-services.test.ts
+++ b/packages/cli/src/functions/wirings/functions/pikku-command-services.test.ts
@@ -172,6 +172,54 @@ describe('pikkuServices', () => {
     assert.match(content, /'auth': true,/)
   })
 
+  const createAgentContext = async (
+    servicesFile: string,
+    agentsMeta: Record<string, unknown>
+  ) => {
+    const context = await createContext(servicesFile)
+    const visitState = await context.getInspectorState()
+    visitState.serviceAggregation.allSingletonServices = [
+      'agentRunService',
+      'todoStore',
+    ]
+    return {
+      ...context,
+      config: { ...context.config, scaffold: { agent: true } },
+      getInspectorState: async () => ({
+        ...visitState,
+        agents: { agentsMeta },
+      }),
+    }
+  }
+
+  test('leaves agentRunService optional when the state carries no agent', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'pikku-command-services-'))
+    const servicesFile = join(outDir, 'pikku-services.gen.ts')
+
+    await (pikkuServices as any).func(
+      await createAgentContext(servicesFile, {}),
+      undefined,
+      {}
+    )
+
+    const content = await readFile(servicesFile, 'utf8')
+    assert.match(content, /'agentRunService': false,/)
+  })
+
+  test('marks agentRunService required when the state carries an agent', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'pikku-command-services-'))
+    const servicesFile = join(outDir, 'pikku-services.gen.ts')
+
+    await (pikkuServices as any).func(
+      await createAgentContext(servicesFile, { supportAgent: {} }),
+      undefined,
+      {}
+    )
+
+    const content = await readFile(servicesFile, 'utf8')
+    assert.match(content, /'agentRunService': true,/)
+  })
+
   // An unresolved `SingletonServices` used to be written out as an empty map,
   // which made every service optional downstream and surfaced as a scatter of
   // "possibly undefined" errors in files that had not changed. The type is

--- a/packages/cli/src/functions/wirings/functions/pikku-command-services.ts
+++ b/packages/cli/src/functions/wirings/functions/pikku-command-services.ts
@@ -60,7 +60,9 @@ export const serializeServicesMap = (
   // The generated public-agent permission (isThreadOwner) always destructures
   // agentRunService, but agent.gen.ts is written after requiredServices is
   // computed from inspecting hand-written sources, so the inspector never
-  // sees that usage — force it required whenever the agent scaffold runs.
+  // sees that usage. The caller decides whether this state actually carries an
+  // agent surface — the scaffold being configured is a project-wide fact and
+  // says nothing about a single deployment unit.
   if (agentScaffoldEnabled) {
     usedServices.add('agentRunService')
   }
@@ -175,7 +177,10 @@ export const pikkuServices = pikkuSessionlessFunc<void, void>({
       wireServicesImport,
       config.addonName ? visitState.addonRequiredParentServices : [],
       Boolean(visitState.auth?.definition),
-      Boolean(config.scaffold?.agent)
+      Boolean(
+        config.scaffold?.agent &&
+        Object.keys(visitState.agents?.agentsMeta ?? {}).length > 0
+      )
     )
     await writeFileInDir(logger, config.servicesFile, servicesCode)
   },

--- a/packages/skills/skills/pikku-services/references/services.md
+++ b/packages/skills/skills/pikku-services/references/services.md
@@ -1,6 +1,5 @@
 # Pikku Services (Dependency Injection)
 
-
 ## Before You Start
 
 ```bash
@@ -194,6 +193,13 @@ const createSingletonServices = pikkuServices(async (config) => {
   return { config, logger, jwt, database }
 })
 ```
+
+A deployment split regenerates this manifest **per unit**, so the same
+`services.ts` sees a different manifest in each bundle and each unit builds only
+what its own functions, middleware and permissions reach. A `services.ts` that
+constructs unconditionally gets none of that: every unit pays for every service,
+and the split buys nothing but duplicated bytes. Branching on the manifest is
+what makes the split real.
 
 ### Audit Wire Service
 

--- a/verifiers/deploy-serverless/test-deploy.ts
+++ b/verifiers/deploy-serverless/test-deploy.ts
@@ -384,6 +384,35 @@ check(
   }
 )
 
+// --- Per-unit service requirements ---
+// `scaffold.agent` is a project-wide config flag. A unit that holds no agent
+// must not be told it needs agentRunService, or every unit in the app pays for
+// the service its factory builds behind that flag.
+
+const AGENT_UNIT = 'agent-todo-assistant'
+
+function requiredSingletons(unitName: string): string {
+  const path = join(getUnitPath(unitName), '.pikku', 'pikku-services.gen.ts')
+  if (!existsSync(path))
+    throw new Error(`${unitName}: missing .pikku/pikku-services.gen.ts`)
+  return readText(path)
+}
+
+check(`${LEAN_UNIT}: does not require agentRunService`, () => {
+  const content = requiredSingletons(LEAN_UNIT)
+  if (!content.includes("'agentRunService': false,"))
+    throw new Error('agentRunService is required in a unit that holds no agent')
+})
+
+check(`${AGENT_UNIT}: requires agentRunService (marker valid)`, () => {
+  // Anti-tautology: prove the flag still turns on where an agent actually runs.
+  if (!unitDirs.includes(AGENT_UNIT))
+    throw new Error(`${AGENT_UNIT} unit not found`)
+  const content = requiredSingletons(AGENT_UNIT)
+  if (!content.includes("'agentRunService': true,"))
+    throw new Error('agentRunService is optional in a unit that holds an agent')
+})
+
 // --- Results ---
 console.log('='.repeat(60))
 console.log('Serverless Deploy Verifier Results')


### PR DESCRIPTION
## What

`scaffold.agent` is a project-wide config flag. `pikku-command-services.ts` forced `agentRunService` into `requiredSingletonServices` whenever it was set, so **every** deployment unit was told it needs the service — including units with no agent anywhere near them.

Its three siblings behave correctly: `post-process.ts:320` gates `agentStorage` / `agentRunState` / `agentRunner` on `state.agents.agentsMeta`, which per-unit filtering prunes properly. The force now requires that same signal alongside the config flag.

Found on a real app: a Cloudflare unit holding one function whose body destructures only `kysely` came out requiring 9 singletons, `agentRunService` among them, with `agentStorage`/`agentRunner` correctly `false` right beside it.

## Measured

`templates/functions` (51 units, `scaffold.agent: true`), per-unit `.pikku/pikku-services.gen.ts`:

- before — `'agentRunService': true` in all 51
- after — true in exactly `agent-todo-assistant`, `agent-daily-planner`, `agent-main-router`; false in the other 48

## Checklist

- **Unit tests** — two new cases on the `pikkuServices` call site: a state with `scaffold.agent` and no agent leaves it `false`, one with an agent keeps it `true`. Falsified: reverting the one-line condition fails the first and leaves the other nine green. The two existing `serializeServicesMap` cases still cover the serializer's boolean directly.
- **Verifier** — `verifiers/deploy-serverless`: `greet: does not require agentRunService`, plus an anti-tautology `agent-todo-assistant: requires agentRunService (marker valid)` so the first can't pass trivially. Full run: 23 tests, 0 failed.
- **Docs** — `docs/pikku-cli/tree-shaking.mdx` (website repo) gains a paragraph that the map is regenerated per unit, and its example import path is corrected to `.pikku/pikku-services.gen.js`.
- **Skills** — `pikku-services/references/services.md`: same point, next to the dynamic-import pattern.
- **Changeset** — patch, `@pikku/cli`.
- **E2E** — none added. The deploy verifier already runs a real codegen + `deploy plan` over 51 units and asserts the generated map, which is the whole surface this touches; an e2e run would exercise nothing further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment units now require the agent run service only when they contain configured agent functionality.
  - Units without agents no longer include unnecessary agent services, resulting in leaner deployments.

- **Documentation**
  - Clarified how deployment splits generate service manifests per unit and optimize bundled services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->