### PR TITLE
fix(console): move the phone breakpoint from sm to md

### DIFF
--- a/.changeset/console-phone-breakpoint-md.md
+++ b/.changeset/console-phone-breakpoint-md.md
@@ -1,0 +1,5 @@
+---
+'@pikku/console': patch
+---
+
+The console's phone breakpoint moves from `sm` to `md`, so a 900px viewport gets the tab bar and bottom sheets rather than a docked panel it has no room for.

--- a/packages/console/src/components/shell/PageCard.module.css
+++ b/packages/console/src/components/shell/PageCard.module.css
@@ -40,7 +40,7 @@
    screen and cost it 16px of a 390px viewport. Full-bleed below the phone
    breakpoint, which is MOBILE_QUERY in lib/breakpoints.ts (CSS cannot import the
    constant; the two must be changed together). */
-@media (max-width: 48em) {
+@media (max-width: 62em) {
   .pageStack {
     padding: 0;
   }

--- a/packages/console/src/lib/breakpoints.ts
+++ b/packages/console/src/lib/breakpoints.ts
@@ -3,12 +3,19 @@ import { useMediaQuery } from '@mantine/hooks'
 /**
  * The phone breakpoint, defined once.
  *
- * It matches Mantine's `sm`: below it a split view collapses to a single column
+ * It matches Mantine's `md`: below it a split view collapses to a single column
  * and its panel moves into the bottom sheet. Kept in one place because the one
  * number deciding whether a second column can exist at all was previously the
  * bare string `'(max-width: 48em)'` in a dozen files.
+ *
+ * It covers tablets and landscape phones, not just portrait phones. At `sm` a
+ * 900px viewport still ran the pointer layout — the nav dock rather than the tab
+ * bar, and a panel docked beside the page rather than a sheet raised from the
+ * foot — on a screen with no room for a second column. A host app that embeds
+ * these screens inside its own shell saw the halves disagree: the shell in its
+ * mobile layout, every page inside it still on the desktop path.
  */
-export const MOBILE_QUERY = '(max-width: 48em)'
+export const MOBILE_QUERY = '(max-width: 62em)'
 
 /**
  * True on phone-width viewports.
@@ -23,9 +30,12 @@ export function usePhone(): boolean {
 }
 
 /**
- * The tablet-and-below breakpoint — Mantine's `md`. Wider than {@link MOBILE_QUERY}:
- * a second column still fits here, but a wide one-line row (label, metadata and a
- * trailing action all on one baseline) does not, so those rows stack instead.
+ * The tablet-and-below breakpoint — Mantine's `md`, where a wide one-line row
+ * (label, metadata and a trailing action all on one baseline) stops fitting and
+ * stacks instead. It is now the same number as {@link MOBILE_QUERY}, which moved
+ * up to meet it; the two are kept apart because they answer different questions
+ * — "can a second column exist" and "does a row still fit on one line" — and the
+ * first is the one a phone-shaped layout hangs off.
  */
 export const COMPACT_QUERY = '(max-width: 62em)'
 


### PR DESCRIPTION
At `48em` a 900px viewport still ran the pointer layout — the nav dock rather than the tab bar, and a split view's panel docked beside the page rather than raised as a sheet from the foot — on a screen with no room for a second column.

It also split the layout in half for a host app that embeds these screens inside its own shell: the shell went mobile at `md` while every page inside it stayed on the desktop path, so surfaces that should have risen as sheets appeared as docked panels between 768px and 992px.

`MOBILE_QUERY` moves to `62em`. `PageCard.module.css`'s full-bleed media query moves with it, as its own comment asks (CSS cannot import the constant). `COMPACT_QUERY` is left alone — it is now the same number, but it answers a different question ("does a row still fit on one line") and is expected to drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)