### PR TITLE
feat(cli): add deploy.grouping.strategy 'services'

### DIFF
--- a/.changeset/deploy-grouping-services-strategy.md
+++ b/.changeset/deploy-grouping-services-strategy.md
@@ -1,0 +1,22 @@
+---
+'@pikku/cli': patch
+'@pikku/deploy': patch
+---
+
+Add `deploy.grouping.strategy: 'services'` — one deployment unit per distinct
+set of singleton services.
+
+One unit per function is a lot of units, and `'single'` is the only alternative,
+which is too coarse: it puts the AI SDKs in with everything. `'services'` keys a
+function on the singleton services its body destructures, minus the ones every
+unit builds regardless, and names the unit for that set (`svc-todo-store`,
+`svc-base`). On `templates/functions` it turns 44 units into 10.
+
+The deploy target is part of the key, so a `server` unit is named `-server` and
+never merges with its serverless twin — a function can declare `deploy: 'server'`
+itself while carrying exactly the services a serverless one does, and keying on
+services alone made that plan fail the mixed-target refusal.
+
+Units named this way record their key as `servicesKey` in the deployment
+manifest. The existing `services` list is keyed by capability and cannot tell
+`workflowService` from `workflowRunService`.

--- a/packages/cli/src/deploy/analyzer/analyzer.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.ts
@@ -119,9 +119,29 @@ export function analyzeDeployment(
         prefixed(r.route),
       ]),
     tagsForFunction: tagsFor,
+    servicesForFunction: (funcId) =>
+      functionsMeta[funcId]?.services?.services ?? [],
+    targetForFunction: (funcId) => {
+      const funcMeta = functionsMeta[funcId]
+      return funcMeta
+        ? resolveDeployTarget(
+            funcMeta,
+            serverlessIncompatible,
+            funcId,
+            defaultTarget
+          )
+        : defaultTarget
+    },
   })
 
   const addFunctionUnit = (unit: DeploymentUnit) => {
+    // Set here rather than at each call site: a unit is created from six
+    // places (functions, channels, agents, MCP, workflow orchestrators, steps)
+    // and a unit missing its key reads as one the strategy never named.
+    if (!unit.servicesKey) {
+      const key = resolver.serviceKeyForUnit(unit.name)
+      if (key) unit.servicesKey = key
+    }
     const existing = units.find((u) => u.name === unit.name)
     if (!existing) {
       units.push(unit)

--- a/packages/cli/src/deploy/analyzer/grouping.test.ts
+++ b/packages/cli/src/deploy/analyzer/grouping.test.ts
@@ -1,7 +1,7 @@
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
 import { analyzeDeployment } from './analyzer.js'
-import type { GroupingConfig } from './grouping.js'
+import { serviceUnitName, type GroupingConfig } from './grouping.js'
 import type { InspectorState } from '@pikku/inspector'
 
 function state(): InspectorState {
@@ -276,6 +276,162 @@ describe("deploy.grouping - strategy 'single'", () => {
       rules: [{ unit: 'purge', tags: ['heavy'] }],
     }).scheduledTasks.find((t) => t.name === 'nightly')
     assert.equal(task?.unitName, 'app')
+  })
+})
+
+describe("deploy.grouping - strategy 'services'", () => {
+  test('functions sharing a service set share a unit', () => {
+    assert.deepEqual(unitNames({ strategy: 'services' }), [
+      'addon-console',
+      'svc-base',
+      'svc-file-store-server',
+      'svc-kysely',
+    ])
+  })
+
+  test('a unit is named after the services it builds', () => {
+    const unit = analyze({ strategy: 'services' }).units.find(
+      (u) => u.name === 'svc-kysely'
+    )
+    assert.deepEqual(unit!.functionIds, ['bookRetreat'])
+  })
+
+  test('functions that need nothing beyond the base land together', () => {
+    const unit = analyze({ strategy: 'services' }).units.find(
+      (u) => u.name === 'svc-base'
+    )
+    assert.deepEqual(unit!.functionIds.sort(), [
+      'handleWebhook',
+      'listRetreats',
+      'nightlyReport',
+      'sendEmail',
+    ])
+  })
+
+  test('a rule still beats the strategy', () => {
+    assert.deepEqual(
+      unitNames({
+        strategy: 'services',
+        rules: [{ unit: 'purge', tags: ['heavy'] }],
+      }),
+      ['addon-console', 'purge', 'svc-base', 'svc-kysely']
+    )
+  })
+
+  test('the scheduled task follows its function into the service unit', () => {
+    const task = analyze({ strategy: 'services' }).scheduledTasks.find(
+      (t) => t.name === 'nightly'
+    )
+    assert.equal(task?.unitName, 'svc-base')
+  })
+
+  test('the queue follows its function into the service unit', () => {
+    const queue = analyze({ strategy: 'services' }).queues.find(
+      (q) => q.name === 'emails'
+    )
+    assert.equal(queue?.consumerUnit, 'svc-base')
+  })
+
+  test('a unit never mixes targets, because the target is part of the key', () => {
+    const units = analyze({ strategy: 'services' }).units
+    assert.equal(
+      units.find((u) => u.name === 'svc-file-store-server')?.target,
+      'server'
+    )
+    assert.equal(units.find((u) => u.name === 'svc-base')?.target, 'serverless')
+  })
+
+  test('the same service set on two targets is two units', () => {
+    // A function may name `deploy: 'server'` itself while carrying exactly the
+    // services a serverless one does. Keying on services alone merged them and
+    // hit the mixed-target refusal.
+    const s = state()
+    s.functions.meta.serverSideEffect = {
+      pikkuFuncId: 'serverSideEffect',
+      name: 'serverSideEffect',
+      deploy: 'server',
+      services: { services: ['kysely'] },
+    } as never
+    ;(s.http.meta as Record<string, unknown>).post = {
+      ...(s.http.meta.post as object),
+      '/api/side-effect': {
+        pikkuFuncId: 'serverSideEffect',
+        method: 'post',
+        route: '/api/side-effect',
+      },
+    }
+    const units = analyzeDeployment(s, {
+      projectId: 'test',
+      serverlessIncompatible: ['fileStore'],
+      grouping: { strategy: 'services' },
+    }).units
+    assert.equal(
+      units.find((u) => u.name === 'svc-kysely')?.target,
+      'serverless'
+    )
+    assert.equal(
+      units.find((u) => u.name === 'svc-kysely-server')?.target,
+      'server'
+    )
+  })
+})
+
+describe('deploy.grouping - service unit names', () => {
+  test('a server set never collides with the serverless one', () => {
+    assert.notEqual(
+      serviceUnitName(['kysely'], 'serverless'),
+      serviceUnitName(['kysely'], 'server')
+    )
+    assert.notEqual(
+      serviceUnitName([], 'serverless'),
+      serviceUnitName([], 'server')
+    )
+  })
+
+  test('the name is stable under a reordered set', () => {
+    assert.equal(
+      serviceUnitName(['kysely', 'eventHub']),
+      serviceUnitName(['eventHub', 'kysely'])
+    )
+  })
+
+  test('base services never reach the name', () => {
+    assert.equal(
+      serviceUnitName(['logger', 'config', 'secrets', 'schema', 'variables']),
+      'svc-base'
+    )
+    assert.equal(
+      serviceUnitName(['rpc', 'userSession', 'kysely']),
+      'svc-kysely'
+    )
+  })
+
+  test('a long set keeps a readable head and a digest of the whole', () => {
+    const long = [
+      'agentRunService',
+      'agentRunState',
+      'agentRunner',
+      'agentStorage',
+      'eventHub',
+      'kysely',
+      'scopeService',
+      'workflowService',
+    ]
+    const name = serviceUnitName(long)
+    assert.ok(name.length <= 58, `name too long: ${name}`)
+    assert.ok(name.startsWith('svc-agent-run-service'), name)
+    // A different set of the same shape must not collide with it.
+    assert.notEqual(
+      name,
+      serviceUnitName([...long.slice(0, 7), 'workflowRunService'])
+    )
+  })
+
+  test('an unlisted service still keys, so a new service splits a unit', () => {
+    assert.notEqual(
+      serviceUnitName(['kysely']),
+      serviceUnitName(['kysely', 'redis'])
+    )
   })
 })
 

--- a/packages/cli/src/deploy/analyzer/grouping.ts
+++ b/packages/cli/src/deploy/analyzer/grouping.ts
@@ -1,8 +1,10 @@
+import { createHash } from 'node:crypto'
+
 import type { GroupingRule } from '@pikku/deploy'
 
 import { toSafeKebab } from './naming.js'
 
-export type GroupingStrategy = 'function' | 'single'
+export type GroupingStrategy = 'function' | 'single' | 'services'
 
 export type { GroupingRule } from '@pikku/deploy'
 
@@ -14,6 +16,19 @@ export interface GroupingConfig {
 export interface UnitResolverInput {
   routesForFunction: (funcId: string) => string[]
   tagsForFunction: (funcId: string) => string[]
+  /**
+   * The singleton services the function's own body destructures. Only used by
+   * `strategy: 'services'`, which keys a unit on this set.
+   */
+  servicesForFunction: (funcId: string) => string[]
+  /**
+   * Where the function runs. Part of the `strategy: 'services'` key, because a
+   * target is not always implied by the services: a function carrying no
+   * serverless-incompatible service can still name `deploy: 'server'` itself,
+   * and merging it with a serverless function that happens to build the same
+   * services is the one grouping a target refusal exists to stop.
+   */
+  targetForFunction: (funcId: string) => 'serverless' | 'server'
 }
 
 export interface UnitResolver {
@@ -21,9 +36,81 @@ export interface UnitResolver {
   forAddon: (namespace: string) => string
   isGrouped: boolean
   ruleForUnit: (unitName: string) => GroupingRule | undefined
+  /**
+   * The service set that named a unit under `strategy: 'services'`, or
+   * undefined for a unit that came from a rule or from one-per-function. The
+   * manifest's own `services` list cannot stand in for it: that list is keyed
+   * by capability, so `workflowService` and `workflowRunService` both arrive as
+   * `workflow-state` and two genuinely different units read as identical.
+   */
+  serviceKeyForUnit: (unitName: string) => string[] | undefined
 }
 
 const SINGLE_UNIT_NAME = 'app'
+
+/**
+ * Services every unit is given regardless of what it holds, so they say nothing
+ * about which functions belong together. `config`, `logger`, `variables`,
+ * `schema` and `secrets` are written into every generated services map as
+ * `defaultServices`; `rpc`, `mcp`, `channel` and `userSession` are the
+ * per-request services the inspector already excludes from tree-shaking.
+ *
+ * Only the base set is subtracted. A service that happens to be app-wide today
+ * — `auth` under a declared auth definition, say — is left in the key on
+ * purpose: it is constant, so it cannot split a partition, and dropping it
+ * would make the unit name lie about what the unit builds.
+ */
+const BASE_SERVICES = new Set([
+  'config',
+  'logger',
+  'variables',
+  'schema',
+  'secrets',
+  'rpc',
+  'mcp',
+  'channel',
+  'userSession',
+])
+
+const SERVICE_UNIT_PREFIX = 'svc'
+/** Kept short enough to survive a provider's own name length limits. */
+const SERVICE_UNIT_NAME_LIMIT = 58
+
+/**
+ * The distinguishing services in a set: what is left once the services every
+ * unit gets regardless are removed. This is the grouping key.
+ */
+export const serviceKey = (services: string[]): string[] =>
+  [...new Set(services)].filter((service) => !BASE_SERVICES.has(service)).sort()
+
+/**
+ * The unit name for one service set. Names the services themselves so a plan
+ * reads as what each unit builds; a set too long to spell out keeps the first
+ * few names and a digest of the whole set, which stays stable for that exact
+ * set and distinct from every other.
+ */
+export const serviceUnitName = (
+  services: string[],
+  target: 'serverless' | 'server' = 'serverless'
+): string => {
+  const suffix = target === 'server' ? '-server' : ''
+  const key = serviceKey(services)
+  if (key.length === 0) {
+    return `${SERVICE_UNIT_PREFIX}-base${suffix}`
+  }
+
+  const full = `${SERVICE_UNIT_PREFIX}-${key.map(toSafeKebab).join('-')}${suffix}`
+  if (full.length <= SERVICE_UNIT_NAME_LIMIT) {
+    return full
+  }
+
+  const digest = createHash('sha256')
+    .update(key.join(','))
+    .digest('hex')
+    .slice(0, 6)
+  const room = SERVICE_UNIT_NAME_LIMIT - digest.length - suffix.length - 1
+  return `${full.slice(0, room).replace(/-+$/, '')}-${digest}${suffix}`
+}
 
 const routeMatcher = (pattern: string): RegExp => {
   const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&')
@@ -73,6 +160,7 @@ export const createUnitResolver = (
   }))
 
   const byUnitName = new Map(compiled.map((c) => [c.unit, c.rule]))
+  const serviceKeys = new Map<string, string[]>()
 
   const matches = (
     c: (typeof compiled)[number],
@@ -92,12 +180,23 @@ export const createUnitResolver = (
     return true
   }
 
-  const fallback = (funcId: string) =>
-    strategy === 'single' ? SINGLE_UNIT_NAME : toSafeKebab(funcId)
+  const fallback = (funcId: string) => {
+    if (strategy === 'single') {
+      return SINGLE_UNIT_NAME
+    }
+    if (strategy === 'services') {
+      const services = input.servicesForFunction(funcId)
+      const name = serviceUnitName(services, input.targetForFunction(funcId))
+      serviceKeys.set(name, serviceKey(services))
+      return name
+    }
+    return toSafeKebab(funcId)
+  }
 
   return {
     isGrouped: strategy !== 'function' || compiled.length > 0,
     ruleForUnit: (unitName) => byUnitName.get(unitName),
+    serviceKeyForUnit: (unitName) => serviceKeys.get(unitName),
     forFunction: (funcId) => {
       if (compiled.length > 0) {
         const tags = input.tagsForFunction(funcId)

--- a/packages/deploy/deploy-core/src/manifest.ts
+++ b/packages/deploy/deploy-core/src/manifest.ts
@@ -68,6 +68,13 @@ export interface DeploymentUnit {
    */
   groupedBy?: GroupingRule
   /**
+   * The services that named this unit under `deploy.grouping.strategy:
+   * 'services'` — the set left after the ones every unit builds regardless.
+   * Absent under every other strategy. Recorded because `services` below is
+   * keyed by capability and so cannot tell two different service sets apart.
+   */
+  servicesKey?: string[]
+  /**
    * Services in `deploy.serverlessIncompatible` that forced `target: 'server'`.
    * Absent when the target came from a function's own `deploy` flag or from
    * `defaultTarget`, so its presence is what distinguishes a chosen target

--- a/packages/skills/skills/pikku-build/references/ship.md
+++ b/packages/skills/skills/pikku-build/references/ship.md
@@ -42,10 +42,36 @@ for each. `deploy.grouping` in `pikku.config.json` sets the shape:
 }
 ```
 
-`strategy` is the fallback for a function no rule matches — `function` (one unit
-each, the default) or `single` (one shared unit). Rules are ordered, first match
-wins, and match on `tags`, an `addon` namespace or `routes` globs; under
-`function` a rule merges, under `single` it carves out.
+`strategy` is the fallback for a function no rule matches:
+
+| strategy | fallback |
+| --- | --- |
+| `function` | one unit each (the default) |
+| `services` | one unit per distinct set of singleton services |
+| `single` | one shared unit |
+
+Rules are ordered, first match wins, and match on `tags`, an `addon` namespace
+or `routes` globs. A rule always beats the strategy, so under `function` a rule
+merges and under `single` or `services` it carves out.
+
+`services` is the middle ground when `single` is too coarse. Functions are keyed
+on the singleton services their bodies destructure, minus the ones every unit
+builds anyway (`config`, `logger`, `variables`, `schema`, `secrets`, and the
+per-request `rpc`/`mcp`/`channel`/`userSession`). Units are named for that set —
+`svc-todo-store`, `svc-event-hub-todo-store`, `svc-base` for functions needing
+nothing else — and each records it as `servicesKey` in the manifest. On the
+`templates/functions` app it turns 44 units into 10.
+
+The deploy target is part of the key, so a `server` unit is named `-server` and
+can never merge with its serverless twin. That is what keeps `services` from
+tripping the mixed-target refusal below: two functions can carry identical
+services and still run in different places, because a function may name
+`deploy: 'server'` itself without any service crossing it.
+
+Read the shape before adopting it. The win depends entirely on how varied the
+app's service use is: an app where nearly every function reaches the same
+database collapses to roughly `single` with a few carve-outs, which may or may
+not be what you want.
 
 `tags` matches the tags a function inherits from its wirings — `wireHTTP({ ...,
 tags: ['pdf'] })` — as well as any on the function itself, which is where almost

--- a/verifiers/deploy-grouping/test-grouping.ts
+++ b/verifiers/deploy-grouping/test-grouping.ts
@@ -34,6 +34,7 @@ type Unit = {
     addon?: string
     routes?: string[]
   }
+  servicesKey?: string[]
   targetForcedBy?: string[]
 }
 type Manifest = {
@@ -297,6 +298,117 @@ try {
         .dependsOn) {
         assert(names.has(dep), `${unit.name} depends on missing unit ${dep}`)
       }
+    }
+  })
+
+  console.log("\nGrouped: strategy 'services'")
+  withGrouping({ strategy: 'services' })
+  const byServices = runPlan()
+
+  assert(
+    byServices.ok,
+    `services-strategy plan failed:\n${!byServices.ok ? byServices.output : ''}`
+  )
+  const svcUnits = functionUnits(byServices.manifest)
+
+  check('it produces fewer units than one-per-function', () => {
+    assert(
+      svcUnits.length < baseUnits.length,
+      `${svcUnits.length} units vs ${baseUnits.length} ungrouped — nothing merged`
+    )
+  })
+
+  // The server units are merged into one container downstream of the analyzer,
+  // so it is the only unit in the manifest that the strategy never named.
+  const SERVER_CONTAINER = 'pikku-server-container'
+
+  check('every app unit is named after its service set', () => {
+    const stray = svcUnits.filter(
+      (u) =>
+        !u.name.startsWith('svc-') &&
+        !u.name.startsWith('addon-') &&
+        u.name !== SERVER_CONTAINER
+    )
+    assert(
+      stray.length === 0,
+      `not named by service set: ${stray.map((u) => u.name).join(', ')}`
+    )
+  })
+
+  check('no function was lost or duplicated', () => {
+    const before = baseUnits.flatMap((u) => u.functionIds).sort()
+    const after = svcUnits.flatMap((u) => u.functionIds).sort()
+    assert(
+      after.join(',') === before.join(','),
+      `functions changed:\n  ungrouped: ${before.join(', ')}\n  grouped:   ${after.join(', ')}`
+    )
+  })
+
+  check('every service unit records the key that made it', () => {
+    for (const unit of svcUnits) {
+      if (unit.name.startsWith('addon-') || unit.name === SERVER_CONTAINER)
+        continue
+      assert(
+        Array.isArray(unit.servicesKey),
+        `${unit.name} does not record the service set it was named for`
+      )
+    }
+  })
+
+  check('two units never share one service key', () => {
+    // The whole premise: if two units need the same services they should have
+    // been one unit, and the strategy did not do its job. Compared on the
+    // recorded key, not on `services` — that list is keyed by capability, so
+    // workflowService and workflowRunService both read as `workflow-state`.
+    const seen = new Map<string, string>()
+    for (const unit of svcUnits) {
+      if (!unit.servicesKey) continue
+      const key = `${unit.target}:${unit.servicesKey.join(',')}`
+      const other = seen.get(key)
+      assert(!other, `${unit.name} and ${other} share the key (${key})`)
+      seen.set(key, unit.name)
+    }
+  })
+
+  check('a server unit is named apart from its serverless twin', () => {
+    // Why this strategy never hits the mixed-target refusal below: the target
+    // is part of the key. Keying on services alone merged `processReminder@v2`
+    // with `dailySummary` — same services, one serverless and one server — and
+    // the whole plan was refused.
+    const server = svcUnits.filter((u) => u.target === 'server')
+    assert(server.length > 0, 'the template has no server-target unit to check')
+    for (const unit of server) {
+      assert(
+        unit.name.endsWith('-server') ||
+          unit.name.startsWith('addon-') ||
+          unit.name === SERVER_CONTAINER,
+        `${unit.name} runs on server but is not named as one`
+      )
+    }
+  })
+
+  check('no queue or cron points at a unit that no longer exists', () => {
+    const names = new Set(byServices.manifest.units.map((u) => u.name))
+    for (const queue of byServices.manifest.queues) {
+      assert(
+        names.has(queue.consumerUnit),
+        `queue ${queue.name} points at missing unit ${queue.consumerUnit}`
+      )
+    }
+    for (const task of byServices.manifest.scheduledTasks) {
+      assert(
+        names.has(task.unitName),
+        `cron ${task.name} points at missing unit ${task.unitName}`
+      )
+    }
+  })
+
+  check('every service unit actually bundles', () => {
+    for (const unit of svcUnits) {
+      if (unit.target !== 'serverless') continue
+      const bundle = join(UNITS_DIR, unit.name, 'bundle.js')
+      assert(existsSync(bundle), `no bundle at ${bundle}`)
+      assert(statSync(bundle).size > 0, `${unit.name} bundled empty`)
     }
   })
 


### PR DESCRIPTION
## What

A third grouping strategy: `deploy.grouping.strategy: 'services'`. Every function goes into a unit named after the set of services it actually needs, minus the base set every unit builds regardless (`config`, `logger`, `variables`, `schema`, `secrets`, `rpc`, `mcp`, `channel`, `userSession`).

```yaml
deploy:
  grouping:
    strategy: services
```

`function` (the default) gives every function its own unit; `single` collapses everything into one. Neither is a sensible default for a real app — `single` is too coarse, `function` too fine. This sits between them and is the one worth reaching for.

On `templates/functions`: **44 function units → 10.**

```
addon-console              63 fn  key=-
pikku-server-container      1 fn  key=-
svc-base                   19 fn  key=(empty)
svc-event-hub               2 fn  key=eventHub
svc-event-hub-todo-store    4 fn  key=eventHub,todoStore
svc-kysely                  1 fn  key=kysely
svc-queue-service           1 fn  key=queueService
svc-todo-store              9 fn  key=todoStore
svc-workflow-run-service    2 fn  key=workflowRunService
svc-workflow-service        4 fn  key=workflowService
```

Explicit `rules` still win over the strategy; the strategy only names units the rules didn't.

## Two things the verifier caught

**The deploy target has to be part of the key.** I claimed a service-set key could not collide deploy targets. It can: a function may declare `deploy: 'server'` itself without carrying any serverless-incompatible service, and the grouping verifier refused the whole plan (`unit "svc-todo-store" would hold both serverless and server functions`). The target is now part of the key, with a `-server` name suffix, and a verifier check guards it.

**`DeploymentUnit.services` is lossy.** It is keyed by capability, so `workflowService` and `workflowRunService` both report `workflow-state` — two different service sets that read as identical. The unit now also records `servicesKey`, the exact set that named it. Absent under every other strategy.

## Caveat worth stating

On a real app the partition can be thin. Measured on perauset (182 units): 5 distinct combinations, 162 of them in one bucket. There it is `single` with four carve-outs. The template's spread is more typical of an app with varied services, but read `pikku deploy plan` before adopting it — the skill note says so too.

## Checklist

- **Unit tests** — 13 new in `packages/cli/src/deploy/analyzer/grouping.test.ts` (8 for the strategy, 5 for name generation incl. the length cap and hash fallback). 87/0 in the analyzer directory, 114/0 across `packages/cli/src/deploy`.
- **Verifier** — `verifiers/deploy-grouping` gained a `Grouped: strategy 'services'` section, 8 checks. 27/0. Two of those checks caught the real defects above.
- **E2E** — the verifier *is* the e2e here: it runs real pikku codegen against `templates/functions` and bundles.
- **Skills** — `packages/skills/skills/pikku-build/references/ship.md`: the strategy table, the key, `servicesKey`, the `-server` suffix, and the read-the-plan-first caveat.
- **Docs** — website `docs/deploy/index.md`, pushed separately to the website repo.
- **Changeset** — patch, `@pikku/cli` + `@pikku/deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)