### PR TITLE
fix(console): read a scenario ladder as gherkin

### DIFF
--- a/.changeset/ladder-and-continuation.md
+++ b/.changeset/ladder-and-continuation.md
@@ -1,0 +1,5 @@
+---
+'@pikku/console': patch
+---
+
+A scenario ladder reads like gherkin: a step continuing its phase is labelled `And` instead of losing its keyword, and a step repeating the actor above it drops the repeated subject.

--- a/packages/console/messages/ar.json
+++ b/packages/console/messages/ar.json
@@ -878,6 +878,7 @@
   "scenarios_no_steps": "لا يعلن هذا السيناريو أي خطوات",
   "scenarios_scenario_count": "{count} سيناريوهات",
   "scenarios_scenario_count_one": "سيناريو واحد",
+  "scenarios_phase_and": "و",
   "scenarios_phase_given": "بافتراض",
   "scenarios_phase_when": "عندما",
   "scenarios_phase_then": "عندئذٍ",

--- a/packages/console/messages/de.json
+++ b/packages/console/messages/de.json
@@ -878,6 +878,7 @@
   "scenarios_no_steps": "Dieses Szenario deklariert keine Schritte",
   "scenarios_scenario_count": "{count} Szenarien",
   "scenarios_scenario_count_one": "1 Szenario",
+  "scenarios_phase_and": "Und",
   "scenarios_phase_given": "Angenommen",
   "scenarios_phase_when": "Wenn",
   "scenarios_phase_then": "Dann",

--- a/packages/console/messages/en.json
+++ b/packages/console/messages/en.json
@@ -918,6 +918,7 @@
   "scenarios_no_steps": "This scenario declares no steps",
   "scenarios_scenario_count": "{count} scenarios",
   "scenarios_scenario_count_one": "1 scenario",
+  "scenarios_phase_and": "And",
   "scenarios_phase_given": "Given",
   "scenarios_phase_when": "When",
   "scenarios_phase_then": "Then",

--- a/packages/console/messages/zh.json
+++ b/packages/console/messages/zh.json
@@ -878,6 +878,7 @@
   "scenarios_no_steps": "此场景未声明任何步骤",
   "scenarios_scenario_count": "{count} 个场景",
   "scenarios_scenario_count_one": "1 个场景",
+  "scenarios_phase_and": "并且",
   "scenarios_phase_given": "假设",
   "scenarios_phase_when": "当",
   "scenarios_phase_then": "那么",

--- a/packages/console/src/components/scenarios/LadderStep.tsx
+++ b/packages/console/src/components/scenarios/LadderStep.tsx
@@ -15,6 +15,8 @@ type LadderStepProps = {
   step: ScenarioLadderStep
   /** True when the step above declared the same phase — gherkin's `And`. */
   continuation: boolean
+  /** True when the step above named the same actor, so the subject carries over. */
+  continuesActor?: boolean
   /** The actor's display name, when the project configures one. */
   actorName?: string
   onOpenPersona?: (key: string) => void
@@ -29,12 +31,15 @@ type LadderStepProps = {
 export const LadderStep: React.FC<LadderStepProps> = ({
   step,
   continuation,
+  continuesActor,
   actorName,
   onOpenPersona,
   onSelectStep,
 }) => {
   const label = PHASE_LABEL[step.phase]?.()
+  const carried = continuation && continuesActor === true
   const actor = step.actor
+  const subject = carried ? undefined : actor
 
   return (
     <Group
@@ -60,9 +65,9 @@ export const LadderStep: React.FC<LadderStepProps> = ({
       style={{ paddingLeft: 8 + step.depth * 24 }}
     >
       <Box style={{ width: 52, flexShrink: 0, textAlign: 'right' }}>
-        {label && !continuation && !step.repeat && (
+        {label && !step.repeat && (
           <Text size="sm" fw={600} c="dimmed" style={{ lineHeight: 1.6 }}>
-            {asI18n(label)}
+            {continuation ? m.scenarios_phase_and() : asI18n(label)}
           </Text>
         )}
       </Box>
@@ -77,23 +82,23 @@ export const LadderStep: React.FC<LadderStepProps> = ({
         </Text>
       ) : (
         <Text size="sm" style={{ lineHeight: 1.6 }}>
-          {actor ? (
+          {subject ? (
             <Anchor
               component="span"
               fw={600}
               data-testid="ladder-actor"
-              data-persona-key={actor}
+              data-persona-key={subject}
               className={classes.ladderActor}
               onClick={(event: React.MouseEvent) => {
                 event.stopPropagation()
-                onOpenPersona?.(actor)
+                onOpenPersona?.(subject)
               }}
               style={{
                 cursor: onOpenPersona ? 'pointer' : 'default',
                 marginRight: 6,
               }}
             >
-              {asI18n(actorName ?? actor)}
+              {asI18n(actorName ?? subject)}
             </Anchor>
           ) : null}
           <span className={classes.ladderSentence}>

--- a/packages/console/src/components/scenarios/ScenarioLadder.tsx
+++ b/packages/console/src/components/scenarios/ScenarioLadder.tsx
@@ -37,6 +37,7 @@ export const ScenarioLadder: React.FC<ScenarioLadderProps> = ({
           key={step.id}
           step={step}
           continuation={steps[index - 1]?.phase === step.phase}
+          continuesActor={steps[index - 1]?.actor === step.actor}
           actorName={step.actor ? actorNames?.get(step.actor) : undefined}
           onOpenPersona={onOpenPersona}
           onSelectStep={onSelectStep}


### PR DESCRIPTION
Two things a scenario ladder got wrong, both about repetition.

**Continuation steps lost their keyword.** A step whose phase matched the one above it rendered an empty gutter, so a three-step `Given` block showed one "Given" and two blanks. Gherkin has a word for that position — `And` — so the ladder now shows it, as a translated message (`scenarios_phase_and`) beside the other phase labels rather than a hardcoded string.

**Repeated actors restated the subject.** A run of steps by the same actor named them on every line. The subject now carries over, and only a change of actor reprints it — the actor anchor (and its persona click target) is simply not rendered on a carried line.

Downstream consumers are carrying this as a package patch today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)