### PR TITLE
feat(console): give the empty state a test id

### DIFF
--- a/.changeset/empty-state-testid.md
+++ b/.changeset/empty-state-testid.md
@@ -1,0 +1,5 @@
+---
+'@pikku/console': patch
+---
+
+`EmptyStatePlaceholder` carries a `data-testid="empty-state"`, so a test can assert a screen is empty without matching its prose.

--- a/packages/console/src/components/layout/EmptyStatePlaceholder.tsx
+++ b/packages/console/src/components/layout/EmptyStatePlaceholder.tsx
@@ -26,6 +26,7 @@ export const EmptyStatePlaceholder: React.FC<EmptyStatePlaceholderProps> = ({
   useLocale()
   return (
     <Stack
+      data-testid="empty-state"
       align="center"
       justify="center"
       gap="md"


### PR DESCRIPTION
`EmptyStatePlaceholder` gets `data-testid="empty-state"`.

An empty screen could otherwise only be recognised by its copy, which is translated and rewritten far more often than it is asserted on. Downstream consumers are carrying this as a package patch today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)