### PR TITLE
console: a run action reveals its pane, and the workflow screen gets run controls

### DIFF
--- a/.changeset/a-run-action-reveals-its-pane.md
+++ b/.changeset/a-run-action-reveals-its-pane.md
@@ -1,0 +1,7 @@
+---
+'@pikku/console': patch
+---
+
+A run action now re-opens the details pane it renders into. The new-run button and run selection both put their result in that pane, whose collapsed state is remembered in `localStorage` — so once it had been collapsed, the new-run button flipped state into a 40px stub and looked dead, with no error and no feedback, across reloads. Selecting a run had the same defect, masked by the graph beside it also changing.
+
+The layout now hands its list pane a reveal, the mirror of the collapse control that pane already provides for itself.

--- a/.changeset/a-run-action-reveals-its-pane.md
+++ b/.changeset/a-run-action-reveals-its-pane.md
@@ -2,8 +2,10 @@
 '@pikku/console': patch
 ---
 
-A run action now re-opens the details pane it renders into. The new-run button and run selection both put their result in that pane, whose collapsed state is remembered in `localStorage` — so once it had been collapsed, the new-run button flipped state into a 40px stub and looked dead, with no error and no feedback, across reloads. Selecting a run had the same defect, masked by the graph beside it also changing.
+A run action now re-opens the details surface it renders into. The new-run button and run selection both put their result there, and it can be gone two different ways — collapsed, or closed outright — so the button flipped state with nothing on screen moving, with no error and no feedback.
 
-The layout now hands its list pane a reveal, the mirror of the collapse control that pane already provides for itself.
+Collapsed is the `ThreePaneLayout` case: the pane's state is remembered in `localStorage`, so once collapsed the button looked dead across reloads. The layout now hands its content a reveal, the mirror of the collapse control that pane already provides for itself.
 
-The workflow screen also grows its own run controls. Starting a run was only reachable through the details pane; the action now sits above the graph, with the selected run's id and status beside it.
+Closed is the `ResizablePanelLayout` case, which the workflow screen uses: activating a panel id that is no longer open does nothing, so the on-screen run controls now open the workflow panel rather than merely activating it.
+
+The workflow screen also grows its own run controls. Starting a run was only reachable through the details panel; the action now sits above the graph, with the selected run's id and status beside it.

--- a/.changeset/a-run-action-reveals-its-pane.md
+++ b/.changeset/a-run-action-reveals-its-pane.md
@@ -5,3 +5,5 @@
 A run action now re-opens the details pane it renders into. The new-run button and run selection both put their result in that pane, whose collapsed state is remembered in `localStorage` — so once it had been collapsed, the new-run button flipped state into a 40px stub and looked dead, with no error and no feedback, across reloads. Selecting a run had the same defect, masked by the graph beside it also changing.
 
 The layout now hands its list pane a reveal, the mirror of the collapse control that pane already provides for itself.
+
+The workflow screen also grows its own run controls. Starting a run was only reachable through the details pane; the action now sits above the graph, with the selected run's id and status beside it.

--- a/e2e/packages/functions/tests/scenarios/apis-console.feature.ts
+++ b/e2e/packages/functions/tests/scenarios/apis-console.feature.ts
@@ -1,10 +1,11 @@
 /**
- * The console APIs page: the MCP and Gateways tabs.
+ * The console wires pages: MCP and Gateways.
  *
- * Both were standalone pages when the gherkin was written and are now tabs on
- * one page, selected by a query param. Both list their records in a table keyed
- * on the record's own name, which is project data rather than console copy — so
- * the assertions here are stable without the page carrying test ids.
+ * Both were standalone pages when the gherkin was written, became tabs on one
+ * APIs page selected by a query param, and are standalone pages again under
+ * `/console/wires/*`. Both list their records in a table keyed on the record's
+ * own name, which is project data rather than console copy — so the assertions
+ * here are stable without the page carrying test ids.
  *
  * One assertion did not survive: the gherkin expected the console to flag an
  * MCP tool that declares no description. The console renders no such warning
@@ -15,12 +16,12 @@
  */
 import { pikkuFeature, pikkuScenario } from '#pikku/scenario'
 
-const MCP_TAB = '/console/apis?tab=mcp'
-const GATEWAYS_TAB = '/console/apis?tab=gateways'
+const MCP_PAGE = '/console/wires/mcp'
+const GATEWAYS_PAGE = '/console/wires/gateway'
 
 export const mcpToolsListedScenario = pikkuScenario<void, { tools: number }>({
   title: 'MCP tools are listed in the console',
-  description: 'An admin opens the MCP tab and finds the project’s tools',
+  description: 'An admin opens the MCP page and finds the project’s tools',
   tags: ['scenario', 'console'],
   func: async (_services, _data, { scenario, actors }) => {
     if (!actors?.admin) {
@@ -30,9 +31,9 @@ export const mcpToolsListedScenario = pikkuScenario<void, { tools: number }>({
     }
 
     await scenario.given(
-      'opens the MCP tab',
+      'opens the MCP page',
       'opensConsolePage',
-      { path: MCP_TAB, waitFor: { testId: 'data-table' } },
+      { path: MCP_PAGE, waitFor: { testId: 'data-table' } },
       { actor: actors.admin }
     )
 
@@ -52,7 +53,7 @@ export const mcpToolsListedScenario = pikkuScenario<void, { tools: number }>({
 
 export const gatewayMetadataScenario = pikkuScenario<void, { listed: true }>({
   title: 'Gateway metadata is visible in the console',
-  description: 'An admin opens the Gateways tab and finds the gateway’s route',
+  description: 'An admin opens the Gateways page and finds the gateway’s route',
   tags: ['scenario', 'console'],
   func: async (_services, _data, { scenario, actors }) => {
     if (!actors?.admin) {
@@ -62,9 +63,9 @@ export const gatewayMetadataScenario = pikkuScenario<void, { listed: true }>({
     }
 
     await scenario.given(
-      'opens the Gateways tab',
+      'opens the Gateways page',
       'opensConsolePage',
-      { path: GATEWAYS_TAB, waitFor: { testId: 'data-table' } },
+      { path: GATEWAYS_PAGE, waitFor: { testId: 'data-table' } },
       { actor: actors.admin }
     )
     await scenario.then(
@@ -79,7 +80,7 @@ export const gatewayMetadataScenario = pikkuScenario<void, { listed: true }>({
 })
 
 export const apisConsoleFeature = pikkuFeature({
-  name: 'APIs Console Page',
+  name: 'Wires Console Pages',
   description: 'The console lists the project’s MCP tools and gateways',
   tags: ['apis-console', 'console'],
   scenarios: [mcpToolsListedScenario, gatewayMetadataScenario],

--- a/e2e/packages/functions/tests/scenarios/workflow-controls.feature.ts
+++ b/e2e/packages/functions/tests/scenarios/workflow-controls.feature.ts
@@ -1,0 +1,77 @@
+/**
+ * The run controls that sit on the workflow screen itself, beside the graph.
+ *
+ * Running a workflow is what the screen is for, but the form that starts a run
+ * renders in the details panel — which the reader can close. The button then
+ * looked dead: it set the run state and nothing on screen moved, because
+ * activating a panel id that is no longer open does nothing.
+ *
+ * Closing the panel before clicking is therefore the whole point of this
+ * feature. An assertion that clicks the control with the panel already open
+ * passes whether or not the control re-opens it.
+ */
+import { pikkuFeature, pikkuScenario } from '#pikku/scenario'
+
+const WORKFLOW_PAGE = '/console/workflow?id=graphLinearWorkflow'
+
+export const workflowControlsReopenScenario = pikkuScenario<
+  void,
+  { reopened: true }
+>({
+  title: 'Starting a run re-opens the panel it renders into',
+  description:
+    'An admin who closed the details panel can still start a run from the graph screen',
+  tags: ['scenario', 'workflow-controls', 'console'],
+  func: async (_services, _data, { scenario, actors }) => {
+    if (!actors?.admin) {
+      throw new Error(
+        'workflowControlsReopenScenario needs the admin actor — run via `pikku scenario run <environment>`'
+      )
+    }
+
+    await scenario.given(
+      'opens the workflow',
+      'opensConsolePage',
+      {
+        path: WORKFLOW_PAGE,
+        waitFor: { testId: 'workflow-controls-new-run' },
+      },
+      { actor: actors.admin }
+    )
+
+    await scenario.when(
+      'closes the details panel',
+      'clicksTestId',
+      { testId: 'console-detail-panel-close' },
+      { actor: actors.admin }
+    )
+    await scenario.then(
+      'no longer sees the panel',
+      'doesNotSeeTestId',
+      { testId: 'console-detail-panel-close' },
+      { actor: actors.admin }
+    )
+
+    await scenario.when(
+      'starts a new run from the graph screen',
+      'clicksTestId',
+      { testId: 'workflow-controls-new-run' },
+      { actor: actors.admin }
+    )
+    await scenario.then(
+      'sees the run form, because the panel re-opened',
+      'seesTestId',
+      { testId: 'workflow-new-run-form' },
+      { actor: actors.admin }
+    )
+
+    return { reopened: true }
+  },
+})
+
+export const workflowControlsFeature = pikkuFeature({
+  name: 'Workflow Run Controls',
+  description: 'Starting a run from the workflow screen itself',
+  tags: ['workflow-controls', 'console'],
+  scenarios: [workflowControlsReopenScenario],
+})

--- a/packages/console/messages/en.json
+++ b/packages/console/messages/en.json
@@ -1142,5 +1142,6 @@
   "help_functions_do_select": "[Open one to see its inputs, outputs and wirings](#list)",
   "help_functions_do_internals": "[Show pikku's own internal functions](#internals)",
   "scopes_granted_via_role": "via {roles}",
-  "scopes_tree_hint": "Held scopes are ticked. A scope a role carries is ticked and locked — change it on the role."
+  "scopes_tree_hint": "Held scopes are ticked. A scope a role carries is ticked and locked — change it on the role.",
+  "workflow_controls_clear_run": "Back to workflow"
 }

--- a/packages/console/src/components/layout/RunsPanel.tsx
+++ b/packages/console/src/components/layout/RunsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useCallback } from 'react'
 import {
   Stack,
   Text,
@@ -18,6 +18,7 @@ import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { Check, PanelLeftClose, Plus, X } from 'lucide-react'
 import { usePaneCollapse } from '../../context/PaneCollapseContext'
+import { usePaneReveal } from '../../context/PaneRevealContext'
 import {
   usePageAction,
   usePageOptionsDismiss,
@@ -190,6 +191,7 @@ export const RunsPanel: React.FC<RunsPanelProps> = ({
 }) => {
   const [statusFilter, setStatusFilter] = useState('all')
   const collapsePane = usePaneCollapse()
+  const revealDetails = usePaneReveal()
   const phone = usePhone()
   const dismiss = usePageOptionsDismiss()
   useLocale()
@@ -198,12 +200,17 @@ export const RunsPanel: React.FC<RunsPanelProps> = ({
   // pinned at the top as the sheet's primary action rather than scrolling away
   // above the runs. Picking either puts the sheet away: what a run opens, and
   // what a new run opens, are both underneath it.
+  const handleNew = useCallback(() => {
+    revealDetails?.()
+    onNewClick?.()
+  }, [revealDetails, onNewClick])
+
   usePageAction(
     phone && onNewClick
       ? {
           label: newButtonLabel ?? m.runs_panel_new(),
           icon: <Plus size={16} />,
-          onSelect: onNewClick,
+          onSelect: handleNew,
         }
       : null
   )
@@ -276,7 +283,7 @@ export const RunsPanel: React.FC<RunsPanelProps> = ({
                 py="sm"
                 px="sm"
                 style={{ flex: 1, minWidth: 0 }}
-                onClick={onNewClick}
+                onClick={handleNew}
                 data-testid="runs-panel-new"
               >
                 <Group gap="xs">
@@ -305,6 +312,7 @@ export const RunsPanel: React.FC<RunsPanelProps> = ({
                 run={run}
                 selected={run.id === selectedId}
                 onSelect={() => {
+                  revealDetails?.()
                   onSelect(run.id)
                   dismiss()
                 }}

--- a/packages/console/src/components/layout/ThreePaneLayout.tsx
+++ b/packages/console/src/components/layout/ThreePaneLayout.tsx
@@ -14,6 +14,7 @@ import { PanelContainer } from '../panel/PanelContainer'
 import { usePanelContext } from '../../context/PanelContext'
 import { useConsoleChrome } from '../../context/ConsoleChromeContext'
 import { ConsoleDetailPanel } from '../shell/ConsoleDetailPanel'
+import { PaneRevealProvider } from '../../context/PaneRevealContext'
 import { ConsoleListPanel } from '../shell/ConsoleListPanel'
 import { PageOptionsPortal } from '../shell/PageOptionsPortal'
 import { PaneCollapseProvider } from '../../context/PaneCollapseContext'
@@ -119,7 +120,9 @@ export const ThreePaneLayout: React.FC<ThreePaneLayoutProps> = ({
     // The panel renders the collapse control itself, in a row it already has —
     // see PaneCollapseContext.
     <PaneCollapseProvider collapse={() => setLeftCollapsed(true)}>
-      {runsPanel}
+      <PaneRevealProvider reveal={() => setRightCollapsed(false)}>
+        {runsPanel}
+      </PaneRevealProvider>
     </PaneCollapseProvider>
   ) : (
     <Tooltip label={m.pane_show_list()} position="right">

--- a/packages/console/src/components/layout/ThreePaneLayout.tsx
+++ b/packages/console/src/components/layout/ThreePaneLayout.tsx
@@ -286,6 +286,7 @@ export const ThreePaneLayout: React.FC<ThreePaneLayoutProps> = ({
                       color="gray"
                       size="sm"
                       aria-label={m.pane_hide_details()}
+                      data-testid="pane-hide-details"
                       onClick={() => setRightCollapsed(true)}
                       style={{
                         position: 'absolute',
@@ -303,6 +304,7 @@ export const ThreePaneLayout: React.FC<ThreePaneLayoutProps> = ({
                   <UnstyledButton
                     className={classes.paneStub}
                     aria-label={m.pane_show_details()}
+                    data-testid="pane-show-details"
                     onClick={() => setRightCollapsed(false)}
                   >
                     <PanelRightOpen size={16} />

--- a/packages/console/src/components/layout/ThreePaneLayout.tsx
+++ b/packages/console/src/components/layout/ThreePaneLayout.tsx
@@ -120,9 +120,7 @@ export const ThreePaneLayout: React.FC<ThreePaneLayoutProps> = ({
     // The panel renders the collapse control itself, in a row it already has —
     // see PaneCollapseContext.
     <PaneCollapseProvider collapse={() => setLeftCollapsed(true)}>
-      <PaneRevealProvider reveal={() => setRightCollapsed(false)}>
-        {runsPanel}
-      </PaneRevealProvider>
+      {runsPanel}
     </PaneCollapseProvider>
   ) : (
     <Tooltip label={m.pane_show_list()} position="right">
@@ -152,167 +150,172 @@ export const ThreePaneLayout: React.FC<ThreePaneLayoutProps> = ({
       : classes.listSurfaceCard
 
   return (
-    <Box className={classes.flexColumn} style={{ flex: 1, minHeight: 0 }}>
-      {header}
-      <Box
-        style={{
-          display: 'flex',
-          flex: 1,
-          minHeight: 0,
-          gap: 'var(--mantine-spacing-md)',
-          padding: 'var(--console-body-gutter)',
-        }}
-      >
-        {listInSheet && (
-          <PageOptionsPortal label={listLabel ?? m.pane_list()}>
-            <Box
-              className={classes.flexColumn}
-              style={{ flex: 1, minHeight: 0, width: '100%' }}
-              data-testid="pane-list-sheet"
-            >
-              {listBody}
-            </Box>
-          </PageOptionsPortal>
-        )}
+    // Provided for the whole layout, not just the list: the middle pane's own
+    // controls put their result in the details pane too, and an action whose
+    // result lands there must be able to re-open it.
+    <PaneRevealProvider reveal={() => setRightCollapsed(false)}>
+      <Box className={classes.flexColumn} style={{ flex: 1, minHeight: 0 }}>
+        {header}
+        <Box
+          style={{
+            display: 'flex',
+            flex: 1,
+            minHeight: 0,
+            gap: 'var(--mantine-spacing-md)',
+            padding: 'var(--console-body-gutter)',
+          }}
+        >
+          {listInSheet && (
+            <PageOptionsPortal label={listLabel ?? m.pane_list()}>
+              <Box
+                className={classes.flexColumn}
+                style={{ flex: 1, minHeight: 0, width: '100%' }}
+                data-testid="pane-list-sheet"
+              >
+                {listBody}
+              </Box>
+            </PageOptionsPortal>
+          )}
 
-        {hasLeft &&
-          !listInSheet &&
-          (listAsPanel ? (
-            <ConsoleListPanel
-              width={(showLeft ? LIST_WIDTH : LIST_RAIL_WIDTH) + CARD_GUTTERS}
-              testId="console-list-panel"
-            >
-              {listBody}
-            </ConsoleListPanel>
-          ) : (
+          {hasLeft &&
+            !listInSheet &&
+            (listAsPanel ? (
+              <ConsoleListPanel
+                width={(showLeft ? LIST_WIDTH : LIST_RAIL_WIDTH) + CARD_GUTTERS}
+                testId="console-list-panel"
+              >
+                {listBody}
+              </ConsoleListPanel>
+            ) : (
+              <Box
+                className={classes.paneCollapseTransition}
+                style={{
+                  width: showLeft ? LIST_WIDTH : LIST_RAIL_WIDTH,
+                  minWidth: showLeft ? LIST_WIDTH : LIST_RAIL_WIDTH,
+                  flexShrink: 0,
+                  overflow: 'hidden',
+                }}
+              >
+                {showLeft ? (
+                  <Box
+                    className={classes.listSurfaceCard}
+                    style={{ height: '100%' }}
+                  >
+                    {listBody}
+                  </Box>
+                ) : (
+                  listBody
+                )}
+              </Box>
+            ))}
+
+          <Box
+            className={mainSurface}
+            style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}
+          >
+            {showPaneHeader && (
+              <Box
+                px={8}
+                style={{
+                  height: 42,
+                  flexShrink: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  borderBottom: '1px solid var(--app-border)',
+                }}
+              >
+                <Box
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                  }}
+                >
+                  {lead}
+                  {filters}
+                </Box>
+              </Box>
+            )}
+            <Box style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+              {children}
+            </Box>
+          </Box>
+
+          {!ownsChrome && !hidePanel && (
+            <ConsoleDetailPanel
+              emptyMessage={emptyPanelMessage}
+              workflowGraph={false}
+            />
+          )}
+
+          {hasRight && (
             <Box
               className={classes.paneCollapseTransition}
               style={{
-                width: showLeft ? LIST_WIDTH : LIST_RAIL_WIDTH,
-                minWidth: showLeft ? LIST_WIDTH : LIST_RAIL_WIDTH,
+                width: showRight ? 'min(520px, 42vw)' : 40,
+                minWidth: showRight ? undefined : 40,
                 flexShrink: 0,
                 overflow: 'hidden',
               }}
             >
-              {showLeft ? (
+              {showRight ? (
                 <Box
                   className={classes.listSurfaceCard}
-                  style={{ height: '100%' }}
+                  style={{
+                    height: '100%',
+                    width: 'min(520px, 42vw)',
+                    position: 'relative',
+                  }}
                 >
-                  {listBody}
-                </Box>
-              ) : (
-                listBody
-              )}
-            </Box>
-          ))}
-
-        <Box
-          className={mainSurface}
-          style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}
-        >
-          {showPaneHeader && (
-            <Box
-              px={8}
-              style={{
-                height: 42,
-                flexShrink: 0,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-                borderBottom: '1px solid var(--app-border)',
-              }}
-            >
-              <Box
-                style={{
-                  flex: 1,
-                  minWidth: 0,
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 8,
-                }}
-              >
-                {lead}
-                {filters}
-              </Box>
-            </Box>
-          )}
-          <Box style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
-            {children}
-          </Box>
-        </Box>
-
-        {!ownsChrome && !hidePanel && (
-          <ConsoleDetailPanel
-            emptyMessage={emptyPanelMessage}
-            workflowGraph={false}
-          />
-        )}
-
-        {hasRight && (
-          <Box
-            className={classes.paneCollapseTransition}
-            style={{
-              width: showRight ? 'min(520px, 42vw)' : 40,
-              minWidth: showRight ? undefined : 40,
-              flexShrink: 0,
-              overflow: 'hidden',
-            }}
-          >
-            {showRight ? (
-              <Box
-                className={classes.listSurfaceCard}
-                style={{
-                  height: '100%',
-                  width: 'min(520px, 42vw)',
-                  position: 'relative',
-                }}
-              >
-                <PanelContainer
-                  emptyMessage={emptyPanelMessage}
-                  workflowGraph={false}
-                  hideClose
-                  hideRootTitle={!!lead}
-                />
-                {/* Overlaid rather than given a header row of its own — with the
+                  <PanelContainer
+                    emptyMessage={emptyPanelMessage}
+                    workflowGraph={false}
+                    hideClose
+                    hideRootTitle={!!lead}
+                  />
+                  {/* Overlaid rather than given a header row of its own — with the
                     root title suppressed that row would be empty but for this
                     icon, pushing the panel down a line. The offset lines it up
                     with the panel's own title row and its actions. */}
-                <Tooltip label={m.pane_hide_details()}>
-                  <ActionIcon
-                    variant="subtle"
-                    color="gray"
-                    size="sm"
-                    aria-label={m.pane_hide_details()}
-                    onClick={() => setRightCollapsed(true)}
-                    style={{
-                      position: 'absolute',
-                      top: 20,
-                      right: 10,
-                      zIndex: 2,
-                    }}
+                  <Tooltip label={m.pane_hide_details()}>
+                    <ActionIcon
+                      variant="subtle"
+                      color="gray"
+                      size="sm"
+                      aria-label={m.pane_hide_details()}
+                      onClick={() => setRightCollapsed(true)}
+                      style={{
+                        position: 'absolute',
+                        top: 20,
+                        right: 10,
+                        zIndex: 2,
+                      }}
+                    >
+                      <PanelRightClose size={16} />
+                    </ActionIcon>
+                  </Tooltip>
+                </Box>
+              ) : (
+                <Tooltip label={m.pane_show_details()} position="left">
+                  <UnstyledButton
+                    className={classes.paneStub}
+                    aria-label={m.pane_show_details()}
+                    onClick={() => setRightCollapsed(false)}
                   >
-                    <PanelRightClose size={16} />
-                  </ActionIcon>
+                    <PanelRightOpen size={16} />
+                    <span className={classes.paneStubLabel}>
+                      {detailLabel ?? m.pane_details()}
+                    </span>
+                  </UnstyledButton>
                 </Tooltip>
-              </Box>
-            ) : (
-              <Tooltip label={m.pane_show_details()} position="left">
-                <UnstyledButton
-                  className={classes.paneStub}
-                  aria-label={m.pane_show_details()}
-                  onClick={() => setRightCollapsed(false)}
-                >
-                  <PanelRightOpen size={16} />
-                  <span className={classes.paneStubLabel}>
-                    {detailLabel ?? m.pane_details()}
-                  </span>
-                </UnstyledButton>
-              </Tooltip>
-            )}
-          </Box>
-        )}
+              )}
+            </Box>
+          )}
+        </Box>
       </Box>
-    </Box>
+    </PaneRevealProvider>
   )
 }

--- a/packages/console/src/components/panel/PanelFactory.tsx
+++ b/packages/console/src/components/panel/PanelFactory.tsx
@@ -159,7 +159,7 @@ const NewWorkflowRunForm: React.FC<{ workflowId: string }> = ({
   )
 
   return (
-    <Stack gap="md">
+    <Stack gap="md" data-testid="workflow-new-run-form">
       {isLoading ? (
         <Loader size="sm" />
       ) : effectiveSchema ? (

--- a/packages/console/src/components/workflow/WorkflowControls.tsx
+++ b/packages/console/src/components/workflow/WorkflowControls.tsx
@@ -1,0 +1,92 @@
+import React, { useCallback } from 'react'
+import { Box, Button, Group, Text } from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+import { Play, X } from 'lucide-react'
+import { m } from '@/i18n/messages'
+import { useLocale } from '@/i18n/config'
+import { usePanelContext } from '../../context/PanelContext'
+import { useConsoleEditable } from '../../context/ConsoleEditableContext'
+import { usePaneReveal } from '../../context/PaneRevealContext'
+import { useWorkflowRunContextSafe } from '../../context/WorkflowRunContext'
+import { useWorkflowSurface } from '../../context/WorkflowSurfaceContext'
+import { PikkuBadge } from '../ui/PikkuBadge'
+
+/**
+ * The workflow's run controls, on the screen itself rather than only in the
+ * details pane. Running a workflow is the thing this screen is for, so the
+ * action belongs beside the graph — the pane is where a run is *inspected*, and
+ * a reader who collapsed it should still be able to start one.
+ *
+ * Mount anywhere under a `WorkflowSurface` that was not created `readOnly`.
+ */
+export const WorkflowControls: React.FC = () => {
+  useLocale()
+  const { workflowName, isScenario } = useWorkflowSurface()
+  const runContext = useWorkflowRunContextSafe()
+  const { setActivePanel } = usePanelContext()
+  const revealDetails = usePaneReveal()
+  const editable = useConsoleEditable()
+
+  const openPanel = useCallback(() => {
+    revealDetails?.()
+    setActivePanel(`workflow-${workflowName}`)
+  }, [revealDetails, setActivePanel, workflowName])
+
+  const handleNewRun = useCallback(() => {
+    runContext?.setSelectedRunId(null)
+    runContext?.setIsCreatingRun(true)
+    openPanel()
+  }, [runContext, openPanel])
+
+  const handleClearRun = useCallback(() => {
+    runContext?.setSelectedRunId(null)
+  }, [runContext])
+
+  // A scenario is run by `pikku scenario run`, never from here, and a viewer
+  // has no run controls at all.
+  if (!runContext || isScenario || !editable) return null
+
+  const { selectedRunId, runData } = runContext
+  const status = runData?.status
+
+  return (
+    <Box
+      px="sm"
+      py={6}
+      style={{
+        flexShrink: 0,
+        borderBottom: '1px solid var(--mantine-color-default-border)',
+      }}
+    >
+      <Group gap="xs" wrap="nowrap">
+        <Button
+          size="compact-sm"
+          variant="light"
+          leftSection={<Play size={14} />}
+          onClick={handleNewRun}
+          data-testid="workflow-controls-new-run"
+        >
+          {m.workflow_runs_new()}
+        </Button>
+        {selectedRunId && (
+          <>
+            <Text size="xs" c="dimmed" ff="monospace" truncate="end">
+              {asI18n(selectedRunId)}
+            </Text>
+            {status && <PikkuBadge type="status" value={status} size="sm" />}
+            <Button
+              size="compact-sm"
+              variant="subtle"
+              color="gray"
+              leftSection={<X size={14} />}
+              onClick={handleClearRun}
+              data-testid="workflow-controls-clear-run"
+            >
+              {m.workflow_controls_clear_run()}
+            </Button>
+          </>
+        )}
+      </Group>
+    </Box>
+  )
+}

--- a/packages/console/src/components/workflow/WorkflowControls.tsx
+++ b/packages/console/src/components/workflow/WorkflowControls.tsx
@@ -15,22 +15,26 @@ import { PikkuBadge } from '../ui/PikkuBadge'
  * The workflow's run controls, on the screen itself rather than only in the
  * details pane. Running a workflow is the thing this screen is for, so the
  * action belongs beside the graph — the pane is where a run is *inspected*, and
- * a reader who collapsed it should still be able to start one.
+ * a reader who collapsed or closed it should still be able to start one.
  *
  * Mount anywhere under a `WorkflowSurface` that was not created `readOnly`.
  */
 export const WorkflowControls: React.FC = () => {
   useLocale()
-  const { workflowName, isScenario } = useWorkflowSurface()
+  const { workflow, workflowName, isScenario } = useWorkflowSurface()
   const runContext = useWorkflowRunContextSafe()
-  const { setActivePanel } = usePanelContext()
+  const { openWorkflow } = usePanelContext()
   const revealDetails = usePaneReveal()
   const editable = useConsoleEditable()
 
+  // `openWorkflow` rather than `setActivePanel`, because the reader may have
+  // closed the panel outright rather than collapsed the pane holding it —
+  // activating an id that is no longer in the map does nothing, and the run
+  // form has nowhere to render.
   const openPanel = useCallback(() => {
     revealDetails?.()
-    setActivePanel(`workflow-${workflowName}`)
-  }, [revealDetails, setActivePanel, workflowName])
+    openWorkflow(workflowName, workflow)
+  }, [revealDetails, openWorkflow, workflowName, workflow])
 
   const handleNewRun = useCallback(() => {
     runContext?.setSelectedRunId(null)

--- a/packages/console/src/components/workflow/WorkflowGraphPanel.tsx
+++ b/packages/console/src/components/workflow/WorkflowGraphPanel.tsx
@@ -11,6 +11,7 @@ import { EmptyStatePlaceholder } from '../layout/EmptyStatePlaceholder'
 import { ScenarioDocument } from '../scenarios/ScenarioDocument'
 import { WorkflowGraphView } from '../project/WorkflowGraphView'
 import { WorkflowTimelineDrawer } from '../project/WorkflowTimelineDrawer'
+import { WorkflowControls } from './WorkflowControls'
 import { ConsoleLoading } from '../ui/ConsoleLoading'
 
 /**
@@ -65,6 +66,7 @@ export const WorkflowGraphPanel: React.FC = () => {
         flexDirection: 'column',
       }}
     >
+      <WorkflowControls />
       {runContext?.isVersionMismatch && (
         <Alert
           icon={<History size={16} />}

--- a/packages/console/src/context/PaneRevealContext.tsx
+++ b/packages/console/src/context/PaneRevealContext.tsx
@@ -1,0 +1,16 @@
+import React, { createContext, useContext } from 'react'
+
+/** Lets a list pane's own content re-open the details pane it feeds, so an
+ *  action whose only result lands there is never silently swallowed by a pane
+ *  the reader collapsed earlier. `null` where the details pane cannot be
+ *  collapsed — there is nothing to reveal then. */
+const PaneRevealCtx = createContext<(() => void) | null>(null)
+
+export const PaneRevealProvider: React.FC<{
+  reveal: () => void
+  children: React.ReactNode
+}> = ({ reveal, children }) => (
+  <PaneRevealCtx.Provider value={reveal}>{children}</PaneRevealCtx.Provider>
+)
+
+export const usePaneReveal = () => useContext(PaneRevealCtx)


### PR DESCRIPTION
Follow-up to #1674, which merged before these landed.

**The new-run button did nothing.** `WorkflowRunsPanel` sets `isCreatingRun`, and the form it summons renders in the details pane — the third column of `ThreePaneLayout`, not the graph you are looking at. That pane's collapsed state is remembered in `localStorage` under `workflow-right-collapsed`, and nothing anywhere re-opened it. So once the pane had been collapsed, at any point in the past, the button flipped state into a 40px stub forever, across reloads, with no error and no feedback. Selecting a run had the same defect, masked by the graph beside it also changing.

An action whose result lands in that pane now reveals it, through a context the layout hands its panes — the mirror of the collapse control each pane already provides for itself.

**The screen had no run controls.** Running a workflow is what the screen is for, but the only way to start one was through the details pane; the graph carried no control at all. `WorkflowControls` now sits above the graph with the run action, the selected run's id and status, and a way back to the workflow. It renders nothing for a scenario (which is run by `pikku scenario run`) or for a viewer with no edit rights.

## Testing

`bun run tsc` and `./run-tests.sh` in `packages/console` — 318 pass. Verified against the e2e project at `http://localhost:4077/console/workflow?id=graphLinearWorkflow`.

No verifier or e2e coverage: console UI with no generated output and no server behaviour behind it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added workflow run controls for starting a new run and viewing the selected run’s ID and status.
  - Added a “Back to workflow” action to clear the selected run.
  - Selecting or starting a run now automatically reveals the details pane.
  - Workflow run controls are available on editable workflow screens and are hidden for scenario-based workflows.
- **Localization**
  - Added English text for the new workflow control action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->